### PR TITLE
Use annotations for all commands where it applies

### DIFF
--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -123,7 +123,7 @@ var _ = Describe("Config", func() {
 			})
 		})
 
-		Describe("when expanding config", func() {
+		Describe("when processing config", func() {
 			var (
 				token   string
 				command *exec.Cmd
@@ -132,7 +132,7 @@ var _ = Describe("Config", func() {
 			BeforeEach(func() {
 				token = "testtoken"
 				command = exec.Command(pathCLI,
-					"config", "expand",
+					"config", "process",
 					"--token", token,
 					"--endpoint", testServer.URL(),
 					config.Path,
@@ -208,7 +208,7 @@ var _ = Describe("Config", func() {
 		})
 	})
 
-	Describe("collapse", func() {
+	Describe("pack", func() {
 		var (
 			command *exec.Cmd
 			results []byte
@@ -217,12 +217,12 @@ var _ = Describe("Config", func() {
 		Describe("a .circleci folder with config.yml and local orbs folder containing the hugo orb", func() {
 			BeforeEach(func() {
 				var err error
-				command = exec.Command(pathCLI, "config", "collapse", "testdata/hugo-collapse/.circleci")
+				command = exec.Command(pathCLI, "config", "pack", "testdata/hugo-collapse/.circleci")
 				results, err = ioutil.ReadFile("testdata/hugo-collapse/result.yml")
 				Expect(err).ShouldNot(HaveOccurred())
 			})
 
-			It("collapse all YAML contents as expected", func() {
+			It("pack all YAML contents as expected", func() {
 				session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 				session.Wait()
 				Expect(err).ShouldNot(HaveOccurred())
@@ -236,12 +236,12 @@ var _ = Describe("Config", func() {
 			BeforeEach(func() {
 				var err error
 				var path string = "nested-orbs-and-local-commands-etc"
-				command = exec.Command(pathCLI, "config", "collapse", filepath.Join("testdata", path, "test"))
+				command = exec.Command(pathCLI, "config", "pack", filepath.Join("testdata", path, "test"))
 				results, err = ioutil.ReadFile(filepath.Join("testdata", path, "result.yml"))
 				Expect(err).ShouldNot(HaveOccurred())
 			})
 
-			It("collapse all YAML contents as expected", func() {
+			It("pack all YAML contents as expected", func() {
 				session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 				session.Wait()
 				Expect(err).ShouldNot(HaveOccurred())
@@ -254,12 +254,12 @@ var _ = Describe("Config", func() {
 		Describe("an orb containing local executors and commands in folder", func() {
 			BeforeEach(func() {
 				var err error
-				command = exec.Command(pathCLI, "config", "collapse", "testdata/myorb/test")
+				command = exec.Command(pathCLI, "config", "pack", "testdata/myorb/test")
 				results, err = ioutil.ReadFile("testdata/myorb/result.yml")
 				Expect(err).ShouldNot(HaveOccurred())
 			})
 
-			It("collapse all YAML contents as expected", func() {
+			It("pack all YAML contents as expected", func() {
 				session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 				session.Wait()
 				Expect(err).ShouldNot(HaveOccurred())
@@ -273,12 +273,12 @@ var _ = Describe("Config", func() {
 			BeforeEach(func() {
 				var err error
 				var path string = "test-with-large-nested-rails-orb"
-				command = exec.Command(pathCLI, "config", "collapse", filepath.Join("testdata", path, "test"))
+				command = exec.Command(pathCLI, "config", "pack", filepath.Join("testdata", path, "test"))
 				results, err = ioutil.ReadFile(filepath.Join("testdata", path, "result.yml"))
 				Expect(err).ShouldNot(HaveOccurred())
 			})
 
-			It("collapse all YAML contents as expected", func() {
+			It("pack all YAML contents as expected", func() {
 				session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 				session.Wait()
 				Expect(err).ShouldNot(HaveOccurred())

--- a/cmd/namespace.go
+++ b/cmd/namespace.go
@@ -22,11 +22,9 @@ func newNamespaceCommand() *cobra.Command {
 		Annotations: make(map[string]string),
 	}
 
+	createCmd.Annotations["NAME"] = "The name to give your new namespace"
 	createCmd.Annotations["VCS-TYPE"] = `Your VCS provider, can be either "github" or "bitbucket"`
 	createCmd.Annotations["ORG-NAME"] = `The name used for your organization`
-
-	// "org-name", "", "organization name (required)"
-	// "vcs", "github", "organization vcs, e.g. 'github', 'bitbucket'"
 
 	namespaceCmd.AddCommand(createCmd)
 

--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -15,6 +15,12 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+var annotations = map[string]string{
+	"PATH":      "The path to your orb (use \"-\" for STDIN)",
+	"NAMESPACE": "The namespace used for the orb (i.e. circleci)",
+	"ORB":       "The name of your orb (i.e. rails)",
+}
+
 func newOrbCommand() *cobra.Command {
 
 	listCommand := &cobra.Command{
@@ -24,44 +30,60 @@ func newOrbCommand() *cobra.Command {
 	}
 
 	validateCommand := &cobra.Command{
-		Use:   "validate PATH (use \"-\" for STDIN)",
-		Short: "validate an orb.yml",
-		RunE:  validateOrb,
-		Args:  cobra.ExactArgs(1),
+		Use:         "validate PATH",
+		Short:       "validate an orb.yml",
+		RunE:        validateOrb,
+		Args:        cobra.ExactArgs(1),
+		Annotations: make(map[string]string),
 	}
+	validateCommand.Annotations["PATH"] = annotations["PATH"]
 
 	expandCommand := &cobra.Command{
-		Use:   "expand PATH (use \"-\" for STDIN)",
-		Short: "expand an orb.yml",
-		RunE:  expandOrb,
-		Args:  cobra.ExactArgs(1),
+		Use:         "expand PATH",
+		Short:       "expand an orb.yml",
+		RunE:        expandOrb,
+		Args:        cobra.ExactArgs(1),
+		Annotations: make(map[string]string),
 	}
+	expandCommand.Annotations["PATH"] = annotations["PATH"]
 
 	publishCommand := &cobra.Command{
 		Use:   "publish",
 		Short: "publish a version of an orb",
 	}
 
-	publishCommand.AddCommand(&cobra.Command{
-		Use:   "release PATH NAMESPACE ORB SEMVER",
-		Short: "release a semantic version of an orb",
-		RunE:  releaseOrb,
-		Args:  cobra.ExactArgs(4),
-	})
+	releaseCommand := &cobra.Command{
+		Use:         "release PATH NAMESPACE ORB SEMVER",
+		Short:       "release a semantic version of an orb",
+		RunE:        releaseOrb,
+		Args:        cobra.ExactArgs(4),
+		Annotations: make(map[string]string),
+	}
+	releaseCommand.Annotations["PATH"] = annotations["PATH"]
+	releaseCommand.Annotations["NAMESPACE"] = annotations["NAMESPACE"]
+	releaseCommand.Annotations["ORB"] = annotations["ORB"]
+	releaseCommand.Annotations["SEMVER"] = "The semantic version used for this release (i.e. 0.3.6)"
+	publishCommand.AddCommand(releaseCommand)
 
 	sourceCommand := &cobra.Command{
-		Use:   "source NAMESPACE ORB",
-		Short: "Show the source of an orb",
-		RunE:  showSource,
-		Args:  cobra.ExactArgs(2),
+		Use:         "source NAMESPACE ORB",
+		Short:       "Show the source of an orb",
+		RunE:        showSource,
+		Args:        cobra.ExactArgs(2),
+		Annotations: make(map[string]string),
 	}
+	sourceCommand.Annotations["NAMESPACE"] = annotations["NAMESPACE"]
+	sourceCommand.Annotations["ORB"] = annotations["ORB"]
 
 	orbCreate := &cobra.Command{
-		Use:   "create NAMESPACE ORB",
-		Short: "create an orb",
-		RunE:  createOrb,
-		Args:  cobra.ExactArgs(2),
+		Use:         "create NAMESPACE ORB",
+		Short:       "create an orb",
+		RunE:        createOrb,
+		Args:        cobra.ExactArgs(2),
+		Annotations: make(map[string]string),
 	}
+	orbCreate.Annotations["NAMESPACE"] = annotations["NAMESPACE"]
+	orbCreate.Annotations["ORB"] = annotations["ORB"]
 
 	orbCommand := &cobra.Command{
 		Use:   "orb",

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -11,12 +11,16 @@ import (
 )
 
 func newQueryCommand() *cobra.Command {
-	return &cobra.Command{
-		Use:   "query PATH (use \"-\" for STDIN)",
-		Short: "Query the CircleCI GraphQL API.",
-		RunE:  query,
-		Args:  cobra.ExactArgs(1),
+	queryCommand := &cobra.Command{
+		Use:         "query PATH",
+		Short:       "Query the CircleCI GraphQL API.",
+		RunE:        query,
+		Args:        cobra.ExactArgs(1),
+		Annotations: make(map[string]string),
 	}
+	queryCommand.Annotations["PATH"] = "The path to your query (use \"-\" for STDIN)"
+
+	return queryCommand
 }
 
 func query(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
Notable changes include:

* Rename `config collapse` to `config pack`
* Rename `config expand`  to `config process`
* Rename `orb expand`  to `orb process`