### PR TITLE
Remove 'context' dependency from API

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -167,8 +167,9 @@ func prepareRequest(ctx context.Context, address string, request *Request) (*htt
 // Run sends an HTTP request to the GraphQL server and deserializes the response or returns an error.
 // TODO(zzak): This function is fairly complex, we should refactor it
 // nolint: gocyclo
-func (cl *Client) Run(ctx context.Context, request *Request, resp interface{}) error {
+func (cl *Client) Run(request *Request, resp interface{}) error {
 	l := log.New(os.Stderr, "", 0)
+	ctx := context.Background()
 
 	select {
 	case <-ctx.Done():

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,14 +1,12 @@
 package client
 
 import (
-	"context"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
 	"testing"
-	"time"
 )
 
 func TestServerAddress(t *testing.T) {
@@ -72,15 +70,12 @@ func TestDoJSON(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	ctx := context.Background()
 	client := NewClient(srv.URL, "/", "token", false)
 
-	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
-	defer cancel()
 	var resp struct {
 		Something string
 	}
-	err := client.Run(ctx, &Request{Query: "query {}"}, &resp)
+	err := client.Run(&Request{Query: "query {}"}, &resp)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
@@ -111,8 +106,6 @@ func TestQueryJSON(t *testing.T) {
 		}
 	}))
 	defer srv.Close()
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
-	defer cancel()
 
 	client := NewClient(srv.URL, "/", "token", false)
 
@@ -131,7 +124,7 @@ func TestQueryJSON(t *testing.T) {
 	var resp struct {
 		Value string
 	}
-	err := client.Run(ctx, req, &resp)
+	err := client.Run(req, &resp)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
@@ -174,15 +167,11 @@ func TestDoJSONErr(t *testing.T) {
 
 	defer server.Close()
 
-	ctx := context.Background()
 	client := NewClient(server.URL, "/", "token", false)
-
-	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
-	defer cancel()
 
 	var responseData map[string]interface{}
 
-	err := client.Run(ctx, &Request{Query: "query {}"}, &responseData)
+	err := client.Run(&Request{Query: "query {}"}, &responseData)
 	if err.Error() != "Something went wrong\nSomething else went wrong" {
 		t.Errorf(err.Error())
 	}
@@ -202,8 +191,6 @@ func TestHeader(t *testing.T) {
 		}
 	}))
 	defer srv.Close()
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
-	defer cancel()
 
 	client := NewClient(srv.URL, "/", "token", false)
 
@@ -213,7 +200,7 @@ func TestHeader(t *testing.T) {
 	var resp struct {
 		Value string
 	}
-	err := client.Run(ctx, req, &resp)
+	err := client.Run(req, &resp)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
@@ -240,8 +227,6 @@ func TestStatusCode200(t *testing.T) {
 		}
 	}))
 	defer srv.Close()
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
-	defer cancel()
 
 	client := NewClient(srv.URL, "/", "token", false)
 
@@ -249,7 +234,7 @@ func TestStatusCode200(t *testing.T) {
 
 	var resp interface{}
 
-	err := client.Run(ctx, req, &resp)
+	err := client.Run(req, &resp)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
@@ -272,8 +257,6 @@ func TestStatusCode500(t *testing.T) {
 		}
 	}))
 	defer srv.Close()
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
-	defer cancel()
 
 	client := NewClient(srv.URL, "/", "token", false)
 
@@ -281,7 +264,7 @@ func TestStatusCode500(t *testing.T) {
 
 	var resp interface{}
 
-	err := client.Run(ctx, req, &resp)
+	err := client.Run(req, &resp)
 	if err == nil {
 		t.Error("expected error")
 	}
@@ -308,8 +291,6 @@ func TestStatusCode413(t *testing.T) {
 		}
 	}))
 	defer srv.Close()
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
-	defer cancel()
 
 	client := NewClient(srv.URL, "/", "token", false)
 
@@ -317,7 +298,7 @@ func TestStatusCode413(t *testing.T) {
 
 	var resp interface{}
 
-	err := client.Run(ctx, req, &resp)
+	err := client.Run(req, &resp)
 	if err == nil {
 		t.Error("expected error")
 	}

--- a/cmd/diagnostic.go
+++ b/cmd/diagnostic.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"os"
 
@@ -13,15 +12,14 @@ import (
 )
 
 type diagnosticOptions struct {
-	cfg     *settings.Config
-	apiOpts api.Options
-	args    []string
+	cfg  *settings.Config
+	cl   *client.Client
+	args []string
 }
 
 func newDiagnosticCommand(config *settings.Config) *cobra.Command {
 	opts := diagnosticOptions{
-		apiOpts: api.Options{},
-		cfg:     config,
+		cfg: config,
 	}
 
 	diagnosticCommand := &cobra.Command{
@@ -29,8 +27,7 @@ func newDiagnosticCommand(config *settings.Config) *cobra.Command {
 		Short: "Check the status of your CircleCI CLI.",
 		PreRun: func(cmd *cobra.Command, args []string) {
 			opts.args = args
-			opts.apiOpts.Context = context.Background()
-			opts.apiOpts.Client = client.NewClient(config.Host, config.Endpoint, config.Token, config.Debug)
+			opts.cl = client.NewClient(config.Host, config.Endpoint, config.Token, config.Debug)
 		},
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return diagnostic(opts)
@@ -56,7 +53,7 @@ https://circleci.com/account/api`)
 
 	fmt.Println("Trying an introspection query on API... ")
 
-	responseIntro, err := api.IntrospectionQuery(opts.apiOpts)
+	responseIntro, err := api.IntrospectionQuery(opts.cl)
 	if responseIntro.Schema.QueryType.Name == "" {
 		fmt.Println("Unable to make a query against the GraphQL API, please check your settings")
 		if err != nil {
@@ -73,7 +70,7 @@ https://circleci.com/account/api`)
 		}
 	}
 
-	responseWho, err := api.WhoamiQuery(opts.apiOpts)
+	responseWho, err := api.WhoamiQuery(opts.cl)
 
 	if err != nil {
 		return err

--- a/cmd/namespace.go
+++ b/cmd/namespace.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
@@ -12,15 +11,14 @@ import (
 )
 
 type namespaceOptions struct {
-	apiOpts api.Options
-	cfg     *settings.Config
-	args    []string
+	cfg  *settings.Config
+	cl   *client.Client
+	args []string
 }
 
 func newNamespaceCommand(config *settings.Config) *cobra.Command {
 	opts := namespaceOptions{
-		apiOpts: api.Options{},
-		cfg:     config,
+		cfg: config,
 	}
 
 	namespaceCmd := &cobra.Command{
@@ -35,8 +33,7 @@ func newNamespaceCommand(config *settings.Config) *cobra.Command {
 Please note that at this time all namespaces created in the registry are world-readable.`,
 		PreRun: func(cmd *cobra.Command, args []string) {
 			opts.args = args
-			opts.apiOpts.Context = context.Background()
-			opts.apiOpts.Client = client.NewClient(config.Host, config.Endpoint, config.Token, config.Debug)
+			opts.cl = client.NewClient(config.Host, config.Endpoint, config.Token, config.Debug)
 		},
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return createNamespace(opts)
@@ -57,7 +54,7 @@ Please note that at this time all namespaces created in the registry are world-r
 func createNamespace(opts namespaceOptions) error {
 	namespaceName := opts.args[0]
 
-	_, err := api.CreateNamespace(opts.apiOpts, namespaceName, opts.args[2], strings.ToUpper(opts.args[1]))
+	_, err := api.CreateNamespace(opts.cl, namespaceName, opts.args[2], strings.ToUpper(opts.args[1]))
 
 	if err != nil {
 		return err

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -62,7 +61,7 @@ func query(opts queryOptions) error {
 	if err != nil {
 		return err
 	}
-	err = opts.cl.Run(context.Background(), req, &resp)
+	err = opts.cl.Run(req, &resp)
 	if err != nil {
 		return errors.Wrap(err, "Error occurred when running query")
 	}


### PR DESCRIPTION
Since we only ever used context.Background() we can simplify our API
code by assuming the client only cares about the context.

This means we only need to setup and pass a client in from commands.

Leaving this only dependency when calling API functions we can also
remove a type and simplify our commands as well.

- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/master/CONTRIBUTING.md).
- [x] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)

**Here are some helpful tips you can follow when submitting a pull request:**

1. Fork [the repository](https://github.com/CircleCI-Public/circleci-cli) and create your branch from `master`.
2. Run `make build` in the repository root.
3. If you've fixed a bug or added code that should be tested, add tests!
4. Ensure the test suite passes (`make test`).
5. The `--debug` flag is often helpful for debugging HTTP client requests and responses.
6. Format your code with [gofmt](https://golang.org/cmd/gofmt/).
7. Make sure your code lints (`make lint`). Tip: `make dev` will install `gometalinter`.

**If you have any questions, feel free to ping us at @CircleCI-Public/dx-clients.**
