### PR TITLE
Snapcraft creates file in $PWD

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,7 @@ jobs:
           command: |
             mkdir .snapcraft
             echo $SNAPCRAFT_LOGIN_FILE | base64 --decode --ignore-garbage > .snapcraft/snapcraft.cfg
-            snapcraft push dist/*.snap --release stable
+            snapcraft push *.snap --release stable
 
   shellcheck:
     docker:


### PR DESCRIPTION
This failed here:
https://circleci.com/gh/CircleCI-Public/circleci-cli/1238

```
Error: Invalid value for "snap-file": Path "dist/*.snap" does not exist.
```

This is because `snapcraft` doesn't create packages there, but instead:

```
Pulling circleci 
Preparing to build circleci 
Building circleci 
Staging circleci 
Priming circleci 
Snapping 'circleci' \

Snapped circleci_0.1.1237+5196715_amd64.snap
```