### PR TITLE
Fix homebrew deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,13 +183,13 @@ workflows:
             branches:
               only: master
   weekly:
-    triggers:
-      - schedule:
-          cron: "0 3 * * 3"
-          filters:
-            branches:
-              only:
-                - master
+    #triggers:
+    #  - schedule:
+    #      cron: "0 3 * * 3"
+    #      filters:
+    #        branches:
+    #          only:
+    #            - master
     jobs:
       - run-brew-deploy-gate:
           type: approval

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,11 +152,12 @@ jobs:
           git config --global user.name "$GH_NAME" > /dev/null 2>&1
       - run: brew --version
       - run: |
-          export VERSION=v$(./dist/darwin_amd64/circleci version | sed s/\+/\\n/g | head -n 1)
-          export REVISION=$(git rev-parse $(./dist/darwin_amd64/circleci version | sed s/\+/\\n/g | head -2 | tail -1))
-          echo "Bumping circleci to $VERSION+$REVISION"
+          export VERSION=$(./dist/darwin_amd64/circleci version)
+          export TAG=v$(ruby -e "puts '$VERSION'.split('+')[0]")
+          export REVISION=$(git rev-parse $(ruby -e "puts '$VERSION'.split('+')[1]"))
+          echo "Bumping circleci to $TAG+$REVISION"
           brew bump-formula-pr --strict \
-            --tag=$VERSION \
+            --tag=$TAG \
             --revision=$CIRCLE_SHA1 \
             circleci
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,6 +127,7 @@ jobs:
   brew-prepare:
     machine: true
     steps:
+      - checkout
       - run: |
           docker run -v $PWD:/go/src/github.com/CircleCI-Public/circleci-cli \
             -w /go/src/github.com/CircleCI-Public/circleci-cli \


### PR DESCRIPTION
This fixes how we determine the `$TAG` and `$REVISION` inside of a macos container.

Weekly deploy is disabled until a new release is made after this PR gets merged.