### PR TITLE
[CIRCLE-15952]: Replace CI packr install with vendored binary

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,6 +130,7 @@ jobs:
       - checkout
       - install-goreleaser
       - gomod
+      - run: make dev
       - run:
           name: Release
           command: goreleaser --skip-publish --skip-validate
@@ -153,6 +154,7 @@ jobs:
             git tag -a      "v0.1.$CIRCLE_BUILD_NUM" -m "Release v0.1.$CIRCLE_BUILD_NUM"
             git push origin "v0.1.$CIRCLE_BUILD_NUM"
       - gomod
+      - run: make dev
       - run:
           name: Release
           command: goreleaser

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,6 +67,7 @@ commands:
     steps:
       - slack/status:
           fail_only: "true"
+          only_for_branch: "master"
 
 jobs:
   test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,15 +54,15 @@ commands:
             sudo apt install ~/goreleaser_amd64.deb
   install-packr:
     parameters:
-      PACKR_URL:
+      PACKR_VERSION:
         type: string
-        default: https://github.com/gobuffalo/packr/releases/download/v2.0.0-rc.13/packr_2.0.0-rc.13_linux_amd64.tar.gz
+        default: 2.0.1
     steps:
       - run:
           name: Install packr2 to build packrd data before goreleaser builds final binary
           command: |
             cd $(mktemp -d)
-            curl -SL << parameters.PACKR_URL >> | tar -xzv
+            curl -SL https://github.com/gobuffalo/packr/releases/download/v<<parameters.PACKR_VERSION>>/packr_<<parameters.PACKR_VERSION>>_linux_amd64.tar.gz | tar -xzv
             sudo mv packr2 /usr/local/bin/packr2
   gomod:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,18 +52,6 @@ commands:
           command: |
             [ -f ~/goreleaser_amd64.db ] || curl --silent --location --fail --retry 3 << parameters.GORELEASER_URL >> > ~/goreleaser_amd64.deb
             sudo apt install ~/goreleaser_amd64.deb
-  install-packr:
-    parameters:
-      PACKR_VERSION:
-        type: string
-        default: 2.0.1
-    steps:
-      - run:
-          name: Install packr2 to build packrd data before goreleaser builds final binary
-          command: |
-            cd $(mktemp -d)
-            curl -SL https://github.com/gobuffalo/packr/releases/download/v<<parameters.PACKR_VERSION>>/packr_<<parameters.PACKR_VERSION>>_linux_amd64.tar.gz | tar -xzv
-            sudo mv packr2 /usr/local/bin/packr2
   gomod:
     steps:
       - restore_cache:
@@ -142,7 +130,6 @@ jobs:
       - checkout
       - install-goreleaser
       - gomod
-      - install-packr
       - run:
           name: Release
           command: goreleaser --skip-publish --skip-validate
@@ -166,7 +153,6 @@ jobs:
             git tag -a      "v0.1.$CIRCLE_BUILD_NUM" -m "Release v0.1.$CIRCLE_BUILD_NUM"
             git push origin "v0.1.$CIRCLE_BUILD_NUM"
       - gomod
-      - install-packr
       - run:
           name: Release
           command: goreleaser

--- a/.circleci/install-packr.sh
+++ b/.circleci/install-packr.sh
@@ -48,7 +48,7 @@ ARCH="$(get_arch_base)_$(get_arch_type)"
 
 PACKR_RELEASE_URL=$(grep -i "$ARCH" tarball_urls.txt)
 
-echo "Fetching packr for $ARCH at $PACKR_RELEASE_URL"
+echo "Fetching packr from $PACKR_RELEASE_URL"
 
 curl --retry 3 --fail --location "$PACKR_RELEASE_URL" | tar -xz
 

--- a/.circleci/install-packr.sh
+++ b/.circleci/install-packr.sh
@@ -40,11 +40,9 @@ elif [[ "$OSTYPE" == "darwin"* ]]; then
     ARCH_BASE="darwin"
 fi
 
-ARCH="$ARCH_BASE"_"$ARCH_TYPE"
+grep -i "$ARCH_BASE"_"$ARCH_TYPE" tarball_urls.txt | xargs curl --retry 3 --fail --location | tar -xz
 
-grep -i "$ARCH" tarball_urls.txt | xargs curl --retry 3 --fail --location | tar -xz
-
-echo "Installing packr for $ARCH to $DESTDIR"
+echo "Installing packr for $ARCH_BASE-$ARCH_TYPE to $DESTDIR"
 mv packr2 "$DESTDIR"
 chmod +x "$DESTDIR/packr2"
 

--- a/.circleci/install-packr.sh
+++ b/.circleci/install-packr.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+PACKR_DEST=bin/packr2
+PACKR_VERSION=2.0.1
+PACKR_URL=https://github.com/gobuffalo/packr/releases/download/v"$PACKR_VERSION"/packr_"$PACKR_VERSION"_linux_amd64.tar.gz
+
+export PACKR_DEST
+export PACKR_VERSION
+export PACKR_URL
+
+TDIR=$(mktemp -d)
+ORIGIN="$PWD"
+
+cleanup() {
+    test -n "$TDIR" && test -d "$TDIR" && rm -rf "$TDIR"
+}
+
+trap cleanup SIGINT
+trap 'cleanup; exit 127' INT TERM
+
+(
+    cd "$TDIR"
+    curl -SL "$PACKR_URL" | tar -xzv
+)
+
+(
+    cd "$ORIGIN"
+    mv "$TDIR"/packr2 "$PACKR_DEST"
+
+    rm -rf "$TDIR"
+)
+
+exit 0

--- a/.circleci/install-packr.sh
+++ b/.circleci/install-packr.sh
@@ -4,7 +4,8 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-RELEASE_URL="https://api.github.com/repos/gobuffalo/packr/releases/latest"
+PACKR_VERSION="2.0.1"
+RELEASE_URL="https://github.com/gobuffalo/packr/releases/download"
 DESTDIR="${DESTDIR:-$PWD/bin}"
 
 SCRATCH=$(mktemp -d)
@@ -16,17 +17,6 @@ function error() {
 }
 
 trap error SIGINT
-
-echo "Finding latest release of packr."
-curl --retry 3 --fail --location --silent --output release.json "$RELEASE_URL"
-python -m json.tool release.json > formatted_release.json
-
-STRIP_JSON_STRING='s/.*"([^"]+)".*/\1/'
-
-echo -n 'Downloading packr '
-grep tag_name formatted_release.json | sed -E "$STRIP_JSON_STRING"
-
-grep browser_download_url formatted_release.json | sed -E "$STRIP_JSON_STRING" > tarball_urls.txt
 
 function get_arch_type() {
     if [[ $(uname -m) == "i686" ]]; then
@@ -45,8 +35,7 @@ function get_arch_base() {
 }
 
 ARCH="$(get_arch_base)_$(get_arch_type)"
-
-PACKR_RELEASE_URL=$(grep -i "$ARCH" tarball_urls.txt)
+PACKR_RELEASE_URL="${RELEASE_URL}/v${PACKR_VERSION}/packr_${PACKR_VERSION}_${ARCH}.tar.gz"
 
 echo "Fetching packr from $PACKR_RELEASE_URL"
 

--- a/.circleci/install-packr.sh
+++ b/.circleci/install-packr.sh
@@ -56,7 +56,7 @@ echo "Installing packr for $ARCH to $DESTDIR"
 mv packr2 "$DESTDIR"
 chmod +x "$DESTDIR/packr2"
 
-command -v packr2
+command -v "$DESTDIR/packr2"
 
 # Delete the working directory when the install was successful.
 rm -r "$SCRATCH"

--- a/.circleci/install-packr.sh
+++ b/.circleci/install-packr.sh
@@ -29,9 +29,9 @@ grep tag_name formatted_release.json | sed -E "$STRIP_JSON_STRING"
 grep browser_download_url formatted_release.json | sed -E "$STRIP_JSON_STRING" > tarball_urls.txt
 
 function get_arch_type() {
-    if [[ $(uname -i) == "i686" ]]; then
+    if [[ $(uname -m) == "i686" ]]; then
         echo "386"
-    elif [[ $(uname -i) == "x86_64" ]]; then
+    elif [[ $(uname -m) == "x86_64" ]]; then
         echo "amd64"
     fi
 }

--- a/.circleci/install-packr.sh
+++ b/.circleci/install-packr.sh
@@ -46,7 +46,11 @@ function get_arch_base() {
 
 ARCH="$(get_arch_base)_$(get_arch_type)"
 
-grep -i "$ARCH" tarball_urls.txt | xargs curl --retry 3 --fail --location | tar -xz
+PACKR_RELEASE_URL=$(grep -i "$ARCH" tarball_urls.txt)
+
+echo "Fetching packr for $ARCH at $PACKR_RELEASE_URL"
+
+curl --retry 3 --fail --location "$PACKR_RELEASE_URL" | tar -xz
 
 echo "Installing packr for $ARCH to $DESTDIR"
 mv packr2 "$DESTDIR"

--- a/.circleci/install-packr.sh
+++ b/.circleci/install-packr.sh
@@ -28,21 +28,27 @@ grep tag_name formatted_release.json | sed -E "$STRIP_JSON_STRING"
 
 grep browser_download_url formatted_release.json | sed -E "$STRIP_JSON_STRING" > tarball_urls.txt
 
-if [[ $(uname -i) == "i686" ]]; then
-    ARCH_TYPE="386"
-elif [[ $(uname -i) == "x86_64" ]]; then
-    ARCH_TYPE="amd64"
-fi
+function get_arch_type() {
+    if [[ $(uname -i) == "i686" ]]; then
+        echo "386"
+    elif [[ $(uname -i) == "x86_64" ]]; then
+        echo "amd64"
+    fi
+}
 
-if [[ "$OSTYPE" == "linux-gnu" ]]; then
-    ARCH_BASE="linux"
-elif [[ "$OSTYPE" == "darwin"* ]]; then
-    ARCH_BASE="darwin"
-fi
+function get_arch_base() {
+    if [[ "$OSTYPE" == "linux-gnu" ]]; then
+        echo "linux"
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        echo "darwin"
+    fi
+}
 
-grep -i "$ARCH_BASE"_"$ARCH_TYPE" tarball_urls.txt | xargs curl --retry 3 --fail --location | tar -xz
+ARCH="$(get_arch_base)_$(get_arch_type)"
 
-echo "Installing packr for $ARCH_BASE-$ARCH_TYPE to $DESTDIR"
+grep -i "$ARCH" tarball_urls.txt | xargs curl --retry 3 --fail --location | tar -xz
+
+echo "Installing packr for $ARCH to $DESTDIR"
 mv packr2 "$DESTDIR"
 chmod +x "$DESTDIR/packr2"
 

--- a/.circleci/install-packr.sh
+++ b/.circleci/install-packr.sh
@@ -27,11 +27,24 @@ echo -n 'Downloading packr '
 grep tag_name formatted_release.json | sed -E "$STRIP_JSON_STRING"
 
 grep browser_download_url formatted_release.json | sed -E "$STRIP_JSON_STRING" > tarball_urls.txt
-grep -i "$(uname)" tarball_urls.txt | xargs curl --silent --retry 3 --fail --location --output packr.tgz
 
-tar zxf packr.tgz --strip 1
+if [[ $(uname -i) == "i686" ]]; then
+    ARCH_TYPE="386"
+elif [[ $(uname -i) == "x86_64" ]]; then
+    ARCH_TYPE="amd64"
+fi
 
-echo "Installing to $DESTDIR"
+if [[ "$OSTYPE" == "linux-gnu" ]]; then
+    ARCH_BASE="linux"
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+    ARCH_BASE="darwin"
+fi
+
+ARCH="$ARCH_BASE"_"$ARCH_TYPE"
+
+grep -i "$ARCH" tarball_urls.txt | xargs curl --retry 3 --fail --location | tar -xz
+
+echo "Installing packr for $ARCH to $DESTDIR"
 mv packr2 "$DESTDIR"
 chmod +x "$DESTDIR/packr2"
 

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ stage/
 # packr related
 */*-packr.go
 packrd/
+/bin/packr2

--- a/HACKING.md
+++ b/HACKING.md
@@ -36,6 +36,14 @@ If you cloned the repo inside of your `$GOPATH`, you can use `GO111MODULE=on` in
 $ make
 ```
 
+The `make` file assumes you have the `packr2` binary available which is installable via `make dev`. This will pull the latest stable binary into the project's `./bin/packr2` path.
+
+If you don't run `make dev`, you will see a make error:
+
+```
+/bin/sh: 1: bin/packr2: not found
+```
+
 ### 3. Run tests
 
 ```

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ GOOS=$(shell go env GOOS)
 GOARCH=$(shell go env GOARCH)
 
 build: always
-	GO111MODULE=on packr2
+	GO111MODULE=on bin/packr2
 	go build -o build/$(GOOS)/$(GOARCH)/circleci
 
 build-all: build/linux/amd64/circleci build/darwin/amd64/circleci
@@ -16,7 +16,7 @@ build/%/amd64/circleci: always
 clean:
 	GO111MODULE=off go clean -i
 	rm -rf build out docs dist
-	packr2 clean
+	bin/packr2 clean
 
 .PHONY: test
 test:
@@ -43,11 +43,11 @@ doc:
 
 .PHONY: dev
 dev:
-	go get golang.org/x/tools/cmd/godoc
+	bash .circleci/install-packr.sh
 
 .PHONY: pack
 pack:
-	GO111MODULE=on packr2 build
+	GO111MODULE=on bin/packr2 build
 
 .PHONY: always
 always:


### PR DESCRIPTION
We have to do this in the case of homebrew, installing go dependencies during their build isn't acceptable.

See also: Homebrew/homebrew-core#36546