### PR TITLE
Ensure build command is backwards compatible

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -14,6 +14,24 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// These options are purely here to retain a mock of the structure of the flags used by `build`.
+// They don't reflect the entire structure or available flags, only those which are public in the original command.
+type proxyBuildArgs struct {
+	configFilename string
+	taskInfo       struct {
+		NodeTotal     int
+		NodeIndex     int
+		Job           string
+		SkipCheckout  bool
+		Volumes       []string
+		Revision      string
+		Branch        string
+		RepositoryURI string
+	}
+	checkoutKey string
+	envVarArgs  []string
+}
+
 func newBuildCommand() *cobra.Command {
 	buildCommand := &cobra.Command{
 		Use:                "build",
@@ -21,6 +39,24 @@ func newBuildCommand() *cobra.Command {
 		RunE:               runBuild,
 		DisableFlagParsing: true,
 	}
+
+	opts := proxyBuildArgs{}
+	flags := buildCommand.Flags()
+
+	flags.StringVarP(&opts.configFilename, "config", "c", defaultConfigPath, "config file")
+	flags.StringVar(&opts.taskInfo.Job, "job", "build", "job to be executed")
+	flags.IntVar(&opts.taskInfo.NodeTotal, "node-total", 1, "total number of parallel nodes")
+	flags.IntVar(&opts.taskInfo.NodeIndex, "index", 0, "node index of parallelism")
+
+	flags.BoolVar(&opts.taskInfo.SkipCheckout, "skip-checkout", true, "use local path as-is")
+	flags.StringSliceVarP(&opts.taskInfo.Volumes, "volume", "v", nil, "Volume bind-mounting")
+
+	flags.StringVar(&opts.checkoutKey, "checkout-key", "~/.ssh/id_rsa", "Git Checkout key")
+	flags.StringVar(&opts.taskInfo.Revision, "revision", "", "Git Revision")
+	flags.StringVar(&opts.taskInfo.Branch, "branch", "", "Git branch")
+	flags.StringVar(&opts.taskInfo.RepositoryURI, "repo-url", "", "Git Url")
+
+	flags.StringArrayVarP(&opts.envVarArgs, "env", "e", nil, "Set environment variables, e.g. `-e VAR=VAL`")
 
 	return buildCommand
 }

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -49,8 +49,8 @@ var _ = Describe("Config", func() {
 				token = "testtoken"
 				command = exec.Command(pathCLI,
 					"config", "validate",
-					"-t", token,
-					"-e", testServer.URL(),
+					"--token", token,
+					"--endpoint", testServer.URL(),
 					config.Path,
 				)
 			})
@@ -133,8 +133,8 @@ var _ = Describe("Config", func() {
 				token = "testtoken"
 				command = exec.Command(pathCLI,
 					"config", "expand",
-					"-t", token,
-					"-e", testServer.URL(),
+					"--token", token,
+					"--endpoint", testServer.URL(),
 					config.Path,
 				)
 			})

--- a/cmd/namespace_test.go
+++ b/cmd/namespace_test.go
@@ -30,8 +30,8 @@ var _ = Describe("Namespace integration tests", func() {
 		BeforeEach(func() {
 			command = exec.Command(pathCLI,
 				"namespace", "create",
-				"-t", token,
-				"-e", testServer.URL(),
+				"--token", token,
+				"--endpoint", testServer.URL(),
 				"foo-ns",
 				"BITBUCKET",
 				"test-org",
@@ -95,8 +95,8 @@ var _ = Describe("Namespace integration tests", func() {
 		BeforeEach(func() {
 			command = exec.Command(pathCLI,
 				"namespace", "create",
-				"-t", token,
-				"-e", testServer.URL(),
+				"--token", token,
+				"--endpoint", testServer.URL(),
 				"foo-ns",
 				"BITBUCKET",
 				"test-org",

--- a/cmd/orb_test.go
+++ b/cmd/orb_test.go
@@ -48,8 +48,8 @@ var _ = Describe("Orb integration tests", func() {
 				token = "testtoken"
 				command = exec.Command(pathCLI,
 					"orb", "validate",
-					"-t", token,
-					"-e", testServer.URL(),
+					"--token", token,
+					"--endpoint", testServer.URL(),
 					"-",
 				)
 				stdin, err := command.StdinPipe()
@@ -117,8 +117,8 @@ var _ = Describe("Orb integration tests", func() {
 				token = "testtoken"
 				command = exec.Command(pathCLI,
 					"orb", "validate", orb.Path,
-					"-t", token,
-					"-e", testServer.URL(),
+					"--token", token,
+					"--endpoint", testServer.URL(),
 				)
 			})
 
@@ -166,8 +166,8 @@ var _ = Describe("Orb integration tests", func() {
 			BeforeEach(func() {
 				command = exec.Command(pathCLI,
 					"orb", "validate", orb.Path,
-					"-t", token,
-					"-e", testServer.URL(),
+					"--token", token,
+					"--endpoint", testServer.URL(),
 				)
 			})
 
@@ -246,8 +246,8 @@ var _ = Describe("Orb integration tests", func() {
 			BeforeEach(func() {
 				command = exec.Command(pathCLI,
 					"orb", "expand",
-					"-t", token,
-					"-e", testServer.URL(),
+					"--token", token,
+					"--endpoint", testServer.URL(),
 					orb.Path,
 				)
 			})
@@ -329,8 +329,8 @@ var _ = Describe("Orb integration tests", func() {
 			BeforeEach(func() {
 				command = exec.Command(pathCLI,
 					"orb", "publish", "release",
-					"-t", token,
-					"-e", testServer.URL(),
+					"--token", token,
+					"--endpoint", testServer.URL(),
 					orb.Path,
 					"my",
 					"orb",
@@ -456,8 +456,8 @@ var _ = Describe("Orb integration tests", func() {
 			BeforeEach(func() {
 				command = exec.Command(pathCLI,
 					"orb", "create",
-					"-t", token,
-					"-e", testServer.URL(),
+					"--token", token,
+					"--endpoint", testServer.URL(),
 					"bar-ns", "foo-orb",
 				)
 			})

--- a/cmd/query_test.go
+++ b/cmd/query_test.go
@@ -32,8 +32,8 @@ var _ = Describe("Query", func() {
 
 		token = "mytoken"
 		command = exec.Command(pathCLI, "query", "-",
-			"-t", token,
-			"-e", server.URL(),
+			"--token", token,
+			"--endpoint", server.URL(),
 		)
 		command.Stdin = &stdin
 		command.Env = append(os.Environ(),

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -84,9 +84,9 @@ func MakeCommands() *cobra.Command {
 	rootCmd.AddCommand(newUpdateCommand())
 	rootCmd.AddCommand(newNamespaceCommand())
 	rootCmd.AddCommand(newUsageCommand())
-	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Enable verbose logging.")
-	rootCmd.PersistentFlags().StringP("endpoint", "e", defaultEndpoint, "the endpoint of your CircleCI GraphQL API")
-	rootCmd.PersistentFlags().StringP("token", "t", "", "your token for using CircleCI")
+	rootCmd.PersistentFlags().Bool("verbose", false, "Enable verbose logging.")
+	rootCmd.PersistentFlags().String("endpoint", defaultEndpoint, "the endpoint of your CircleCI GraphQL API")
+	rootCmd.PersistentFlags().String("token", "", "your token for using CircleCI")
 
 	for _, flag := range []string{"endpoint", "token", "verbose"} {
 		bindCobraFlagToViper(rootCmd, flag)


### PR DESCRIPTION
This change also removes the short-hand for global flags,
a convention introduced in the original CLI we should honor.

## Original help text 

```
$ circleci help build
Run a full build locally

Usage:
  circleci build [flags]

Flags:
      --branch string           Git branch
      --checkout-key filename   Git Checkout key (default ~/.ssh/id_rsa)
  -c, --config string           config file (default ".circleci/config.yml")
  -e, --env -e VAR=VAL          Set environment variables, e.g. -e VAR=VAL
  -h, --help                    help for build
      --index int               node index of parallelism
      --job string              job to be executed (default "build")
      --node-total int          total number of parallel nodes (default 1)
      --repo-url string         Git Url
      --revision string         Git Revision
      --skip-checkout           use local path as-is (default true)
  -v, --volume stringSlice      Volume bind-mounting

Global Flags:
      --verbose   enable verbose logging output
```

## New CLI format

```
$ circleci help build
Run a build

Usage:
  circleci build [flags]
  circleci build [command]

Available Commands:
  update      Update the build agent to the latest version

Flags:
      --branch string         Git branch
      --checkout-key string   Git Checkout key (default "~/.ssh/id_rsa")
  -c, --config string         config file (default ".circleci/config.yml")
  -e, --env -e VAR=VAL        Set environment variables, e.g. -e VAR=VAL
  -h, --help                  help for build
      --index int             node index of parallelism
      --job string            job to be executed (default "build")
      --node-total int        total number of parallel nodes (default 1)
      --repo-url string       Git Url
      --revision string       Git Revision
      --skip-checkout         use local path as-is (default true)
  -v, --volume strings        Volume bind-mounting

Global Flags:
      --endpoint string   the endpoint of your CircleCI GraphQL API (default "https://circleci.com/graphql-unstable")
      --token string      your token for using CircleCI
      --verbose           Enable verbose logging.

Use "circleci build [command] --help" for more information about a command.
```