### PR TITLE
[CIRCLE-15483]: Catch all 400s from GitHub release api in `update`

### DIFF
--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -165,6 +165,10 @@ var _ = Describe("Update", func() {
 
 			// TODO: This should exit with error status 1, since 255 is a
 			// special error status for: "exit status outside of range".
+			//
+			// However this may be difficult to change, since all commands that return
+			// an error after executing cause the program to exit with a non-zero code:
+			// https://github.com/CircleCI-Public/circleci-cli/blob/5896baa95dad1b66f9c4a5b0a14571717c92aa55/cmd/root.go#L38
 			stderr := session.Wait().Err.Contents()
 			Expect(string(stderr)).To(ContainSubstring(`Error: Failed to query the GitHub API for updates.
 
@@ -173,13 +177,13 @@ This is most likely due to GitHub rate-limiting on unauthenticated requests.
 To have the circleci-cli make authenticated requests please:
 
   1. Generate a token at https://github.com/settings/tokens
-  2. Set the token by either adding it to your ~/.gitconfig
+  2. Set the token by either adding it to your ~/.gitconfig or
      setting the GITHUB_TOKEN environment variable.
 
 Instructions for generating a token can be found at:
 https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/
 
-We call the github releases API to look for new releases.
+We call the GitHub releases API to look for new releases.
 More information about that API can be found here: https://developer.github.com/v3/repos/releases/`))
 		})
 	})

--- a/update/update.go
+++ b/update/update.go
@@ -148,7 +148,7 @@ func latestRelease(opts *Options) error {
 		ghErr, ok := err.(*github.ErrorResponse)
 
 		if ok {
-			if ghErr.Response.StatusCode >= 400 || ghErr.Response.StatusCode < 500 {
+			if ghErr.Response.StatusCode >= 400 && ghErr.Response.StatusCode < 500 {
 				return errors.Wrap(err, `Failed to query the GitHub API for updates.
 
 This is most likely due to GitHub rate-limiting on unauthenticated requests.
@@ -156,19 +156,19 @@ This is most likely due to GitHub rate-limiting on unauthenticated requests.
 To have the circleci-cli make authenticated requests please:
 
   1. Generate a token at https://github.com/settings/tokens
-  2. Set the token by either adding it to your ~/.gitconfig
+  2. Set the token by either adding it to your ~/.gitconfig or
      setting the GITHUB_TOKEN environment variable.
 
 Instructions for generating a token can be found at:
 https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/
 
-We call the github releases API to look for new releases.
+We call the GitHub releases API to look for new releases.
 More information about that API can be found here: https://developer.github.com/v3/repos/releases/
 `)
 			}
 
 			if ghErr.Response.StatusCode == http.StatusUnauthorized {
-				return errors.Wrap(err, "Your Github token is invalid. Check the [github] section in ~/.gitconfig\n")
+				return errors.Wrap(err, "Your GitHub token is invalid. Check the [github] section in ~/.gitconfig\n")
 			}
 		} else {
 			return errors.Wrap(err, "error finding latest release")


### PR DESCRIPTION
We want to make sure we cover all bases and catch every 4** error
GitHub might return to us and display a verbose message for how to
treat these kinds of errors.

Since the majority of the the time this error occurs when the user
hits the API without setting a GITHUB_TOKEN, and results in a rate
limit for their IP address; these directions should help solve this problem.