### PR TITLE
[CIRCLE-13833] When passing stdin to to `orb validate` the message is confusing

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -354,11 +354,9 @@ func ConfigQuery(ctx context.Context, log *logger.Logger, cl *client.Client, con
 			}
 		}`
 
-	request, err := client.NewAuthorizedRequest(query, cl.Token)
-	if err != nil {
-		return nil, err
-	}
+	request := client.NewUnauthorizedRequest(query)
 	request.Var("config", config)
+	request.Header.Set("Authorization", cl.Token)
 
 	err = cl.Run(ctx, log, request, &response)
 
@@ -392,11 +390,9 @@ func OrbQuery(ctx context.Context, log *logger.Logger, cl *client.Client, config
 			}
 		}`
 
-	request, err := client.NewAuthorizedRequest(query, cl.Token)
-	if err != nil {
-		return nil, err
-	}
+	request := client.NewUnauthorizedRequest(query)
 	request.Var("config", config)
+	request.Header.Set("Authorization", cl.Token)
 
 	err = cl.Run(ctx, log, request, &response)
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -140,7 +140,12 @@ func validateConfig(opts configOptions) error {
 		return err
 	}
 
-	opts.log.Infof("Config file at %s is valid", path)
+	if path == "-" {
+		opts.log.Infof("Config input is valid.")
+	} else {
+		opts.log.Infof("Config file at %s is valid.", path)
+	}
+
 	return nil
 }
 

--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -255,7 +255,11 @@ func validateOrb(opts orbOptions) error {
 		return err
 	}
 
-	opts.log.Infof("Orb input is valid.")
+	if opts.args[0] == "-" {
+		opts.log.Infof("Orb input is valid.")
+	} else {
+		opts.log.Infof("Orb at `%s` is valid.", opts.args[0])
+	}
 
 	return nil
 }

--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -255,7 +255,8 @@ func validateOrb(opts orbOptions) error {
 		return err
 	}
 
-	opts.log.Infof("Orb at `%s` is valid.", opts.args[0])
+	opts.log.Infof("Orb input is valid.")
+
 	return nil
 }
 

--- a/cmd/orb_test.go
+++ b/cmd/orb_test.go
@@ -106,7 +106,7 @@ var _ = Describe("Orb integration tests", func() {
 				session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 
 				Expect(err).ShouldNot(HaveOccurred())
-				Eventually(session.Out).Should(gbytes.Say("Orb at `-` is valid."))
+				Eventually(session.Out).Should(gbytes.Say("Orb input is valid."))
 				Eventually(session).Should(gexec.Exit(0))
 			})
 		})
@@ -160,7 +160,7 @@ var _ = Describe("Orb integration tests", func() {
 
 				Expect(err).ShouldNot(HaveOccurred())
 				// the .* is because the full path with temp dir is printed
-				Eventually(session.Out).Should(gbytes.Say("Orb at `.*orb.yml` is valid."))
+				Eventually(session.Out).Should(gbytes.Say("Orb input is valid."))
 				Eventually(session).Should(gexec.Exit(0))
 			})
 		})
@@ -205,7 +205,7 @@ var _ = Describe("Orb integration tests", func() {
 
 				Expect(err).ShouldNot(HaveOccurred())
 				// the .* is because the full path with temp dir is printed
-				Eventually(session.Out).Should(gbytes.Say("Orb at `.*myorb/orb.yml` is valid"))
+				Eventually(session.Out).Should(gbytes.Say("Orb input is valid."))
 				Eventually(session).Should(gexec.Exit(0))
 			})
 

--- a/cmd/orb_test.go
+++ b/cmd/orb_test.go
@@ -160,7 +160,7 @@ var _ = Describe("Orb integration tests", func() {
 
 				Expect(err).ShouldNot(HaveOccurred())
 				// the .* is because the full path with temp dir is printed
-				Eventually(session.Out).Should(gbytes.Say("Orb input is valid."))
+				Eventually(session.Out).Should(gbytes.Say("Orb at `.*orb.yml` is valid."))
 				Eventually(session).Should(gexec.Exit(0))
 			})
 		})
@@ -205,7 +205,7 @@ var _ = Describe("Orb integration tests", func() {
 
 				Expect(err).ShouldNot(HaveOccurred())
 				// the .* is because the full path with temp dir is printed
-				Eventually(session.Out).Should(gbytes.Say("Orb input is valid."))
+				Eventually(session.Out).Should(gbytes.Say("Orb at `.*myorb/orb.yml` is valid."))
 				Eventually(session).Should(gexec.Exit(0))
 			})
 


### PR DESCRIPTION
Assuming the user can easily see the path they passed as an argument, re-printing it to the user can be confusing especially if its STDIN.