### PR TITLE
Use built-in function to locate homedir

### DIFF
--- a/local/local.go
+++ b/local/local.go
@@ -80,7 +80,7 @@ func Execute(opts BuildOptions) error {
 	arguments := []string{"docker", "run", "--interactive", "--tty", "--rm",
 		"--volume", "/var/run/docker.sock:/var/run/docker.sock",
 		"--volume", fmt.Sprintf("%s:%s", pwd, pwd),
-		"--volume", fmt.Sprintf("%s:/root/.circleci", circleCiDir()),
+		"--volume", fmt.Sprintf("%s:/root/.circleci", settings.SettingsPath()),
 		"--workdir", pwd,
 		image, "circleci", "build"}
 
@@ -218,26 +218,22 @@ func findLatestPicardSha() (string, error) {
 	return latest, nil
 }
 
-func circleCiDir() string {
-	return path.Join(settings.UserHomeDir(), ".circleci")
-}
-
 func buildAgentSettingsPath() string {
-	return path.Join(circleCiDir(), "build_agent_settings.json")
+	return path.Join(settings.SettingsPath(), "build_agent_settings.json")
 }
 
 func storeBuildAgentSha(sha256 string) error {
-	settings := buildAgentSettings{
+	agentSettings := buildAgentSettings{
 		LatestSha256: sha256,
 	}
 
-	settingsJSON, err := json.Marshal(settings)
+	settingsJSON, err := json.Marshal(agentSettings)
 
 	if err != nil {
 		return errors.Wrap(err, "Failed to serialize build agent settings")
 	}
 
-	if err = os.MkdirAll(circleCiDir(), 0700); err != nil {
+	if err = os.MkdirAll(settings.SettingsPath(), 0700); err != nil {
 		return errors.Wrap(err, "Could not create settings directory")
 	}
 

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"time"
 
@@ -34,7 +33,7 @@ type UpdateCheck struct {
 
 // Load will read the update check settings from the user's disk and then deserialize it into the current instance.
 func (upd *UpdateCheck) Load() error {
-	path := filepath.Join(settingsPath(), updateCheckFilename())
+	path := filepath.Join(SettingsPath(), updateCheckFilename())
 
 	if err := ensureSettingsFileExists(path); err != nil {
 		return err
@@ -75,7 +74,7 @@ func (cfg *Config) Load() error {
 
 // LoadFromDisk is used to read config from the user's disk and deserialize the YAML into our runtime config.
 func (cfg *Config) LoadFromDisk() error {
-	path := filepath.Join(settingsPath(), configFilename())
+	path := filepath.Join(SettingsPath(), configFilename())
 
 	if err := ensureSettingsFileExists(path); err != nil {
 		return err
@@ -124,18 +123,6 @@ func ReadFromEnv(prefix, field string) string {
 	return os.Getenv(strings.ToUpper(name))
 }
 
-// UserHomeDir returns the path to the current user's HOME directory.
-func UserHomeDir() string {
-	if runtime.GOOS == "windows" {
-		home := os.Getenv("HOMEDRIVE") + os.Getenv("HOMEPATH")
-		if home == "" {
-			home = os.Getenv("USERPROFILE")
-		}
-		return home
-	}
-	return os.Getenv("HOME")
-}
-
 // updateCheckFilename returns the name of the cli update checks file
 func updateCheckFilename() string {
 	return "update_check.yml"
@@ -148,9 +135,10 @@ func configFilename() string {
 }
 
 // settingsPath returns the path of the CLI settings directory
-func settingsPath() string {
+func SettingsPath() string {
 	// TODO: Make this configurable
-	return path.Join(UserHomeDir(), ".circleci")
+	home, _ := os.UserHomeDir()
+	return path.Join(home, ".circleci")
 }
 
 // ensureSettingsFileExists does just that.


### PR DESCRIPTION
golang 1.12 added a convenience function to get the user's home
directory. We can use this instead of our own.
