### PR TITLE
[CIRCLE-12217] Create namespace

### DIFF
--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -67,7 +67,11 @@ var _ = Describe("Config", func() {
 					}
 				  }`
 
-				appendPostHandler(testServer, token, http.StatusOK, expectedRequestJson, gqlResponse)
+				appendPostHandler(testServer, token, MockRequestResponse{
+					Status:   http.StatusOK,
+					Request:  expectedRequestJson,
+					Response: gqlResponse,
+				})
 
 				session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 
@@ -97,7 +101,11 @@ var _ = Describe("Config", func() {
 					}
 				  }`
 
-				appendPostHandler(testServer, token, http.StatusOK, expectedRequestJson, gqlResponse)
+				appendPostHandler(testServer, token, MockRequestResponse{
+					Status:   http.StatusOK,
+					Request:  expectedRequestJson,
+					Response: gqlResponse,
+				})
 
 				session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 
@@ -143,7 +151,11 @@ var _ = Describe("Config", func() {
 					}
 				  }`
 
-				appendPostHandler(testServer, token, http.StatusOK, expectedRequestJson, gqlResponse)
+				appendPostHandler(testServer, token, MockRequestResponse{
+					Status:   http.StatusOK,
+					Request:  expectedRequestJson,
+					Response: gqlResponse,
+				})
 
 				session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 
@@ -174,7 +186,11 @@ var _ = Describe("Config", func() {
 					}
 				  }`
 
-				appendPostHandler(testServer, token, http.StatusOK, expectedRequestJson, gqlResponse)
+				appendPostHandler(testServer, token, MockRequestResponse{
+					Status:   http.StatusOK,
+					Request:  expectedRequestJson,
+					Response: gqlResponse,
+				})
 
 				session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 

--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/CircleCI-Public/circleci-cli/api"
 	"github.com/CircleCI-Public/circleci-cli/client"
@@ -18,6 +19,8 @@ import (
 var orbPath string
 var orbVersion string
 var orbID string
+var organizationName string
+var organizationVcs string
 
 func newOrbCommand() *cobra.Command {
 
@@ -48,6 +51,17 @@ func newOrbCommand() *cobra.Command {
 	orbPublishCommand.PersistentFlags().StringVarP(&orbVersion, "orb-version", "o", "", "version of orb to publish")
 	orbPublishCommand.PersistentFlags().StringVarP(&orbID, "orb-id", "i", "", "id of orb to publish")
 
+	orbCreateNamespace := &cobra.Command{
+		Use:   "create",
+		Short: "create an orb namespace",
+		RunE:  createOrbNamespace,
+		Args:  cobra.ExactArgs(1),
+	}
+
+	namespaceCommand := &cobra.Command{
+		Use: "ns",
+	}
+
 	orbCommand := &cobra.Command{
 		Use:   "orb",
 		Short: "Operate on orbs",
@@ -62,6 +76,11 @@ func newOrbCommand() *cobra.Command {
 	orbCommand.AddCommand(orbExpandCommand)
 
 	orbCommand.AddCommand(orbPublishCommand)
+
+	orbCreateNamespace.PersistentFlags().StringVar(&organizationName, "org-name", "", "organization name")
+	orbCreateNamespace.PersistentFlags().StringVar(&organizationVcs, "vcs", "github", "organization vcs, e.g. 'github', 'bitbucket'")
+	namespaceCommand.AddCommand(orbCreateNamespace)
+	orbCommand.AddCommand(namespaceCommand)
 
 	return orbCommand
 }
@@ -227,5 +246,23 @@ func publishOrb(cmd *cobra.Command, args []string) error {
 	}
 
 	Logger.Info("Orb published")
+	return nil
+}
+
+func createOrbNamespace(cmd *cobra.Command, args []string) error {
+	var err error
+	ctx := context.Background()
+
+	response, err := api.CreateNamespace(ctx, Logger, args[0], organizationName, strings.ToUpper(organizationVcs))
+
+	if err != nil {
+		return err
+	}
+
+	if len(response.Errors) > 0 {
+		return response.ToError()
+	}
+
+	Logger.Info("Namespace created")
 	return nil
 }

--- a/cmd/orb_test.go
+++ b/cmd/orb_test.go
@@ -64,7 +64,11 @@ var _ = Describe("Orb integration tests", func() {
 					}
 				}`
 
-				appendPostHandler(testServer, token, http.StatusOK, expectedRequestJson, gqlResponse)
+				appendPostHandler(testServer, token, MockRequestResponse{
+					Status:   http.StatusOK,
+					Request:  expectedRequestJson,
+					Response: gqlResponse,
+				})
 
 				By("running the command")
 				session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
@@ -96,7 +100,11 @@ var _ = Describe("Orb integration tests", func() {
 					  "config": "some orb"
 					}
 				  }`
-				appendPostHandler(testServer, token, http.StatusOK, expectedRequestJson, gqlResponse)
+				appendPostHandler(testServer, token, MockRequestResponse{
+					Status:   http.StatusOK,
+					Request:  expectedRequestJson,
+					Response: gqlResponse,
+				})
 
 				By("running the command")
 				session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
@@ -137,7 +145,11 @@ var _ = Describe("Orb integration tests", func() {
 					}
 				  }`
 
-				appendPostHandler(testServer, token, http.StatusOK, expectedRequestJson, gqlResponse)
+				appendPostHandler(testServer, token, MockRequestResponse{
+					Status:   http.StatusOK,
+					Request:  expectedRequestJson,
+					Response: gqlResponse,
+				})
 
 				By("running the command")
 				session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
@@ -170,7 +182,11 @@ var _ = Describe("Orb integration tests", func() {
 					}
 				  }`
 
-				appendPostHandler(testServer, token, http.StatusOK, expectedRequestJson, gqlResponse)
+				appendPostHandler(testServer, token, MockRequestResponse{
+					Status:   http.StatusOK,
+					Request:  expectedRequestJson,
+					Response: gqlResponse,
+				})
 
 				By("running the command")
 				session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
@@ -223,7 +239,11 @@ var _ = Describe("Orb integration tests", func() {
 					}
 				}`
 
-				appendPostHandler(testServer, token, http.StatusOK, expectedRequestJson, gqlResponse)
+				appendPostHandler(testServer, token, MockRequestResponse{
+					Status:   http.StatusOK,
+					Request:  expectedRequestJson,
+					Response: gqlResponse,
+				})
 
 				By("running the command")
 				session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
@@ -257,7 +277,11 @@ var _ = Describe("Orb integration tests", func() {
 					}
 				}`
 
-				appendPostHandler(testServer, token, http.StatusOK, expectedRequestJson, gqlResponse)
+				appendPostHandler(testServer, token, MockRequestResponse{
+					Status:   http.StatusOK,
+					Request:  expectedRequestJson,
+					Response: gqlResponse,
+				})
 
 				By("running the command")
 				session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
@@ -266,6 +290,130 @@ var _ = Describe("Orb integration tests", func() {
 				Eventually(session.Err).Should(gbytes.Say("Error: error1: error2"))
 				Eventually(session).ShouldNot(gexec.Exit(0))
 
+			})
+		})
+
+		Describe("when creating / reserving a namespace", func() {
+			BeforeEach(func() {
+				command = exec.Command(pathCLI,
+					"orb", "ns", "create",
+					"-t", token,
+					"-e", testServer.URL(),
+					"foo-ns",
+					"--org-name", "test-org",
+					"--vcs", "BITBUCKET",
+				)
+			})
+
+			It("works with organizationName and organizationVcs", func() {
+				By("setting up a mock server")
+
+				gqlOrganizationResponse := `{
+    											"organization": {
+      												"name": "test-org",
+      												"id": "bb604b45-b6b0-4b81-ad80-796f15eddf87"
+    											}
+  				}`
+
+				expectedOrganizationRequest := `{
+            "query": "\n\t\t\tquery($organizationName: String!, $organizationVcs: VCSType!) {\n\t\t\t\torganization(\n\t\t\t\t\tname: $organizationName\n\t\t\t\t\tvcsType: $organizationVcs\n\t\t\t\t) {\n\t\t\t\t\tid\n\t\t\t\t}\n\t\t\t}",
+            "variables": {
+              "organizationName": "test-org",
+              "organizationVcs": "BITBUCKET"
+            }
+          }`
+
+				gqlNsResponse := `{
+									"createNamespace": {
+										"errors": [],
+										"namespace": {
+														"createdAt": "2018-07-16T18:03:18.961Z",
+														"id": "bb604b45-b6b0-4b81-ad80-796f15eddf87"
+										}
+									}
+				}`
+
+				expectedNsRequest := `{
+            "query": "\n\t\t\tmutation($name: String!, $organizationId: UUID!) {\n\t\t\t\tcreateNamespace(\n\t\t\t\t\tname: $name,\n\t\t\t\t\torganizationId: $organizationId\n\t\t\t\t) {\n\t\t\t\t\tnamespace {\n\t\t\t\t\t\tcreatedAt\n\t\t\t\t\t\tid\n\t\t\t\t\t}\n\t\t\t\t\terrors {\n\t\t\t\t\t\tmessage\n\t\t\t\t\t\ttype\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t}",
+            "variables": {
+              "name": "foo-ns",
+              "organizationId": "bb604b45-b6b0-4b81-ad80-796f15eddf87"
+            }
+          }`
+
+				appendPostHandler(testServer, token,
+					MockRequestResponse{Status: http.StatusOK,
+						Request:  expectedOrganizationRequest,
+						Response: gqlOrganizationResponse})
+
+				appendPostHandler(testServer, token, MockRequestResponse{
+					Status:   http.StatusOK,
+					Request:  expectedNsRequest,
+					Response: gqlNsResponse})
+
+				By("running the command")
+				session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+
+				Expect(err).ShouldNot(HaveOccurred())
+				Eventually(session.Out).Should(gbytes.Say("Namespace created"))
+				Eventually(session).Should(gexec.Exit(0))
+			})
+
+			It("prints all errors returned by the GraphQL API", func() {
+				By("setting up a mock server")
+
+				gqlOrganizationResponse := `{
+    											"organization": {
+      												"name": "test-org",
+      												"id": "bb604b45-b6b0-4b81-ad80-796f15eddf87"
+    											}
+  				}`
+
+				expectedOrganizationRequest := `{
+            "query": "\n\t\t\tquery($organizationName: String!, $organizationVcs: VCSType!) {\n\t\t\t\torganization(\n\t\t\t\t\tname: $organizationName\n\t\t\t\t\tvcsType: $organizationVcs\n\t\t\t\t) {\n\t\t\t\t\tid\n\t\t\t\t}\n\t\t\t}",
+            "variables": {
+              "organizationName": "test-org",
+              "organizationVcs": "BITBUCKET"
+            }
+          }`
+
+				gqlResponse := `{
+									"createNamespace": {
+										"errors": [
+													{"message": "error1"},
+													{"message": "error2"}
+								  					],
+										"namespace": null
+									}
+								}`
+
+				expectedRequestJson := `{
+            			"query": "\n\t\t\tmutation($name: String!, $organizationId: UUID!) {\n\t\t\t\tcreateNamespace(\n\t\t\t\t\tname: $name,\n\t\t\t\t\torganizationId: $organizationId\n\t\t\t\t) {\n\t\t\t\t\tnamespace {\n\t\t\t\t\t\tcreatedAt\n\t\t\t\t\t\tid\n\t\t\t\t\t}\n\t\t\t\t\terrors {\n\t\t\t\t\t\tmessage\n\t\t\t\t\t\ttype\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t}",
+            			"variables": {
+              			"name": "foo-ns",
+						"organizationId": "bb604b45-b6b0-4b81-ad80-796f15eddf87"
+            			}
+          		}`
+
+				appendPostHandler(testServer, token,
+					MockRequestResponse{
+						Status:   http.StatusOK,
+						Request:  expectedOrganizationRequest,
+						Response: gqlOrganizationResponse,
+					})
+				appendPostHandler(testServer, token,
+					MockRequestResponse{
+						Status:   http.StatusOK,
+						Request:  expectedRequestJson,
+						Response: gqlResponse,
+					})
+
+				By("running the command")
+				session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+
+				Expect(err).ShouldNot(HaveOccurred())
+				Eventually(session.Err).Should(gbytes.Say("Error: error1: error2"))
+				Eventually(session).ShouldNot(gexec.Exit(0))
 			})
 		})
 	})


### PR DESCRIPTION
This PR adds "create namespace" to the list of orb commands (or, more specifically `createns`, which is open to alternate naming suggestions).

I used a lot of copy-pasting to make this work, thank you @eric-hu . I also benefited from some good old, "Please help me see the forest, oh :rubberduck: @johnswanson, because at this point in time I can only see the trees," unsticking. 

Which is all to say, this PR works as expected, but I believe it is a good candidate for some DRY refactoring.

[CIRCLE-12217](https://circleci.atlassian.net/browse/CIRCLE-12217)

Examples of this in action in dev:
_Ignore the weird UUID output in earlier responses, I deleted some print lines_
_Also, "GITHUB" and "BITBUCKET" can now be lower case_
![screen shot 2018-07-24 at 10 16 38 am](https://user-images.githubusercontent.com/18273771/43159090-377284e0-8f36-11e8-9a38-7e3b9ee3038b.png)

Help lists this information:
![screen shot 2018-07-24 at 11 11 32 am](https://user-images.githubusercontent.com/18273771/43159147-5e3566d8-8f36-11e8-987f-46451424975b.png)

