### PR TITLE
Use Alpine for the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,6 @@
-FROM circleci/golang:1.10.3
+FROM alpine:3.8
 
 COPY ./dist/linux_amd64/circleci /usr/local/bin
+
+ENTRYPOINT ["circleci"]
+CMD ["--help"]


### PR DESCRIPTION
I don't see any reason why a go compiler image is being used as base image for the cli, which is a large overhead.
Since the binary seems to be statically compiled already, Alpine seems to be more appropriate for me.
That change would also speed up the workflows of your orb-tools.