### PR TITLE
Allow resetting endpoint via `circleci setup` if its not default

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -96,6 +96,9 @@ func GraphQLServerAddress(endpoint string, host string) (string, error) {
 	if err != nil {
 		return h.String(), errors.Wrapf(err, "Parsing host '%s'", host)
 	}
+	if !h.IsAbs() {
+		return h.String(), fmt.Errorf("Host (%s) must be absolute URL, including scheme", host)
+	}
 
 	// 3. Resolve the two URLs using host as the base
 	// We use ResolveReference which has specific behavior we can rely for


### PR DESCRIPTION
## Don't reset, keeping old endpoint

```
$ go run main.go setup
✔ CircleCI API Token: 
API token has been set.
✔ CircleCI Host: https://circleci.com
CircleCI host has been set.
✗ Do you want to reset the endpoint? (default: graphql-unstable): 
Setup complete. Your configuration has been saved.
```

Config:

```yaml
endpoint: https://circleci.com/graphql
host: https://circleci.com
token: ""
verbose: false
```

## Reset to default endpoint

```
$ go run main.go setup
✔ CircleCI API Token: 
API token has been set.
✔ CircleCI Host: https://circleci.com
CircleCI host has been set.
✔ Do you want to reset the endpoint? (default: graphql-unstable): y
Setup complete. Your configuration has been saved.
```

Config:

```yaml
endpoint: graphql-unstable
host: https://circleci.com
token: ""
verbose: false
```

## Other changes

Also, don't accept host unless it's absolute. (Note, this change affects commands and is not a `setup`-time validation).

For example, a non-absolute host:

```
$ go run main.go diagnostic --host bar.bzasdf
Error: Host (bar.bzasdf) must be absolute URL, including scheme!
```



