### PR TITLE
Fix bin directory used by snap job.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,7 +208,7 @@ jobs:
       - attach_workspace:
           at: .
       - run: |
-          export TAG=$(./dist/linux_amd64/circleci version)
+          TAG=$(./dist/circleci-cli_linux_amd64/circleci version) && export TAG
           sed -i -- "s/%CLI_VERSION_PLACEHOLDER%/$TAG/g" snap/snapcraft.yaml
       - run: snapcraft
       - run:


### PR DESCRIPTION
Fixes #370.

Somewhere along the line the directory where the compiled binaries are stored changed. The snap job then couldn't find the binary. This PR fixes that.