### PR TITLE
Clarify sudo location on install

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,13 @@ If you're installing the new `circleci` CLI for the first time, run the followin
 curl -fLSs https://circle.ci/cli | bash
 ```
 
-By default, the `circleci` app will be installed to the ``/usr/local/bin`` directory. If you do not have write permissions to `/usr/local/bin`, you may need to run the above command with `sudo`. Alternatively, you can install to an alternate location by defining the `DESTDIR` environment variable when invoking `bash`:
+By default, the `circleci` app will be installed to the ``/usr/local/bin`` directory. If you do not have write permissions to `/usr/local/bin`, you may need to run the above command with `sudo`:
+
+```
+curl -fLSs https://circle.ci/cli | sudo bash
+```
+
+Alternatively, you can install to an alternate location by defining the `DESTDIR` environment variable when invoking `bash`:
 
 ```
 curl -fLSs https://circle.ci/cli | DESTDIR=/opt/bin bash


### PR DESCRIPTION
Closes #293 

Some may assume that `sudo` should go in front of the command, as is usually the case. This clarifies for the uninitiated.

- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/master/CONTRIBUTING.md).
- [x] I have checked for similar issues and I **have** found something related, #293 
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)


