### PR TITLE
[CIRCLE-18591] fix `orb info` releases/versions output

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -899,7 +899,7 @@ func OrbInfo(cl *client.Client, orbRef string) (*OrbVersion, error) {
 		                        last30DaysProjectCount,
 		                        last30DaysOrganizationCount
 	                            }
-                                    versions {
+                                    versions(count: 200) {
                                         createdAt
                                         version
                                     }

--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -657,7 +657,7 @@ func orbInfo(opts orbOptions) error {
 		fmt.Printf("Latest: %s@%s\n", info.Orb.Name, info.Orb.HighestVersion)
 		fmt.Printf("Last-updated: %s\n", info.Orb.Versions[0].CreatedAt)
 		fmt.Printf("Created: %s\n", info.Orb.CreatedAt)
-		firstRelease := info.Orb.Versions[len(info.Orb.Versions)-1]
+		// firstRelease := info.Orb.Versions[len(info.Orb.Versions)-1]
 
 		fmt.Printf("Total-revisions: %d\n", len(info.Orb.Versions))
 	} else {

--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -658,7 +658,6 @@ func orbInfo(opts orbOptions) error {
 		fmt.Printf("Last-updated: %s\n", info.Orb.Versions[0].CreatedAt)
 		fmt.Printf("Created: %s\n", info.Orb.CreatedAt)
 		firstRelease := info.Orb.Versions[len(info.Orb.Versions)-1]
-		fmt.Printf("First-release: %s @ %s\n", firstRelease.Version, firstRelease.CreatedAt)
 
 		fmt.Printf("Total-revisions: %d\n", len(info.Orb.Versions))
 	} else {

--- a/cmd/orb_test.go
+++ b/cmd/orb_test.go
@@ -1736,7 +1736,7 @@ query namespaceOrbs ($namespace: String, $after: String!) {
 			edges {
 				cursor
 				node {
-					versions(count: 200) {
+					versions {
 						source
 						version
 					}
@@ -1850,7 +1850,7 @@ query namespaceOrbs ($namespace: String, $after: String!) {
 			edges {
 				cursor
 				node {
-					versions(count: 200) {
+					versions {
 						source
 						version
 					}

--- a/cmd/orb_test.go
+++ b/cmd/orb_test.go
@@ -1736,7 +1736,7 @@ query namespaceOrbs ($namespace: String, $after: String!) {
 			edges {
 				cursor
 				node {
-					versions {
+					versions(count: 200) {
 						source
 						version
 					}
@@ -1850,7 +1850,7 @@ query namespaceOrbs ($namespace: String, $after: String!) {
 			edges {
 				cursor
 				node {
-					versions {
+					versions(count: 200) {
 						source
 						version
 					}
@@ -2055,7 +2055,7 @@ foo.bar/account/api`))
 		                        last30DaysProjectCount,
 		                        last30DaysOrganizationCount
 	                            }
-                                    versions {
+                                    versions(count: 200) {
                                         createdAt
                                         version
                                     }

--- a/cmd/orb_test.go
+++ b/cmd/orb_test.go
@@ -2108,7 +2108,6 @@ foo.bar/account/api`))
 Latest: my/orb@0.0.1
 Last-updated: 2018-10-11T22:12:19.477Z
 Created: 2018-09-24T08:53:37.086Z
-First-release: 0.0.1 @ 2018-10-11T22:12:19.477Z
 Total-revisions: 1
 
 Total-commands: 1
@@ -2169,7 +2168,6 @@ https://circleci.com/orbs/registry/orb/my/orb
 Latest: my/orb@0.0.1
 Last-updated: 2018-10-11T22:12:19.477Z
 Created: 2018-09-24T08:53:37.086Z
-First-release: 0.0.1 @ 2018-10-11T22:12:19.477Z
 Total-revisions: 1
 
 Total-commands: 1


### PR DESCRIPTION
- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/master/CONTRIBUTING.md).
- [x] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)

### problem

we don't currently specify a `count` value when we pull versions from GraphQL API, so we get the default response (most recent 10 releases). thus, we're outputting incorrect information, both for `Total-revisions` and `First-release`:

https://github.com/CircleCI-Public/circleci-cli/blob/master/cmd/orb.go#L646-L688

e.g., `circleci orb info circleci/orb-tools` outputs:

```
Latest: circleci/orb-tools@8.20.1
Last-updated: 2019-06-12T18:56:12.409Z
Created: 2018-09-24T07:55:19.386Z
First-release: 8.13.0 @ 2019-05-24T19:14:38.845Z
Total-revisions: 10
```

but `First-release` is wrong & `Total-revisions` is wrong

### changes

- bump `count` to 200 (arbitrarily large `n`) so we don't truncate our list of releases
- remove `First-release` entirely, since we already output `Created:`—this is inline with the UI/UX in the orb registry, & arguably first release date is not in itself particularly useful or meaningful