### PR TITLE
Add Docker CLI to Alpine image

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -2,6 +2,6 @@ FROM alpine:3.8
 
 COPY ./dist/circleci-cli_linux_amd64/circleci /usr/local/bin
 
-RUN apk add --no-cache --upgrade git openssh ca-certificates
+RUN apk add --no-cache --upgrade git openssh ca-certificates docker
 
 ENTRYPOINT ["circleci"]


### PR DESCRIPTION
- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/master/CONTRIBUTING.md).
- [x] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)

Hi there, noticed that running `circleci local execute` in Docker fails with the following error:

```
Error: could not find `docker` on the PATH; please ensure that docker is installed
```

Was running it using the following command:

```
docker run --rm -v $(pwd):/project-root  -v /var/run/docker.sock:/var/run/docker.sock --workdir /project-root circleci/circleci-cli:alpine local execute
```

Looking through the code, looks like the CLI runs `docker version` and errors out with the error I'm seeing if the call is unsuccessful. I connected to a container based on the latest alpine image. It looks like the image itself doesn't have docker command line installed. After installing it with `apk add docker` and passing in the socket with `-v /var/run/docker.sock:/var/run/docker.sock` I was able to get `docker version` to return a version inside the Docker container successfully.

Adding `docker` to the list of packages should work, you may need to add `apk update` before installing it to update the package index.

Wasn't able to find easily how to build the image with the new changes to see if it fixes the error. If you can either help to get this PR over the finish line or show me how to build a Docker image with the changes that would be great.

Thank you.