### PR TITLE
Disable CGO for goreleaser to produce static release assets

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,6 +11,8 @@ archive:
 
 builds:
   - binary: circleci
+    env:
+      - CGO_ENABLED=0
     goos:
       - windows
       - darwin


### PR DESCRIPTION
This PR should hopefully address https://github.com/CircleCI-Public/circleci-cli/issues/102