### PR TITLE
Improve package manager reporting

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -34,7 +34,7 @@ func checkForUpdates(opts *settings.Config) error {
 		spr.Suffix = " Checking for updates..."
 		spr.Start()
 
-		check, err := update.CheckForUpdates(opts.GitHubAPI, slug, version.Version, PackageManager)
+		check, err := update.CheckForUpdates(opts.GitHubAPI, slug, version.Version, version.PackageManager())
 
 		if err != nil {
 			spr.Stop()

--- a/cmd/check_test.go
+++ b/cmd/check_test.go
@@ -52,7 +52,7 @@ var _ = Describe("Check", func() {
 		BeforeEach(func() {
 			checkCLI, err = gexec.Build("github.com/CircleCI-Public/circleci-cli",
 				"-ldflags",
-				"-X github.com/CircleCI-Public/circleci-cli/cmd.AutoUpdate=false -X github.com/CircleCI-Public/circleci-cli/cmd.PackageManager=release",
+				"-X github.com/CircleCI-Public/circleci-cli/cmd.AutoUpdate=false -X github.com/CircleCI-Public/circleci-cli/version.packageManager=release",
 			)
 			Expect(err).ShouldNot(HaveOccurred())
 

--- a/cmd/disabled.go
+++ b/cmd/disabled.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/CircleCI-Public/circleci-cli/settings"
+	"github.com/CircleCI-Public/circleci-cli/version"
 	"github.com/spf13/cobra"
 )
 
@@ -38,7 +39,7 @@ func newDisabledCommand(config *settings.Config, command string) *cobra.Command 
 }
 
 func disableCommand(opts disableOptions) {
-	fmt.Printf("`%s` is not available because this tool was installed using `%s`.\n", opts.command, PackageManager)
+	fmt.Printf("`%s` is not available because this tool was installed using `%s`.\n", opts.command, version.PackageManager())
 
 	if opts.command == "update" {
 		fmt.Println("Please consult the package manager's documentation on how to update the CLI.")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,6 +7,7 @@ import (
 	"github.com/CircleCI-Public/circleci-cli/data"
 	"github.com/CircleCI-Public/circleci-cli/md_docs"
 	"github.com/CircleCI-Public/circleci-cli/settings"
+	"github.com/CircleCI-Public/circleci-cli/version"
 	"github.com/spf13/cobra"
 )
 
@@ -23,10 +24,6 @@ var rootOptions *settings.Config
 
 // rootTokenFromFlag stores the value passed in through the flag --token
 var rootTokenFromFlag string
-
-// PackageManager defines the package manager which was used to install the CLI.
-// You can override this value using -X flag to the compiler ldflags.
-var PackageManager = "source"
 
 // Execute adds all child commands to rootCmd and
 // sets flags appropriately. This function is called
@@ -116,7 +113,7 @@ func MakeCommands() *cobra.Command {
 	rootCmd.AddCommand(newDiagnosticCommand(rootOptions))
 	rootCmd.AddCommand(newSetupCommand(rootOptions))
 
-	if isUpdateIncluded(PackageManager) {
+	if isUpdateIncluded(version.PackageManager()) {
 		rootCmd.AddCommand(newUpdateCommand(rootOptions))
 	} else {
 		rootCmd.AddCommand(newDisabledCommand(rootOptions, "update"))
@@ -246,7 +243,7 @@ func visitAll(root *cobra.Command, fn func(*cobra.Command)) {
 
 func isUpdateIncluded(packageManager string) bool {
 	switch packageManager {
-	case "homebrew":
+	case "homebrew", "snapcraft":
 		return false
 	default:
 		return true

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -75,7 +75,7 @@ For more help, see the documentation here: https://circleci.com/docs/2.0/local-c
 
 			noUpdateCLI, err = gexec.Build("github.com/CircleCI-Public/circleci-cli",
 				"-ldflags",
-				"-X github.com/CircleCI-Public/circleci-cli/cmd.PackageManager=homebrew",
+				"-X github.com/CircleCI-Public/circleci-cli/version.packageManager=homebrew",
 			)
 			Expect(err).ShouldNot(HaveOccurred())
 		})

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -98,7 +98,7 @@ func updateCLI(opts updateCommandOptions) error {
 	spr.Suffix = " Checking for updates..."
 	spr.Start()
 
-	check, err := update.CheckForUpdates(opts.cfg.GitHubAPI, slug, version.Version, PackageManager)
+	check, err := update.CheckForUpdates(opts.cfg.GitHubAPI, slug, version.Version, version.PackageManager())
 	spr.Stop()
 
 	if err != nil {

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -28,7 +28,7 @@ func newVersionCommand(config *settings.Config) *cobra.Command {
 			opts.args = args
 		},
 		Run: func(_ *cobra.Command, _ []string) {
-			fmt.Printf("%s+%s\n", version.Version, version.Commit)
+			fmt.Printf("%s+%s (%s)\n", version.Version, version.Commit, version.PackageManager())
 		},
 	}
 }

--- a/version/version.go
+++ b/version/version.go
@@ -2,17 +2,40 @@ package version
 
 import (
 	"fmt"
+	"os"
 )
 
 // These vars set by `goreleaser`:
 var (
-	// Version is the current Git tag (the v prefix is stripped) or the name of the snapshot, if you’re using the --snapshot flag
+	// Version is the current Git tag (the v prefix is stripped) or the name of
+	// the snapshot, if you’re using the --snapshot flag
 	Version = "0.0.0-dev"
 	// Commit is the current git commit SHA
 	Commit = "dirty-local-tree"
 )
 
+// PackageManager defines the package manager which was used to install the CLI.
+// You can override this value using -X flag to the compiler ldflags. This is
+// overridden when we build for Homebrew, but not for Snapcraft. the binary that
+// we ship with Snapcraft is the same binary that we ship to the GitHub release.
+var packageManager = "source"
+
+func PackageManager() string {
+	if runningInsideSnap() {
+		return "snap"
+	}
+	return packageManager
+}
+
 // UserAgent returns the user agent that should be user for external requests
 func UserAgent() string {
-	return fmt.Sprintf("circleci-cli/%s+%s", Version, Commit)
+	return fmt.Sprintf("circleci-cli/%s+%s (%s)", Version, Commit, packageManager)
+}
+
+func runningInsideSnap() bool {
+	// Snap sets a bunch of env vars when apps are running inside the snap
+	// containers. SNAP_NAME is the name of the snap as specified in the
+	// `snapcraft.yaml` file.
+	// https://snapcraft.io/docs/environment-variables
+	return os.Getenv("SNAP_NAME") == "circleci"
 }


### PR DESCRIPTION
We want to better record the package manager that is in use.

Add the package manager to the `circleci version` command. This will
make it easier to see how the binary was installed.

Add the package manager to the user agent header. This allows us to
measure the popularity of different installation methods, which in turn
allows us to better focus our energy on the most popular package
managers.

Also report when Snapcraft is the package manager

This change also disables the auto-update when Snapcraft is in use,
since Snap manages the updates itself.