### PR TITLE
[CIRCLE-17397] Bugfix setup diagnostic check

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -141,7 +141,7 @@ type GetOrganizationResponse struct {
 type WhoamiResponse struct {
 	Me struct {
 		Login string
-		Name string
+		Name  string
 	}
 }
 

--- a/api/api.go
+++ b/api/api.go
@@ -140,6 +140,7 @@ type GetOrganizationResponse struct {
 // WhoamiResponse type matches the data shape of the GQL response for the current user
 type WhoamiResponse struct {
 	Me struct {
+		Login string
 		Name string
 	}
 }

--- a/api/api.go
+++ b/api/api.go
@@ -140,8 +140,7 @@ type GetOrganizationResponse struct {
 // WhoamiResponse type matches the data shape of the GQL response for the current user
 type WhoamiResponse struct {
 	Me struct {
-		Login string
-		Name  string
+		Name string
 	}
 }
 

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -211,7 +211,7 @@ func setupDiagnosticCheck(opts setupOptions) {
 
 	if err != nil {
 		fmt.Println("\nUnable to make a query against the GraphQL API, please check your settings.")
-	// If user does not have a name set in their VCS, return their login (VCS handle) instead
+		// If user does not have a name set in their VCS, return their login (VCS handle) instead
 	} else if responseWho.Me.Name == "" {
 		fmt.Printf("Hello, %s.\n", responseWho.Me.Login)
 	} else {

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -206,11 +206,11 @@ func setupDiagnosticCheck(opts setupOptions) {
 		fmt.Println("Ok.")
 	}
 
-	fmt.Printf("Trying to query your username given the provided token... ")
+	fmt.Printf("Trying to query our API for your profile name... ")
 	responseWho, err := api.WhoamiQuery(opts.cl)
 
 	if err != nil {
-		fmt.Println("\nUnable to make a query against the GraphQL API, please check your settings.")
+		fmt.Println("\nUnable to query our API for your profile name, please check your settings.")
 		// If user does not have a name set in their VCS, let's just say hi :)
 	} else if responseWho.Me.Name == "" {
 		fmt.Printf("Hello!")

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -211,9 +211,9 @@ func setupDiagnosticCheck(opts setupOptions) {
 
 	if err != nil {
 		fmt.Println("\nUnable to make a query against the GraphQL API, please check your settings.")
-		// If user does not have a name set in their VCS, return their login (VCS handle) instead
+		// If user does not have a name set in their VCS, let's just say hi :)
 	} else if responseWho.Me.Name == "" {
-		fmt.Printf("Hello, %s.\n", responseWho.Me.Login)
+		fmt.Printf("Hello!")
 	} else {
 		fmt.Printf("Hello, %s.\n", responseWho.Me.Name)
 	}

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -209,8 +209,11 @@ func setupDiagnosticCheck(opts setupOptions) {
 	fmt.Printf("Trying to query your username given the provided token... ")
 	responseWho, err := api.WhoamiQuery(opts.cl)
 
-	if err != nil || responseWho.Me.Name == "" {
-		fmt.Println("\nUnable to query the GraphQL API for your username, please check your settings.")
+	if err != nil {
+		fmt.Println("\nUnable to make a query against the GraphQL API, please check your settings.")
+	// If user does not have a name set in their VCS, return their login (VCS handle) instead
+	} else if responseWho.Me.Name == "" {
+		fmt.Printf("Hello, %s.\n", responseWho.Me.Login)
 	} else {
 		fmt.Printf("Hello, %s.\n", responseWho.Me.Name)
 	}

--- a/cmd/setup_unit_test.go
+++ b/cmd/setup_unit_test.go
@@ -240,7 +240,7 @@ Do you want to reset the endpoint? (default: graphql-unstable)
 Setup complete.
 Your configuration has been saved to %s.
 
-Trying an introspection query on API to verify your setup... 
+Trying an introspection query on API to verify your setup...
 Unable to make a query against the GraphQL API, please check your settings.
 Trying to query your username given the provided token... Hello, %s.
 `, tempSettings.Config.Path, `zomg`)))
@@ -316,8 +316,8 @@ Setup complete.
 Your configuration has been saved to %s.
 
 Trying an introspection query on API to verify your setup... Ok.
-Trying to query your username given the provided token... 
-Unable to query the GraphQL API for your username, please check your settings.
+Trying to query your username given the provided token...
+Unable to make a query against the GraphQL API, please check your settings.
 `, tempSettings.Config.Path)))
 		})
 	})

--- a/cmd/setup_unit_test.go
+++ b/cmd/setup_unit_test.go
@@ -316,7 +316,7 @@ Setup complete.
 Your configuration has been saved to %s.
 
 Trying an introspection query on API to verify your setup... Ok.
-Trying to query your username given the provided token...
+Trying to query your username given the provided token... 
 Unable to make a query against the GraphQL API, please check your settings.
 `, tempSettings.Config.Path)))
 		})

--- a/cmd/setup_unit_test.go
+++ b/cmd/setup_unit_test.go
@@ -240,7 +240,7 @@ Do you want to reset the endpoint? (default: graphql-unstable)
 Setup complete.
 Your configuration has been saved to %s.
 
-Trying an introspection query on API to verify your setup...
+Trying an introspection query on API to verify your setup... 
 Unable to make a query against the GraphQL API, please check your settings.
 Trying to query your username given the provided token... Hello, %s.
 `, tempSettings.Config.Path, `zomg`)))

--- a/cmd/setup_unit_test.go
+++ b/cmd/setup_unit_test.go
@@ -132,7 +132,7 @@ Setup complete.
 Your configuration has been saved to %s.
 
 Trying an introspection query on API to verify your setup... Ok.
-Trying to query your username given the provided token... Hello, %s.
+Trying to query our API for your profile name... Hello, %s.
 `, tempSettings.Config.Path, `zomg`)))
 
 				tempSettings.AssertConfigRereadMatches(fmt.Sprintf(`host: %s
@@ -162,7 +162,7 @@ Setup complete.
 Your configuration has been saved to %s.
 
 Trying an introspection query on API to verify your setup... Ok.
-Trying to query your username given the provided token... Hello, %s.
+Trying to query our API for your profile name... Hello, %s.
 `, tempSettings.Config.Path, `zomg`)))
 
 				tempSettings.AssertConfigRereadMatches(fmt.Sprintf(`host: %s
@@ -242,7 +242,7 @@ Your configuration has been saved to %s.
 
 Trying an introspection query on API to verify your setup... 
 Unable to make a query against the GraphQL API, please check your settings.
-Trying to query your username given the provided token... Hello, %s.
+Trying to query our API for your profile name... Hello, %s.
 `, tempSettings.Config.Path, `zomg`)))
 		})
 	})
@@ -316,7 +316,7 @@ Setup complete.
 Your configuration has been saved to %s.
 
 Trying an introspection query on API to verify your setup... Ok.
-Trying to query your username given the provided token... 
+Trying to query our API for your profile name... 
 Unable to make a query against the GraphQL API, please check your settings.
 `, tempSettings.Config.Path)))
 		})

--- a/cmd/setup_unit_test.go
+++ b/cmd/setup_unit_test.go
@@ -317,7 +317,7 @@ Your configuration has been saved to %s.
 
 Trying an introspection query on API to verify your setup... Ok.
 Trying to query our API for your profile name... 
-Unable to make a query against the GraphQL API, please check your settings.
+Unable to query our API for your profile name, please check your settings.
 `, tempSettings.Config.Path)))
 		})
 	})


### PR DESCRIPTION
- [X] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/master/CONTRIBUTING.md).
- [X] I have checked for similar issues and haven't found anything relevant.
- [X] This is not a security issue (which should be reported here: https://circleci.com/security/)

**Here are some helpful tips you can follow when submitting a pull request:**

1. Fork [the repository](https://github.com/CircleCI-Public/circleci-cli) and create your branch from `master`.
2. Run `make build` in the repository root.
3. If you've fixed a bug or added code that should be tested, add tests!
4. Ensure the test suite passes (`make test`).
5. The `--debug` flag is often helpful for debugging HTTP client requests and responses.
6. Format your code with [gofmt](https://golang.org/cmd/gofmt/).
7. Make sure your code lints (`make lint`). Note: This requires Docker to run inside a local job.

**If you have any questions, feel free to ping us at @CircleCI-Public/dx-clients.**

## problem

[we've hardcoded a requirement that users have a "name" set in their VCS](https://github.com/CircleCI-Public/circleci-cli/blob/82d3083a4bdc5b845246453b2bf37dd2496dc60d/cmd/setup.go#L212), into the `setupDiagnosticCheck` function, which runs automatically at the end of `circleci setup` for all users

for anyone without a name in their VCS, this will result in a misleading error message suggesting that something is wrong with their token or CLI configuration or CircleCI account setup, when in reality everything's fine

## solution

- change error messaging from 'unable to query graphql api for your username' (not accurate, since it's actually looking for a user's _name_, as opposed to username) to a more general graphql api error message
- include specific response for condition in which token is valid but name is blank (just say 'hello' instead of, e.g., 'hello `<name>`')