### PR TITLE
Publish the install script to gh-pages

### DIFF
--- a/.circleci/generate-docs.sh
+++ b/.circleci/generate-docs.sh
@@ -16,3 +16,4 @@ done
 # move index and update links
 mv out/circleci.html out/index.html
 sed -i -- 's#<a href="circleci.html">#<a href="index.html">#g' out/*.html
+cp -v install.sh out/install.sh

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Install the CircleCI CLI tool.
+# https://github.com/circleci-public/circleci-cli
+
 set -o errexit
 set -o nounset
 


### PR DESCRIPTION
This will put the install script on a CDN, which will avoid
any issues where GitHub might rate limit the download of the
script when users try to install it from raw.githubusercontent.com

[`https://circleci-public.github.io/circleci-cli/install.sh`](https://circleci-public.github.io/circleci-cli/install.sh)