### PR TITLE
Add ENV flag to skip update check in Docker container.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
 FROM circleci/golang:1.10.3
 
+ENV CIRCLECI_CLI_SKIP_UPDATE_CHECK true
+
 COPY ./dist/circleci-cli_linux_amd64/circleci /usr/local/bin

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,5 +1,7 @@
 FROM alpine:3.8
 
+ENV CIRCLECI_CLI_SKIP_UPDATE_CHECK true
+
 COPY ./dist/circleci-cli_linux_amd64/circleci /usr/local/bin
 
 RUN apk add --no-cache --upgrade git openssh ca-certificates

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -131,7 +131,7 @@ func MakeCommands() *cobra.Command {
 	flags.StringVar(&rootOptions.Host, "host", rootOptions.Host, "URL to your CircleCI host, also CIRCLECI_CLI_HOST")
 	flags.StringVar(&rootOptions.Endpoint, "endpoint", rootOptions.Endpoint, "URI to your CircleCI GraphQL API endpoint")
 	flags.StringVar(&rootOptions.GitHubAPI, "github-api", "https://api.github.com/", "Change the default endpoint to GitHub API for retrieving updates")
-	flags.BoolVar(&rootOptions.SkipUpdateCheck, "skip-update-check", runningInCi(), "Skip the check for updates check run before every command.")
+	flags.BoolVar(&rootOptions.SkipUpdateCheck, "skip-update-check", skipUpdateByDefault(), "Skip the check for updates check run before every command.")
 
 	hidden := []string{"github-api", "debug", "endpoint"}
 
@@ -255,6 +255,6 @@ This project is the seed for CircleCI's new command-line application.`
 For more help, see the documentation here: %s`, long, config.Data.Links.CLIDocs)
 }
 
-func runningInCi() bool {
-	return os.Getenv("CI") == "true"
+func skipUpdateByDefault() bool {
+	return os.Getenv("CI") == "true" || os.Getenv("CIRCLECI_CLI_SKIP_UPDATE_CHECK") == "true"
 }


### PR DESCRIPTION
- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/master/CONTRIBUTING.md).
- [x] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)

See #226 - This builds off a previous PR (#418) to ensure the Docker image doesn't try to auto-update by implementing the `CIRCLECI_CLI_SKIP_UPDATE_CHECK` flag. #264 previous attempted to do this, but the variable wasn't checked within the CLI itself.