### PR TITLE
Fix interactive terminal issue

### DIFF
--- a/.circleci/brew-deploy.sh
+++ b/.circleci/brew-deploy.sh
@@ -1,17 +1,14 @@
 #!/bin/sh
-
 set -e
 
 # Remove the original circleci-agent from /usr/local/bin for homebrew
 rm /usr/local/bin/circleci
 # Install the latest circleci from homebrew
+brew update
 brew install circleci
 
 VERSION=$("$DESTDIR"/circleci version)
 TAG="v$(ruby -e "puts '$VERSION'.split('+')[0]")"
 REVISION=$(git rev-parse "$(ruby -e "puts '$VERSION'.split('+')[1]")")
 echo "Bumping circleci to $TAG+$REVISION"
-brew bump-formula-pr --strict \
-  --tag="$TAG" \
-  --revision="$REVISION" \
-  circleci
+brew bump-formula-pr --strict --tag="$TAG" --revision="$REVISION" circleci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,8 +225,7 @@ jobs:
       - slack-notify-on-failure
 
   brew-deploy:
-    macos:
-      xcode: "11.3.0"
+    executor: mac
     environment:
       - USER: circleci
       - TRAVIS: circleci

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -11,3 +11,6 @@ We are very grateful to the following people have helped us to build the CLI too
 - [Sam Chapler](https://github.com/SamChapler)
 - [Nick Miyake](https://github.com/nmiyake)
 - [Juan Carlos Mejías Rodríguez](https://github.com/greenled)
+- [Vojtech Novak](https://github.com/vonovak)
+- [Ed Serzo](https://github.com/eserzomcity)
+- [Daniel Ruthardt](https://github.com/DanielRuthardt)


### PR DESCRIPTION
Deployments to homebrew are blocked because the deployment system is
waiting for interactive input. Set the TERM flag to value that should
bypass this.
