### PR TITLE
WIP: Fix broken goreleaser config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,9 +127,9 @@ workflows:
       - docs:
           requires:
             - deploy
-      - snap:
-          requires:
-            - deploy
+      #- snap:
+      #    requires:
+      #      - deploy
       - deploy:
           requires:
             - test

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,7 +18,6 @@ snapcraft:
   confinement: strict
   apps:
     circleci:
-      command: circleci
       plugs: [docker]
 
 builds:


### PR DESCRIPTION
This fixes a config issue:

```
line 21: field command not found in type config.SnapcraftAppMetadata
```

Though, I'm not sure why `command` is invalid metadata as that's exactly what we do for `local-cli`:
https://github.com/circleci/local-cli/blob/dfdab774f712cefb0a897c5b23a498cc8b434e70/snap/snapcraft.yaml#L27

In any case, we still need access to `SNAPCRAFT_LOGIN_FILE` in order to push to the snap store. /cc @felicianotech 