### PR TITLE
Fail earlier when HTTP calls fail

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -192,6 +192,12 @@ func (cl *Client) Run(ctx context.Context, log *logger.Logger, request *Request,
 		}
 	}()
 
+	log.Debug(">> result status: %s", res.Status)
+
+	if res.StatusCode != 200 {
+		return fmt.Errorf("failure calling GraphQL API: %s", res.Status)
+	}
+
 	wrappedResponse := &Response{
 		Data: resp,
 	}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -237,6 +237,11 @@ func TestStatusCode200(t *testing.T) {
 		calls++
 
 		w.WriteHeader(http.StatusOK)
+
+		_, err := io.WriteString(w, `{"data":{"value":"some data"}}`)
+		if err != nil {
+			t.Errorf(err.Error())
+		}
 	}))
 	defer srv.Close()
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
@@ -264,6 +269,11 @@ func TestStatusCode500(t *testing.T) {
 		calls++
 
 		w.WriteHeader(500)
+
+		_, err := io.WriteString(w, "some: data")
+		if err != nil {
+			t.Errorf(err.Error())
+		}
 	}))
 	defer srv.Close()
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
@@ -281,6 +291,42 @@ func TestStatusCode500(t *testing.T) {
 	}
 
 	if err.Error() != "failure calling GraphQL API: 500 Internal Server Error" {
+		t.Errorf("expected %s", err.Error())
+	}
+
+	if calls != 1 {
+		t.Errorf("expected %s", string(calls))
+	}
+}
+
+func TestStatusCode413(t *testing.T) {
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+
+		w.WriteHeader(413)
+
+		_, err := io.WriteString(w, "some: data")
+		if err != nil {
+			t.Errorf(err.Error())
+		}
+	}))
+	defer srv.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	client := NewClient(srv.URL, "/", "token")
+
+	req := NewUnauthorizedRequest("query {}")
+
+	var resp interface{}
+
+	err := client.Run(ctx, log, req, &resp)
+	if err == nil {
+		t.Error("expected error")
+	}
+
+	if err.Error() != "failure calling GraphQL API: 413 Request Entity Too Large" {
 		t.Errorf("expected %s", err.Error())
 	}
 


### PR DESCRIPTION
Add debug logging for HTTP responses.

If API calls return non-200 responses, then fail earlier with a more
clear message.

Error before:

    Error: Unable to validate config: decoding response: invalid character '<' looking for beginning of value

Error after:

    Error: Unable to validate config: failure calling GraphQL API: 413 Request Entity Too Large