### PR TITLE
[Circle-12785] Prefer 'in-band' graphql errors

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -522,9 +522,7 @@ func getNamespace(ctx context.Context, logger *logger.Logger, name string) (stri
 
 	err = graphQLclient.Run(ctx, request, &response)
 
-	if err != nil {
-		err = errors.Wrapf(err, "Unable to find namespace %s", name)
-	} else if response.RegistryNamespace.ID == "" {
+	if err != nil || response.RegistryNamespace.ID == "" {
 		err = fmt.Errorf("Unable to find namespace %s", name)
 	}
 
@@ -571,13 +569,11 @@ func createOrbWithNsID(ctx context.Context, logger *logger.Logger, name string, 
 // CreateOrb creates (reserves) an orb within a namespace
 func CreateOrb(ctx context.Context, logger *logger.Logger, namespace string, name string) (*CreateOrbResponse, error) {
 	namespaceID, err := getNamespace(ctx, logger, namespace)
-
 	if err != nil {
 		return nil, err
 	}
 
-	orb, err := createOrbWithNsID(ctx, logger, name, namespaceID)
-	return orb, err
+	return createOrbWithNsID(ctx, logger, name, namespaceID)
 }
 
 // TODO(zzak): this function is not really related to the API. Move it to another package?

--- a/api/api.go
+++ b/api/api.go
@@ -493,13 +493,7 @@ func CreateNamespace(ctx context.Context, logger *logger.Logger, name string, or
 		return nil, err
 	}
 
-	namespace, err := createNamespaceWithOwnerID(ctx, logger, name, organizationID)
-
-	if err != nil {
-		return nil, err
-	}
-
-	return namespace, err
+	return createNamespaceWithOwnerID(ctx, logger, name, organizationID)
 }
 
 func getNamespace(ctx context.Context, logger *logger.Logger, name string) (string, error) {

--- a/api/api.go
+++ b/api/api.go
@@ -479,7 +479,7 @@ func getOrganization(ctx context.Context, logger *logger.Logger, organizationNam
 
 	err = graphQLclient.Run(ctx, request, &response)
 
-	if err == nil && response.Organization.ID == "" {
+	if err != nil || response.Organization.ID == "" {
 		err = fmt.Errorf("Unable to find organization %s of vcs-type %s", organizationName, organizationVcs)
 	}
 

--- a/cmd/namespace.go
+++ b/cmd/namespace.go
@@ -38,7 +38,7 @@ func createNamespace(cmd *cobra.Command, args []string) error {
 	response, err := api.CreateNamespace(ctx, Logger, args[0], args[2], strings.ToUpper(args[1]))
 
 	// Only fall back to native graphql errors if there are no in-band errors.
-	if err != nil && response == nil && len(response.Errors) == 0 {
+	if err != nil && (response == nil || len(response.Errors) == 0) {
 		return err
 	}
 

--- a/cmd/namespace.go
+++ b/cmd/namespace.go
@@ -37,7 +37,8 @@ func createNamespace(cmd *cobra.Command, args []string) error {
 
 	response, err := api.CreateNamespace(ctx, Logger, args[0], args[2], strings.ToUpper(args[1]))
 
-	if err != nil {
+	// Only fall back to native graphql errors if there are no in-band errors.
+	if err != nil && response == nil && len(response.Errors) == 0 {
 		return err
 	}
 

--- a/cmd/namespace_test.go
+++ b/cmd/namespace_test.go
@@ -155,7 +155,7 @@ var _ = Describe("Namespace integration tests", func() {
 			Eventually(session).Should(gexec.Exit(0))
 		})
 
-		It("prints all errors returned by the GraphQL API", func() {
+		It("prints all in-band errors returned by the GraphQL API", func() {
 			By("setting up a mock server")
 
 			gqlOrganizationResponse := `{
@@ -183,7 +183,9 @@ var _ = Describe("Namespace integration tests", func() {
 									}
 								}`
 
-			expectedRequestJson := `{
+			gqlNativeErrors := `[ { "message": "ignored error" } ]`
+
+			expectedRequestJSON := `{
             			"query": "\n\t\t\tmutation($name: String!, $organizationId: UUID!) {\n\t\t\t\tcreateNamespace(\n\t\t\t\t\tname: $name,\n\t\t\t\t\torganizationId: $organizationId\n\t\t\t\t) {\n\t\t\t\t\tnamespace {\n\t\t\t\t\t\tid\n\t\t\t\t\t}\n\t\t\t\t\terrors {\n\t\t\t\t\t\tmessage\n\t\t\t\t\t\ttype\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t}",
             			"variables": {
               			"name": "foo-ns",
@@ -199,9 +201,10 @@ var _ = Describe("Namespace integration tests", func() {
 				})
 			appendPostHandler(testServer, token,
 				MockRequestResponse{
-					Status:   http.StatusOK,
-					Request:  expectedRequestJson,
-					Response: gqlResponse,
+					Status:        http.StatusOK,
+					Request:       expectedRequestJSON,
+					Response:      gqlResponse,
+					ErrorResponse: gqlNativeErrors,
 				})
 
 			By("running the command")

--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -310,7 +310,8 @@ func createOrb(cmd *cobra.Command, args []string) error {
 
 	response, err := api.CreateOrb(ctx, Logger, args[0], args[1])
 
-	if err != nil {
+	// Only fall back to native graphql errors if there are no in-band errors.
+	if err != nil && response == nil && len(response.Errors) == 0 {
 		return err
 	}
 

--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -311,7 +311,7 @@ func createOrb(cmd *cobra.Command, args []string) error {
 	response, err := api.CreateOrb(ctx, Logger, args[0], args[1])
 
 	// Only fall back to native graphql errors if there are no in-band errors.
-	if err != nil && response == nil && len(response.Errors) == 0 {
+	if err != nil && (response == nil || len(response.Errors) == 0) {
 		return err
 	}
 

--- a/cmd/orb_test.go
+++ b/cmd/orb_test.go
@@ -972,7 +972,7 @@ var _ = Describe("Orb integration tests", func() {
 				Eventually(session).Should(gexec.Exit(0))
 			})
 
-			It("prints all errors returned by the GraphQL API", func() {
+			It("prints all in-band errors returned by the GraphQL API", func() {
 				By("setting up a mock server")
 
 				gqlNamespaceResponse := `{
@@ -998,6 +998,8 @@ var _ = Describe("Orb integration tests", func() {
 									}
 				}`
 
+				gqlErrors := `[ { "message": "ignored error" } ]`
+
 				expectedOrbRequest := `{
             "query": "mutation($name: String!, $registryNamespaceId: UUID!){\n\t\t\t\tcreateOrb(\n\t\t\t\t\tname: $name,\n\t\t\t\t\tregistryNamespaceId: $registryNamespaceId\n\t\t\t\t){\n\t\t\t\t    orb {\n\t\t\t\t      id\n\t\t\t\t    }\n\t\t\t\t    errors {\n\t\t\t\t      message\n\t\t\t\t      type\n\t\t\t\t    }\n\t\t\t\t}\n}",
             "variables": {
@@ -1014,9 +1016,10 @@ var _ = Describe("Orb integration tests", func() {
 					})
 				appendPostHandler(testServer, token,
 					MockRequestResponse{
-						Status:   http.StatusOK,
-						Request:  expectedOrbRequest,
-						Response: gqlOrbResponse,
+						Status:        http.StatusOK,
+						Request:       expectedOrbRequest,
+						Response:      gqlOrbResponse,
+						ErrorResponse: gqlErrors,
 					})
 
 				By("running the command")


### PR DESCRIPTION
Until we make a decision around where errors are going to live, for the users sake, create orb & namespace will prefer 'in-band' errors over native graphql errors.