### PR TITLE
Resolve failing mac deploys by setting TERM

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ executors:
     environment:
       CGO_ENABLED: 0
       HOMEBREW_NO_AUTO_UPDATE: 1
+      TERM: xterm-256color
 
 commands:
   force-http-1:


### PR DESCRIPTION
OSX builds have not been shipping. The homebrew step fails with:
```
WARNING: terminal is not fully functional

-  (press RETURN)

Too long with no output (exceeded 10m0s): context deadline exceeded
```

This can be resolved by setting TERM, as described on CircleCI's Discuss: https://discuss.circleci.com/t/on-macos-runners-warning-terminal-is-not-fully-functional/33656/7

- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/master/CONTRIBUTING.md).
- [x] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)