### PR TITLE
Handle build array type arguments the right way.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/pkg/errors v0.8.0
 	github.com/rhysd/go-github-selfupdate v0.0.0-20180520142321-41c1bbb0804a
 	github.com/spf13/cobra v0.0.3
-	github.com/spf13/pflag v1.0.3
+	github.com/spf13/pflag v1.0.5
 	github.com/tcnksm/go-gitconfig v0.1.2 // indirect
 	github.com/ulikunitz/xz v0.5.4 // indirect
 	golang.org/x/net v0.0.0-20181220203305-927f97764cc3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -341,6 +341,8 @@ github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb6
 github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.2.1/go.mod h1:P4AexN0a+C9tGAnUFNwDMYYZv3pjFuvmeiMyKRaNVlI=
 github.com/spf13/viper v1.3.1/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/local/local.go
+++ b/local/local.go
@@ -117,7 +117,7 @@ func AddFlagsForDocumentation(flags *pflag.FlagSet) {
 	flags.String("revision", "", "Git Revision")
 	flags.String("branch", "", "Git branch")
 	flags.String("repo-url", "", "Git Url")
-	flags.StringArrayP("env", "e", nil, "Set environment variables, e.g. `-e VAR=VAL`")
+	flags.StringSliceP("env", "e", nil, "Set environment variables, e.g. `-e VAR=VAL`")
 }
 
 // Given the full set of flags that were passed to this command, return the path
@@ -135,7 +135,14 @@ func buildAgentArguments(flags *pflag.FlagSet) ([]string, string) {
 	// build a list of all supplied flags, that we will pass on to build-agent
 	flags.Visit(func(flag *pflag.Flag) {
 		if flag.Name != "config" && flag.Name != "debug" {
-			result = append(result, "--"+flag.Name, flag.Value.String())
+			switch flag.Value.Type() {
+			case "stringSlice":
+				for _, value := range flag.Value.(pflag.SliceValue).GetSlice() {
+					result = append(result, "--"+flag.Name, value)
+				}
+			default:
+				result = append(result, "--"+flag.Name, flag.Value.String())
+			}
 		}
 	})
 	result = append(result, flags.Args()...)


### PR DESCRIPTION
Closes #385, but with different approach than #386. It fixes `--volume` as well. pflag dependency needs to be updated to newer version to support `pflag.SliceValue` interface.

:information_source: I'm not go programmer, but I did my best to follow code standards. IMHO this would deserve test coverage as well. If anyone can confirm this is good way to solve this problem, I can take a look and add some test coverage as well.