### PR TITLE
[CIRCLE-13698] Adding world readable warning to namespace, orbs, and versions create.

### DIFF
--- a/cmd/namespace.go
+++ b/cmd/namespace.go
@@ -34,8 +34,9 @@ func newNamespaceCommand() *cobra.Command {
 func createNamespace(cmd *cobra.Command, args []string) error {
 	var err error
 	ctx := context.Background()
+	namespaceName := args[0]
 
-	response, err := api.CreateNamespace(ctx, Logger, args[0], args[2], strings.ToUpper(args[1]))
+	response, err := api.CreateNamespace(ctx, Logger, namespaceName, args[2], strings.ToUpper(args[1]))
 
 	// Only fall back to native graphql errors if there are no in-band errors.
 	if err != nil && (response == nil || len(response.Errors) == 0) {
@@ -46,6 +47,7 @@ func createNamespace(cmd *cobra.Command, args []string) error {
 		return response.ToError()
 	}
 
-	Logger.Info("Namespace created")
+	Logger.Infof("Namespace `%s` created.", namespaceName)
+	Logger.Info("Please note that any orbs you publish in this namespace are open orbs and are world-readable.")
 	return nil
 }

--- a/cmd/namespace_test.go
+++ b/cmd/namespace_test.go
@@ -86,7 +86,8 @@ var _ = Describe("Namespace integration tests", func() {
 			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 
 			Expect(err).ShouldNot(HaveOccurred())
-			Eventually(session.Out).Should(gbytes.Say("Namespace created"))
+			Eventually(session.Out).Should(gbytes.Say("Namespace `foo-ns` created."))
+			Eventually(session.Out).Should(gbytes.Say("Please note that any orbs you publish in this namespace are open orbs and are world-readable."))
 			Eventually(session).Should(gexec.Exit(0))
 		})
 	})
@@ -151,7 +152,8 @@ var _ = Describe("Namespace integration tests", func() {
 			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 
 			Expect(err).ShouldNot(HaveOccurred())
-			Eventually(session.Out).Should(gbytes.Say("Namespace created"))
+			Eventually(session.Out).Should(gbytes.Say("Namespace `foo-ns` created."))
+			Eventually(session.Out).Should(gbytes.Say("Please note that any orbs you publish in this namespace are open orbs and are world-readable."))
 			Eventually(session).Should(gexec.Exit(0))
 		})
 

--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -239,7 +239,8 @@ func releaseOrb(cmd *cobra.Command, args []string) error {
 	response.Namespace = args[1]
 	response.Name = args[2]
 
-	Logger.Infof("Orb published %s/%s@%s", args[1], args[2], response.HighestVersion)
+	Logger.Infof("Orb `%s/%s@%s` was published.", args[1], args[2], response.HighestVersion)
+	Logger.Info("Please note that this is an open orb and is world-readable.")
 	return nil
 }
 
@@ -261,7 +262,8 @@ func devOrb(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	Logger.Infof("Orb published %s/%s@%s", args[1], args[2], response.HighestVersion)
+	Logger.Infof("Orb `%s/%s@%s` was published.", args[1], args[2], response.HighestVersion)
+	Logger.Info("Please note that this is an open orb and is world-readable.")
 	return nil
 }
 
@@ -319,8 +321,9 @@ func createOrb(cmd *cobra.Command, args []string) error {
 		return response.ToError()
 	}
 
-	Logger.Infof("Orb %s/%s created", args[0], args[1])
-	Logger.Infof("You can now register versions of %s/%s using `circleci orb publish`", args[0], args[1])
+	Logger.Infof("Orb `%s/%s` created.", args[0], args[1])
+	Logger.Info("Please not that any versions you publish of this orb are open orb and are world-readable.")
+	Logger.Infof("You can now register versions of `%s/%s` using `circleci orb publish`", args[0], args[1])
 	return nil
 }
 

--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -322,7 +322,7 @@ func createOrb(cmd *cobra.Command, args []string) error {
 	}
 
 	Logger.Infof("Orb `%s/%s` created.", args[0], args[1])
-	Logger.Info("Please not that any versions you publish of this orb are open orb and are world-readable.")
+	Logger.Info("Please note that any versions you publish of this orb are world-readable.")
 	Logger.Infof("You can now register versions of `%s/%s` using `circleci orb publish`", args[0], args[1])
 	return nil
 }

--- a/cmd/orb_test.go
+++ b/cmd/orb_test.go
@@ -395,7 +395,8 @@ var _ = Describe("Orb integration tests", func() {
 				session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 
 				Expect(err).ShouldNot(HaveOccurred())
-				Eventually(session.Out).Should(gbytes.Say("Orb published my/orb@0.0.1"))
+				Eventually(session.Out).Should(gbytes.Say("Orb `my/orb@0.0.1` was published."))
+				Eventually(session.Out).Should(gbytes.Say("Please note that this is an open orb and is world-readable."))
 				Eventually(session).Should(gexec.Exit(0))
 			})
 
@@ -522,7 +523,8 @@ var _ = Describe("Orb integration tests", func() {
 				session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 
 				Expect(err).ShouldNot(HaveOccurred())
-				Eventually(session.Out).Should(gbytes.Say("Orb published my/orb@dev:volatile"))
+				Eventually(session.Out).Should(gbytes.Say("Orb `my/orb@dev:volatile` was published."))
+				Eventually(session.Out).Should(gbytes.Say("Please note that this is an open orb and is world-readable."))
 				Eventually(session).Should(gexec.Exit(0))
 			})
 
@@ -968,7 +970,9 @@ var _ = Describe("Orb integration tests", func() {
 				session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 
 				Expect(err).ShouldNot(HaveOccurred())
-				Eventually(session.Out).Should(gbytes.Say("Orb bar-ns/foo-orb created"))
+				Eventually(session.Out).Should(gbytes.Say("Orb `bar-ns/foo-orb` created."))
+				Eventually(session.Out).Should(gbytes.Say("Please not that any versions you publish of this orb are open orb and are world-readable."))
+				Eventually(session.Out).Should(gbytes.Say("You can now register versions of `bar-ns/foo-orb` using `circleci orb publish`"))
 				Eventually(session).Should(gexec.Exit(0))
 			})
 

--- a/cmd/orb_test.go
+++ b/cmd/orb_test.go
@@ -971,7 +971,7 @@ var _ = Describe("Orb integration tests", func() {
 
 				Expect(err).ShouldNot(HaveOccurred())
 				Eventually(session.Out).Should(gbytes.Say("Orb `bar-ns/foo-orb` created."))
-				Eventually(session.Out).Should(gbytes.Say("Please not that any versions you publish of this orb are open orb and are world-readable."))
+				Eventually(session.Out).Should(gbytes.Say("Please note that any versions you publish of this orb are world-readable."))
 				Eventually(session.Out).Should(gbytes.Say("You can now register versions of `bar-ns/foo-orb` using `circleci orb publish`"))
 				Eventually(session).Should(gexec.Exit(0))
 			})


### PR DESCRIPTION
Let the user know any namespaces, orbs, or versions they create/publish are world readable.