### PR TITLE
[CIRCLE-20193] Add command for enabling unlisting and listing of an orb in the registry

### DIFF
--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -178,7 +178,7 @@ Example: 'circleci orb publish increment foo/orb.yml foo/bar minor' => foo/bar@1
 
 	unlistCmd := &cobra.Command{
 		Use:   "unlist <namespace>/<orb> <true|false>",
-		Short: "Enables or disables the specified orb for listing in the registry.",
+		Short: "Enables or disables the specified orb for listing in the registry",
 		Long: `Enables or disables the specified orb for listing in the registry.
 
 Example: Run 'circleci orb unlist foo/bar true' to disable the listing of the

--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -178,8 +178,8 @@ Example: 'circleci orb publish increment foo/orb.yml foo/bar minor' => foo/bar@1
 
 	unlistCmd := &cobra.Command{
 		Use:   "unlist <namespace>/<orb> <true|false>",
-		Short: "Enables or disables an orb for listing in the registry",
-		Long: `Enables or disables an orb for listing in the registry.
+		Short: "Disable or enable an orb's listing in the registry",
+		Long: `Disable or enable an orb's listing in the registry.
 
 Example: Run 'circleci orb unlist foo/bar true' to disable the listing of the
 orb in the registry and 'circleci orb unlist foo/bar false' to re-enable the

--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -180,6 +180,8 @@ Example: 'circleci orb publish increment foo/orb.yml foo/bar minor' => foo/bar@1
 		Use:   "unlist <namespace>/<orb> <true|false>",
 		Short: "Disable or enable an orb's listing in the registry",
 		Long: `Disable or enable an orb's listing in the registry.
+This only affects whether the orb is displayed in registry search results;
+the orb remains world-readable as long as referenced with a valid name.
 
 Example: Run 'circleci orb unlist foo/bar true' to disable the listing of the
 orb in the registry and 'circleci orb unlist foo/bar false' to re-enable the
@@ -578,7 +580,8 @@ func setOrbListStatus(opts orbOptions) error {
 		if !*listed {
 			displayedStatus = "disabled"
 		}
-		fmt.Printf("The listing of orb `%s` is now %s.\n", ref, displayedStatus)
+		fmt.Printf("The listing of orb `%s` is now %s.\n"+
+			"Note: changes may not be immediately reflected in the registry.\n", ref, displayedStatus)
 	} else {
 		return fmt.Errorf("unexpected error in setting the list status of orb `%s`", ref)
 	}

--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -178,14 +178,17 @@ Example: 'circleci orb publish increment foo/orb.yml foo/bar minor' => foo/bar@1
 
 	unlistCmd := &cobra.Command{
 		Use:   "unlist <namespace>/<orb> <true|false>",
-		Short: "Enables or disables the specified orb for listing in the registry",
-		Long: `Enables or disables the specified orb for listing in the registry.
+		Short: "Enables or disables an orb for listing in the registry",
+		Long: `Enables or disables an orb for listing in the registry.
 
 Example: Run 'circleci orb unlist foo/bar true' to disable the listing of the
 orb in the registry and 'circleci orb unlist foo/bar false' to re-enable the
 listing of the orb in the registry.`,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return setOrbListStatus(opts)
+		},
+		PreRunE: func(_ *cobra.Command, _ []string) error {
+			return validateToken(opts.cfg)
 		},
 		Args: cobra.ExactArgs(2),
 	}

--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -570,7 +570,7 @@ func setOrbListStatus(opts orbOptions) error {
 
 	if listed != nil {
 		displayedStatus := "enabled"
-		if *listed == false {
+		if !*listed {
 			displayedStatus = "disabled"
 		}
 		fmt.Printf("The listing of orb `%s` is now %s.\n", opts.args[0], displayedStatus)

--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -553,17 +553,19 @@ func publishOrb(opts orbOptions) error {
 }
 
 func setOrbListStatus(opts orbOptions) error {
+	ref := opts.args[0]
+	unlistArg := opts.args[1]
 	var err error
 
-	namespace, orb, err := references.SplitIntoOrbAndNamespace(opts.args[0])
+	namespace, orb, err := references.SplitIntoOrbAndNamespace(ref)
 
 	if err != nil {
 		return err
 	}
 
-	unlist, err := strconv.ParseBool(opts.args[1])
+	unlist, err := strconv.ParseBool(unlistArg)
 	if err != nil {
-		return errors.New("Specify \"true\" or \"false\" to set whether the orb should be unlisted or not")
+		return fmt.Errorf("expected \"true\" or \"false\", got \"%s\"", unlistArg)
 	}
 
 	listed, err := api.OrbSetOrbListStatus(opts.cl, namespace, orb, !unlist)
@@ -576,9 +578,9 @@ func setOrbListStatus(opts orbOptions) error {
 		if !*listed {
 			displayedStatus = "disabled"
 		}
-		fmt.Printf("The listing of orb `%s` is now %s.\n", opts.args[0], displayedStatus)
+		fmt.Printf("The listing of orb `%s` is now %s.\n", ref, displayedStatus)
 	} else {
-		return fmt.Errorf("unexpected error in setting the list status of orb `%s`", opts.args[0])
+		return fmt.Errorf("unexpected error in setting the list status of orb `%s`", ref)
 	}
 
 	return nil

--- a/cmd/orb_test.go
+++ b/cmd/orb_test.go
@@ -1499,7 +1499,7 @@ You can now register versions of %s using %s.`,
 						Eventually(session).ShouldNot(gexec.Exit(0))
 					},
 					Entry("invalid orb name", "Error: Invalid orb foo-orb. Expected a namespace and orb in the form 'namespace/orb'", "foo-orb", "true"),
-					Entry("non-boolean value", "Error: Specify \"true\" or \"false\" to set whether the orb should be unlisted or not", "bar-ns/foo-orb", "falsey"),
+					Entry("non-boolean value", "Error: expected \"true\" or \"false\", got \"falsey\"", "bar-ns/foo-orb", "falsey"),
 				)
 			})
 		})


### PR DESCRIPTION
# Purpose
This adds a `circleci orb unlist` command. See: [CIRCLE-20193] or subtask [CIRCLE-20537].

# Screenshots

## Short command description
![cmd-description-short](https://user-images.githubusercontent.com/2923526/64521342-69492800-d32a-11e9-87dd-b1bd47f00c98.png)


## Long command description
![cmd-description-long](https://user-images.githubusercontent.com/2923526/64692367-8404d380-d4c7-11e9-8fdf-97ae232da8a4.png)



## Unlisting an orb with an unauthorized user's token fails as expected
![unlist-fails-with-unauthorized-user](https://user-images.githubusercontent.com/2923526/64518494-de196380-d324-11e9-9f06-73f9da9a11d7.png)

## Unlisting an orb with an authorized user's token succeeds
![unlist-succeeds-with-authorized-user](https://user-images.githubusercontent.com/2923526/64518432-bcb87780-d324-11e9-9c8e-ae5ff3a7bcdd.png)

## Listing an orb with an unauthorized user's token fails as expected
![listing-fails-with-unauthorized-user](https://user-images.githubusercontent.com/2923526/64518556-fa1d0500-d324-11e9-88e3-41a96528f0fc.png)

## Listing an orb with an authorized user's token succeeds
![listing-succeeds-with-authorized-user](https://user-images.githubusercontent.com/2923526/64518645-20db3b80-d325-11e9-9530-5bfc9ad6a9c6.png)

## Validation of number of args and argument values
![cmd-validation](https://user-images.githubusercontent.com/2923526/64526519-1ecda880-d336-11e9-9a60-cc4fccdc211f.png)



## Validation of token setup
![cmd-validation-token](https://user-images.githubusercontent.com/2923526/64521396-8251d900-d32a-11e9-8f63-5691408127e5.png)






[CIRCLE-20193]: https://circleci.atlassian.net/browse/CIRCLE-20193
[CIRCLE-20537]: https://circleci.atlassian.net/browse/CIRCLE-20537