### PR TITLE
Ignore setup.go for Codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - cmd/setup.go


### PR DESCRIPTION
Following up on [this PR](https://github.com/CircleCI-Public/circleci-cli/pull/72#issuecomment-415568649):

Ignore `setup.go` for code coverage purposes. `setup_test.go` only makes assertions on what `setup.go` prints to STDOUT and will miss 1 of 2 code paths for any conditional. This was adding noise to our PRs and to the implementation code, as `setup.go` accepts a hidden `--testing` flag that makes it ignore user input.

Cleaning up test code from `setup.go` is more involved and can wait until after EOL. I'll make a JIRA for that if/when this PR is accepted.