### PR TITLE
Circle-11123 publish orb

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -161,12 +161,18 @@ func OrbPublish(ctx context.Context, logger *logger.Logger,
 
 	return &response.PublishOrb.PublishOrbResponse, publishOrbQuery(ctx, logger,
 		configPath, orbVersion, orbID, &response, `
-		mutation($config: String!, $orbId: $String!, $version: $String!) {
+		mutation($config: String!, $orbId: UUID!, $version: String!) {
 			publishOrb(
 				orbId: $orbId,
 				orbYaml: $config,
 				version: $version
-			)
+			) {
+				orb {
+					version
+					createdAt
+				}
+				errors { message }
+			}
 		}
 	`)
 

--- a/api/api.go
+++ b/api/api.go
@@ -11,6 +11,14 @@ import (
 	"github.com/spf13/viper"
 )
 
+// GQLResponseErrors is a slice of errors returned by the GraphQL server. Each
+// error message is a key-value pair with the structure "Message: string"
+type GQLResponseErrors struct {
+	Errors []struct {
+		Message string
+	}
+}
+
 // ConfigResponse is a structure that matches the result of the GQL
 // query, so that we can use mapstructure to convert from
 // nested maps to a strongly typed struct.
@@ -19,9 +27,7 @@ type ConfigResponse struct {
 	SourceYaml string
 	OutputYaml string
 
-	Errors []struct {
-		Message string
-	}
+	GQLResponseErrors
 }
 
 // The PublishOrbResponse type matches the data shape of the GQL response for
@@ -32,25 +38,12 @@ type PublishOrbResponse struct {
 		Version   string
 	}
 
-	Errors []struct {
-		Message string
-	}
+	GQLResponseErrors
 }
 
-// ToError returns an error created from any error messages, or nil.
-func (response ConfigResponse) ToError() error {
-	messages := []string{}
-
-	for i := range response.Errors {
-		messages = append(messages, response.Errors[i].Message)
-	}
-
-	return errors.New(strings.Join(messages, ": "))
-}
-
-// ToError (PublishOrbResponse) returns all errors that the GraphQL API returns
-// as part of a publish orb request.
-func (response PublishOrbResponse) ToError() error {
+// ToError returns all GraphQL errors for a single response concatenated, or
+// nil.
+func (response GQLResponseErrors) ToError() error {
 	messages := []string{}
 
 	for i := range response.Errors {

--- a/cmd/collapse.go
+++ b/cmd/collapse.go
@@ -16,7 +16,7 @@ func newCollapseCommand() *cobra.Command {
 		Short: "Collapse your CircleCI configuration to a single file",
 		RunE:  collapse,
 	}
-	collapseCommand.Flags().StringVarP(&root, "root", "r", ".circleci", "path to your configuration (default is .circleci)")
+	collapseCommand.Flags().StringVarP(&root, "root", "r", ".", "path to your configuration (default is current path)")
 
 	return collapseCommand
 }

--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -15,7 +15,7 @@ import (
 
 var orbPath string
 var orbVersion string
-var orbId string
+var orbID string
 
 func newOrbCommand() *cobra.Command {
 
@@ -44,7 +44,7 @@ func newOrbCommand() *cobra.Command {
 	}
 	orbPublishCommand.PersistentFlags().StringVarP(&orbPath, "path", "p", "orb.yml", "path to orb file")
 	orbPublishCommand.PersistentFlags().StringVarP(&orbVersion, "orb-version", "o", "", "version of orb to publish")
-	orbPublishCommand.PersistentFlags().StringVarP(&orbId, "orb-id", "i", "", "version of orb to publish")
+	orbPublishCommand.PersistentFlags().StringVarP(&orbID, "orb-id", "i", "", "version of orb to publish")
 
 	orbCommand := &cobra.Command{
 		Use:   "orb",
@@ -168,7 +168,7 @@ func expandOrb(cmd *cobra.Command, args []string) error {
 func publishOrb(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 
-	response, err := api.OrbPublish(ctx, Logger, orbPath, orbVersion, orbId)
+	response, err := api.OrbPublish(ctx, Logger, orbPath, orbVersion, orbID)
 
 	if err != nil {
 		fmt.Println("response error")

--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/CircleCI-Public/circleci-cli/api"
 	"github.com/CircleCI-Public/circleci-cli/client"
@@ -44,7 +43,7 @@ func newOrbCommand() *cobra.Command {
 	}
 	orbPublishCommand.PersistentFlags().StringVarP(&orbPath, "path", "p", "orb.yml", "path to orb file")
 	orbPublishCommand.PersistentFlags().StringVarP(&orbVersion, "orb-version", "o", "", "version of orb to publish")
-	orbPublishCommand.PersistentFlags().StringVarP(&orbID, "orb-id", "i", "", "version of orb to publish")
+	orbPublishCommand.PersistentFlags().StringVarP(&orbID, "orb-id", "i", "", "id of orb to publish")
 
 	orbCommand := &cobra.Command{
 		Use:   "orb",
@@ -171,7 +170,6 @@ func publishOrb(cmd *cobra.Command, args []string) error {
 	response, err := api.OrbPublish(ctx, Logger, orbPath, orbVersion, orbID)
 
 	if err != nil {
-		fmt.Println("response error")
 		return err
 	}
 

--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/CircleCI-Public/circleci-cli/api"
 	"github.com/CircleCI-Public/circleci-cli/client"
@@ -34,6 +35,13 @@ func newOrbCommand() *cobra.Command {
 		RunE:  expandOrb,
 	}
 
+	orbPublishCommand := &cobra.Command{
+		Use:   "publish",
+		Short: "publish a version of an orb",
+		RunE:  publishOrb,
+	}
+	orbPublishCommand.PersistentFlags().StringVarP(&orbPath, "path", "p", "orb.yml", "path to orb file")
+
 	orbCommand := &cobra.Command{
 		Use:   "orb",
 		Short: "Operate on orbs",
@@ -46,6 +54,8 @@ func newOrbCommand() *cobra.Command {
 
 	orbExpandCommand.PersistentFlags().StringVarP(&orbPath, "path", "p", "orb.yml", "path to orb file")
 	orbCommand.AddCommand(orbExpandCommand)
+
+	orbCommand.AddCommand(orbPublishCommand)
 
 	return orbCommand
 }
@@ -148,5 +158,27 @@ func expandOrb(cmd *cobra.Command, args []string) error {
 	}
 
 	Logger.Info(response.OutputYaml)
+	return nil
+}
+
+func publishOrb(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	response, err := api.OrbPublish(ctx, Logger, orbPath)
+
+	if err != nil {
+		return err
+	}
+
+	if !response.Valid {
+		// fmt.Print("response invalid")
+		// print("response invalid")
+		// fmt.Println(">>>>>>>>>>>>>>>>>>>> response invalid >>>>>>>>>>>>>>>>>>>>", response.ToError())
+		fmt.Println(">>>>>>>>>>>>>>>>>>>> response invalid >>>>>>>>>>>>>>>>>>>>", response.ToError().Error())
+		return response.ToError()
+	}
+
+	// Logger.Info(response.OutputYaml)
+	Logger.Info("Orb published")
 	return nil
 }

--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -14,6 +14,8 @@ import (
 )
 
 var orbPath string
+var orbVersion string
+var orbId string
 
 func newOrbCommand() *cobra.Command {
 
@@ -41,6 +43,8 @@ func newOrbCommand() *cobra.Command {
 		RunE:  publishOrb,
 	}
 	orbPublishCommand.PersistentFlags().StringVarP(&orbPath, "path", "p", "orb.yml", "path to orb file")
+	orbPublishCommand.PersistentFlags().StringVarP(&orbVersion, "orb-version", "o", "", "version of orb to publish")
+	orbPublishCommand.PersistentFlags().StringVarP(&orbId, "orb-id", "i", "", "version of orb to publish")
 
 	orbCommand := &cobra.Command{
 		Use:   "orb",
@@ -164,21 +168,17 @@ func expandOrb(cmd *cobra.Command, args []string) error {
 func publishOrb(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 
-	response, err := api.OrbPublish(ctx, Logger, orbPath)
+	response, err := api.OrbPublish(ctx, Logger, orbPath, orbVersion, orbId)
 
 	if err != nil {
+		fmt.Println("response error")
 		return err
 	}
 
-	if !response.Valid {
-		// fmt.Print("response invalid")
-		// print("response invalid")
-		// fmt.Println(">>>>>>>>>>>>>>>>>>>> response invalid >>>>>>>>>>>>>>>>>>>>", response.ToError())
-		fmt.Println(">>>>>>>>>>>>>>>>>>>> response invalid >>>>>>>>>>>>>>>>>>>>", response.ToError().Error())
+	if len(response.Errors) > 0 {
 		return response.ToError()
 	}
 
-	// Logger.Info(response.OutputYaml)
 	Logger.Info("Orb published")
 	return nil
 }

--- a/cmd/orb_test.go
+++ b/cmd/orb_test.go
@@ -12,12 +12,12 @@ import (
 	"github.com/onsi/gomega/ghttp"
 )
 
-var _ = Describe("Orb", func() {
-	Describe("behavior with an api and an orb.yml provided", func() {
+var _ = Describe("Orb integration tests", func() {
+	Describe("CLI behavior with a stubbed api and an orb.yml provided", func() {
 		var (
 			testServer *ghttp.Server
 			orb        tmpFile
-			token      string
+			token      string = "testtoken"
 			command    *exec.Cmd
 		)
 
@@ -36,7 +36,6 @@ var _ = Describe("Orb", func() {
 
 		Describe("when validating orb", func() {
 			BeforeEach(func() {
-				token = "testtoken"
 				command = exec.Command(pathCLI,
 					"orb", "validate",
 					"-t", token,
@@ -109,13 +108,7 @@ var _ = Describe("Orb", func() {
 		})
 
 		Describe("when expanding orb", func() {
-			var (
-				token   string
-				command *exec.Cmd
-			)
-
 			BeforeEach(func() {
-				token = "testtoken"
 				command = exec.Command(pathCLI,
 					"orb", "expand",
 					"-t", token,
@@ -191,7 +184,6 @@ var _ = Describe("Orb", func() {
 
 		Describe("when publishing an orb version", func() {
 			BeforeEach(func() {
-				token = "testtoken"
 				command = exec.Command(pathCLI,
 					"orb", "publish",
 					"-t", token,

--- a/cmd/orb_test.go
+++ b/cmd/orb_test.go
@@ -226,6 +226,8 @@ var _ = Describe("Orb", func() {
 				// 	"query": '{}", version: "0.0.1") { orb { version createdAt } errors { message } } } '
 				// 	}`
 
+				// "query": "mutation($config: String!, $orbId: UUID!, $version: String!) {publishOrb(orbId: $orbId,orbYaml: $config,version: $version)}",
+				// "query": "mutation($config: String!, $orbId: UUID!, $version: String!) {publishOrb(orbId: $orbId,orbYaml: $config,version: $version) {orb {versioncreatedAt}}errors { message }",
 				expectedRequestJson := `{
 					"query": "\n\t\tmutation($config: String!, $orbId: UUID!, $version: String!) {\n\t\t\tpublishOrb(\n\t\t\t\torbId: $orbId,\n\t\t\t\torbYaml: $config,\n\t\t\t\tversion: $version) {orb {\n\t\t\tversion\n\t\t\tcreatedAt\n\t\t}\n\t\t}\n\t\terrors { message }\n\t",
 					"variables": {


### PR DESCRIPTION
User can publish an orb from the CLI

```
$ go run main.go orb publish --path ./tmp-orb.yml -i bb604b45-b6b0-4b81-ad80-796f15eddf87 -o 0.0.2
Orb published

$ go run main.go orb publish --path ./tmp-orb.yml -i bb604b45-b6b0-4b81-ad80-796f15eddf87 -o 0.0.2
Error: orb revision already exists exit status 255
```