### PR TITLE
Snap login lasts 1yr not 3.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,7 +195,7 @@ jobs:
       - run:
           name: Publish to store
           command: |
-            # The Snapcraft login file here will expire March 1st, 2022. A new one will need to be created then.
+            # The Snapcraft login file here will expire March 1st, 2020. A new one will need to be created then.
             mkdir .snapcraft
             echo $SNAPCRAFT_LOGIN_FILE | base64 --decode --ignore-garbage > .snapcraft/snapcraft.cfg
             snapcraft push *.snap --release stable


### PR DESCRIPTION
The Snapcraft Team got back to me. Even though I specified a 3 year refresh period, for the publish permission, we're still capped at 1yr. Updating the config comment/note.