### PR TITLE
Improve "orb process" help text

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -61,7 +61,7 @@ func newConfigCommand() *cobra.Command {
 
 	migrateCommand := &cobra.Command{
 		Use:                "migrate",
-		Short:              "migrate a pre-release 2.0 config to the official release version",
+		Short:              "Migrate a pre-release 2.0 config to the official release version",
 		RunE:               migrateConfig,
 		Hidden:             true,
 		DisableFlagParsing: true,

--- a/cmd/namespace.go
+++ b/cmd/namespace.go
@@ -16,7 +16,7 @@ func newNamespaceCommand() *cobra.Command {
 
 	createCmd := &cobra.Command{
 		Use:         "create <name> <vcs-type> <org-name>",
-		Short:       "create a namespace",
+		Short:       "Create a namespace",
 		RunE:        createNamespace,
 		Args:        cobra.ExactArgs(3),
 		Annotations: make(map[string]string),

--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -39,7 +39,7 @@ func newOrbCommand() *cobra.Command {
 
 	validateCommand := &cobra.Command{
 		Use:         "validate <path>",
-		Short:       "validate an orb.yml",
+		Short:       "Validate an orb.yml",
 		RunE:        validateOrb,
 		Args:        cobra.ExactArgs(1),
 		Annotations: make(map[string]string),
@@ -48,7 +48,7 @@ func newOrbCommand() *cobra.Command {
 
 	processCommand := &cobra.Command{
 		Use:         "process <path>",
-		Short:       "Validates orb, then inlines other orb dependencies",
+		Short:       "Validate an orb and print its form after all pre-registration processing",
 		RunE:        processOrb,
 		Args:        cobra.ExactArgs(1),
 		Annotations: make(map[string]string),
@@ -57,7 +57,7 @@ func newOrbCommand() *cobra.Command {
 
 	publishCommand := &cobra.Command{
 		Use:         "publish <path> <orb>",
-		Short:       "publish an orb to the registry",
+		Short:       "Publish an orb to the registry",
 		RunE:        publishOrb,
 		Args:        cobra.ExactArgs(2),
 		Annotations: make(map[string]string),
@@ -67,7 +67,7 @@ func newOrbCommand() *cobra.Command {
 
 	promoteCommand := &cobra.Command{
 		Use:         "promote <orb> <segment>",
-		Short:       "promote a development version of an orb to a semantic release",
+		Short:       "Promote a development version of an orb to a semantic release",
 		RunE:        promoteOrb,
 		Args:        cobra.ExactArgs(2),
 		Annotations: make(map[string]string),
@@ -77,7 +77,7 @@ func newOrbCommand() *cobra.Command {
 
 	incrementCommand := &cobra.Command{
 		Use:         "increment <path> <namespace>/<orb> <segment>",
-		Short:       "increment a released version of an orb",
+		Short:       "Increment a released version of an orb",
 		RunE:        incrementOrb,
 		Args:        cobra.ExactArgs(3),
 		Annotations: make(map[string]string),
@@ -102,7 +102,7 @@ func newOrbCommand() *cobra.Command {
 
 	orbCreate := &cobra.Command{
 		Use:   "create <namespace>/<orb>",
-		Short: "create an orb in the specified namespace",
+		Short: "Create an orb in the specified namespace",
 		RunE:  createOrb,
 		Args:  cobra.ExactArgs(1),
 	}

--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -48,7 +48,7 @@ func newOrbCommand() *cobra.Command {
 
 	processCommand := &cobra.Command{
 		Use:         "process <path>",
-		Short:       "process an orb",
+		Short:       "Validates orb, then inlines other orb dependencies",
 		RunE:        processOrb,
 		Args:        cobra.ExactArgs(1),
 		Annotations: make(map[string]string),

--- a/cmd/tests.go
+++ b/cmd/tests.go
@@ -18,14 +18,14 @@ func newTestsCommand() *cobra.Command {
 
 	globCmd := &cobra.Command{
 		Use:    "glob",
-		Short:  "glob files using pattern",
+		Short:  "Glob files using pattern",
 		Run:    globRun,
 		Hidden: true,
 	}
 
 	splitCmd := &cobra.Command{
 		Use:    "split",
-		Short:  "return a split batch of provided files",
+		Short:  "Return a split batch of provided files",
 		RunE:   splitRunE,
 		Hidden: true,
 	}


### PR DESCRIPTION
The "config process" help text is similar, but I didn't update that since the
description would exceed what's reasonable for a short description string.
Cobra supports adding a long description string, but seems like something to
discuss before using.