### PR TITLE
Fix snap package permissions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,10 @@ dist/
 docs/
 out/
 .vscode
+
+# Snapcraft Related
+parts/
+prime/
+snap/.snapcraft/
+stage/
+*.snap

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,10 +8,15 @@ confinement: strict
 parts:
   circleci:
     plugin: nil
-    install: |
+    override-build: |
+      snapcraftctl build
       cp dist/linux_amd64/circleci $SNAPCRAFT_PART_INSTALL
+      chmod +x $SNAPCRAFT_PART_INSTALL/circleci
     stage-packages: [docker.io]
 apps:
   circleci:
-    plugs: [docker]
+    plugs:
+      - docker
+      - home
+      - network
     command: circleci


### PR DESCRIPTION
Fixes #82.

What was done:

1) The CircleCI CLI snap needed two additional "plugs" in order to have the right permissions to run. The `home` plugin, which was implied before and suddenly didn't work, is needed for file access to the user's `$HOME`. The `network` plug allows the CLI to access the network, in order to talk to the CircleCI API for example.

2) Snapcraft related local dev files were added to `gitignore`.

3) Moved the Snapcraft config file to where Snapcraft recommends it be placed.

4) Enforced the `circleci` binary have execute permission. This was a regression from the Local CLI snap builds.