### PR TITLE
Add newline to validation output

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -140,9 +140,9 @@ func validateConfig(opts configOptions) error {
 	}
 
 	if path == "-" {
-		fmt.Printf("Config input is valid.")
+		fmt.Printf("Config input is valid.\n")
 	} else {
-		fmt.Printf("Config file at %s is valid.", path)
+		fmt.Printf("Config file at %s is valid.\n", path)
 	}
 
 	return nil


### PR DESCRIPTION
I've simply added a new line to the only two prints to stdout. This returns the new terminal line to the appropriate place.