### PR TITLE
Print request id from the API response header in --debug output.

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -192,7 +192,8 @@ func (cl *Client) Run(ctx context.Context, log *logger.Logger, request *Request,
 		}
 	}()
 
-	log.Debug(">> result status: %s", res.Status)
+	log.Debug("<< request id: %s", res.Header.Get("X-Request-Id"))
+	log.Debug("<< result status: %s", res.Status)
 
 	if res.StatusCode != 200 {
 		return fmt.Errorf("failure calling GraphQL API: %s", res.Status)


### PR DESCRIPTION
A small improvement that will make it easier to find logs related to a CLI call when debugging.

A tiny additional change: `>>` into `<<` to differentiate between data going to or from the server.