### PR TITLE
Allow execute to parse flags again.

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -54,8 +54,12 @@ func newLocalExecuteCommand(config *settings.Config) *cobra.Command {
 	}
 
 	buildCommand := &cobra.Command{
-		Use:   "execute",
+		Use:   "execute [flags] [-- Docker specific flags]",
 		Short: "Run a job in a container on the local machine",
+		Long: `Execute will run a CircleCI job on the local machine via 'docker run'. 
+		Docker specific flags can be passed by appending '--' and then the flags. For 
+		example:
+			circleci local execute -- -e INJECTED_ENVAR=value`,
 		PreRun: func(cmd *cobra.Command, args []string) {
 			opts.args = args
 			opts.log = logger.NewLogger(config.Debug)
@@ -64,7 +68,6 @@ func newLocalExecuteCommand(config *settings.Config) *cobra.Command {
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return runExecute(opts)
 		},
-		DisableFlagParsing: true,
 	}
 
 	// Used as a convenience work-around when DisableFlagParsing is enabled


### PR DESCRIPTION
Fixes #173
Fixes #174

This PR does two things.

1. Renabled flag parsing for the `circleci local execute` command.
2. Adds help text to show people that they can still add their Docker flags by appending a double dash (--) which is a Unix standard that Cobra supports.

With this PR, both will work:

` circleci local execute --help`
` circleci local execute -- -e INJECT_ENVAR=into-docker`