### PR TITLE
Made users can specify install target dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ This will install the CLI into the `/usr/local/bin` directory.
 
 If you do not have write permissions to `/usr/local/bin`, you may need to run the above command with `sudo`.
 
+Optionally, you can install in a arbitrary directory by using `DESTDIR` environment variable.
+
+```
+export DESTDIR=/path/to/install/ && bash -c "$(curl -fSl https://raw.githubusercontent.com/CircleCI-Public/circleci-cli/master/install.sh)"
+```
+
 #### Homebrew
 
 ```

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@ set -o nounset
 set -o pipefail
 
 RELEASE_URL="https://api.github.com/repos/CircleCI-Public/circleci-cli/releases/latest"
-DEST="/usr/local/bin/circleci"
+DEST="${DESTDIR:-/usr/local/bin}/circleci"
 
 # Run the script in a temporary directory that we know is empty.
 SCRATCH=$(mktemp -d)

--- a/install.sh
+++ b/install.sh
@@ -38,6 +38,6 @@ grep -i "$(uname)" tarball_urls.txt | xargs curl --retry 3 --fail --location --o
 tar zxvf circleci.tgz --strip 1
 
 echo "Installing to $DEST"
-mv circleci $DEST
-chmod +x $DEST
+mv circleci "$DEST"
+chmod +x "$DEST"
 command -v circleci


### PR DESCRIPTION
This PR is for https://github.com/CircleCI-Public/circleci-cli/issues/153

This pr makes users can specify install target dir though `DESTDIR`.

If you check, try below.

```
$ export DESTDIR=/path/to/install/ && bash -c "$(curl -fSl https://raw.githubusercontent.com/bananaumai/circleci-cli/change-install-dest/install.sh"
```