### PR TITLE
Remove weekly deployment

### DIFF
--- a/.circleci/brew-deploy.sh
+++ b/.circleci/brew-deploy.sh
@@ -15,4 +15,3 @@ brew bump-formula-pr --strict \
   --tag="$TAG" \
   --revision="$REVISION" \
   circleci
-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -256,6 +256,14 @@ workflows:
       - snap:
           requires:
             - deploy
+      # Only deploy to homebrew after manual approval.
+      - run-brew-deploy-gate:
+          type: approval
+          requires:
+            - deploy
+      - brew-deploy:
+          requires:
+            - run-brew-deploy-gate
       - deploy:
           requires:
             - test
@@ -267,17 +275,3 @@ workflows:
           filters:
             branches:
               only: master
-  weekly:
-    triggers:
-      - schedule:
-          cron: "0 23 * * 0"
-          filters:
-            branches:
-              only:
-                - master
-    jobs:
-      - run-brew-deploy-gate:
-          type: approval
-      - brew-deploy:
-          requires:
-            - run-brew-deploy-gate

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,7 +10,7 @@ parts:
     plugin: nil
     override-build: |
       snapcraftctl build
-      cp dist/linux_amd64/circleci $SNAPCRAFT_PART_INSTALL
+      cp dist/circleci-cli_linux_amd64/circleci $SNAPCRAFT_PART_INSTALL
       chmod +x $SNAPCRAFT_PART_INSTALL/circleci
     stage-packages: [docker.io]
 apps:


### PR DESCRIPTION
Change the deployment strategy to be after a manual approval on master,
rather than on a weekly schedule. This allows us to release features
sooner.