### PR TITLE
Update snap auth expiration note.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,7 +217,7 @@ jobs:
       - run:
           name: Publish to store
           command: |
-            # The Snapcraft login file here will expire March 1st, 2022. A new one will need to be created then.
+            # The Snapcraft login file here will expire: 2021-03-05T18:12:13. A new one will need to be created then.
             mkdir .snapcraft
             echo $SNAPCRAFT_LOGIN_FILE | base64 --decode --ignore-garbage > .snapcraft/snapcraft.cfg
             snapcraft push *.snap --release stable


### PR DESCRIPTION
The Snapcraft auth file has been updated. The next `master` run should pass regardless of this PR. This PR is just to update the config comment on when the token will expire again.