### PR TITLE
Ensure consistency on output for promote/increment

### DIFF
--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -260,7 +260,7 @@ func incrementOrb(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	Logger.Infof("Orb `%s` bumped to '%s'.\n", ref, response.HighestVersion)
+	Logger.Infof("Orb `%s/%s@%s` was published.\n", namespace, orb, response.HighestVersion)
 	Logger.Info("Please note that this is an open orb and is world-readable.")
 	return nil
 }
@@ -287,7 +287,7 @@ func promoteOrb(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	Logger.Infof("Orb `%s` promoted to '%s'.\n", ref, response.HighestVersion)
+	Logger.Infof("Orb `%s/%s@%s` was published.\n", namespace, orb, response.HighestVersion)
 	Logger.Info("Please note that this is an open orb and is world-readable.")
 	return nil
 }

--- a/cmd/orb_test.go
+++ b/cmd/orb_test.go
@@ -662,7 +662,7 @@ var _ = Describe("Orb integration tests", func() {
 				session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 
 				Expect(err).ShouldNot(HaveOccurred())
-				Eventually(session.Out).Should(gbytes.Say("Orb `my/orb` bumped to '0.1.0'."))
+				Eventually(session.Out).Should(gbytes.Say("Orb `my/orb@0.1.0` was published."))
 				Eventually(session.Out).Should(gbytes.Say("Please note that this is an open orb and is world-readable."))
 				Eventually(session).Should(gexec.Exit(0))
 			})
@@ -826,7 +826,7 @@ var _ = Describe("Orb integration tests", func() {
 				session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 
 				Expect(err).ShouldNot(HaveOccurred())
-				Eventually(session.Out).Should(gbytes.Say("Orb `my/orb@dev:foo` promoted to '0.1.0'."))
+				Eventually(session.Out).Should(gbytes.Say("Orb `my/orb@0.1.0` was published."))
 				Eventually(session.Out).Should(gbytes.Say("Please note that this is an open orb and is world-readable."))
 				Eventually(session).Should(gexec.Exit(0))
 			})


### PR DESCRIPTION
This makes it easy to grab the published version ref and copy/paste it into your project's config.