### PR TITLE
Fix typo in goreleaser installation step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ commands:
       - run:
           name: Install GoReleaser
           command: |
-            [ -f ~/goreleaser_amd64.db ] || curl --silent --location --fail --retry 3 << parameters.GORELEASER_URL >> > ~/goreleaser_amd64.deb
+            [ -f ~/goreleaser_amd64.deb ] || curl --silent --location --fail --retry 3 << parameters.GORELEASER_URL >> > ~/goreleaser_amd64.deb
             sudo apt install ~/goreleaser_amd64.deb
   gomod:
     steps:


### PR DESCRIPTION
- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/master/CONTRIBUTING.md).
- [x] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)

This patch avoids re-downloading `goreleaser_amd64.deb` file by fixing a typo on it's name at the file existence check.