### PR TITLE
Send fabricated pipeline values when validating config

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -7,6 +7,7 @@ import (
 	"github.com/CircleCI-Public/circleci-cli/client"
 	"github.com/CircleCI-Public/circleci-cli/filetree"
 	"github.com/CircleCI-Public/circleci-cli/local"
+	"github.com/CircleCI-Public/circleci-cli/pipeline"
 	"github.com/CircleCI-Public/circleci-cli/proxy"
 	"github.com/CircleCI-Public/circleci-cli/settings"
 	"github.com/go-yaml/yaml"
@@ -124,7 +125,7 @@ func validateConfig(opts configOptions) error {
 		path = opts.args[0]
 	}
 
-	_, err := api.ConfigQuery(opts.cl, path)
+	_, err := api.ConfigQuery(opts.cl, path, pipeline.FabricatedValues())
 
 	if err != nil {
 		return err
@@ -140,7 +141,7 @@ func validateConfig(opts configOptions) error {
 }
 
 func processConfig(opts configOptions) error {
-	response, err := api.ConfigQuery(opts.cl, opts.args[0])
+	response, err := api.ConfigQuery(opts.cl, opts.args[0], nil)
 
 	if err != nil {
 		return err

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -14,6 +14,26 @@ import (
 	"gotest.tools/golden"
 )
 
+func predictValidateConfigRequest() string {
+	return `
+{
+		"query": "\n\t\tquery ValidateConfig ($config: String!, $pipelineValues: [StringKeyVal!]) {\n\t\t\tbuildConfig(configYaml: $config, pipelineValues: $pipelineValues) {\n\t\t\t\tvalid,\n\t\t\t\terrors { message },\n\t\t\t\tsourceYaml,\n\t\t\t\toutputYaml\n\t\t\t}\n\t\t}",
+		"variables": {
+				"config": "some config",
+				"pipelineValues": [
+						{"key": "git.base_revision", "val": "0123456789abcdef0123456789abcdef0123"},
+						{"key": "git.branch", "val": "test_git_branch"},
+						{"key": "git.revision", "val": "0123456789abcdef0123456789abcdef0123"},
+						{"key": "git.tag", "val": "test_git_tag"},
+						{"key": "id", "val": "00000000-0000-0000-0000-000000000001"},
+						{"key": "number", "val": "1"},
+						{"key": "project.git_url", "val": "https://test.vcs/test/test"},
+						{"key": "project.type", "val": "vcs_type"}
+				]
+		}
+}`
+}
+
 var _ = Describe("Config", func() {
 	Describe("with an api and config.yml", func() {
 		var tempSettings *clitest.TempSettings
@@ -57,12 +77,7 @@ var _ = Describe("Config", func() {
 							}
 						}`
 
-				expectedRequestJson := ` {
-					"query": "\n\t\tquery ValidateConfig ($config: String!) {\n\t\t\tbuildConfig(configYaml: $config) {\n\t\t\t\tvalid,\n\t\t\t\terrors { message },\n\t\t\t\tsourceYaml,\n\t\t\t\toutputYaml\n\t\t\t}\n\t\t}",
-					"variables": {
-					  "config": "some config"
-					}
-				  }`
+				expectedRequestJson := predictValidateConfigRequest()
 
 				tempSettings.AppendPostHandler(token, clitest.MockRequestResponse{
 					Status:   http.StatusOK,
@@ -90,12 +105,8 @@ var _ = Describe("Config", func() {
 							}
 						}`
 
-				expectedRequestJson := ` {
-					"query": "\n\t\tquery ValidateConfig ($config: String!) {\n\t\t\tbuildConfig(configYaml: $config) {\n\t\t\t\tvalid,\n\t\t\t\terrors { message },\n\t\t\t\tsourceYaml,\n\t\t\t\toutputYaml\n\t\t\t}\n\t\t}",
-					"variables": {
-					  "config": "some config"
-					}
-				  }`
+
+				expectedRequestJson := predictValidateConfigRequest()
 
 				tempSettings.AppendPostHandler(token, clitest.MockRequestResponse{
 					Status:   http.StatusOK,
@@ -144,7 +155,7 @@ var _ = Describe("Config", func() {
 						}`
 
 				expectedRequestJson := ` {
-					"query": "\n\t\tquery ValidateConfig ($config: String!) {\n\t\t\tbuildConfig(configYaml: $config) {\n\t\t\t\tvalid,\n\t\t\t\terrors { message },\n\t\t\t\tsourceYaml,\n\t\t\t\toutputYaml\n\t\t\t}\n\t\t}",
+					"query": "\n\t\tquery ValidateConfig ($config: String!, $pipelineValues: [StringKeyVal!]) {\n\t\t\tbuildConfig(configYaml: $config, pipelineValues: $pipelineValues) {\n\t\t\t\tvalid,\n\t\t\t\terrors { message },\n\t\t\t\tsourceYaml,\n\t\t\t\toutputYaml\n\t\t\t}\n\t\t}",
 					"variables": {
 					  "config": "some config"
 					}
@@ -178,7 +189,7 @@ var _ = Describe("Config", func() {
 						}`
 
 				expectedRequestJson := ` {
-					"query": "\n\t\tquery ValidateConfig ($config: String!) {\n\t\t\tbuildConfig(configYaml: $config) {\n\t\t\t\tvalid,\n\t\t\t\terrors { message },\n\t\t\t\tsourceYaml,\n\t\t\t\toutputYaml\n\t\t\t}\n\t\t}",
+					"query": "\n\t\tquery ValidateConfig ($config: String!, $pipelineValues: [StringKeyVal!]) {\n\t\t\tbuildConfig(configYaml: $config, pipelineValues: $pipelineValues) {\n\t\t\t\tvalid,\n\t\t\t\terrors { message },\n\t\t\t\tsourceYaml,\n\t\t\t\toutputYaml\n\t\t\t}\n\t\t}",
 					"variables": {
 					  "config": "some config"
 					}

--- a/local/local.go
+++ b/local/local.go
@@ -42,7 +42,7 @@ func Execute(flags *pflag.FlagSet, cfg *settings.Config) error {
 
 	processedArgs, configPath := buildAgentArguments(flags)
 	cl := client.NewClient(cfg.Host, cfg.Endpoint, cfg.Token, cfg.Debug)
-	configResponse, err := api.ConfigQuery(cl, configPath)
+	configResponse, err := api.ConfigQuery(cl, configPath, nil)
 
 	if err != nil {
 		return err

--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -1,0 +1,45 @@
+package pipeline
+
+import "sort"
+
+// CircleCI provides various `<< pipeline.x >>` values to be used in your config, but sometimes we need to fabricate those values when validating config.
+type Values map[string]string
+
+
+func FabricatedValues() Values {
+	return map[string]string{
+		"id":     "00000000-0000-0000-0000-000000000001",
+		"number": "1",
+		// TODO: Could these be grabbed from git?
+		"project.git_url":   "https://test.vcs/test/test",
+		"project.type":      "vcs_type",
+		"git.tag":           "test_git_tag",
+		"git.branch":        "test_git_branch",
+		"git.revision":      "0123456789abcdef0123456789abcdef0123",
+		"git.base_revision": "0123456789abcdef0123456789abcdef0123",
+	}
+}
+
+// TODO: type Parameters map[string]string
+
+// KeyVal is a data structure specifically for passing pipeline data to GraphQL which doesn't support free-form maps.
+type KeyVal struct {
+	Key string `json:"key"`
+	Val string `json:"val"`
+}
+
+// PrepareForGraphQL takes a golang homogenous map, and transforms it into a list of keyval pairs, since GraphQL does not support homogenous maps.
+func PrepareForGraphQL(kvMap Values) []KeyVal {
+	// we need to create the slice of KeyVals in a deterministic order for testing purposes
+	keys := make([]string, 0, len(kvMap))
+	for k := range kvMap {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	kvs := make([]KeyVal, 0, len(kvMap))
+	for _, k := range keys {
+		kvs = append(kvs, KeyVal{Key: k, Val: kvMap[k]})
+	}
+	return kvs
+}


### PR DESCRIPTION
Construct fake pipeline values and send them along to the `buildConfig` graphQL query when validating config. This fixes config validation for configs that use pipeline values.