### PR TITLE
CIRCLE-12860 guard against invalid VCS in `namespace create`

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -480,7 +480,7 @@ func getOrganization(ctx context.Context, logger *logger.Logger, organizationNam
 	err = graphQLclient.Run(ctx, request, &response)
 
 	if err != nil || response.Organization.ID == "" {
-		err = fmt.Errorf("Unable to find organization %s of vcs-type %s", organizationName, organizationVcs)
+		err = errors.Wrap(err, fmt.Sprintf("Unable to find organization %s of vcs-type %s", organizationName, organizationVcs))
 	}
 
 	return response.Organization.ID, err


### PR DESCRIPTION
WIP: Show out-of-band errors again for getOrganization

Context:

The CLI currently shows a generic error message on invalid VCS input type:

```
$ circleci namespace create eric-hu bbucket eric-hu
Error: Unable to find organization eric-hu of vcs-type BBUCKET
```

However, the api-service is actually returning pretty clear error messaging,
but it's in out-of-band errors returned at the top level:

```
[machinebox/graphql] << {"errors":[{"message":"Provided argument value `ITBUCKET' is not member of enum type.","value":"ITBUCKET","allowed-values":["GITHUB","BITBUCKET"],"enum-type":"VCSType"}]}
```