### PR TITLE
Add `switch` command for users who accidentally try upgrading twice

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,11 @@ You may first need to generate a CircleCI API Token from the [Personal API Token
 $ circleci setup
 ```
 
-If you are using this tool on `.com`. accept the provided default `CircleCI Host`.
+If you are using this tool on `circleci.com`. accept the provided default `CircleCI Host`.
 
 Server users will have to change the default value to your custom address (i.e. `circleci.my-org.com`).
+
+**Note**: Server does not yet support config processing and orbs, you will only be able to use `circleci local execute` (previously `circleci build`) for now.
 
 
 ## Validate A Build Config

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This project is the seed for CircleCI's new command-line application.
 
 ### Upgrade from existing CLI
 
-If you already have installed the `circleci` CLI previously, run the following commands:
+If you installed the old CLI before, and you're on version less than `0.1.6`, you need to run the following commands:
 
 ```
 circleci update
@@ -28,16 +28,15 @@ This command may prompt you for `sudo` if your user doesn't have write permissio
 
 ### From Scratch
 
-If you haven't already installed `circleci` on your machine, run the following command:
+If you're installing the new `circleci` CLI for the first time, run the following command:
 
 ```
-curl https://raw.githubusercontent.com/CircleCI-Public/circleci-cli/master/install.sh \
-	--fail --show-error | bash
+bash -c "$(curl -fSl https://raw.githubusercontent.com/CircleCI-Public/circleci-cli/master/install.sh)"
 ```
 
-The CLI, `circleci`, is downloaded to the `/usr/local/bin` directory.
+This will install the CLI into the `/usr/local/bin` directory.
 
-If you do not have write permissions for `/usr/local/bin`, you might need to run the above commands with `sudo`.
+If you do not have write permissions to `/usr/local/bin`, you may need to run the above command with `sudo`.
 
 ## Configure the CLI
 
@@ -47,7 +46,9 @@ You may first need to generate a CircleCI API Token from the [Personal API Token
 $ circleci setup
 ```
 
-If you are using this tool on `.com`. accept the provided default `CircleCI API End Point`. If you are using it on Server, change the value to your Server address (i.e. `circleci.my-org.com`).
+If you are using this tool on `.com`. accept the provided default `CircleCI Host`.
+
+Server users will have to change the default value to your custom address (i.e. `circleci.my-org.com`).
 
 
 ## Validate A Build Config
@@ -58,3 +59,7 @@ To ensure that the tool is installed, you can use it to validate a build config 
 $ circleci config validate
 Config file at .circleci/config.yml is valid
 ```
+
+## More
+
+Please see the [documentation](https://circleci-public.github.io/circleci-cli) or `circleci help` for more.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -93,6 +93,7 @@ func MakeCommands() *cobra.Command {
 	rootCmd.AddCommand(newNamespaceCommand())
 	rootCmd.AddCommand(newUsageCommand())
 	rootCmd.AddCommand(newStepCommand())
+	rootCmd.AddCommand(newSwitchCommand())
 	rootCmd.PersistentFlags().Bool("verbose", false, "Enable verbose logging.")
 	rootCmd.PersistentFlags().String("token", "", "your token for using CircleCI")
 	rootCmd.PersistentFlags().String("host", defaultHost, "URL to your CircleCI host")

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -16,7 +16,7 @@ var _ = Describe("Root", func() {
 
 		It("can create commands", func() {
 			commands := cmd.MakeCommands()
-			Expect(len(commands.Commands())).To(Equal(13))
+			Expect(len(commands.Commands())).To(Equal(14))
 		})
 
 	})

--- a/cmd/switch.go
+++ b/cmd/switch.go
@@ -1,0 +1,16 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+func newSwitchCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:    "switch",
+		RunE:   runSwitch,
+		Hidden: true,
+	}
+}
+
+func runSwitch(cmd *cobra.Command, args []string) error {
+	Logger.Infoln("You've already updated to the latest CLI. Please see `circleci help` for usage.")
+	return nil
+}


### PR DESCRIPTION
This resolves #79. :pray: 

Added note about version `0.1.6`, because that was the first build we deployed to GH releases:
https://github.com/CircleCI-Public/circleci-cli/releases?after=v0.1.19

The old CLI was using `0.1.0` and never updated beyond that, so these docs reflect that status.