### PR TITLE
Fix brew deploy script replacing $CIRCLE_SHA1 with $REVISION

### DIFF
--- a/.circleci/brew-deploy.sh
+++ b/.circleci/brew-deploy.sh
@@ -7,12 +7,12 @@ rm /usr/local/bin/circleci
 # Install the latest circleci from homebrew
 brew install circleci
 
-VERSION=$(./dist/darwin_amd64/circleci version)
+VERSION=$("$DESTDIR"/circleci version)
 TAG="v$(ruby -e "puts '$VERSION'.split('+')[0]")"
 REVISION=$(git rev-parse "$(ruby -e "puts '$VERSION'.split('+')[1]")")
 echo "Bumping circleci to $TAG+$REVISION"
 brew bump-formula-pr --strict \
   --tag="$TAG" \
-  --revision="$CIRCLE_SHA1" \
+  --revision="$REVISION" \
   circleci
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,29 +120,18 @@ jobs:
             echo $SNAPCRAFT_LOGIN_FILE | base64 --decode --ignore-garbage > .snapcraft/snapcraft.cfg
             snapcraft push *.snap --release stable
 
-  brew-prepare:
-    machine: true
-    steps:
-      - checkout
-      - run: |
-          docker run -v $PWD:/go/src/github.com/CircleCI-Public/circleci-cli \
-            -w /go/src/github.com/CircleCI-Public/circleci-cli \
-            -it goreleaser/goreleaser:latest release --skip-validate --skip-publish --rm-dist
-      - persist_to_workspace:
-          root: .
-          paths:
-            - "dist"
-
   brew-deploy:
     macos:
       xcode: "10.0.0"
     environment:
       - USER: circleci
       - TRAVIS: circleci
+      - DESTDIR: /Users/distiller/dest
     steps:
       - checkout
-      - attach_workspace:
-          at: .
+      - run: |
+          mkdir $DESTDIR
+          curl -fLSs https://circle.ci/cli | DESTDIR="$DESTDIR" bash
       - run: |
           git config --global user.email "$GH_EMAIL" > /dev/null 2>&1
           git config --global user.name "$GH_NAME" > /dev/null 2>&1
@@ -184,9 +173,6 @@ workflows:
     jobs:
       - run-brew-deploy-gate:
           type: approval
-      - brew-prepare:
-          requires:
-            - run-brew-deploy-gate
       - brew-deploy:
           requires:
-            - brew-prepare
+            - run-brew-deploy-gate


### PR DESCRIPTION
Also removed the `brew-prepare` job which reused packages built with
goreleaser to prepare the deploy to homebrew by using install.sh