### PR TITLE
[CIRCLE-13842]: Add circleci setup --no-prompt for easy scripting of config

### DIFF
--- a/cmd/orb_test.go
+++ b/cmd/orb_test.go
@@ -3,7 +3,6 @@ package cmd_test
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -1760,23 +1759,20 @@ query namespaceOrbs ($namespace: String, $after: String!) {
 		})
 
 		Describe("when creating an orb without a token", func() {
-			var tempHome string
+			var tempSettings *temporarySettings
 
 			BeforeEach(func() {
-				tempHome, _, _ = withTempSettings()
+				tempSettings = withTempSettings()
 
-				command = exec.Command(pathCLI,
+				command = commandWithHome(pathCLI, tempSettings.home,
 					"orb", "create", "bar-ns/foo-orb",
 					"--skip-update-check",
 					"--token", "",
 				)
-				command.Env = append(os.Environ(),
-					fmt.Sprintf("HOME=%s", tempHome),
-				)
 			})
 
 			AfterEach(func() {
-				Expect(os.RemoveAll(tempHome)).To(Succeed())
+				Expect(os.RemoveAll(tempSettings.home)).To(Succeed())
 			})
 
 			It("instructs the user to run 'circleci setup' and create a new token", func() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -122,9 +122,9 @@ func MakeCommands() *cobra.Command {
 	rootCmd.PersistentFlags().BoolVar(&rootOptions.Debug,
 		"debug", rootOptions.Debug, "Enable debug logging.")
 	rootCmd.PersistentFlags().StringVar(&rootTokenFromFlag,
-		"token", "", "your token for using CircleCI")
+		"token", "", "your token for using CircleCI, also CIRCLECI_CLI_TOKEN")
 	rootCmd.PersistentFlags().StringVar(&rootOptions.Host,
-		"host", rootOptions.Host, "URL to your CircleCI host")
+		"host", rootOptions.Host, "URL to your CircleCI host, also CIRCLECI_CLI_HOST")
 	rootCmd.PersistentFlags().StringVar(&rootOptions.Endpoint,
 		"endpoint", rootOptions.Endpoint, "URI to your CircleCI GraphQL API endpoint")
 

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -13,9 +13,13 @@ import (
 var testing = false
 
 type setupOptions struct {
-	cfg  *settings.Config
-	cl   *client.Client
-	args []string
+	cfg      *settings.Config
+	cl       *client.Client
+	noPrompt bool
+	// Add host and token for use with --no-prompt
+	host  string
+	token string
+	args  []string
 }
 
 func newSetupCommand(config *settings.Config) *cobra.Command {
@@ -40,10 +44,26 @@ func newSetupCommand(config *settings.Config) *cobra.Command {
 		panic(err)
 	}
 
+	setupCommand.Flags().BoolVar(&opts.noPrompt, "no-prompt", false, "Disable prompt to bypass interactive UI. (MUST supply --host and --token)")
+
+	setupCommand.Flags().StringVar(&opts.host, "host", "", "URL to your CircleCI host")
+	if err := setupCommand.Flags().MarkHidden("host"); err != nil {
+		panic(err)
+	}
+
+	setupCommand.Flags().StringVar(&opts.token, "token", "", "your token for using CircleCI")
+	if err := setupCommand.Flags().MarkHidden("token"); err != nil {
+		panic(err)
+	}
+
 	return setupCommand
 }
 
 func setup(opts setupOptions) error {
+	if opts.noPrompt {
+		return setupNoPrompt(opts)
+	}
+
 	var tty ui.UserInterface = ui.InteractiveUI{}
 
 	if testing {
@@ -74,6 +94,57 @@ func setup(opts setupOptions) error {
 		return errors.Wrap(err, "Failed to save config file")
 	}
 
-	fmt.Println("Setup complete. Your configuration has been saved.")
+	fmt.Printf("Setup complete.\nYour configuration has been saved to %s.\n", opts.cfg.FileUsed)
+	return nil
+}
+
+func existingConfigExists(opts setupOptions) bool {
+	return opts.cfg.Host != "" && opts.cfg.Token != ""
+}
+
+func setupNoPrompt(opts setupOptions) error {
+	if existingConfigExists(opts) {
+		fmt.Printf("Setup has kept your existing configuation at %s.\n", opts.cfg.FileUsed)
+		return nil
+	}
+
+	var err error
+
+	if opts.host == "" {
+		err = errors.New("You must specify --host to use --no-prompt")
+	}
+
+	if opts.token == "" {
+		msg := "You must specify --token to use --no-prompt"
+
+		if err != nil {
+			err = errors.Wrap(err, msg)
+		} else {
+			err = errors.New(msg)
+		}
+	}
+
+	if err != nil {
+		return errors.Wrap(err, "No existing host or token saved.\nThe proper format is `circleci setup --host HOST --token TOKEN --no-prompt")
+	}
+
+	config := settings.Config{}
+
+	// First calling load will ensure the new config can be saved to disk
+	if err = config.LoadFromDisk(); err != nil {
+		return errors.Wrap(err, "Failed to create config file on disk")
+	}
+
+	// Update the config with flags passed in and inherit default endpoint
+	config.Endpoint = defaultEndpoint
+	config.Host = opts.host
+	config.Token = opts.token
+
+	// Then save the new config to disk
+	if err := config.WriteToDisk(); err != nil {
+		return errors.Wrap(err, "Failed to save config file")
+	}
+
+	fmt.Printf("Setup complete.\nYour configuration has been saved to %s.\n", config.FileUsed)
 	return nil
 }

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -129,7 +129,7 @@ func setupNoPrompt(opts setupOptions) error {
 	}
 
 	if opts.token == "" {
-		fmt.Println("No token saved. You must specify --token to use with --no-prompt.")
+		fmt.Println("No token saved. You didn't specify a --token to use with --no-prompt.")
 	}
 
 	// BOTH are blank!

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -129,21 +129,19 @@ func setupNoPrompt(opts setupOptions) error {
 
 	// Use the default endpoint since we don't expose that to users
 	config.Endpoint = defaultEndpoint
+	config.Host = opts.host   // Set new host to flag
+	config.Token = opts.token // Set new token to flag
 
-	// Keep the host setting from their config unless it's changed and not blank
-	if opts.cfg.Host == opts.host || opts.host == "" {
+	// Reset their host if the flag was blank
+	if opts.host == "" {
 		fmt.Println("Host unchanged from existing config. Use --host with --no-prompt to overwrite it.")
 		config.Host = opts.cfg.Host
-	} else {
-		config.Host = opts.host
 	}
 
-	// Keep the token setting from their config unless it's changed and not blank
-	if opts.cfg.Token == opts.token || opts.token == "" {
+	// Reset their token if the flag was blank
+	if opts.token == "" {
 		fmt.Println("Token unchanged from existing config. Use --token with --no-prompt to overwrite it.")
 		config.Token = opts.cfg.Token
-	} else {
-		config.Token = opts.token
 	}
 
 	// Then save the new config to disk

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -115,15 +115,7 @@ func setupNoPrompt(opts setupOptions) error {
 		return nil
 	}
 
-	if opts.host == "" {
-		fmt.Println("No host saved. You didn't specify a --host to use with --no-prompt.")
-	}
-
-	if opts.token == "" {
-		fmt.Println("No token saved. You didn't specify a --token to use with --no-prompt.")
-	}
-
-	// BOTH are blank!
+	// Throw an error if both flags are blank are blank!
 	if opts.host == "" && opts.token == "" {
 		return errors.New("No existing host or token saved.\nThe proper format is `circleci setup --host HOST --token TOKEN --no-prompt")
 	}
@@ -140,6 +132,7 @@ func setupNoPrompt(opts setupOptions) error {
 
 	// Keep the host setting from their config unless it's changed and not blank
 	if opts.cfg.Host == opts.host || opts.host == "" {
+		fmt.Println("Host unchanged from existing config. Use --host with --no-prompt to overwrite it.")
 		config.Host = opts.cfg.Host
 	} else {
 		config.Host = opts.host
@@ -147,6 +140,7 @@ func setupNoPrompt(opts setupOptions) error {
 
 	// Keep the token setting from their config unless it's changed and not blank
 	if opts.cfg.Token == opts.token || opts.token == "" {
+		fmt.Println("Token unchanged from existing config. Use --token with --no-prompt to overwrite it.")
 		config.Token = opts.cfg.Token
 	} else {
 		config.Token = opts.token

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -99,23 +99,14 @@ func setup(opts setupOptions) error {
 }
 
 func shouldKeepExistingConfig(opts setupOptions) bool {
-	// Check if host or token is set
-	if opts.cfg.Host == "" || opts.cfg.Token == "" {
+	// Host will always be set, since it has a default value of circleci.com
+	// We assume by an empty token there is no existing config.
+	if opts.cfg.Token == "" {
 		return false
 	}
 
-	// Check if host is different and flag is not blank
-	if opts.cfg.Host != opts.host && opts.host != "" {
-		return false
-	}
-
-	// Check if token is different and flag is not blank
-	if opts.cfg.Token != opts.token && opts.token != "" {
-		return false
-	}
-
-	// Otherwise, use existing settings
-	return true
+	// If they pass either host or token with a value this will be false, overwriting their existing config
+	return opts.host == "" && opts.token == ""
 }
 
 func setupNoPrompt(opts setupOptions) error {

--- a/cmd/setup_test.go
+++ b/cmd/setup_test.go
@@ -219,7 +219,7 @@ token: fooBarBaz
 				Expect(err).ShouldNot(HaveOccurred())
 
 				stdout := session.Wait().Out.Contents()
-				Expect(string(stdout)).To(Equal(fmt.Sprintf(`No token saved. You must specify --token to use with --no-prompt.
+				Expect(string(stdout)).To(Equal(fmt.Sprintf(`No token saved. You didn't specify a --token to use with --no-prompt.
 Setup complete.
 Your configuration has been saved to %s.
 `, configPath)))

--- a/cmd/setup_test.go
+++ b/cmd/setup_test.go
@@ -27,6 +27,8 @@ var _ = Describe("Setup with prompts", func() {
 		tempHome, err = ioutil.TempDir("", "circleci-cli-test-")
 		Expect(err).ToNot(HaveOccurred())
 
+		configPath = filepath.Join(tempHome, configDir, configFile)
+
 		command = exec.Command(pathCLI,
 			"setup",
 			"--testing",
@@ -52,7 +54,6 @@ var _ = Describe("Setup with prompts", func() {
 			Eventually(session.Out).Should(gbytes.Say("CircleCI Host"))
 			Eventually(session.Out).Should(gbytes.Say("CircleCI host has been set."))
 
-			configPath = filepath.Join(tempHome, configDir, configFile)
 			Eventually(session.Out).Should(gbytes.Say(fmt.Sprintf("Setup complete.\nYour configuration has been saved to %s.\n", configPath)))
 			Eventually(session.Err.Contents()).Should(BeEmpty())
 			Eventually(session).Should(gexec.Exit(0))
@@ -70,7 +71,7 @@ var _ = Describe("Setup with prompts", func() {
 			Expect(os.Mkdir(filepath.Join(tempHome, configDir), 0700)).To(Succeed())
 
 			var err error
-			configPath = filepath.Join(tempHome, configDir, configFile)
+
 			config, err = os.OpenFile(
 				configPath,
 				os.O_RDWR|os.O_CREATE,
@@ -190,9 +191,6 @@ token: fooBarBaz
 				Context("re-open the config to check the contents", func() {
 					file, err := os.Open(configPath)
 					Expect(err).ShouldNot(HaveOccurred())
-					go func() {
-						defer file.Close()
-					}()
 
 					reread, err := ioutil.ReadAll(file)
 					Expect(err).ShouldNot(HaveOccurred())
@@ -228,9 +226,6 @@ Your configuration has been saved to %s.
 				Context("re-open the config to check the contents", func() {
 					file, err := os.Open(configPath)
 					Expect(err).ShouldNot(HaveOccurred())
-					go func() {
-						defer file.Close()
-					}()
 
 					reread, err := ioutil.ReadAll(file)
 					Expect(err).ShouldNot(HaveOccurred())

--- a/cmd/setup_test.go
+++ b/cmd/setup_test.go
@@ -217,7 +217,7 @@ token: fooBarBaz
 				Expect(err).ShouldNot(HaveOccurred())
 
 				stdout := session.Wait().Out.Contents()
-				Expect(string(stdout)).To(Equal(fmt.Sprintf(`No token saved. You didn't specify a --token to use with --no-prompt.
+				Expect(string(stdout)).To(Equal(fmt.Sprintf(`Token unchanged from existing config. Use --token with --no-prompt to overwrite it.
 Setup complete.
 Your configuration has been saved to %s.
 `, configPath)))
@@ -252,7 +252,7 @@ token: fooBarBaz
 				Expect(err).ShouldNot(HaveOccurred())
 
 				stdout := session.Wait().Out.Contents()
-				Expect(string(stdout)).To(Equal(fmt.Sprintf(`No host saved. You didn't specify a --host to use with --no-prompt.
+				Expect(string(stdout)).To(Equal(fmt.Sprintf(`Host unchanged from existing config. Use --host with --no-prompt to overwrite it.
 Setup complete.
 Your configuration has been saved to %s.
 `, configPath)))


### PR DESCRIPTION
- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/master/CONTRIBUTING.md).
- [x] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)

**Here are some helpful tips you can follow when submitting a pull request:**

1. Fork [the repository](https://github.com/CircleCI-Public/circleci-cli) and create your branch from `master`.
2. Run `make build` in the repository root.
3. If you've fixed a bug or added code that should be tested, add tests!
4. Ensure the test suite passes (`make test`).
5. The `--debug` flag is often helpful for debugging HTTP client requests and responses.
6. Format your code with [gofmt](https://golang.org/cmd/gofmt/).
7. Make sure your code lints (`make lint`). Tip: `make dev` will install `gometalinter`.

**If you have any questions, feel free to ping us at @CircleCI-Public/dx-clients.**
