### PR TITLE
[CIRCLE-14155]:  Surface out-of-band GraphQL errors for `namespace create`

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -615,8 +615,14 @@ func createNamespaceWithOwnerID(ctx context.Context, logger *logger.Logger, name
 
 	err = graphQLclient.Run(ctx, request, &response)
 
-	if err != nil {
-		return nil, errors.Wrapf(err, "Unable to create namespace %s for ownerId %s", name, ownerID)
+	// Only fall back to native graphql errors if there are no in-band errors.
+	if err != nil && len(response.Data.CreateNamespace.Errors) == 0 {
+		return nil, err
+	}
+
+	// Only fall back to out-of-band errors if there are no in-band errors
+	if len(response.Errors) > 0 && len(response.Data.CreateNamespace.Errors) == 0 {
+		return nil, response.Errors
 	}
 
 	if len(response.Data.CreateNamespace.Errors) > 0 {
@@ -654,6 +660,10 @@ func getOrganization(ctx context.Context, logger *logger.Logger, organizationNam
 		return nil, errors.Wrap(err, fmt.Sprintf("Unable to find organization %s of vcs-type %s", organizationName, organizationVcs))
 	}
 
+	if len(response.Errors) > 0 {
+		return nil, response.Errors
+	}
+
 	return &response, nil
 }
 
@@ -661,15 +671,25 @@ func namespaceNotFound(name string) error {
 	return fmt.Errorf("the namespace '%s' does not exist. Did you misspell the namespace, or maybe you meant to create the namespace first?", name)
 }
 
+func organizationNotFound(name string, vcs string) error {
+	return fmt.Errorf("the organization '%s' under '%s' VCS-type does not exist. Did you misspell the organization or VCS?", name, vcs)
+}
+
 // CreateNamespace creates (reserves) a namespace for an organization
 func CreateNamespace(ctx context.Context, logger *logger.Logger, name string, organizationName string, organizationVcs string) (*CreateNamespaceResponse, error) {
-	response, err := getOrganization(ctx, logger, organizationName, organizationVcs)
+	getOrgResponse, getOrgError := getOrganization(ctx, logger, organizationName, organizationVcs)
 
-	if err != nil {
-		return nil, err
+	if getOrgError != nil {
+		return nil, errors.Wrap(organizationNotFound(organizationName, organizationVcs), getOrgError.Error())
 	}
 
-	return createNamespaceWithOwnerID(ctx, logger, name, response.Data.Organization.ID)
+	createNSResponse, createNSError := createNamespaceWithOwnerID(ctx, logger, name, getOrgResponse.Data.Organization.ID)
+
+	if createNSError != nil {
+		return nil, createNSError
+	}
+
+	return createNSResponse, nil
 }
 
 func getNamespace(ctx context.Context, logger *logger.Logger, name string) (*GetNamespaceResponse, error) {

--- a/api/api.go
+++ b/api/api.go
@@ -615,18 +615,16 @@ func createNamespaceWithOwnerID(ctx context.Context, logger *logger.Logger, name
 
 	err = graphQLclient.Run(ctx, request, &response)
 
-	// Only fall back to native graphql errors if there are no in-band errors.
-	if err != nil && len(response.Data.CreateNamespace.Errors) == 0 {
+	if len(response.Data.CreateNamespace.Errors) > 0 {
+		return nil, response.Data.CreateNamespace.Errors
+	}
+
+	if err != nil {
 		return nil, err
 	}
 
-	// Only fall back to out-of-band errors if there are no in-band errors
-	if len(response.Errors) > 0 && len(response.Data.CreateNamespace.Errors) == 0 {
+	if len(response.Errors) > 0 {
 		return nil, response.Errors
-	}
-
-	if len(response.Data.CreateNamespace.Errors) > 0 {
-		return nil, response.Data.CreateNamespace.Errors
 	}
 
 	return &response, nil

--- a/api/api.go
+++ b/api/api.go
@@ -31,7 +31,7 @@ func (errs GQLErrorsCollection) Error() string {
 		messages = append(messages, errs[i].Message)
 	}
 
-	return strings.Join(messages, ": ")
+	return strings.Join(messages, "\n")
 }
 
 // GQLResponseError is a mapping of the data returned by the GraphQL server of key-value pairs.

--- a/client/client.go
+++ b/client/client.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io"
 	"net/http"
 
 	"github.com/CircleCI-Public/circleci-cli/logger"
@@ -108,15 +107,11 @@ func (c *Client) Run(ctx context.Context, request *Request, resp interface{}) er
 			c.logger.Debug(err.Error())
 		}
 	}()
-	var buf bytes.Buffer
-	if _, err := io.Copy(&buf, res.Body); err != nil {
-		return errors.Wrap(err, "reading body")
-	}
 
-	c.logger.Debug("<< %s", buf.String())
-	if err := json.NewDecoder(&buf).Decode(&resp); err != nil {
+	if err := json.NewDecoder(res.Body).Decode(&resp); err != nil {
 		return errors.Wrap(err, "decoding response")
 	}
+	c.logger.Debug("<< %+v", resp)
 
 	return nil
 }

--- a/client/client.go
+++ b/client/client.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"io"
-	"log"
 	"net/http"
 
 	"github.com/CircleCI-Public/circleci-cli/logger"
@@ -106,7 +105,7 @@ func (c *Client) Run(ctx context.Context, request *Request, resp interface{}) er
 	defer func() {
 		err := res.Body.Close()
 		if err != nil {
-			log.Fatal(err)
+			c.logger.Debug(err.Error())
 		}
 	}()
 	var buf bytes.Buffer

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -202,7 +202,7 @@ var _ = Describe("Config", func() {
 				session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 
 				Expect(err).ShouldNot(HaveOccurred())
-				Eventually(session.Err).Should(gbytes.Say("Error: error1: error2"))
+				Eventually(session.Err).Should(gbytes.Say("Error: error1\nerror2"))
 				Eventually(session).ShouldNot(gexec.Exit(0))
 			})
 		})

--- a/cmd/diagnostic.go
+++ b/cmd/diagnostic.go
@@ -28,7 +28,7 @@ func diagnostic(cmd *cobra.Command, args []string) error {
 	token := viper.GetString("token")
 
 	Logger.Infoln("\n---\nCircleCI CLI Diagnostics\n---")
-	Logger.Infof("Verbose mode: %v\n", viper.GetBool("verbose"))
+	Logger.Infof("Debugger mode: %v\n", viper.GetBool("debug"))
 
 	Logger.Infof("Config found: %v\n", viper.ConfigFileUsed())
 

--- a/cmd/diagnostic_test.go
+++ b/cmd/diagnostic_test.go
@@ -147,7 +147,7 @@ token: mytoken
 				command = exec.Command(pathCLI,
 					"diagnostic",
 					"--endpoint", testServer.URL(),
-					"--verbose",
+					"--debug",
 				)
 
 				command.Env = append(os.Environ(),

--- a/cmd/namespace.go
+++ b/cmd/namespace.go
@@ -34,19 +34,13 @@ Please note that at this time all namespaces created in the registry are world-r
 }
 
 func createNamespace(cmd *cobra.Command, args []string) error {
-	var err error
 	ctx := context.Background()
 	namespaceName := args[0]
 
-	response, err := api.CreateNamespace(ctx, Logger, namespaceName, args[2], strings.ToUpper(args[1]))
+	_, err := api.CreateNamespace(ctx, Logger, namespaceName, args[2], strings.ToUpper(args[1]))
 
-	// Only fall back to native graphql errors if there are no in-band errors.
-	if err != nil && (response == nil || len(response.Data.CreateNamespace.Errors) == 0) {
+	if err != nil {
 		return err
-	}
-
-	if len(response.Data.CreateNamespace.Errors) > 0 {
-		return response.Data.CreateNamespace.Errors
 	}
 
 	Logger.Infof("Namespace `%s` created.", namespaceName)

--- a/cmd/namespace_test.go
+++ b/cmd/namespace_test.go
@@ -208,7 +208,7 @@ var _ = Describe("Namespace integration tests", func() {
 			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 
 			Expect(err).ShouldNot(HaveOccurred())
-			Eventually(session.Err).Should(gbytes.Say("Error: error1: error2"))
+			Eventually(session.Err).Should(gbytes.Say("Error: error1\nerror2"))
 			Eventually(session).ShouldNot(gexec.Exit(0))
 		})
 	})

--- a/cmd/orb_test.go
+++ b/cmd/orb_test.go
@@ -1041,7 +1041,7 @@ var _ = Describe("Orb integration tests", func() {
 				command = exec.Command(pathCLI,
 					"orb", "list",
 					"--host", testServer.URL(),
-					"--verbose",
+					"--debug",
 				)
 			})
 
@@ -1083,7 +1083,7 @@ var _ = Describe("Orb integration tests", func() {
 				command = exec.Command(pathCLI,
 					"orb", "list",
 					"--host", testServer.URL(),
-					"--verbose",
+					"--debug",
 					"--json",
 				)
 			})
@@ -1135,7 +1135,7 @@ var _ = Describe("Orb integration tests", func() {
 					"orb", "list",
 					"--uncertified",
 					"--host", testServer.URL(),
-					"--verbose",
+					"--debug",
 				)
 				By("setting up a mock server")
 
@@ -1197,7 +1197,7 @@ var _ = Describe("Orb integration tests", func() {
 						"orb", "list",
 						"--uncertified",
 						"--host", testServer.URL(),
-						"--verbose",
+						"--debug",
 						"--json",
 					)
 				})
@@ -1223,7 +1223,7 @@ var _ = Describe("Orb integration tests", func() {
 				command = exec.Command(pathCLI,
 					"orb", "list", "circleci",
 					"--host", testServer.URL(),
-					"--verbose",
+					"--debug",
 				)
 				By("setting up a mock server")
 				// These requests and responses are generated from production data,
@@ -1299,7 +1299,7 @@ var _ = Describe("Orb integration tests", func() {
 					command = exec.Command(pathCLI,
 						"orb", "list", "circleci",
 						"--host", testServer.URL(),
-						"--verbose",
+						"--debug",
 						"--json",
 					)
 				})

--- a/cmd/orb_test.go
+++ b/cmd/orb_test.go
@@ -321,7 +321,7 @@ var _ = Describe("Orb integration tests", func() {
 				session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 
 				Expect(err).ShouldNot(HaveOccurred())
-				Eventually(session.Err).Should(gbytes.Say("Error: error1: error2"))
+				Eventually(session.Err).Should(gbytes.Say("Error: error1\nerror2"))
 				Eventually(session).ShouldNot(gexec.Exit(0))
 
 			})
@@ -449,7 +449,7 @@ var _ = Describe("Orb integration tests", func() {
 				session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 
 				Expect(err).ShouldNot(HaveOccurred())
-				Eventually(session.Err).Should(gbytes.Say("Error: error1: error2"))
+				Eventually(session.Err).Should(gbytes.Say("Error: error1\nerror2"))
 				Eventually(session).ShouldNot(gexec.Exit(0))
 
 			})
@@ -577,7 +577,7 @@ var _ = Describe("Orb integration tests", func() {
 				session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 
 				Expect(err).ShouldNot(HaveOccurred())
-				Eventually(session.Err).Should(gbytes.Say("Error: error1: error2"))
+				Eventually(session.Err).Should(gbytes.Say("Error: error1\nerror2"))
 				Eventually(session).ShouldNot(gexec.Exit(0))
 
 			})
@@ -742,7 +742,7 @@ var _ = Describe("Orb integration tests", func() {
 				session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 
 				Expect(err).ShouldNot(HaveOccurred())
-				Eventually(session.Err).Should(gbytes.Say("Error: error1: error2"))
+				Eventually(session.Err).Should(gbytes.Say("Error: error1\nerror2"))
 				Eventually(session).ShouldNot(gexec.Exit(0))
 
 			})
@@ -908,7 +908,7 @@ var _ = Describe("Orb integration tests", func() {
 				session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 
 				Expect(err).ShouldNot(HaveOccurred())
-				Eventually(session.Err).Should(gbytes.Say("Error: error1: error2"))
+				Eventually(session.Err).Should(gbytes.Say("Error: error1\nerror2"))
 				Eventually(session).ShouldNot(gexec.Exit(0))
 
 			})
@@ -1031,7 +1031,7 @@ var _ = Describe("Orb integration tests", func() {
 				session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 
 				Expect(err).ShouldNot(HaveOccurred())
-				Eventually(session.Err).Should(gbytes.Say("Error: error1: error2"))
+				Eventually(session.Err).Should(gbytes.Say("Error: error1\nerror2"))
 				Eventually(session).ShouldNot(gexec.Exit(0))
 			})
 		})

--- a/cmd/orb_test.go
+++ b/cmd/orb_test.go
@@ -1041,7 +1041,6 @@ var _ = Describe("Orb integration tests", func() {
 				command = exec.Command(pathCLI,
 					"orb", "list",
 					"--host", testServer.URL(),
-					"--debug",
 				)
 			})
 
@@ -1083,7 +1082,6 @@ var _ = Describe("Orb integration tests", func() {
 				command = exec.Command(pathCLI,
 					"orb", "list",
 					"--host", testServer.URL(),
-					"--debug",
 					"--json",
 				)
 			})
@@ -1135,7 +1133,6 @@ var _ = Describe("Orb integration tests", func() {
 					"orb", "list",
 					"--uncertified",
 					"--host", testServer.URL(),
-					"--debug",
 				)
 				By("setting up a mock server")
 
@@ -1197,7 +1194,6 @@ var _ = Describe("Orb integration tests", func() {
 						"orb", "list",
 						"--uncertified",
 						"--host", testServer.URL(),
-						"--debug",
 						"--json",
 					)
 				})
@@ -1223,7 +1219,6 @@ var _ = Describe("Orb integration tests", func() {
 				command = exec.Command(pathCLI,
 					"orb", "list", "circleci",
 					"--host", testServer.URL(),
-					"--debug",
 				)
 				By("setting up a mock server")
 				// These requests and responses are generated from production data,
@@ -1299,7 +1294,6 @@ var _ = Describe("Orb integration tests", func() {
 					command = exec.Command(pathCLI,
 						"orb", "list", "circleci",
 						"--host", testServer.URL(),
-						"--debug",
 						"--json",
 					)
 				})

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -96,15 +96,19 @@ func MakeCommands() *cobra.Command {
 	rootCmd.AddCommand(newUsageCommand())
 	rootCmd.AddCommand(newStepCommand())
 	rootCmd.AddCommand(newSwitchCommand())
-	rootCmd.PersistentFlags().Bool("verbose", false, "Enable verbose logging.")
+	rootCmd.PersistentFlags().Bool("debug", false, "Enable debug logging.")
 	rootCmd.PersistentFlags().String("token", "", "your token for using CircleCI")
 	rootCmd.PersistentFlags().String("host", defaultHost, "URL to your CircleCI host")
 	rootCmd.PersistentFlags().String("endpoint", defaultEndpoint, "URI to your CircleCI GraphQL API endpoint")
+	if err := rootCmd.PersistentFlags().MarkHidden("debug"); err != nil {
+		panic(err)
+	}
+
 	if err := rootCmd.PersistentFlags().MarkHidden("endpoint"); err != nil {
 		panic(err)
 	}
 
-	for _, flag := range []string{"endpoint", "host", "token", "verbose"} {
+	for _, flag := range []string{"endpoint", "host", "token", "debug"} {
 		bindCobraFlagToViper(rootCmd, flag)
 	}
 
@@ -183,7 +187,7 @@ func init() {
 }
 
 func prepare() {
-	Logger = logger.NewLogger(viper.GetBool("verbose"))
+	Logger = logger.NewLogger(viper.GetBool("debug"))
 }
 
 func visitAll(root *cobra.Command, fn func(*cobra.Command)) {

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -153,10 +153,10 @@ func setup(cmd *cobra.Command, args []string) error {
 		viper.Set("endpoint", defaultEndpoint)
 	}
 
-	// Marc: I can't find a way to prevent the verbose flag from
+	// Marc: I can't find a way to prevent the debug flag from
 	// being written to the config file, so set it to false in
 	// the config file.
-	viper.Set("verbose", false)
+	viper.Set("debug", false)
 
 	if err := viper.WriteConfig(); err != nil {
 		return errors.Wrap(err, "Failed to save config file")

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -9,32 +9,32 @@ import (
 // Logger wraps a few log.Logger instances in private fields.
 // They are accessible via their respective methods.
 type Logger struct {
-	debug   *log.Logger
-	info    *log.Logger
-	error   *log.Logger
-	verbose bool
+	debug    *log.Logger
+	info     *log.Logger
+	error    *log.Logger
+	debugger bool
 }
 
 // NewLogger returns a reference to a Logger.
 // We usually call this when initializing cmd.Logger.
 // Later we pass this to client.NewClient so it can also log.
 // By default debug and error go to os.Stderr, and info goes to os.Stdout
-func NewLogger(verbose bool) *Logger {
+func NewLogger(debugger bool) *Logger {
 	result := &Logger{
 		log.New(os.Stderr, "", 0),
 		log.New(os.Stdout, "", 0),
 		log.New(os.Stderr, "", 0),
-		verbose,
+		debugger,
 	}
-	result.Debug("Verbose Logging: %t", verbose)
+	result.Debug("Debugger Logging: %t", debugger)
 	return result
 }
 
-// Debug prints a formatted message to stderr only if verbose is set.
+// Debug prints a formatted message to stderr only if debug is set.
 // Consider these messages useful for developers of the CLI.
 // This method wraps log.Logger.Printf
 func (l *Logger) Debug(format string, args ...interface{}) {
-	if l.verbose {
+	if l.debugger {
 		l.debug.Printf(format, args...)
 	}
 }


### PR DESCRIPTION

This catches an error when trying to find an org that doesn't exist:

```
$ circleci namespace create asdf github asdf
Error: Must have member permission.: the organization 'asdf' under 'GITHUB' VCS-type does not exist. Did you misspell the organization or VCS?
exit status 255
```

We've also made sure the in-band errors for createNamespace mutation
are preferred over out-of-band errors and runtime errors.