### PR TITLE
Always print Help when a flag error or args are invalid

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -19,6 +19,29 @@ var _ = Describe("Root", func() {
 			Expect(len(commands.Commands())).To(Equal(14))
 		})
 
+		Context("when run with insufficient arguments", func() {
+			It("returns exit code 255 and prints the subcommand's help body", func() {
+				command := exec.Command(pathCLI, "orb", "publish", "dev")
+				session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+				Expect(err).ShouldNot(HaveOccurred())
+				Eventually(session.Out).Should(gbytes.Say("Usage:"))
+				Eventually(session.Out).Should(gbytes.Say("\\s*circleci orb publish dev PATH NAMESPACE ORB LABEL \\[flags\\]"))
+				Eventually(session.Err).Should(gbytes.Say("Error: accepts 4 arg\\(s\\), received 0"))
+				Eventually(session).Should(gexec.Exit(255))
+			})
+		})
+
+		Context("when a subcommand is run with invalid flags", func() {
+			It("returns exit code 255 and prints the subcommand's help body", func() {
+				command := exec.Command(pathCLI, "orb", "publish", "dev", "--foo")
+				session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+				Expect(err).ShouldNot(HaveOccurred())
+				Eventually(session.Out).Should(gbytes.Say("Usage:"))
+				Eventually(session.Out).Should(gbytes.Say("\\s*circleci orb publish dev PATH NAMESPACE ORB LABEL \\[flags\\]"))
+				Eventually(session.Err).Should(gbytes.Say("unknown flag: --foo"))
+				Eventually(session).Should(gexec.Exit(255))
+			})
+		})
 	})
 
 	Describe("when run with --help", func() {


### PR DESCRIPTION
## Calling without required positional arguments

```
$ circleci orb publish dev
release a development version of an orb


Usage:
  circleci orb publish dev PATH NAMESPACE ORB LABEL [flags]

Args:
  PATH        The path to your orb (use "-" for STDIN)
  NAMESPACE   The namespace used for the orb (i.e. circleci)
  ORB         The name of your orb (i.e. rails)
  LABEL       Tag to use for this development version (i.e. "volatile")


Flags:
  -h, --help   help for dev

Global Flags:
      --host string    URL to your CircleCI host (default "https://circleci.com")
      --token string   your token for using CircleCI
      --verbose        Enable verbose logging.

Error: accepts 4 arg(s), received 0
exit status 255
```

## Calling with invalid flag

```
$ circleci orb publish dev --foo
release a development version of an orb


Usage:
  circleci orb publish dev PATH NAMESPACE ORB LABEL [flags]

Args:
  PATH        The path to your orb (use "-" for STDIN)
  NAMESPACE   The namespace used for the orb (i.e. circleci)
  ORB         The name of your orb (i.e. rails)
  LABEL       Tag to use for this development version (i.e. "volatile")


Flags:
  -h, --help   help for dev

Global Flags:
      --host string    URL to your CircleCI host (default "https://circleci.com")
      --token string   your token for using CircleCI
      --verbose        Enable verbose logging.

Error: unknown flag: --foo
exit status 255
```