### PR TITLE
Set CGO_ENABLED to build static linux binary

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,6 +11,8 @@ archive:
 
 builds:
   - binary: circleci
+    env:
+      - CGO_ENABLED=0
     goos:
       - windows
       - darwin


### PR DESCRIPTION
Fixes #102 

The darwin and windows binaries are already static (because they are cross compiled) so we should probably be doing the same for linux.