### PR TITLE
Skip auto-update check while running in CI.

### DIFF
--- a/cmd/check_test.go
+++ b/cmd/check_test.go
@@ -57,7 +57,7 @@ var _ = Describe("Check", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 
 			command = commandWithHome(checkCLI, tempSettings.Home,
-				"help", "--github-api", tempSettings.TestServer.URL(),
+				"help", "--skip-update-check=false", "--github-api", tempSettings.TestServer.URL(),
 			)
 
 			response = `

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -124,31 +124,21 @@ func MakeCommands() *cobra.Command {
 	rootCmd.AddCommand(newStepCommand(rootOptions))
 	rootCmd.AddCommand(newSwitchCommand(rootOptions))
 
-	rootCmd.PersistentFlags().BoolVar(&rootOptions.Debug,
-		"debug", rootOptions.Debug, "Enable debug logging.")
-	rootCmd.PersistentFlags().StringVar(&rootTokenFromFlag,
-		"token", "", "your token for using CircleCI, also CIRCLECI_CLI_TOKEN")
-	rootCmd.PersistentFlags().StringVar(&rootOptions.Host,
-		"host", rootOptions.Host, "URL to your CircleCI host, also CIRCLECI_CLI_HOST")
-	rootCmd.PersistentFlags().StringVar(&rootOptions.Endpoint,
-		"endpoint", rootOptions.Endpoint, "URI to your CircleCI GraphQL API endpoint")
+	flags := rootCmd.PersistentFlags()
 
-	rootCmd.PersistentFlags().StringVar(&rootOptions.GitHubAPI, "github-api", "https://api.github.com/", "Change the default endpoint to  GitHub API for retrieving updates")
-	if err := rootCmd.PersistentFlags().MarkHidden("github-api"); err != nil {
-		panic(err)
-	}
+	flags.BoolVar(&rootOptions.Debug, "debug", rootOptions.Debug, "Enable debug logging.")
+	flags.StringVar(&rootTokenFromFlag, "token", "", "your token for using CircleCI, also CIRCLECI_CLI_TOKEN")
+	flags.StringVar(&rootOptions.Host, "host", rootOptions.Host, "URL to your CircleCI host, also CIRCLECI_CLI_HOST")
+	flags.StringVar(&rootOptions.Endpoint, "endpoint", rootOptions.Endpoint, "URI to your CircleCI GraphQL API endpoint")
+	flags.StringVar(&rootOptions.GitHubAPI, "github-api", "https://api.github.com/", "Change the default endpoint to GitHub API for retrieving updates")
+	flags.BoolVar(&rootOptions.SkipUpdateCheck, "skip-update-check", runningInCi(), "Skip the check for updates check run before every command.")
 
-	rootCmd.PersistentFlags().BoolVar(&rootOptions.SkipUpdateCheck, "skip-update-check", false, "Skip the check for updates check run before every command")
-	if err := rootCmd.PersistentFlags().MarkHidden("skip-update-check"); err != nil {
-		panic(err)
-	}
+	hidden := []string{"github-api", "debug", "endpoint"}
 
-	if err := rootCmd.PersistentFlags().MarkHidden("debug"); err != nil {
-		panic(err)
-	}
-
-	if err := rootCmd.PersistentFlags().MarkHidden("endpoint"); err != nil {
-		panic(err)
+	for _, f := range hidden {
+		if err := flags.MarkHidden(f); err != nil {
+			panic(err)
+		}
 	}
 
 	// Cobra has a peculiar default behaviour:
@@ -263,4 +253,8 @@ This project is the seed for CircleCI's new command-line application.`
 	return fmt.Sprintf(`%s
 
 For more help, see the documentation here: %s`, long, config.Data.Links.CLIDocs)
+}
+
+func runningInCi() bool {
+	return os.Getenv("CI") == "true"
 }


### PR DESCRIPTION
- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/master/CONTRIBUTING.md).
- [x] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)

The CLI will always check for an update when run, unless explicitly told
not to. This can lead to rate limiting on shared IPs, especially in
CircleCI jobs. This helps alleviate this issue by checking for the $CI
environment variable before attempting to check for an update on GitHub.

It might be better to throw a message that the CLI is outdated but
continue with the command, however, this would have to account for being
piped into configuration files.