### PR TITLE
Re-enable query test and fix it

### DIFF
--- a/cmd/query_test.go
+++ b/cmd/query_test.go
@@ -77,6 +77,7 @@ var _ = Describe("Query", func() {
 	}
 }
 `
+
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
 					ghttp.VerifyRequest("POST", "/"),
@@ -96,7 +97,7 @@ var _ = Describe("Query", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			session.Wait()
 			Eventually(session.Err.Contents()).Should(BeEmpty())
-			//Eventually(session.Out.Contents()).Should(MatchJSON(responseData))
+			Eventually(session.Out.Contents()).Should(MatchJSON(responseData))
 			Eventually(session).Should(gexec.Exit(0))
 		})
 	})

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -73,9 +73,9 @@ func (l *Logger) FatalOnError(msg string, err error) {
 	}
 }
 
-// Prettyify accepts a map fo data and pretty prints it.
+// Prettyify accepts a map of data and pretty prints it.
 // It's using json.MarshalIndent and printing with log.Logger.Infoln
-func (l *Logger) Prettyify(data ...interface{}) {
+func (l *Logger) Prettyify(data map[string]interface{}) {
 	bytes, err := json.MarshalIndent(data, "", "  ")
 	if err != nil {
 		l.error.Fatalln(err)


### PR DESCRIPTION
This test was originally broken here:
https://github.com/CircleCI-Public/circleci-cli/commit/1eea78433bd405e6b428ef3899cbf93003846db2
    
We stopped using Prettify in `collapse` here:
https://github.com/CircleCI-Public/circleci-cli/commit/980eb71e3bdb31df5d7ec0fd56dfce86943e19c5
    
This means the `query` command is the only user of Prettify so we can change it back.