### PR TITLE
Fix segfault from inability to infer Project (WIP)

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -15,3 +15,4 @@ We are very grateful to the following people have helped us to build the CLI too
 - [Ed Serzo](https://github.com/eserzomcity)
 - [Daniel Ruthardt](https://github.com/DanielRuthardt)
 - [Josef Šimánek](https://github.com/simi)
+- [Brady Sullivan](https://github.com/d1str0)

--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -16,7 +16,8 @@ func FabricatedValues() Values {
 	gitUrl := "https://github.com/CircleCI-Public/circleci-cli"
 	projectType := "github"
 
-	if remote, err := git.InferProjectFromGitRemotes(); err != nil {
+	// If we encounter an error infering project, skip this and use defaults.
+	if remote, err := git.InferProjectFromGitRemotes(); err == nil {
 		switch remote.VcsType {
 		case git.GitHub:
 			gitUrl = fmt.Sprintf("https://github.com/%s/%s", remote.Organization, remote.Project)


### PR DESCRIPTION
Fixes #414 

Currently, a segfault is produced if git.InferProjectFromGitRemotes() returns an error, as the 'remote' returned is nil. We immediately dereference it in a switch. To fix, we check and skip if error so we don't dereference.

- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/master/CONTRIBUTING.md).
- [x] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)


