### PR TITLE
Improve error message in update.checkFromHomebrew

### DIFF
--- a/update/update.go
+++ b/update/update.go
@@ -73,7 +73,7 @@ func checkFromHomebrew(check *Options) error {
 	command := exec.Command(brew, "outdated", "--json=v1") // #nosec
 	out, err := command.Output()
 	if err != nil {
-		return errors.Wrap(err, "failed to check for updates via `brew`")
+		return errors.Wrap(err, "failed to check for updates. `brew outdated --json=v1` returned an error")
 	}
 
 	var outdated HomebrewOutdated


### PR DESCRIPTION
- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/master/CONTRIBUTING.md).
- [x] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)

On MacOS with a Homebrew installation if a person has an issue with the Homebrew setup which causes `brew outdated --json=v1` to return an error they are not able to use the CLI. The only error they see is "Error: failed to check for updates via `brew`: exit status 1".

It took me great amount of time to understand why this was happening to me and only after I looked at the code here I figured out that the problem is with the `brew outdated --json=v1` command. In my case it returned "Error: kubernetes-helm was renamed to helm and needs to be migrated. Please run `brew migrate kubernetes-helm`" and once this issue was resolved I could start using the CircleCI CLI.

I am suggesting a wording of the error message that would save a lot of debugging to a person who encounters the same problem.