### PR TITLE
Delete unnecessary validation on orb's versions

### DIFF
--- a/references/references.go
+++ b/references/references.go
@@ -21,10 +21,6 @@ func SplitIntoOrbNamespaceAndVersion(ref string) (namespace, orb, version string
 
 	errorMessage := fmt.Errorf("Invalid orb reference '%s': Expected a namespace, orb and version in the format 'namespace/orb@version'", ref)
 
-	if len(strings.Split(ref, "/")) != 2 {
-		return "", "", "", errorMessage
-	}
-
 	re := regexp.MustCompile("^(.+)/(.+)@(.+)$")
 
 	matches := re.FindStringSubmatch(ref)


### PR DESCRIPTION
I think the following validation is not necessary:

https://github.com/CircleCI-Public/circleci-cli/blob/14dfd68fab4e081f1584dcd72d9d519f3f714c13/references/references.go#L24-L26

Also this code seems to cause the issue #213. I hope this patch will solve #213.