### PR TITLE
Allow slashes in dev labels

### DIFF
--- a/references/references.go
+++ b/references/references.go
@@ -21,10 +21,6 @@ func SplitIntoOrbNamespaceAndVersion(ref string) (namespace, orb, version string
 
 	errorMessage := fmt.Errorf("Invalid orb reference '%s': Expected a namespace, orb and version in the format 'namespace/orb@version'", ref)
 
-	if len(strings.Split(ref, "/")) != 2 {
-		return "", "", "", errorMessage
-	}
-
 	re := regexp.MustCompile("^(.+)/(.+)@(.+)$")
 
 	matches := re.FindStringSubmatch(ref)

--- a/references/references_test.go
+++ b/references/references_test.go
@@ -36,4 +36,12 @@ var _ = Describe("Parsing Orbs", func() {
 		Expect(err).Should(MatchError("Invalid orb catdog. Expected a namespace and orb in the form 'namespace/orb'"))
 
 	})
+
+	It("Should split correctly when dev label contains a fwslash", func() {
+		ns, orb, version, err := references.SplitIntoOrbNamespaceAndVersion("foo/bar@dev:bah/bah")
+		Expect(ns).To(Equal("foo"))
+		Expect(orb).To(Equal("bar"))
+		Expect(version).To(Equal("dev:bah/bah"))
+		Expect(err).ShouldNot(HaveOccurred())
+	})
 })


### PR DESCRIPTION
The server now allows the dev label to contain a `/` character, so the CLI
should allow it as well.