### PR TITLE
Fix gometalinter flakes by setting CGO_ENABLED=0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,9 +30,11 @@ jobs:
     docker:
       - image: supinf/gometalinter:latest
     working_directory: /go/src/github.com/CircleCI-Public/circleci-cli
+    environment:
+      CGO_ENABLED: 0
     steps:
       - checkout
-      - run: gometalinter --deadline 60s --exclude=/usr/local/go/ --exclude ^vendor ./...
+      - run: gometalinter ./...
 
   deploy:
     executor: go

--- a/.gometalinter.json
+++ b/.gometalinter.json
@@ -1,0 +1,34 @@
+{
+  "Vendor": true,
+  "Deadline": "5m",
+  "Concurrency": 2,
+  "Linters": {
+    "gofmt": {"Command": "gofmt -l -s -w"},
+    "goimports": {"Command": "goimports -l -w"}
+  },
+
+  "Enable": [
+    "deadcode",
+    "errcheck",
+    "gas",
+    "goconst",
+    "gocyclo",
+    "gofmt",
+    "goimports",
+    "golint",
+    "gosimple",
+    "gotype",
+    "gotypex",
+    "ineffassign",
+    "interfacer",
+    "megacheck",
+    "misspell",
+    "nakedret",
+    "structcheck",
+    "unconvert",
+    "unparam",
+    "varcheck",
+    "vet",
+    "vetshadow"
+  ]
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -60,7 +60,7 @@ func MakeCommands() *cobra.Command {
 	// https://github.com/spf13/cobra/issues/340
 	// If you expose a command with `RunE`, and return an error from your
 	// command, then Cobra will print the error message, followed by the usage
-	// infomation for the command. This makes it really difficult to see what's
+	// information for the command. This makes it really difficult to see what's
 	// gone wrong. It usually prints a one line error message followed by 15
 	// lines of usage information.
 	// This flag disables that behaviour, so that if a comment fails, it prints


### PR DESCRIPTION
I looked into the lint CI failures in #17 by re-running the job with ssh enabled. In the shell I ran 

```
gometalinter --debug --vendor ./...
```
In the debug output I noticed 

```
/go/bin/structcheck returned exit status 1: exec: "gcc": executable file not found in $PATH
```
Often (maybe always) when you get linter errors reported for `/usr/local/go` this indicates that linting is failing because `go build` failed. 

The `gometalinter` docker image uses alpine and doesn't include `gcc` and all the c header files, so running with `CGO_ENABLED=0` fixes the build by using the pure-go compiler.

Also added a config file to explicitly define and configure linters.  I added a few additional linters that aren't in the [default set](https://github.com/alecthomas/gometalinter#supported-linters) but which I find helpful (`gosimple`, `misspell`, `goimports`, `nakedret`, `unparam`). 

I also removed `dupl` from the list, which is enabled by default. In my experience the warnings this reports are often not very valuable, but I would be happy to re-enabled it if you would like.

