### PR TITLE
Remove firstRelease var from orbInfo cmd

### DIFF
--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -657,7 +657,6 @@ func orbInfo(opts orbOptions) error {
 		fmt.Printf("Latest: %s@%s\n", info.Orb.Name, info.Orb.HighestVersion)
 		fmt.Printf("Last-updated: %s\n", info.Orb.Versions[0].CreatedAt)
 		fmt.Printf("Created: %s\n", info.Orb.CreatedAt)
-		// firstRelease := info.Orb.Versions[len(info.Orb.Versions)-1]
 
 		fmt.Printf("Total-revisions: %d\n", len(info.Orb.Versions))
 	} else {


### PR DESCRIPTION
- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/master/CONTRIBUTING.md).
- [x] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)

https://github.com/CircleCI-Public/circleci-cli/pull/309 commented out, but did not fully remove, the `firstRelease` variable from the `orbInfo` command. this PR simply deletes it entirely.