### PR TITLE
fix(install): Actually leave temp dir behind.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 set -o errexit
 set -o nounset
-set -o pipefail
 
 RELEASE_URL="https://api.github.com/repos/CircleCI-Public/circleci-cli/releases/latest"
 DEST="/usr/local/bin/circleci"
@@ -10,21 +9,15 @@ DEST="/usr/local/bin/circleci"
 SCRATCH=$(mktemp -d)
 cd "$SCRATCH"
 
-function finish {
-  # Delete the working directory when the install was successful.
-  rm -r "$SCRATCH"
-}
-
 function error {
   echo "An error occured installing the tool."
   echo "The contents of the directory $SCRATCH have been left in place to help to debug the issue."
 }
 
-trap finish EXIT
 trap error ERR
 
 echo "Finding latest release."
-curl --retry 3 --fail --location --silent --output release.json "$RELEASE_URL" 
+curl --retry 3 --fail --location --silent --output release.json "$RELEASE_URL"
 python -m json.tool release.json > formatted_release.json
 
 STRIP_JSON_STRING='s/.*"([^"]+)".*/\1/'
@@ -38,6 +31,9 @@ grep -i "$(uname)" tarball_urls.txt | xargs curl --retry 3 --fail --location --o
 tar zxvf circleci.tgz --strip 1
 
 echo "Installing to $DEST"
-mv circleci $DEST
-chmod +x $DEST
+mv circleci "$DEST"
+chmod +x "$DEST"
 command -v circleci
+
+# Delete the working directory when the install was successful.
+rm -r "$SCRATCH"


### PR DESCRIPTION
The install script says it leaves behind the temporary
directory where the release archive was downloaded and
unpacked. But this is actually not true due to a trap that
removes it upon script exit. That trap interacts badly with
the `set -o errexit` directive issued earlier.

Closes #159 
