### PR TITLE
Use Print instead of Printf for printing config

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -149,7 +149,7 @@ func processConfig(opts configOptions) error {
 		return err
 	}
 
-	fmt.Printf(response.OutputYaml)
+	fmt.Print(response.OutputYaml)
 	return nil
 }
 


### PR DESCRIPTION
If the config contains things like `%m` then using `fmt.Printf` will render this as `%!m(MISSING)`.