### PR TITLE
Document positional args in help text

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -388,7 +388,7 @@ func createOrbWithNsID(ctx context.Context, logger *logger.Logger, name string, 
 }
 
 // CreateOrb creates (reserves) an orb within a namespace
-func CreateOrb(ctx context.Context, logger *logger.Logger, name string, namespace string) (*CreateOrbResponse, error) {
+func CreateOrb(ctx context.Context, logger *logger.Logger, namespace string, name string) (*CreateOrbResponse, error) {
 	namespaceID, err := getNamespace(ctx, logger, namespace)
 
 	if err != nil {
@@ -400,7 +400,8 @@ func CreateOrb(ctx context.Context, logger *logger.Logger, name string, namespac
 }
 
 // OrbSource gets the source or an orb
-func OrbSource(ctx context.Context, logger *logger.Logger, name string) (string, error) {
+func OrbSource(ctx context.Context, logger *logger.Logger, namespace string, orb string) (string, error) {
+	name := namespace + "/" + orb
 
 	var response struct {
 		Orb struct {

--- a/api/api.go
+++ b/api/api.go
@@ -152,7 +152,8 @@ func OrbQuery(ctx context.Context, logger *logger.Logger, configPath string) (*C
 
 // OrbPublish publishes a new version of an orb
 func OrbPublish(ctx context.Context, logger *logger.Logger,
-	name string, configPath string, orbVersion string) (*PublishOrbResponse, error) {
+	configPath string, namespace string, orb string, orbVersion string) (*PublishOrbResponse, error) {
+	name := namespace + "/" + orb
 	orbID, err := getOrbID(ctx, logger, name)
 	if err != nil {
 		return nil, err

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -36,8 +36,8 @@ func newConfigCommand() *cobra.Command {
 		RunE:    validateConfig,
 		Args:    cobra.MaximumNArgs(1),
 	}
-	validateCommand.PersistentFlags().StringVarP(&configPath, "path", "p", ".circleci/config.yml", "path to build config")
-	err := validateCommand.PersistentFlags().MarkHidden("path")
+	validateCommand.PersistentFlags().StringVarP(&configPath, "config", "c", ".circleci/config.yml", "path to config file (default \".circleci/config.yml\")")
+	err := validateCommand.PersistentFlags().MarkHidden("config")
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -46,7 +46,7 @@ func newConfigCommand() *cobra.Command {
 		Use:   "expand PATH (use \"-\" for STDIN)",
 		Short: "Expand the config.",
 		RunE:  expandConfig,
-		Args:  cobra.MaximumNArgs(1),
+		Args:  cobra.ExactArgs(1),
 	}
 
 	configCmd.AddCommand(collapseCommand)

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -12,6 +12,10 @@ import (
 
 const defaultConfigPath = ".circleci/config.yml"
 
+// Path to the config.yml file to operate on.
+// Used to for compatibility with `circleci config validate --path`
+var configPath string
+
 func newConfigCommand() *cobra.Command {
 	configCmd := &cobra.Command{
 		Use:   "config",
@@ -19,22 +23,27 @@ func newConfigCommand() *cobra.Command {
 	}
 
 	collapseCommand := &cobra.Command{
-		Use:   "collapse [path]",
+		Use:   "collapse [PATH] (default is \".\")",
 		Short: "Collapse your CircleCI configuration to a single file",
 		RunE:  collapseConfig,
 		Args:  cobra.MaximumNArgs(1),
 	}
 
 	validateCommand := &cobra.Command{
-		Use:     "validate [config.yml]",
+		Use:     "validate PATH (use \"-\" for STDIN)",
 		Aliases: []string{"check"},
 		Short:   "Check that the config file is well formed.",
 		RunE:    validateConfig,
 		Args:    cobra.MaximumNArgs(1),
 	}
+	validateCommand.PersistentFlags().StringVarP(&configPath, "path", "p", ".circleci/config.yml", "path to build config")
+	err := validateCommand.PersistentFlags().MarkHidden("path")
+	if err != nil {
+		panic(err)
+	}
 
 	expandCommand := &cobra.Command{
-		Use:   "expand [config.yml]",
+		Use:   "expand PATH (use \"-\" for STDIN)",
 		Short: "Expand the config.",
 		RunE:  expandConfig,
 		Args:  cobra.MaximumNArgs(1),
@@ -47,13 +56,21 @@ func newConfigCommand() *cobra.Command {
 	return configCmd
 }
 
+// The PATH arg is actually optional, in order to support compatibility with the --path flag.
 func validateConfig(cmd *cobra.Command, args []string) error {
-	configPath := defaultConfigPath
-	if len(args) == 1 {
-		configPath = args[0]
+	path := defaultConfigPath
+	// First, set the path to configPath set by --path flag for compatibility
+	if configPath != "" {
+		path = configPath
 	}
+
+	// Then, if an arg is passed in, choose that instead
+	if len(args) == 1 {
+		path = args[0]
+	}
+
 	ctx := context.Background()
-	response, err := api.ConfigQuery(ctx, Logger, configPath)
+	response, err := api.ConfigQuery(ctx, Logger, path)
 
 	if err != nil {
 		return err
@@ -63,17 +80,17 @@ func validateConfig(cmd *cobra.Command, args []string) error {
 		return response.ToError()
 	}
 
-	Logger.Infof("Config file at %s is valid", configPath)
+	Logger.Infof("Config file at %s is valid", path)
 	return nil
 }
 
 func expandConfig(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
-	configPath := defaultConfigPath
+	path := defaultConfigPath
 	if len(args) == 1 {
-		configPath = args[0]
+		path = args[0]
 	}
-	response, err := api.ConfigQuery(ctx, Logger, configPath)
+	response, err := api.ConfigQuery(ctx, Logger, path)
 
 	if err != nil {
 		return err

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -86,11 +86,7 @@ func validateConfig(cmd *cobra.Command, args []string) error {
 
 func expandConfig(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
-	path := defaultConfigPath
-	if len(args) == 1 {
-		path = args[0]
-	}
-	response, err := api.ConfigQuery(ctx, Logger, path)
+	response, err := api.ConfigQuery(ctx, Logger, args[0])
 
 	if err != nil {
 		return err

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -23,7 +23,7 @@ func newConfigCommand() *cobra.Command {
 	}
 
 	collapseCommand := &cobra.Command{
-		Use:   "collapse [PATH] (default is \".\")",
+		Use:   "collapse PATH",
 		Short: "Collapse your CircleCI configuration to a single file",
 		RunE:  collapseConfig,
 		Args:  cobra.MaximumNArgs(1),
@@ -101,11 +101,7 @@ func expandConfig(cmd *cobra.Command, args []string) error {
 }
 
 func collapseConfig(cmd *cobra.Command, args []string) error {
-	root := "."
-	if len(args) > 0 {
-		root = args[0]
-	}
-	tree, err := filetree.NewTree(root)
+	tree, err := filetree.NewTree(args[0])
 	if err != nil {
 		return errors.Wrap(err, "An error occurred trying to build the tree")
 	}

--- a/cmd/namespace.go
+++ b/cmd/namespace.go
@@ -15,8 +15,8 @@ func newNamespaceCommand() *cobra.Command {
 	}
 
 	createCmd := &cobra.Command{
-		Use:   "create NAME github|bitbucket ORG-NAME",
-		Short: "create an namespace",
+		Use:   "create NAME VCS-TYPE ORG-NAME",
+		Short: "create a namespace",
 		RunE:  createNamespace,
 		Args:  cobra.ExactArgs(3),
 	}

--- a/cmd/namespace.go
+++ b/cmd/namespace.go
@@ -15,7 +15,7 @@ func newNamespaceCommand() *cobra.Command {
 	}
 
 	createCmd := &cobra.Command{
-		Use:   "create [name] [vcs] [org-name]",
+		Use:   "create NAME github|bitbucket ORG-NAME",
 		Short: "create an namespace",
 		RunE:  createNamespace,
 		Args:  cobra.ExactArgs(3),

--- a/cmd/namespace.go
+++ b/cmd/namespace.go
@@ -15,11 +15,15 @@ func newNamespaceCommand() *cobra.Command {
 	}
 
 	createCmd := &cobra.Command{
-		Use:   "create NAME VCS-TYPE ORG-NAME",
-		Short: "create a namespace",
-		RunE:  createNamespace,
-		Args:  cobra.ExactArgs(3),
+		Use:         "create NAME VCS-TYPE ORG-NAME",
+		Short:       "create a namespace",
+		RunE:        createNamespace,
+		Args:        cobra.ExactArgs(3),
+		Annotations: make(map[string]string),
 	}
+
+	createCmd.Annotations["VCS-TYPE"] = `Your VCS provider, can be either "github" or "bitbucket"`
+	createCmd.Annotations["ORG-NAME"] = `The name used for your organization`
 
 	// "org-name", "", "organization name (required)"
 	// "vcs", "github", "organization vcs, e.g. 'github', 'bitbucket'"

--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -27,17 +27,17 @@ func newOrbCommand() *cobra.Command {
 	}
 
 	validateCommand := &cobra.Command{
-		Use:   "validate [orb.yml]",
+		Use:   "validate PATH (use \"-\" for STDIN)",
 		Short: "validate an orb.yml",
 		RunE:  validateOrb,
-		Args:  cobra.MaximumNArgs(1),
+		Args:  cobra.ExactArgs(1),
 	}
 
 	expandCommand := &cobra.Command{
-		Use:   "expand [orb.yml]",
+		Use:   "expand PATH (use \"-\" for STDIN)",
 		Short: "expand an orb.yml",
 		RunE:  expandOrb,
-		Args:  cobra.MaximumNArgs(1),
+		Args:  cobra.ExactArgs(1),
 	}
 
 	publishCommand := &cobra.Command{
@@ -216,15 +216,10 @@ query ListOrbs ($after: String!) {
 	return nil
 }
 
-const defaultOrbPath = "orb.yml"
-
 func validateOrb(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
-	orbPath := defaultOrbPath
-	if len(args) == 1 {
-		orbPath = args[0]
-	}
-	response, err := api.OrbQuery(ctx, Logger, orbPath)
+
+	response, err := api.OrbQuery(ctx, Logger, args[0])
 
 	if err != nil {
 		return err
@@ -240,11 +235,7 @@ func validateOrb(cmd *cobra.Command, args []string) error {
 
 func expandOrb(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
-	orbPath := defaultOrbPath
-	if len(args) == 1 {
-		orbPath = args[0]
-	}
-	response, err := api.OrbQuery(ctx, Logger, orbPath)
+	response, err := api.OrbQuery(ctx, Logger, args[0])
 
 	if err != nil {
 		return err
@@ -260,7 +251,6 @@ func expandOrb(cmd *cobra.Command, args []string) error {
 
 func publishOrb(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
-
 	response, err := api.OrbPublish(ctx, Logger, args[0], args[1], orbVersion)
 
 	if err != nil {

--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/CircleCI-Public/circleci-cli/api"
 	"github.com/CircleCI-Public/circleci-cli/client"
@@ -51,17 +50,17 @@ func newOrbCommand() *cobra.Command {
 	})
 
 	sourceCommand := &cobra.Command{
-		Use:   "source <namespace>/<name>",
+		Use:   "source NAMESPACE ORB",
 		Short: "Show the source of an orb",
 		RunE:  showSource,
-		Args:  cobra.ExactArgs(1),
+		Args:  cobra.ExactArgs(2),
 	}
 
 	orbCreate := &cobra.Command{
-		Use:   "create <namespace>/<name>",
+		Use:   "create NAMESPACE ORB",
 		Short: "create an orb",
 		RunE:  createOrb,
-		Args:  cobra.ExactArgs(1),
+		Args:  cobra.ExactArgs(2),
 	}
 
 	orbCommand := &cobra.Command{
@@ -267,13 +266,7 @@ func createOrb(cmd *cobra.Command, args []string) error {
 	var err error
 	ctx := context.Background()
 
-	arr := strings.Split(args[0], "/")
-
-	if len(arr) != 2 {
-		return fmt.Errorf("Invalid orb name: %s", args[0])
-	}
-
-	response, err := api.CreateOrb(ctx, Logger, arr[1], arr[0])
+	response, err := api.CreateOrb(ctx, Logger, args[0], args[1])
 
 	if err != nil {
 		return err
@@ -288,9 +281,9 @@ func createOrb(cmd *cobra.Command, args []string) error {
 }
 
 func showSource(cmd *cobra.Command, args []string) error {
-	source, err := api.OrbSource(context.Background(), Logger, args[0])
+	source, err := api.OrbSource(context.Background(), Logger, args[0], args[1])
 	if err != nil {
-		return errors.Wrapf(err, "Failed to get source for '%s'", args[0])
+		return errors.Wrapf(err, "Failed to get source for '%s' in %s", args[1], args[0])
 	}
 	Logger.Info(source)
 	return nil

--- a/cmd/orb_test.go
+++ b/cmd/orb_test.go
@@ -458,7 +458,7 @@ var _ = Describe("Orb integration tests", func() {
 					"orb", "create",
 					"-t", token,
 					"-e", testServer.URL(),
-					"bar-ns/foo-orb",
+					"bar-ns", "foo-orb",
 				)
 			})
 

--- a/cmd/orb_test.go
+++ b/cmd/orb_test.go
@@ -111,15 +111,15 @@ var _ = Describe("Orb integration tests", func() {
 		Describe("when using default path", func() {
 			BeforeEach(func() {
 				var err error
+				orb, err = openTmpFile(command.Dir, "orb.yml")
+				Expect(err).ToNot(HaveOccurred())
+
 				token = "testtoken"
 				command = exec.Command(pathCLI,
-					"orb", "validate",
+					"orb", "validate", orb.Path,
 					"-t", token,
 					"-e", testServer.URL(),
 				)
-
-				orb, err = openTmpFile(command.Dir, "orb.yml")
-				Expect(err).ToNot(HaveOccurred())
 			})
 
 			AfterEach(func() {
@@ -165,10 +165,9 @@ var _ = Describe("Orb integration tests", func() {
 		Describe("when validating orb", func() {
 			BeforeEach(func() {
 				command = exec.Command(pathCLI,
-					"orb", "validate",
+					"orb", "validate", orb.Path,
 					"-t", token,
 					"-e", testServer.URL(),
-					orb.Path,
 				)
 			})
 
@@ -326,15 +325,16 @@ var _ = Describe("Orb integration tests", func() {
 			})
 		})
 
-		Describe("when publishing an orb version", func() {
+		Describe("when releasing an semantic version", func() {
 			BeforeEach(func() {
 				command = exec.Command(pathCLI,
-					"orb", "publish",
+					"orb", "publish", "release",
 					"-t", token,
 					"-e", testServer.URL(),
-					"my/orb",
 					orb.Path,
-					"--orb-version", "0.0.1",
+					"my",
+					"orb",
+					"0.0.1",
 				)
 			})
 

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -12,21 +12,29 @@ import (
 
 func newQueryCommand() *cobra.Command {
 	return &cobra.Command{
-		Use:   "query",
-		Short: "Query the CircleCI GraphQL API using input from stdin.",
+		Use:   "query PATH (use \"-\" for STDIN)",
+		Short: "Query the CircleCI GraphQL API.",
 		RunE:  query,
+		Args:  cobra.ExactArgs(1),
 	}
 }
 
 func query(cmd *cobra.Command, args []string) error {
+	var err error
+	var q []byte
 	c := client.NewClient(viper.GetString("endpoint"), Logger)
 
-	query, err := ioutil.ReadAll(os.Stdin)
+	if args[0] == "-" {
+		q, err = ioutil.ReadAll(os.Stdin)
+	} else {
+		q, err = ioutil.ReadFile(args[0])
+	}
+
 	if err != nil {
 		return errors.Wrap(err, "Unable to read query from stdin")
 	}
 
-	resp, err := client.Run(c, viper.GetString("token"), string(query))
+	resp, err := client.Run(c, viper.GetString("token"), string(q))
 	if err != nil {
 		return errors.Wrap(err, "Error occurred when running query")
 	}

--- a/cmd/query_test.go
+++ b/cmd/query_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Query", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		token = "mytoken"
-		command = exec.Command(pathCLI, "query",
+		command = exec.Command(pathCLI, "query", "-",
 			"-t", token,
 			"-e", server.URL(),
 		)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,14 +28,46 @@ func Execute() {
 // This allows us to print to the log at anytime from within the `cmd` package.
 var Logger *logger.Logger
 
+func hasAnnotations(cmd *cobra.Command) bool {
+	return len(cmd.Annotations) > 0
+}
+
+var usageTemplate = `
+Usage:{{if .Runnable}}
+  {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
+  {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
+Aliases:
+  {{.NameAndAliases}}{{end}}{{if .HasExample}}
+
+Examples:
+{{.Example}}{{end}}{{if .HasAvailableSubCommands}}
+
+Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if (HasAnnotations .)}}
+
+Args:{{range $arg, $desc := .Annotations}}
+  {{rpad $arg 11}} {{$desc}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
+
+Flags:
+{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
+
+Global Flags:
+{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
+Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
+  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
+Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}`
+
 // MakeCommands creates the top level commands
 func MakeCommands() *cobra.Command {
-
 	rootCmd := &cobra.Command{
 		Use:   "circleci",
 		Short: "Use CircleCI from the command line.",
 		Long:  `Use CircleCI from the command line.`,
 	}
+
+	// For supporting "Args" in command usage help
+	cobra.AddTemplateFunc("HasAnnotations", hasAnnotations)
+	rootCmd.SetUsageTemplate(usageTemplate)
 
 	rootCmd.AddCommand(newQueryCommand())
 	rootCmd.AddCommand(newConfigCommand())


### PR DESCRIPTION
Using a combination of the default `UsageTemplate` [from cobra](https://github.com/spf13/cobra/blob/4dab30cb33e6633c33c787106bafbfbfdde7842d/command.go#L388), and a custom function which [we've added to cobra template](https://godoc.org/github.com/spf13/cobra#AddTemplateFunc), we can create our own template which will display args in the help text for commands that have annotations (which are documented [here](https://godoc.org/github.com/spf13/cobra#Command) as a `map[string]string`).

This PR was created on top of #40 in hopes that will be merged first, and we can preview it's changes on this branch. Once that PR is merged, we can rebase this one and it should merge cleanly into master.

## Demo

Here's the help text for a command without args:

```
$ go run main.go help namespace

Operate on namespaces


Usage:
  circleci namespace [command]

Available Commands:
  create      create a namespace

Flags:
  -h, --help   help for namespace
```

Here's the help text for a command with args:

```
$ go run main.go help namespace create
create a namespace


Usage:
  circleci namespace create NAME VCS-TYPE ORG-NAME [flags]

Args:
  ORG-NAME    The name used for your organization
  VCS-TYPE    Your VCS provider, can be either "github" or "bitbucket"

Flags:
  -h, --help   help for create
```
