### PR TITLE
Attach deploy dist to .

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,7 @@ jobs:
     steps:
       - checkout
       - attach_workspace:
-          at: dist
+          at: .
       - run: |
           export TAG=$(./dist/linux_amd64/circleci version)
           sed -i -- "s/%CLI_VERSION_PLACEHOLDER%/$TAG/g" snapcraft.yaml


### PR DESCRIPTION
This was causing `dist` to be nested, which you can see under the
"snap" artifacts from this job:
https://circleci.com/gh/CircleCI-Public/circleci-cli/1217#artifacts/containers/0

`snap/dist/dist/...` was created including the binaries we need to release