### PR TITLE
Fix install script failure for macOS < 10.11

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,7 @@ RELEASE_URL="https://api.github.com/repos/CircleCI-Public/circleci-cli/releases/
 DESTDIR="${DESTDIR:-/usr/local/bin}"
 
 # Run the script in a temporary directory that we know is empty.
-SCRATCH=$(mktemp -d)
+SCRATCH=$(mktemp -d -t tmp)
 cd "$SCRATCH"
 
 function error {

--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,7 @@ RELEASE_URL="https://api.github.com/repos/CircleCI-Public/circleci-cli/releases/
 DESTDIR="${DESTDIR:-/usr/local/bin}"
 
 # Run the script in a temporary directory that we know is empty.
-SCRATCH=$(mktemp -d -t tmp)
+SCRATCH=$(mktemp -d || mktemp -d -t 'tmp')
 cd "$SCRATCH"
 
 function error {


### PR DESCRIPTION
MacOS versions prior to 10.11 included a version of mktemp that did not set
a default template. This should be compatible with both BSD and GNU
versions of mktemp.

Credit to @patcon for the solution

Addresses: https://github.com/CircleCI-Public/circleci-cli/issues/274