### PR TITLE
CIRCLE-13450 Fix "orb list namespace"

### DIFF
--- a/cmd/orb_test.go
+++ b/cmd/orb_test.go
@@ -1139,7 +1139,12 @@ var _ = Describe("Orb integration tests", func() {
 				session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 
 				Expect(err).ShouldNot(HaveOccurred())
+				Eventually(session.Out).Should(gbytes.Say("circleci/gradle"))
+				Eventually(session.Out).Should(gbytes.Say("Jobs"))
+				Eventually(session.Out).Should(gbytes.Say("- test"))
 				Eventually(session.Out).Should(gbytes.Say("circleci/rollbar"))
+				Eventually(session.Out).Should(gbytes.Say("Commands"))
+				Eventually(session.Out).Should(gbytes.Say("- notify_deploy"))
 				Eventually(session).Should(gexec.Exit(0))
 				Expect(testServer.ReceivedRequests()).Should(HaveLen(2))
 			})


### PR DESCRIPTION
Fixes "circleci orb list namespace" printing orb contents separate from the orb
name and version.

Also move last api-calling function into api.go

Note: This changes the output of "circleci orb list" slightly. Blank newlines are not inserted after empty orbs. It seemed inconsequential, but I can add this back in as formatting if those seem worth keeping.

Before:

```
$ circleci orb list
circleci/codecov-clojure (0.0.4)
  Commands:
    - upload
  Jobs:
    - code-coverage
circleci/delete-me (0.2.0)

circleci/gradle (0.0.1)
  Commands:
    - with_cache
  Jobs:
    - test
```

After:
```
$ go run main.go orb list
circleci/codecov-clojure (0.0.4)
  Commands:
    - upload
  Jobs:
    - code-coverage
circleci/delete-me (0.2.0)
circleci/gradle (0.0.1)
  Commands:
    - with_cache
  Jobs:
    - test
```

