### PR TITLE
Hide build command, and add 'local execute' as the canonical command

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -32,11 +32,11 @@ type proxyBuildArgs struct {
 	envVarArgs  []string
 }
 
-func newBuildCommand() *cobra.Command {
+func newLocalExecuteCommand() *cobra.Command {
 	buildCommand := &cobra.Command{
-		Use:                "build",
-		Short:              "Run a build",
-		RunE:               runBuild,
+		Use:                "execute",
+		Short:              "Run a job in a container on the local machine",
+		RunE:               runExecute,
 		DisableFlagParsing: true,
 	}
 
@@ -59,6 +59,22 @@ func newBuildCommand() *cobra.Command {
 	flags.StringArrayVarP(&opts.envVarArgs, "env", "e", nil, "Set environment variables, e.g. `-e VAR=VAL`")
 
 	return buildCommand
+}
+
+func newBuildCommand() *cobra.Command {
+	cmd := newLocalExecuteCommand()
+	cmd.Hidden = true
+	cmd.Use = "build"
+	return cmd
+}
+
+func newLocalCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "local",
+		Short: "Debug jobs on the local machine",
+	}
+	cmd.AddCommand(newLocalExecuteCommand())
+	return cmd
 }
 
 func circleCiDir() string {
@@ -138,7 +154,7 @@ func picardImage() (string, error) {
 	return fmt.Sprintf("%s@%s", picardRepo, sha), nil
 }
 
-func runBuild(cmd *cobra.Command, args []string) error {
+func runExecute(cmd *cobra.Command, args []string) error {
 
 	pwd, err := os.Getwd()
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -78,6 +78,7 @@ func MakeCommands() *cobra.Command {
 	rootCmd.AddCommand(newQueryCommand())
 	rootCmd.AddCommand(newConfigCommand())
 	rootCmd.AddCommand(newOrbCommand())
+	rootCmd.AddCommand(newLocalCommand())
 	rootCmd.AddCommand(newBuildCommand())
 	rootCmd.AddCommand(newVersionCommand())
 	rootCmd.AddCommand(newDiagnosticCommand())

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -16,7 +16,7 @@ var _ = Describe("Root", func() {
 
 		It("can create commands", func() {
 			commands := cmd.MakeCommands()
-			Expect(len(commands.Commands())).To(Equal(11))
+			Expect(len(commands.Commands())).To(Equal(12))
 		})
 
 	})


### PR DESCRIPTION
This is my proposal for renaming the `build` command to something that makes a bit more sense with the new terminology.

A `build` is one or more workflows, and this command only runs a job, so I don't think the term build can appear in the name.