### PR TITLE
Tighten up Picard SHA extract regexp

### DIFF
--- a/cmd/update.go
+++ b/cmd/update.go
@@ -127,7 +127,7 @@ func findLatestPicardSha() (string, error) {
 	}
 
 	output := string(outputBytes)
-	sha256 := regexp.MustCompile("(?m)sha256.*$")
+	sha256 := regexp.MustCompile("(?m)sha256:[0-9a-f]+")
 	latest := sha256.FindString(output)
 
 	if latest == "" {


### PR DESCRIPTION
On Fedora systems, the previous regular expression for extracting the
latest sha256 of the picard image was matching extra characters, which
resulted in garbage being written to
~/.circleci/build_agent_settings.json.

This caused the subsquent docker
run to fail complaining that the sha256 was not a valid repository or
tag, which was definitely the case.

This updated regular expression does the right thing on Fedora systems
now.

Tested on both Fedora and Ubuntu (the latter of which worked fine both
before and after this change)

Fixes #190