### PR TITLE
[CIRCLE-15447]: Add more details to `circleci help orb process`

### DIFF
--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -80,6 +80,11 @@ func newOrbCommand(config *settings.Config) *cobra.Command {
 	processCommand := &cobra.Command{
 		Use:   "process <path>",
 		Short: "Validate an orb and print its form after all pre-registration processing",
+		Long: strings.Join([]string{
+			"You can use `$ circleci orb process` to resolve an orb, and it's dependencies to see how it would be expanded when you publish it to the registry.",
+			"", // purposeful new-line
+			"This can be helpful for validating an orb and debugging the processed form before publishing",
+		}, "\n"),
 		PreRun: func(cmd *cobra.Command, args []string) {
 			opts.args = args
 			opts.cl = client.NewClient(config.Host, config.Endpoint, config.Token, config.Debug)
@@ -90,6 +95,7 @@ func newOrbCommand(config *settings.Config) *cobra.Command {
 		Args:        cobra.ExactArgs(1),
 		Annotations: make(map[string]string),
 	}
+	processCommand.Example = `  circleci orb process src/my-orb/@orb.yml`
 	processCommand.Annotations["<path>"] = orbAnnotations["<path>"]
 
 	publishCommand := &cobra.Command{


### PR DESCRIPTION
I've also added an example, here's the full `help` output:

```
help orb process
You can use `$ circleci orb process` to resolve an orb, and it's dependencies to see how it would be expanded when you publish it to the registry.

This can be helpful for validating an orb and debugging the processed form before publishing


Usage:
  circleci orb process <path> [flags]

Examples:
  circleci orb process src/my-orb/@orb.yml

Args:
  <path>      The path to your orb (use "-" for STDIN)


Flags:
  -h, --help   help for process

Global Flags:
      --host string    URL to your CircleCI host (default "https://circleci.com")
      --token string   your token for using CircleCI
```

---

- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/master/CONTRIBUTING.md).
- [x] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)

**Here are some helpful tips you can follow when submitting a pull request:**

1. Fork [the repository](https://github.com/CircleCI-Public/circleci-cli) and create your branch from `master`.
2. Run `make build` in the repository root.
3. If you've fixed a bug or added code that should be tested, add tests!
4. Ensure the test suite passes (`make test`).
5. The `--debug` flag is often helpful for debugging HTTP client requests and responses.
6. Format your code with [gofmt](https://golang.org/cmd/gofmt/).
7. Make sure your code lints (`make lint`). Tip: `make dev` will install `gometalinter`.

**If you have any questions, feel free to ping us at @CircleCI-Public/dx-clients.**
