### PR TITLE
Remove broken config step for deploy job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,7 +154,6 @@ jobs:
             git tag -a      "v0.1.$CIRCLE_BUILD_NUM" -m "Release v0.1.$CIRCLE_BUILD_NUM"
             git push origin "v0.1.$CIRCLE_BUILD_NUM"
       - gomod
-      - run: make dev
       - run:
           name: Release
           command: goreleaser


### PR DESCRIPTION
- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/master/CONTRIBUTING.md).
- [x] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)

Rationale:
Missed a `make dev` line in the merge to master: https://circleci.com/gh/CircleCI-Public/circleci-cli/5596