### PR TITLE
Pass string array arguments to docker correctly.

### DIFF
--- a/local/local.go
+++ b/local/local.go
@@ -135,7 +135,7 @@ func buildAgentArguments(flags *pflag.FlagSet) ([]string, string) {
 	// build a list of all supplied flags, that we will pass on to build-agent
 	flags.Visit(func(flag *pflag.Flag) {
 		if flag.Name != "config" && flag.Name != "debug" {
-			result = append(result, "--"+flag.Name, flag.Value.String())
+			result = append(result, unparseFlag(flags, flag)...)
 		}
 	})
 	result = append(result, flags.Args()...)
@@ -296,4 +296,27 @@ func generateDockerCommand(configPath, image, pwd string, arguments ...string) [
 		"--workdir", pwd,
 		image, "circleci", "build", "--config", configPathInsideContainer}
 	return append(core, arguments...)
+}
+
+// Convert the given flag back into a list of strings suitable to be passed on
+// the command line to run docker.
+// https://github.com/CircleCI-Public/circleci-cli/issues/391
+func unparseFlag(flags *pflag.FlagSet, flag *pflag.Flag) []string {
+	flagName := "--" + flag.Name
+	result := []string{}
+	switch flag.Value.Type() {
+	// A stringArray type argument is collapsed into a single flag:
+	// `--foo 1 --foo 2` will result in a single `foo` flag with an array of values.
+	case "stringArray":
+		vals, err := flags.GetStringArray(flag.Name)
+		if err != nil {
+			panic("Failed reading string array from flag that must be a string array")
+		}
+		for _, val := range vals {
+			result = append(result, flagName, val)
+		}
+	default:
+		result = append(result, flagName, flag.Value.String())
+	}
+	return result
 }

--- a/local/local_test.go
+++ b/local/local_test.go
@@ -97,6 +97,12 @@ var _ = Describe("build", func() {
 				expectedArgs:       []string{"--index", "9", "--job", "horse", "d"},
 			}),
 
+			Entry("many args, multiple envs", TestCase{
+				input:              []string{"--env", "foo", "--env", "bar", "--env", "baz"},
+				expectedConfigPath: ".circleci/config.yml",
+				expectedArgs:       []string{"--env", "foo", "--env", "bar", "--env", "baz"},
+			}),
+
 			Entry("args that are not flags", TestCase{
 				input:              []string{"a", "--debug", "b", "--config", "foo", "d"},
 				expectedConfigPath: "foo",


### PR DESCRIPTION
String array arguments were being converted to strings using golang
array formatting. So `--foo a --foo b --foo c` was being passed to
docker as `--foo [a,b,c]`. Handle this case explicitly in the code.

Fixes #391 #395
