### PR TITLE
[CIRCLE-15454, CIRCLE-15496]: Link back to documentation in --help

### DIFF
--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/CircleCI-Public/circleci-cli/api"
 	"github.com/CircleCI-Public/circleci-cli/client"
+	"github.com/CircleCI-Public/circleci-cli/link"
 	"github.com/CircleCI-Public/circleci-cli/references"
 	"github.com/CircleCI-Public/circleci-cli/settings"
 	"github.com/pkg/errors"
@@ -205,6 +206,7 @@ Please note that at this time all orbs created in the registry are world-readabl
 	orbCommand := &cobra.Command{
 		Use:   "orb",
 		Short: "Operate on orbs",
+		Long:  orbHelpLong(config),
 	}
 
 	orbCommand.AddCommand(listCommand)
@@ -216,6 +218,17 @@ Please note that at this time all orbs created in the registry are world-readabl
 	orbCommand.AddCommand(orbInfoCmd)
 
 	return orbCommand
+}
+
+func orbHelpLong(config *settings.Config) string {
+	// We should only print this for cloud users
+	if config.Host != defaultHost {
+		return ""
+	}
+
+	return fmt.Sprintf(`Operate on orbs
+
+See a full explanation and documentation on orbs here: %s`, link.OrbDocs)
 }
 
 func parameterDefaultToString(parameter api.OrbElementParameter) string {

--- a/cmd/orb_test.go
+++ b/cmd/orb_test.go
@@ -3,6 +3,7 @@ package cmd_test
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/CircleCI-Public/circleci-cli/link"
 	"github.com/CircleCI-Public/circleci-cli/md_docs"
 	"github.com/CircleCI-Public/circleci-cli/settings"
 	"github.com/spf13/cobra"
@@ -83,9 +84,8 @@ func MakeCommands() *cobra.Command {
 	}
 
 	rootCmd = &cobra.Command{
-		Use:   "circleci",
-		Short: `Use CircleCI from the command line.`,
-		Long:  `This project is the seed for CircleCI's new command-line application.`,
+		Use:  "circleci",
+		Long: rootHelpLong(rootOptions),
 		PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
 			return rootCmdPreRun(rootOptions)
 		},
@@ -222,4 +222,19 @@ func isUpdateIncluded(packageManager string) bool {
 	default:
 		return true
 	}
+}
+
+func rootHelpLong(config *settings.Config) string {
+	long := `Use CircleCI from the command line.
+
+This project is the seed for CircleCI's new command-line application.`
+
+	// We should only print this for cloud users
+	if config.Host != defaultHost {
+		return long
+	}
+
+	return fmt.Sprintf(`%s
+
+For more help, see the documentation here: %s`, long, link.CLIDocs)
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -19,6 +19,69 @@ var _ = Describe("Root", func() {
 		})
 	})
 
+	Describe("Help text", func() {
+		It("shows a link to the docs", func() {
+			command := exec.Command(pathCLI, "--help")
+			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			Eventually(session.Out).Should(gbytes.Say(`Use CircleCI from the command line.
+
+This project is the seed for CircleCI's new command-line application.
+
+For more help, see the documentation here: https://circleci.com/docs/2.0/local-cli/
+`))
+			Eventually(session).Should(gexec.Exit(0))
+		})
+
+		Context("if user changes host settings through configuration", func() {
+			var (
+				err        error
+				tempHome   string
+				command    *exec.Cmd
+				config     *os.File
+				configDir  = ".circleci"
+				configFile = "cli.yml"
+			)
+
+			BeforeEach(func() {
+				command = exec.Command(pathCLI, "--help")
+
+				tempHome, err = ioutil.TempDir("", "circleci-cli-test-")
+				Expect(err).ToNot(HaveOccurred())
+
+				command.Env = append(os.Environ(),
+					fmt.Sprintf("HOME=%s", tempHome),
+					fmt.Sprintf("USERPROFILE=%s", tempHome), // windows
+				)
+
+				Expect(os.Mkdir(filepath.Join(tempHome, configDir), 0700)).To(Succeed())
+
+				config, err = os.OpenFile(
+					filepath.Join(tempHome, configDir, configFile),
+					os.O_RDWR|os.O_CREATE,
+					0600,
+				)
+				Expect(err).ToNot(HaveOccurred())
+				_, err = config.Write([]byte(`host: foo.bar`))
+				Expect(err).ToNot(HaveOccurred())
+				Expect(config.Close()).To(Succeed())
+			})
+
+			AfterEach(func() {
+				Expect(os.RemoveAll(tempHome)).To(Succeed())
+			})
+
+			It("doesn't link to docs if user changes --host", func() {
+				session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				Consistently(session.Out).ShouldNot(gbytes.Say("For more help, see the documentation here: https://circleci.com/docs/2.0/local-cli/"))
+				Eventually(session).Should(gexec.Exit(0))
+			})
+		})
+	})
+
 	Describe("build without auto update", func() {
 		var (
 			command      *exec.Cmd

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,8 +1,11 @@
 package cmd_test
 
 import (
+	"fmt"
+	"io/ioutil"
 	"os"
 	"os/exec"
+	"path/filepath"
 
 	"github.com/CircleCI-Public/circleci-cli/cmd"
 	. "github.com/onsi/ginkgo"

--- a/link/link.go
+++ b/link/link.go
@@ -1,0 +1,6 @@
+package link
+
+var (
+	CLIDocs = "https://circleci.com/docs/2.0/local-cli/"
+	OrbDocs = "https://circleci.com/docs/2.0/orb-intro/"
+)

--- a/link/link.go
+++ b/link/link.go
@@ -1,6 +1,9 @@
 package link
 
 var (
+	// CLIDocs links to CLI documentation on circleci.com
 	CLIDocs = "https://circleci.com/docs/2.0/local-cli/"
+
+	// OrbDocs links to Orb documentation on circleci.com
 	OrbDocs = "https://circleci.com/docs/2.0/orb-intro/"
 )


### PR DESCRIPTION
## NOTE: When help is called, flags aren't parsed yet, so users passing in the --host flag won't see this message in help output

- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/master/CONTRIBUTING.md).
- [x] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)

**Here are some helpful tips you can follow when submitting a pull request:**

1. Fork [the repository](https://github.com/CircleCI-Public/circleci-cli) and create your branch from `master`.
2. Run `make build` in the repository root.
3. If you've fixed a bug or added code that should be tested, add tests!
4. Ensure the test suite passes (`make test`).
5. The `--debug` flag is often helpful for debugging HTTP client requests and responses.
6. Format your code with [gofmt](https://golang.org/cmd/gofmt/).
7. Make sure your code lints (`make lint`). Tip: `make dev` will install `gometalinter`.

**If you have any questions, feel free to ping us at @CircleCI-Public/dx-clients.**
