### PR TITLE
Add Alpine Docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,13 +73,23 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
-          name: Build Docker Image
+          name: Docker Login
+          command: docker login -u $DOCKER_HUB_USERNAME -p $DOCKER_HUB_PASSWORD
+      - run:
+          name: Build Latest Docker Image
           command: |
-            docker login -u $DOCKER_HUB_USERNAME -p $DOCKER_HUB_PASSWORD
             docker build -t circleci/circleci-cli:0.1.$CIRCLE_BUILD_NUM .
             docker push     circleci/circleci-cli:0.1.$CIRCLE_BUILD_NUM
             docker tag      circleci/circleci-cli:0.1.$CIRCLE_BUILD_NUM circleci/circleci-cli:latest
             docker push     circleci/circleci-cli:latest
+      - run:
+          name: Build Alpine Docker Image
+          command: |
+            docker build -t circleci/circleci-cli:0.1.$CIRCLE_BUILD_NUM-alpine --file Dockerfile.alpine .
+            docker run --rm circleci/circleci-cli:0.1.$CIRCLE_BUILD_NUM-alpine update check
+            docker push     circleci/circleci-cli:0.1.$CIRCLE_BUILD_NUM-alpine
+            docker tag      circleci/circleci-cli:0.1.$CIRCLE_BUILD_NUM-alpine circleci/circleci-cli:alpine
+            docker push     circleci/circleci-cli:alpine
       - save_cache:
           key: v2-goreleaser-{{ checksum "~/goreleaser_amd64.deb" }}
           paths: [~/goreleaser_amd64.deb]

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,0 +1,7 @@
+FROM alpine:3.8
+
+COPY ./dist/linux_amd64/circleci /usr/local/bin
+
+RUN apk add --no-cache --upgrade git openssh ca-certificates
+
+ENTRYPOINT ["circleci"]

--- a/README.md
+++ b/README.md
@@ -87,6 +87,14 @@ $ circleci config validate
 Config file at .circleci/config.yml is valid
 ```
 
+## Docker
+
+The CLI may also be used without installation by using Docker.
+
+```
+docker run --rm -v $(pwd):/data circleci/circleci-cli:alpine config validate /data/.circleci/config.yml --token $TOKEN
+```
+
 ## Contributing
 
 Development instructions for the CircleCI CLI can be found in [HACKING.md](HACKING.md).


### PR DESCRIPTION
This PR adds a separate Alpine Docker image with the tag suffix `-alpine` and a secondary tag `alpine`.

Git, openssh and CA certificates are added. Git (and accordingly OpenSSH) are recommended requirements for CircleCI usage. The certificates are also necessary for all CLI commands that depend on GraphQL, which requires valid certificates. The packages are added after adding the binary to prevent a skip of adding cached outdated certificates.

As @zzak pointed out, entrypoints are not respected by CircleCI but that is intended. The `circleci` entrypoint is just for regular CLI users that may use the Docker image instead of CLI installation. So I just removed the `CMD` and kept the `ENTRYPOINT`.

Since there is no compose test in the build configuration yet but the CLI depends on root certificates and maybe other low-level packages, I've added a simple test command that executes `update check`.

Last, I've also added a section in the README to show a Docker usage example.