### PR TITLE
Fix Snap Deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -219,7 +219,7 @@ jobs:
       - attach_workspace:
           at: .
       - run: |
-          TAG=$(./dist/circleci-cli_linux_amd64/circleci version) && export TAG
+          TAG=$(./dist/circleci-cli_linux_amd64/circleci version | cut -d' ' -f 1) && export TAG
           sed -i -- "s/%CLI_VERSION_PLACEHOLDER%/$TAG/g" snap/snapcraft.yaml
       - run: snapcraft
       - run:

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ curl -fLSs https://circle.ci/cli | VERSION=0.1.5222 sudo bash
 brew install circleci
 ```
 
-#### Snapcraft
+#### Snap
 
 ```
 sudo snap install circleci
@@ -155,9 +155,11 @@ The particular considerations that we make are:
 1. Since Homebrew [doesn't "like tools that upgrade themselves"](https://docs.brew.sh/Acceptable-Formulae#we-dont-like-tools-that-upgrade-themselves), we disable the `circleci update` command when the tool is released through homebrew. We do this by [defining the PackageManager](https://github.com/Homebrew/homebrew-core/blob/eb1fdb84e2924289bcc8c85ee45081bf83dc024d/Formula/circleci.rb#L28) constant to `homebrew`, which allows us to [disable the `update` command at runtime](https://github.com/CircleCI-Public/circleci-cli/blob/67c7d52bace63846f87a1ed79f67f257c94a55b4/cmd/root.go#L119-L123).
 1. We want to avoid every push to `master` from creating a Pull Request to the `circleci` formula on Homebrew. We want to avoid overloading the Homebrew team with pull requests to update our formula for small changes (changes to docs or other files that don't change functionality in the tool).
 
-### Snapcraft
+### Snap
 
-We publish Linux builds of the tool to the Snapcraft package manager.
+We publish Linux builds of the tool to the Snap package manager.
+
+Further [package information is available on Snap website](https://snapcraft.io/circleci).
 
 ## Contributing
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -243,7 +243,7 @@ func visitAll(root *cobra.Command, fn func(*cobra.Command)) {
 
 func isUpdateIncluded(packageManager string) bool {
 	switch packageManager {
-	case "homebrew", "snapcraft":
+	case "homebrew", "snap":
 		return false
 	default:
 		return true

--- a/version/version.go
+++ b/version/version.go
@@ -16,8 +16,8 @@ var (
 
 // PackageManager defines the package manager which was used to install the CLI.
 // You can override this value using -X flag to the compiler ldflags. This is
-// overridden when we build for Homebrew, but not for Snapcraft. the binary that
-// we ship with Snapcraft is the same binary that we ship to the GitHub release.
+// overridden when we build for Homebrew, but not for Snap. the binary that we
+// ship with Snap is the same binary that we ship to the GitHub release.
 var packageManager = "source"
 
 func PackageManager() string {


### PR DESCRIPTION
Fixes a couple of issues:

- Snap deployments are currently failing because we are attempting to
  release a version with a space in the name.
- Change the string "snapcraft" to "snap" Snapcraft is the tool for
  managing Snaps. The packages are Snaps.
- Update some docs.
