### PR TITLE
Skip the deploy-test ci job on forked PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,6 +148,13 @@ jobs:
   deploy-test:
     executor: go
     steps:
+      - run:
+          name: Skip this job if this is a forked pull request
+          command: |
+            if [ -n "$CIRCLE_PR_NUMBER" ]; then
+              echo "Forked PRs can't run this step."
+              circleci step halt
+            fi
       - checkout
       - install-goreleaser
       - gomod


### PR DESCRIPTION
I was quite confused by this deploy-test job failing, and I noticed the same from others while reading through open PRs.

It seems that the deploy-test job in the CircleCI config file doesn't pass on forked
PRs because build secrets aren't available, so this commit skips this test
on forked PRs using the method suggested on this CircleCI blog:
- https://circleci.com/blog/managing-secrets-when-you-have-pull-requests-from-outside-contributors/

- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/master/CONTRIBUTING.md).
- [x] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)