### PR TITLE
Add job to start Chocolatey package deployment [skip ci]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -301,6 +301,7 @@ jobs:
           name: Trigger Chocolatey repository build
           command: |
             curl -X POST https://circleci.com/api/v2/project/gh/CircleCI-Public/chocolatey-circleci-cli/pipeline \
+              --fail --silent \
               -H 'Content-Type: application/json' \
               -H 'Accept: application/json' \
               -H "Circle-Token: $CIRCLE_TOKEN" \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -293,6 +293,19 @@ jobs:
       - run: ./.circleci/brew-deploy.sh
       - slack-notify-on-failure
 
+  trigger-chocolatey-deploy:
+    docker:
+      - image: cimg/base:edge
+    steps:
+      - run:
+          name: Trigger Chocolatey repository build
+          command: |
+            curl -X POST https://circleci.com/api/v2/project/gh/CircleCI-Public/chocolatey-circleci-cli/pipeline \
+              -H 'Content-Type: application/json' \
+              -H 'Accept: application/json' \
+              -H "Circle-Token: $CIRCLE_TOKEN" \
+              --data '{ "parameters": { "deploy-production": true } }'
+
 workflows:
   ci:
     jobs:
@@ -329,6 +342,12 @@ workflows:
             - lint
             - deploy-test
             - shellcheck/check
+          filters:
+            branches:
+              only: master
+      - trigger-chocolatey-deploy:
+          requires:
+            - deploy
           filters:
             branches:
               only: master


### PR DESCRIPTION
Adds a job to the configuration to trigger a new job in the https://github.com/CircleCI-Public/chocolatey-circleci-cli repository, which builds and deploys a new package to the Chocolatey repository.