### PR TITLE
Infer the git pipeline parameters

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -103,3 +103,33 @@ func getRemoteUrl(remoteName string) (string, error) {
 	}
 	return string(out), nil
 }
+
+func commandOutputOrDefault(cmd *exec.Cmd, defaultValue string) string {
+	output, err := cmd.CombinedOutput()
+
+	if err != nil {
+		return defaultValue
+	}
+
+	return strings.TrimSpace(string(output))
+}
+
+func Branch() string {
+	// Git 2.22 (Q2 2019)added `git branch --show-current`, but using
+	// `git rev-parse` works in all versions.
+	return commandOutputOrDefault(
+		exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD"),
+		"master")
+}
+
+func Revision() string {
+	return commandOutputOrDefault(
+		exec.Command("git", "rev-parse", "HEAD"),
+		"0000000000000000000000000000000000000000")
+}
+
+func Tag() string {
+	return commandOutputOrDefault(
+		exec.Command("git", "tag", "--points-at", "HEAD"),
+		"")
+}

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -1,11 +1,52 @@
 package git
 
 import (
+	"os"
+	"os/exec"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Dealing with git", func() {
+
+	Context("running commands", func() {
+
+		It("returns output in the happy path", func() {
+			Expect(commandOutputOrDefault(
+				exec.Command("echo", "hello"), "goodbye",
+			)).To(Equal("hello"))
+		})
+
+		It("handles programs that exit with a failure", func() {
+
+			Expect(commandOutputOrDefault(
+				exec.Command("git", "this", "it", "not", "a", "command"), "goodbye",
+			)).To(Equal("goodbye"))
+		})
+
+		It("handles invalid programs", func() {
+
+			Expect(commandOutputOrDefault(
+				exec.Command("this/is/not/a/command"), "morning",
+			)).To(Equal("morning"))
+		})
+
+	})
+
+	Context("can read the data to drive pipeline variables", func() {
+
+		if os.Getenv("CIRCLECI") != "true" {
+			return
+		}
+
+		It("computes the branch, tag and revision", func() {
+			Expect(Branch()).To(Equal(os.Getenv("CIRCLE_BRANCH")))
+			Expect(Revision()).To(Equal(os.Getenv("CIRCLE_SHA1")))
+			Expect(Tag()).To(Equal(os.Getenv("CIRCLE_TAG")))
+		})
+
+	})
 
 	Context("remotes", func() {
 
@@ -27,49 +68,49 @@ var _ = Describe("Dealing with git", func() {
 		It("should parse these", func() {
 
 			cases := map[string]*Remote{
-				"git@github.com:foobar/foo-service.git": &Remote{
+				"git@github.com:foobar/foo-service.git": {
 					VcsType:      GitHub,
 					Organization: "foobar",
 					Project:      "foo-service",
 				},
 
-				"git@bitbucket.org:example/makefile_sh.git": &Remote{
+				"git@bitbucket.org:example/makefile_sh.git": {
 					VcsType:      Bitbucket,
 					Organization: "example",
 					Project:      "makefile_sh",
 				},
 
-				"https://github.com/apple/pear.git": &Remote{
+				"https://github.com/apple/pear.git": {
 					VcsType:      GitHub,
 					Organization: "apple",
 					Project:      "pear",
 				},
 
-				"git@bitbucket.org:example/makefile_sh": &Remote{
+				"git@bitbucket.org:example/makefile_sh": {
 					VcsType:      Bitbucket,
 					Organization: "example",
 					Project:      "makefile_sh",
 				},
 
-				"https://example@bitbucket.org/kiwi/fruit.git": &Remote{
+				"https://example@bitbucket.org/kiwi/fruit.git": {
 					VcsType:      Bitbucket,
 					Organization: "kiwi",
 					Project:      "fruit",
 				},
 
-				"https://example@bitbucket.org/kiwi/fruit": &Remote{
+				"https://example@bitbucket.org/kiwi/fruit": {
 					VcsType:      Bitbucket,
 					Organization: "kiwi",
 					Project:      "fruit",
 				},
 
-				"ssh://git@github.com/cloud/rain": &Remote{
+				"ssh://git@github.com/cloud/rain": {
 					VcsType:      GitHub,
 					Organization: "cloud",
 					Project:      "rain",
 				},
 
-				"ssh://git@bitbucket.org/snow/ice": &Remote{
+				"ssh://git@bitbucket.org/snow/ice": {
 					VcsType:      Bitbucket,
 					Organization: "snow",
 					Project:      "ice",

--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -1,22 +1,41 @@
 package pipeline
 
-import "sort"
+import (
+	"fmt"
+	"sort"
+
+	"github.com/CircleCI-Public/circleci-cli/git"
+)
 
 // CircleCI provides various `<< pipeline.x >>` values to be used in your config, but sometimes we need to fabricate those values when validating config.
 type Values map[string]string
 
-
 func FabricatedValues() Values {
+
+	revision := git.Revision()
+	gitUrl := "https://github.com/CircleCI-Public/circleci-cli"
+	projectType := "github"
+
+	if remote, err := git.InferProjectFromGitRemotes(); err != nil {
+		switch remote.VcsType {
+		case git.GitHub:
+			gitUrl = fmt.Sprintf("https://github.com/%s/%s", remote.Organization, remote.Project)
+			projectType = "github"
+		case git.Bitbucket:
+			gitUrl = fmt.Sprintf("https://bitbucket.org/%s/%s", remote.Organization, remote.Project)
+			projectType = "bitbucket"
+		}
+	}
+
 	return map[string]string{
-		"id":     "00000000-0000-0000-0000-000000000001",
-		"number": "1",
-		// TODO: Could these be grabbed from git?
-		"project.git_url":   "https://test.vcs/test/test",
-		"project.type":      "vcs_type",
-		"git.tag":           "test_git_tag",
-		"git.branch":        "test_git_branch",
-		"git.revision":      "0123456789abcdef0123456789abcdef0123",
-		"git.base_revision": "0123456789abcdef0123456789abcdef0123",
+		"id":                "00000000-0000-0000-0000-000000000001",
+		"number":            "1",
+		"project.git_url":   gitUrl,
+		"project.type":      projectType,
+		"git.tag":           git.Tag(),
+		"git.branch":        git.Branch(),
+		"git.revision":      revision,
+		"git.base_revision": revision,
 	}
 }
 


### PR DESCRIPTION
If git is available, read the remote, sha, branch and tag from it.
This creates more realistic pipeline parameters.
