### PR TITLE
Make the install script a little bit safer when being piped

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -10,66 +10,72 @@
 
 set -o errexit
 
-echo "Starting installation."
-
-# GitHub's URL for the latest release, will redirect.
-GITHUB_BASE_URL="https://github.com/CircleCI-Public/circleci-cli"
-LATEST_URL="${GITHUB_BASE_URL}/releases/latest/"
-DESTDIR="${DESTDIR:-/usr/local/bin}"
-
-if [ -z "$VERSION" ]; then
-	VERSION=$(curl -sLI -o /dev/null -w '%{url_effective}' "$LATEST_URL" | cut -d "v" -f 2)
-fi
-
-echo "Installing CircleCI CLI v${VERSION}"
-
-# Run the script in a temporary directory that we know is empty.
-SCRATCH=$(mktemp -d || mktemp -d -t 'tmp')
-cd "$SCRATCH"
-
 function error {
   echo "An error occured installing the tool."
   echo "The contents of the directory $SCRATCH have been left in place to help to debug the issue."
 }
 
-trap error ERR
+# Use a function to ensure connection errors don't partially execute when being piped
+function install {
 
-# Determine release filename.
-case "$(uname)" in
-	Linux)
-		OS='linux'
-	;;
-	Darwin)
-		OS='darwin'
-	;;
-	*)
-		echo "This operating system is not supported."
-		exit 1	
-	;;
-esac
+	echo "Starting installation."
 
-case "$(uname -m)" in
-	aarch64 | arm64)
-		ARCH='arm64'
-	;;
-	x86_64)
-		ARCH="amd64"
-	;;
-	*)
-		echo "This architecture is not supported."
-		exit 1
-	;;
-esac
+	# GitHub's URL for the latest release, will redirect.
+	GITHUB_BASE_URL="https://github.com/CircleCI-Public/circleci-cli"
+	LATEST_URL="${GITHUB_BASE_URL}/releases/latest/"
+	DESTDIR="${DESTDIR:-/usr/local/bin}"
 
-RELEASE_URL="${GITHUB_BASE_URL}/releases/download/v${VERSION}/circleci-cli_${VERSION}_${OS}_${ARCH}.tar.gz"
+	if [ -z "$VERSION" ]; then
+		VERSION=$(curl -sLI -o /dev/null -w '%{url_effective}' "$LATEST_URL" | cut -d "v" -f 2)
+	fi
 
-# Download & unpack the release tarball.
-curl --ssl-reqd -sL --retry 3 "${RELEASE_URL}" | tar zx --strip 1
+	echo "Installing CircleCI CLI v${VERSION}"
 
-echo "Installing to $DESTDIR"
-install circleci "$DESTDIR"
+	# Run the script in a temporary directory that we know is empty.
+	SCRATCH=$(mktemp -d || mktemp -d -t 'tmp')
+	cd "$SCRATCH"
 
-command -v circleci
+	trap error ERR
 
-# Delete the working directory when the install was successful.
-rm -r "$SCRATCH"
+	# Determine release filename.
+	case "$(uname)" in
+		Linux)
+			OS='linux'
+		;;
+		Darwin)
+			OS='darwin'
+		;;
+		*)
+			echo "This operating system is not supported."
+			exit 1	
+		;;
+	esac
+
+	case "$(uname -m)" in
+		aarch64 | arm64)
+			ARCH='arm64'
+		;;
+		x86_64)
+			ARCH="amd64"
+		;;
+		*)
+			echo "This architecture is not supported."
+			exit 1
+		;;
+	esac
+
+	RELEASE_URL="${GITHUB_BASE_URL}/releases/download/v${VERSION}/circleci-cli_${VERSION}_${OS}_${ARCH}.tar.gz"
+
+	# Download & unpack the release tarball.
+	curl --ssl-reqd -sL --retry 3 "${RELEASE_URL}" | tar zx --strip 1
+
+	echo "Installing to $DESTDIR"
+	install circleci "$DESTDIR"
+
+	command -v circleci
+
+	# Delete the working directory when the install was successful.
+	rm -r "$SCRATCH"
+}
+
+install


### PR DESCRIPTION
- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/master/CONTRIBUTING.md).
- [x] I have checked for similar issues and haven't found anything relevant.
- (ish, but minor) This is not a security issue (which should be reported here: https://circleci.com/security/)

If the connection cut out midway through, the script would partially execute.

Wrapping in a function ensures that nothing will be executed unless the file is fully downloaded
