### PR TITLE
feature(install): Easy DEST override.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,14 @@ This project is the seed for CircleCI's new command-line application.
 If you're installing the new `circleci` CLI for the first time, run the following command:
 
 ```
+export CIRCLECI_CLI_DEST=~/bin/circleci  # Optional defaults to /usr/local/bin/circleci
 bash -c "$(curl -fSl https://raw.githubusercontent.com/CircleCI-Public/circleci-cli/master/install.sh)"
 ```
 
 This will install the CLI into the `/usr/local/bin` directory.
 
-If you do not have write permissions to `/usr/local/bin`, you may need to run the above command with `sudo`.
+If you do not have write permissions to `/usr/local/bin`, you may need to run the above command with `sudo`
+or define the `CIRCLECI_CLI_DEST` variable to point to a directory you can write into and is in your `PATH`.
 
 #### Homebrew
 

--- a/install.sh
+++ b/install.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 set -o errexit
-set -o nounset
 set -o pipefail
 
 RELEASE_URL="https://api.github.com/repos/CircleCI-Public/circleci-cli/releases/latest"
-DEST="/usr/local/bin/circleci"
+DEST="${CIRCLECI_CLI_DEST:-/usr/local/bin/circleci}"
+
+set -o nounset
 
 # Run the script in a temporary directory that we know is empty.
 SCRATCH=$(mktemp -d)
@@ -24,7 +25,7 @@ trap finish EXIT
 trap error ERR
 
 echo "Finding latest release."
-curl --retry 3 --fail --location --silent --output release.json "$RELEASE_URL" 
+curl --retry 3 --fail --location --silent --output release.json "$RELEASE_URL"
 python -m json.tool release.json > formatted_release.json
 
 STRIP_JSON_STRING='s/.*"([^"]+)".*/\1/'
@@ -38,6 +39,6 @@ grep -i "$(uname)" tarball_urls.txt | xargs curl --retry 3 --fail --location --o
 tar zxvf circleci.tgz --strip 1
 
 echo "Installing to $DEST"
-mv circleci $DEST
-chmod +x $DEST
-command -v circleci
+mv circleci "$DEST"
+chmod +x "$DEST"
+command -v "$(basename "$DEST")"


### PR DESCRIPTION
This tiny commit makes it easy to override the installation
directory of the circleci cli tool.

That tool being a statically linked, easy to move, binary it
is a shame to require root privileges to install it when it
so easy to not to.