### PR TITLE
Replace gometalinter with golangci-lint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,21 +108,11 @@ jobs:
       - slack-notify-on-failure
 
   lint:
-    docker:
-      - image: supinf/gometalinter:latest
-    environment:
-      CGO_ENABLED: 0
-      SHELL: /bin/bash
-    working_directory: /go/src/github.com/CircleCI-Public/circleci-cli
+    executor: go
     steps:
       - checkout
-      - run:
-          name: Install deps to use with gometalinter
-          command: |
-            apk --no-cache add git bash curl
-            go get -u github.com/golang/dep/cmd/dep
-            dep init
-      - run: gometalinter ./...
+      - run: make install-lint
+      - run: make lint
       - slack-notify-on-failure
 
   deploy-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,6 +112,7 @@ jobs:
     steps:
       - checkout
       - run: make install-lint
+      - run: make build
       - run: make lint
       - slack-notify-on-failure
 

--- a/.circleci/install-lint.sh
+++ b/.circleci/install-lint.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+function error() {
+    echo "An error occured installing golangci-lint."
+}
+
+trap error SIGINT
+
+curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.16.0
+
+command -v ./bin/golangci-lint

--- a/.circleci/lint.sh
+++ b/.circleci/lint.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+function error() {
+    echo "An error occured running golangci-lint."
+    echo "Have you run `make install-lint`?"
+}
+
+trap error SIGINT
+
+./bin/golangci-lint run

--- a/.circleci/lint.sh
+++ b/.circleci/lint.sh
@@ -6,7 +6,7 @@ set -o nounset
 
 function error() {
     echo "An error occured running golangci-lint."
-    echo "Have you run `make install-lint`?"
+    echo "Have you run \"make install-lint\"?"
 }
 
 trap error SIGINT

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ stage/
 # packr related
 */*-packr.go
 packrd/
+
+# golangci-lint
+# We expect to install the binary each time in CI
+bin/golangci-lint

--- a/Makefile
+++ b/Makefile
@@ -28,14 +28,7 @@ cover:
 
 .PHONY: lint
 lint:
-	@echo Executing local build of lint job until gometalinter supports Go 1.11 modules...
-	@echo This requires Docker to run, so it may fail if docker cannot be found.
-	@echo 
-	@echo Generating tmp/processed.yml from .circleci/config.yml 2.1 version
-	go run main.go config process .circleci/config.yml > .circleci/processed.yml
-	@echo 
-	@echo Running local build..
-	go run main.go local execute -c .circleci/processed.yml --job lint
+	bash .circleci/lint.sh
 
 .PHONY: doc
 doc:
@@ -48,6 +41,11 @@ install-packr:
 .PHONY: pack
 pack:
 	bash .circleci/pack.sh
+
+.PHONY: install-lint
+install-lint:
+	bash .circleci/install-lint.sh
+
 
 .PHONY: always
 always:

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -62,11 +62,14 @@ func TestDoJSON(t *testing.T) {
 			t.Errorf("expected %s", string(b))
 		}
 
-		io.WriteString(w, `{
+		_, err = io.WriteString(w, `{
 			"data": {
 				"something": "yes"
 			}
 		}`)
+		if err != nil {
+			t.Errorf(err.Error())
+		}
 	}))
 	defer srv.Close()
 
@@ -152,7 +155,7 @@ func TestDoJSONErr(t *testing.T) {
 			t.Errorf("expected %s", body)
 		}
 
-		io.WriteString(writer,
+		_, err = io.WriteString(writer,
 			`{
 				"errors": [
 					{
@@ -163,6 +166,9 @@ func TestDoJSONErr(t *testing.T) {
 					}
 				]
 			}`)
+		if err != nil {
+			t.Errorf(err.Error())
+		}
 	}))
 
 	defer server.Close()

--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -80,7 +80,8 @@ var _ = Describe("build", func() {
 				args: []string{"--help"},
 				help: mockHelp,
 			}
-			runExecute(mockOptions)
+			err := runExecute(mockOptions)
+			Expect(err).ToNot(HaveOccurred())
 			Expect(called).To(BeTrue())
 		})
 
@@ -94,7 +95,8 @@ var _ = Describe("build", func() {
 				args: []string{"--skip-checkout", "--help"},
 				help: mockHelp,
 			}
-			runExecute(mockOptions)
+			err := runExecute(mockOptions)
+			Expect(err).ToNot(HaveOccurred())
 			Expect(called).To(BeTrue())
 		})
 
@@ -108,7 +110,8 @@ var _ = Describe("build", func() {
 				args: []string{"-h"},
 				help: mockHelp,
 			}
-			runExecute(mockOptions)
+			err := runExecute(mockOptions)
+			Expect(err).ToNot(HaveOccurred())
 			Expect(called).To(BeTrue())
 		})
 
@@ -122,7 +125,8 @@ var _ = Describe("build", func() {
 				args: []string{"--skip-checkout", "-h"},
 				help: mockHelp,
 			}
-			runExecute(mockOptions)
+			err := runExecute(mockOptions)
+			Expect(err).ToNot(HaveOccurred())
 			Expect(called).To(BeTrue())
 		})
 	})

--- a/cmd/orb_test.go
+++ b/cmd/orb_test.go
@@ -94,7 +94,10 @@ See a full explanation and documentation on orbs here: https://circleci.com/docs
 				Expect(err).ToNot(HaveOccurred())
 				go func() {
 					defer stdin.Close()
-					io.WriteString(stdin, "{}")
+					_, err := io.WriteString(stdin, "{}")
+					if err != nil {
+						panic(err)
+					}
 				}()
 			})
 

--- a/md_docs/util.go
+++ b/md_docs/util.go
@@ -1,8 +1,6 @@
 package md_docs
 
 import (
-	"strings"
-
 	"github.com/spf13/cobra"
 )
 
@@ -20,15 +18,6 @@ func hasSeeAlso(cmd *cobra.Command) bool {
 		return true
 	}
 	return false
-}
-
-// Temporary workaround for yaml lib generating incorrect yaml with long strings
-// that do not contain \n.
-func forceMultiLine(s string) string {
-	if len(s) > 60 && !strings.Contains(s, "\n") {
-		s = s + "\n"
-	}
-	return s
 }
 
 type byName []*cobra.Command


### PR DESCRIPTION
Following alecthomas/gometalinter#590 we should replace the deprecated `gometalinter` with `golangci-lint`

---

- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/master/CONTRIBUTING.md).
- [x] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)

**Here are some helpful tips you can follow when submitting a pull request:**

1. Fork [the repository](https://github.com/CircleCI-Public/circleci-cli) and create your branch from `master`.
2. Run `make build` in the repository root.
3. If you've fixed a bug or added code that should be tested, add tests!
4. Ensure the test suite passes (`make test`).
5. The `--debug` flag is often helpful for debugging HTTP client requests and responses.
6. Format your code with [gofmt](https://golang.org/cmd/gofmt/).
7. Make sure your code lints (`make lint`). Note: This requires Docker to run inside a local job.

**If you have any questions, feel free to ping us at @CircleCI-Public/x-team.**
