### PR TITLE
Add note about Snapcraft login.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,6 +195,7 @@ jobs:
       - run:
           name: Publish to store
           command: |
+            # The Snapcraft login file here will expire March 1st, 2022. A new one will need to be created then.
             mkdir .snapcraft
             echo $SNAPCRAFT_LOGIN_FILE | base64 --decode --ignore-garbage > .snapcraft/snapcraft.cfg
             snapcraft push *.snap --release stable


### PR DESCRIPTION
The issue with the snap job failing on `master` should be fixed. The auth file expired. I updated it in CircleCI but a fresh master build needs to be kicked off to test if it works.

Here, I added a note in the config that the new auth I generated will expire in 3 years. Merging this will give us a nice note for the future, as well as kick off the new `master` build that should then deploy the updated snap file.

Snapcraft's Docs weren't clean about the 1 year default expiration timeline so I'll attempt to get their docs updated as well.