### PR TITLE
[CIRCLE-15511]: Document running `lint` job locally until gometalinter supports Go modules

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,6 +10,6 @@
 4. Ensure the test suite passes (`make test`).
 5. The `--debug` flag is often helpful for debugging HTTP client requests and responses.
 6. Format your code with [gofmt](https://golang.org/cmd/gofmt/).
-7. Make sure your code lints (`make lint`). Tip: `make dev` will install `gometalinter`.
+7. Make sure your code lints (`make lint`). Note: This requires Docker to run inside a local job.
 
 **If you have any questions, feel free to ping us at @CircleCI-Public/dx-clients.**

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ out/
 vendor/
 .vscode
 
+# For supporting generated config of 2.1 syntax for local testing
+.circleci/processed.yml
+
 # Snapcraft Related
 parts/
 prime/

--- a/HACKING.md
+++ b/HACKING.md
@@ -65,16 +65,19 @@ https://github.com/golang/go/wiki/Modules
 
 We use [`gometalinter`](github.com/alecthomas/gometalinter) for linting.
 
-You can install it via `$ make dev` or manually with:
+However, since we updated to Go 1.11 modules this doesn't work.
 
-```
-$ go get -u github.com/alecthomas/gometalinter
-$ gometalinter --install
-```
+You will have to run our `lint` job inside a local build in order to lint your code changes.
 
-Then you can run it with `$ make lint`.
+This requires docker and may fail if the docker is not available on your machine.
+
+Once you have installed Docker, you can execute the `lint` job locally with `$ make lint`.
+
+## Code coverage
 
 There is also a `coverage` job as part of the build which will lint any code you commit.
+
+This can be run manually with `$ make cover`.
 
 ## Editor support
 

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,14 @@ cover:
 
 .PHONY: lint
 lint:
-	gometalinter ./...
+	@echo Executing local build of lint job until gometalinter supports Go 1.11 modules...
+	@echo This requires Docker to run, so it may fail if docker cannot be found.
+	@echo 
+	@echo Generating tmp/processed.yml from .circleci/config.yml 2.1 version
+	go run main.go config process .circleci/config.yml > .circleci/processed.yml
+	@echo 
+	@echo Running local build..
+	go run main.go local execute -c .circleci/processed.yml --job lint
 
 .PHONY: doc
 doc:
@@ -35,8 +42,6 @@ doc:
 .PHONY: dev
 dev:
 	go get golang.org/x/tools/cmd/godoc
-	go get -u github.com/alecthomas/gometalinter
-	gometalinter --install
 
 .PHONY: always
 always:


### PR DESCRIPTION
- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/master/CONTRIBUTING.md).
- [x] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)

**Here are some helpful tips you can follow when submitting a pull request:**

1. Fork [the repository](https://github.com/CircleCI-Public/circleci-cli) and create your branch from `master`.
2. Run `make build` in the repository root.
3. If you've fixed a bug or added code that should be tested, add tests!
4. Ensure the test suite passes (`make test`).
5. The `--debug` flag is often helpful for debugging HTTP client requests and responses.
6. Format your code with [gofmt](https://golang.org/cmd/gofmt/).
7. Make sure your code lints (`make lint`). Tip: `make dev` will install `gometalinter`.

**If you have any questions, feel free to ping us at @CircleCI-Public/dx-clients.**
