### PR TITLE
WIP DO NO MERGE: Disable update checks in the CLI Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
 FROM circleci/golang:1.10.3
 
 COPY ./dist/linux_amd64/circleci /usr/local/bin
+
+ENTRYPOINT ["circleci", "--skip-update-check"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM circleci/golang:1.10.3
 
-COPY ./dist/linux_amd64/circleci /usr/local/bin
+ENV CIRCLECI_CLI_SKIP_UPDATE_CHECK=1
 
-ENTRYPOINT ["circleci", "--skip-update-check"]
+COPY ./dist/linux_amd64/circleci /usr/local/bin

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -4,4 +4,4 @@ COPY ./dist/linux_amd64/circleci /usr/local/bin
 
 RUN apk add --no-cache --upgrade git openssh ca-certificates
 
-ENTRYPOINT ["circleci"]
+ENTRYPOINT ["circleci", "--skip-update-check"]


### PR DESCRIPTION
This approach does not use the approach as discussed in this PR comment,
as I tried CIRCLECI_CLI_SKIP_UPDATE_CHECK and couldn't get it working
successfully within Docker on my local machine.

https://github.com/CircleCI-Public/circleci-cli/issues/226


- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/master/CONTRIBUTING.md).
- [x] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)

The tests aren't currently passing on my local machine. The tests around
`circleci update` are failing. I haven't changed any Go code, so I want
to see how they behave on CI.