### PR TITLE
Orb pack

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -293,6 +293,20 @@ jobs:
       - run: ./.circleci/brew-deploy.sh
       - slack-notify-on-failure
 
+  trigger-chocolatey-deploy:
+    docker:
+      - image: cimg/base:edge
+    steps:
+      - run:
+          name: Trigger Chocolatey repository build
+          command: |
+            curl -X POST https://circleci.com/api/v2/project/gh/CircleCI-Public/chocolatey-circleci-cli/pipeline \
+              --fail --silent \
+              -H 'Content-Type: application/json' \
+              -H 'Accept: application/json' \
+              -H "Circle-Token: $CIRCLE_TOKEN" \
+              --data '{ "parameters": { "deploy-production": true } }'
+
 workflows:
   ci:
     jobs:
@@ -329,6 +343,12 @@ workflows:
             - lint
             - deploy-test
             - shellcheck/check
+          filters:
+            branches:
+              only: master
+      - trigger-chocolatey-deploy:
+          requires:
+            - deploy
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,7 +166,7 @@ jobs:
           path: coverage.txt
       - slack-notify-on-failure
 
-  docs:
+  docs: 
     executor: go
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,7 +166,7 @@ jobs:
           path: coverage.txt
       - slack-notify-on-failure
 
-  docs: 
+  docs:
     executor: go
     steps:
       - checkout

--- a/api/api.go
+++ b/api/api.go
@@ -14,8 +14,8 @@ import (
 	"github.com/CircleCI-Public/circleci-cli/pipeline"
 	"github.com/CircleCI-Public/circleci-cli/references"
 	"github.com/Masterminds/semver"
-	"github.com/go-yaml/yaml"
 	"github.com/pkg/errors"
+	"gopkg.in/yaml.v3"
 )
 
 // GQLErrorsCollection is a slice of errors returned by the GraphQL server.

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -10,9 +10,9 @@ import (
 	"github.com/CircleCI-Public/circleci-cli/pipeline"
 	"github.com/CircleCI-Public/circleci-cli/proxy"
 	"github.com/CircleCI-Public/circleci-cli/settings"
-	"github.com/go-yaml/yaml"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 )
 
 type configOptions struct {

--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -254,7 +254,8 @@ Please note that at this time all orbs created in the registry are world-readabl
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return packOrb(opts)
 		},
-		Args: cobra.ExactArgs(1),
+		Args:   cobra.ExactArgs(1),
+		Hidden: true,
 	}
 
 	orbCreate.Flags().BoolVar(&opts.integrationTesting, "integration-testing", false, "Enable test mode to bypass interactive UI.")

--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -770,9 +770,17 @@ type OrbSchema struct {
 	Examples    map[string]ExampleSchema `yaml:"examples,omitempty"`
 }
 
+type ExampleUsageSchema struct {
+	Version   string      `yaml:"version,omitempty"`
+	Orbs      interface{} `yaml:"orbs,omitempty"`
+	Jobs      interface{} `yaml:"jobs,omitempty"`
+	Workflows interface{} `yaml:"workflows"`
+}
+
 type ExampleSchema struct {
-	Description string    `yaml:"description,omitempty"`
-	Usage       OrbSchema `yaml:"usage,omitempty"`
+	Description string             `yaml:"description,omitempty"`
+	Usage       ExampleUsageSchema `yaml:"usage,omitempty"`
+	Result      ExampleUsageSchema `yaml:"result,omitempty"`
 }
 
 func packOrb(opts orbOptions) error {

--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -249,7 +249,7 @@ Please note that at this time all orbs created in the registry are world-readabl
 
 	orbPack := &cobra.Command{
 		Use:   "pack <path>",
-		Short: "Pack an orb with local scripts.",
+		Short: "Pack an Orb with local scripts.",
 		Long:  ``,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return packOrb(opts)
@@ -798,24 +798,24 @@ func packOrb(opts orbOptions) error {
 
 	y, err := yaml.Marshal(&tree)
 	if err != nil {
-		return errors.Wrap(err, "Failed trying to marshal the tree to YAML ")
+		return errors.Wrap(err, "Failed trying to marshal the tree to YAML")
 	}
 
 	// Create generic YAML node.
 	var node yaml.Node
 	err = yaml.Unmarshal(y, &node)
 	if err != nil {
-		return errors.Wrap(err, "Failed unmarshal YAML tree.")
+		return errors.Wrap(err, "Failed unmarshal YAML tree")
 	}
 
 	err = travelOrbTree(&node, opts.args[0])
 	if err != nil {
-		return errors.Wrap(err, "Failed trying to travel Orb YAML.")
+		return errors.Wrap(err, "Failed trying to travel Orb YAML")
 	}
 
 	final, err := yaml.Marshal(&node)
 	if err != nil {
-		return errors.Wrap(err, "Failed trying to marshal Orb YAML.")
+		return errors.Wrap(err, "Failed trying to marshal Orb YAML")
 	}
 
 	// Unmarshal again into a struct so that it can be
@@ -823,12 +823,12 @@ func packOrb(opts orbOptions) error {
 	var orb OrbSchema
 	err = yaml.Unmarshal(final, &orb)
 	if err != nil {
-		return errors.Wrap(err, "Failed unmarshal YAML tree.")
+		return errors.Wrap(err, "Failed unmarshal YAML tree")
 	}
 
 	finalOrdered, err := yaml.Marshal(&orb)
 	if err != nil {
-		return errors.Wrap(err, "Failed trying to marshal Orb YAML.")
+		return errors.Wrap(err, "Failed trying to marshal Orb YAML")
 	}
 
 	fmt.Println(string(finalOrdered))
@@ -858,7 +858,7 @@ func travelOrbTree(node *yaml.Node, orbRoot string) error {
 			filepath := filepath.Join(orbRoot, includeMatches[1])
 			file, err := ioutil.ReadFile(filepath)
 			if err != nil {
-				return errors.Wrap(err, fmt.Sprintf("Could not open %s for inclusion in Orb.", filepath))
+				return errors.Wrap(err, fmt.Sprintf("Could not open %s for inclusion in Orb", filepath))
 			}
 
 			node.Value = string(file)
@@ -868,7 +868,10 @@ func travelOrbTree(node *yaml.Node, orbRoot string) error {
 		// then if we have a match we verify there is no closing tag for it.
 		maybeHeredocMatches := maybeHeredocRegex.FindAllString(node.Value, -1)
 		// View: https://regexr.com/57bh8
-		paramRegex, _ := regexp.Compile(`(?i)<<.+?>>`)
+		paramRegex, err := regexp.Compile(`(?i)<<.+?>>`)
+		if err != nil {
+			return err
+		}
 
 		if len(maybeHeredocMatches) > 0 {
 			for _, match := range maybeHeredocMatches {

--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -844,7 +844,7 @@ func travelOrbTree(node *yaml.Node, orbRoot string) error {
 		return err
 	}
 	// View: https://regexr.com/57b7a
-	maybeHeredocRegex, err := regexp.Compile(`(<<[\w\s\d\.>]*)`)
+	maybeHeredocRegex, err := regexp.Compile(`(<<[\w\d\.>]*\S*)`)
 	if err != nil {
 		return err
 	}
@@ -874,10 +874,15 @@ func travelOrbTree(node *yaml.Node, orbRoot string) error {
 		}
 
 		if len(maybeHeredocMatches) > 0 {
+			// This is a little messier, hope to tweak soon.
+			// Loop through matches, if match has already been replaced we skip it,
+			// otherwise we replace it and mark it as having been done.
+			escaped := make(map[string]struct{})
 			for _, match := range maybeHeredocMatches {
 				isParam := len(paramRegex.FindStringSubmatch(match)) > 0
-				if !isParam {
+				if _, done := escaped[match]; !done && !isParam {
 					node.Value = strings.Replace(node.Value, match, "\\"+match, -1)
+					escaped[match] = struct{}{}
 				}
 			}
 		}

--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -813,6 +813,8 @@ func travelTree(node *yaml.Node, orbRoot string) error {
 			node.Value = string(file)
 		}
 	} else {
+		// I am *slightly* worried about performance related to this approach, but don't have any
+		// larger Orbs to test against.
 		for _, child := range node.Content {
 			err := travelTree(child, orbRoot)
 			if err != nil {

--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -759,6 +759,22 @@ https://circleci.com/orbs/registry/orb/%s
 	return nil
 }
 
+type OrbSchema struct {
+	Version     string                   `yaml:"version,omitempty"`
+	Description string                   `yaml:"description,omitempty"`
+	Display     interface{}              `yaml:"display,omitempty"`
+	Orbs        interface{}              `yaml:"orbs,omitempty"`
+	Commands    interface{}              `yaml:"commands,omitempty"`
+	Executors   interface{}              `yaml:"executors,omitempty"`
+	Jobs        interface{}              `yaml:"jobs,omitempty"`
+	Examples    map[string]ExampleSchema `yaml:"examples,omitempty"`
+}
+
+type ExampleSchema struct {
+	Description string    `yaml:"description,omitempty"`
+	Usage       OrbSchema `yaml:"usage,omitempty"`
+}
+
 func packOrb(opts orbOptions) error {
 	// Travel our Orb and build a tree from the YAML files.
 	// Non-YAML files will be ignored here.
@@ -794,7 +810,20 @@ func packOrb(opts orbOptions) error {
 		return errors.Wrap(err, "Failed trying to marshal Orb YAML.")
 	}
 
-	fmt.Println(string(final))
+	// Unmarshal again into a struct so that it can be
+	// marhsalled again but with custom-ordered keys
+	var orb OrbSchema
+	err = yaml.Unmarshal(final, &orb)
+	if err != nil {
+		return errors.Wrap(err, "Failed unmarshal YAML tree.")
+	}
+
+	finalOrdered, err := yaml.Marshal(&orb)
+	if err != nil {
+		return errors.Wrap(err, "Failed trying to marshal Orb YAML.")
+	}
+
+	fmt.Println(string(finalOrdered))
 
 	return nil
 }

--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -795,7 +795,7 @@ func packOrb(opts orbOptions) error {
 	if err != nil {
 		return errors.Wrap(err, "An unexpected error occurred")
 	}
-	tree.MarshalYAML()
+
 	y, err := yaml.Marshal(&tree)
 	if err != nil {
 		return errors.Wrap(err, "An unexpected error occurred")

--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -773,6 +773,9 @@ func packOrb(opts orbOptions) error {
 	// Create generic YAML node.
 	var node yaml.Node
 	err = yaml.Unmarshal(y, &node)
+	if err != nil {
+		return errors.Wrap(err, "Failed unmarshal YAML tree.")
+	}
 
 	err = travelTree(&node, opts.args[0])
 	if err != nil {

--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -838,12 +838,12 @@ func packOrb(opts orbOptions) error {
 
 // Travel down a YAML node, replacing values as we go.
 func travelOrbTree(node *yaml.Node, orbRoot string) error {
-	// View: https://regexr.com/57bg7
-	includeRegex, err := regexp.Compile(`(?U)<<\s*include\((.*\/*[^\/]+)\)\s*?>>`)
+	// View: https://regexr.com/582gb
+	includeRegex, err := regexp.Compile(`(?U)^<<\s*include\((.*\/*[^\/]+)\)\s*?>>$`)
 	if err != nil {
 		return err
 	}
-	// View: regexr.com/57hl9
+	// View: https://regexr.com/57hl9
 	maybeHeredocRegex, err := regexp.Compile(`(<<[\s\#\^\/]*[^<<]*)`)
 	if err != nil {
 		return err

--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -843,8 +843,8 @@ func travelOrbTree(node *yaml.Node, orbRoot string) error {
 	if err != nil {
 		return err
 	}
-	// View: https://regexr.com/57b7a
-	maybeHeredocRegex, err := regexp.Compile(`(<<[\w\d\.>]*\S*)`)
+	// View: regexr.com/57hl9
+	maybeHeredocRegex, err := regexp.Compile(`(<<[\s\#\^\/]*[^<<]*)`)
 	if err != nil {
 		return err
 	}
@@ -868,7 +868,7 @@ func travelOrbTree(node *yaml.Node, orbRoot string) error {
 		// then if we have a match we verify there is no closing tag for it.
 		maybeHeredocMatches := maybeHeredocRegex.FindAllString(node.Value, -1)
 		// View: https://regexr.com/57bh8
-		paramRegex, err := regexp.Compile(`(?i)<<.+?>>`)
+		paramRegex, err := regexp.Compile(`(?iU)<<.+?>>`)
 		if err != nil {
 			return err
 		}

--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -761,7 +762,12 @@ https://circleci.com/orbs/registry/orb/%s
 func packOrb(opts orbOptions) error {
 	// Travel our Orb and build a tree from the YAML files.
 	// Non-YAML files will be ignored here.
-	tree, err := filetree.NewTree(opts.args[0])
+	_, err := os.Stat(filepath.Join(opts.args[0], "@orb.yml"))
+	if err != nil {
+		return errors.Wrap(err, "@orb.yml file not found, are you sure this is the Orb root?")
+	}
+
+	tree, err := filetree.NewTree(opts.args[0], "executors", "jobs", "commands", "examples")
 	if err != nil {
 		return errors.Wrap(err, "An error occurred trying to build the tree")
 	}

--- a/cmd/orb_test.go
+++ b/cmd/orb_test.go
@@ -2626,24 +2626,6 @@ https://circleci.com/orbs/registry/orb/my/orb
 `))
 			Eventually(session).Should(gexec.Exit(0))
 		})
-		It("Escapes a heredoc.", func() {
-			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
-			Expect(err).ShouldNot(HaveOccurred())
-			script = clitest.OpenTmpFile(tempSettings.Home, filepath.Join("scripts", "script.sh"))
-			script.Write([]byte(`cat << EOF > test.txt
-this is some text.
-EOF`))
-			Eventually(session.Out).Should(gbytes.Say(`commands:
-    orb:
-        steps:
-            - run:
-                command: |
-                    cat \<< EOF > test.txt
-                    this is some text
-                    EOF
-                name: Say hello
-`))
-			Eventually(session).Should(gexec.Exit(0))
-		})
+
 	})
 })

--- a/cmd/orb_test.go
+++ b/cmd/orb_test.go
@@ -2581,4 +2581,49 @@ https://circleci.com/orbs/registry/orb/my/orb
 			})
 		})
 	})
+
+	Describe("Orb pack", func() {
+		var (
+			tempSettings *clitest.TempSettings
+			orb          *clitest.TmpFile
+			script       *clitest.TmpFile
+			command      *exec.Cmd
+		)
+		BeforeEach(func() {
+			tempSettings = clitest.WithTempSettings()
+			orb = clitest.OpenTmpFile(tempSettings.Home, filepath.Join("myorb", "orb.yml"))
+			orb.Write([]byte(`steps:
+    - run:
+        name: Say hello
+        command: <<include(myorb/script.sh)>>
+`))
+			script = clitest.OpenTmpFile(tempSettings.Home, filepath.Join("myorb", "script.sh"))
+			script.Write([]byte(`echo Hello, world!`))
+			command = exec.Command(pathCLI,
+				"orb", "pack",
+				"--skip-update-check",
+				orb.RootDir,
+			)
+		})
+
+		AfterEach(func() {
+			tempSettings.Close()
+			orb.Close()
+			script.Close()
+		})
+
+		It("Includes a script in the packed Orb file", func() {
+			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			Eventually(session.Out).Should(gbytes.Say(`myorb:
+    orb:
+        steps:
+            - run:
+                command: echo Hello, world!
+                name: Say hello
+`))
+			Eventually(session).Should(gexec.Exit(0))
+		})
+	})
 })

--- a/cmd/orb_test.go
+++ b/cmd/orb_test.go
@@ -2626,5 +2626,24 @@ https://circleci.com/orbs/registry/orb/my/orb
 `))
 			Eventually(session).Should(gexec.Exit(0))
 		})
+		It("Escapes a heredoc.", func() {
+			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+			Expect(err).ShouldNot(HaveOccurred())
+			script = clitest.OpenTmpFile(tempSettings.Home, filepath.Join("scripts", "script.sh"))
+			script.Write([]byte(`cat << EOF > test.txt
+this is some text.
+EOF`))
+			Eventually(session.Out).Should(gbytes.Say(`commands:
+    orb:
+        steps:
+            - run:
+                command: |
+                    cat \<< EOF > test.txt
+                    this is some text
+                    EOF
+                name: Say hello
+`))
+			Eventually(session).Should(gexec.Exit(0))
+		})
 	})
 })

--- a/cmd/orb_test.go
+++ b/cmd/orb_test.go
@@ -2591,18 +2591,19 @@ https://circleci.com/orbs/registry/orb/my/orb
 		)
 		BeforeEach(func() {
 			tempSettings = clitest.WithTempSettings()
-			orb = clitest.OpenTmpFile(tempSettings.Home, filepath.Join("myorb", "orb.yml"))
+			orb = clitest.OpenTmpFile(tempSettings.Home, filepath.Join("commands", "orb.yml"))
+			clitest.OpenTmpFile(tempSettings.Home, "@orb.yml")
 			orb.Write([]byte(`steps:
     - run:
         name: Say hello
-        command: <<include(myorb/script.sh)>>
+        command: <<include(scripts/script.sh)>>
 `))
-			script = clitest.OpenTmpFile(tempSettings.Home, filepath.Join("myorb", "script.sh"))
+			script = clitest.OpenTmpFile(tempSettings.Home, filepath.Join("scripts", "script.sh"))
 			script.Write([]byte(`echo Hello, world!`))
 			command = exec.Command(pathCLI,
 				"orb", "pack",
 				"--skip-update-check",
-				orb.RootDir,
+				tempSettings.Home,
 			)
 		})
 
@@ -2616,7 +2617,7 @@ https://circleci.com/orbs/registry/orb/my/orb
 			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 			Expect(err).ShouldNot(HaveOccurred())
 
-			Eventually(session.Out).Should(gbytes.Say(`myorb:
+			Eventually(session.Out).Should(gbytes.Say(`commands:
     orb:
         steps:
             - run:

--- a/data/data.go
+++ b/data/data.go
@@ -1,8 +1,8 @@
 package data
 
 import (
-	"github.com/go-yaml/yaml"
 	packr "github.com/gobuffalo/packr/v2"
+	"gopkg.in/yaml.v3"
 )
 
 // YML maps the YAML found in _data/data.yml

--- a/filetree/filetree.go
+++ b/filetree/filetree.go
@@ -8,8 +8,8 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/go-yaml/yaml"
 	"github.com/mitchellh/mapstructure"
+	"gopkg.in/yaml.v3"
 )
 
 // This is a quick hack of a function to convert interfaces

--- a/filetree/filetree.go
+++ b/filetree/filetree.go
@@ -172,7 +172,7 @@ func buildTree(absRootPath string, pathNodes PathNodes) *Node {
 	return rootNode
 }
 
-func collectNodes(absRootPath string) (PathNodes, error) {
+func collectNodes(absRootPath string, allowedDirs map[string]string) (PathNodes, error) {
 	pathNodes := PathNodes{}
 	pathNodes.Map = make(map[string]*Node)
 	pathNodes.Keys = []string{}
@@ -182,8 +182,12 @@ func collectNodes(absRootPath string) (PathNodes, error) {
 			return err
 		}
 
-		// Skip any dotfolders that aren't the root path
-		if absRootPath != path && dotfolder(info) {
+		// Skip any dotfolders or dirs not explicitly allowed, if available.
+		isAllowed := true
+		if len(allowedDirs) > 0 && info.IsDir() {
+			_, isAllowed = allowedDirs[info.Name()]
+		}
+		if absRootPath != path && (dotfolder(info) || !isAllowed) {
 			// Turn off logging to stdout in this package
 			//fmt.Printf("Skipping dotfolder: %+v\n", path)
 			return filepath.SkipDir
@@ -207,13 +211,19 @@ func collectNodes(absRootPath string) (PathNodes, error) {
 }
 
 // NewTree creates a new filetree starting at the root
-func NewTree(rootPath string) (*Node, error) {
+func NewTree(rootPath string, allowedDirectories ...string) (*Node, error) {
+	allowedDirs := make(map[string]string)
+
+	for _, dir := range allowedDirectories {
+		allowedDirs[dir] = "1"
+	}
+
 	absRootPath, err := filepath.Abs(rootPath)
 	if err != nil {
 		return nil, err
 	}
 
-	pathNodes, err := collectNodes(absRootPath)
+	pathNodes, err := collectNodes(absRootPath, allowedDirs)
 	if err != nil {
 		return nil, err
 	}

--- a/filetree/filetree_test.go
+++ b/filetree/filetree_test.go
@@ -7,9 +7,9 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/go-yaml/yaml"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"gopkg.in/yaml.v3"
 
 	"github.com/CircleCI-Public/circleci-cli/filetree"
 )

--- a/filetree/filetree_test.go
+++ b/filetree/filetree_test.go
@@ -99,6 +99,7 @@ sub_dir:
 			Expect(err).ToNot(HaveOccurred())
 
 			out, err := yaml.Marshal(tree)
+			Expect(err).ToNot(HaveOccurred())
 			Expect(out).To(MatchYAML(`sub_dir:
   sub_dir_file:
     foo:

--- a/filetree/filetree_test.go
+++ b/filetree/filetree_test.go
@@ -17,6 +17,7 @@ import (
 var _ = Describe("filetree", func() {
 	var (
 		tempRoot string
+		subDir   string
 	)
 
 	BeforeEach(func() {
@@ -30,7 +31,7 @@ var _ = Describe("filetree", func() {
 	})
 
 	Describe("NewTree", func() {
-		var subDir, subDirFile, emptyDir string
+		var subDirFile, emptyDir string
 
 		BeforeEach(func() {
 			subDir = filepath.Join(tempRoot, "sub_dir")
@@ -86,6 +87,19 @@ var _ = Describe("filetree", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(out).To(MatchYAML(`empty_dir: {}
 sub_dir:
+  sub_dir_file:
+    foo:
+      bar:
+        baz
+`))
+		})
+
+		It("Only checks specified directories", func() {
+			tree, err := filetree.NewTree(tempRoot, "sub_dir")
+			Expect(err).ToNot(HaveOccurred())
+
+			out, err := yaml.Marshal(tree)
+			Expect(out).To(MatchYAML(`sub_dir:
   sub_dir_file:
     foo:
       bar:

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e // indirect
 	github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 // indirect
 	github.com/fatih/color v1.9.0 // indirect
-	github.com/go-yaml/yaml v2.1.0+incompatible
 	github.com/gobuffalo/buffalo-plugins v1.9.3 // indirect
 	github.com/gobuffalo/flect v0.0.0-20181210151238-24a2b68e0316 // indirect
 	github.com/gobuffalo/packr/v2 v2.0.0-rc.13
@@ -35,7 +34,7 @@ require (
 	golang.org/x/oauth2 v0.0.0-20180724155351-3d292e4d0cdc // indirect
 	golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4 // indirect
 	golang.org/x/tools v0.0.0-20181221235234-d00ac6d27372 // indirect
-	gopkg.in/yaml.v2 v2.2.2
+	gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c
 	gotest.tools v2.1.0+incompatible
 )
 

--- a/go.sum
+++ b/go.sum
@@ -35,8 +35,6 @@ github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
-github.com/go-yaml/yaml v2.1.0+incompatible h1:RYi2hDdss1u4YE7GwixGzWwVo47T8UQwnTLB6vQiq+o=
-github.com/go-yaml/yaml v2.1.0+incompatible/go.mod h1:w2MrLa16VYP0jy6N7M5kHaCkaLENm+P+Tv+MfurjSw0=
 github.com/gobuffalo/buffalo v0.12.8-0.20181004233540-fac9bb505aa8/go.mod h1:sLyT7/dceRXJUxSsE813JTQtA3Eb1vjxWfo/N//vXIY=
 github.com/gobuffalo/buffalo v0.13.0/go.mod h1:Mjn1Ba9wpIbpbrD+lIDMy99pQ0H0LiddMIIDGse7qT4=
 github.com/gobuffalo/buffalo-plugins v1.0.2/go.mod h1:pOp/uF7X3IShFHyobahTkTLZaeUXwb0GrUTb9ngJWTs=
@@ -452,9 +450,10 @@ gopkg.in/gomail.v2 v2.0.0-20160411212932-81ebce5c23df/go.mod h1:LRQQ+SO6ZHR7tOkp
 gopkg.in/mail.v2 v2.0.0-20180731213649-a0242b2233b4/go.mod h1:htwXN1Qh09vZJ1NVKxQqHPBaCBbzKhp5GzuJEA4VJWw=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
-gopkg.in/yaml.v2 v2.2.1 h1:mUhvW9EsL+naU5Q3cakzfE91YhliOondGd6ZrsDBHQE=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c h1:grhR+C34yXImVGp7EzNk+DTIk+323eIUWOmEevy6bDo=
+gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools v2.1.0+incompatible h1:5USw7CrJBYKqjg9R7QlA6jzqZKEAtvW82aNmsxxGPxw=
 gotest.tools v2.1.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=

--- a/integration_tests/features/orb_pack.feature
+++ b/integration_tests/features/orb_pack.feature
@@ -1,0 +1,48 @@
+Feature: Orb pack
+  @mocked_home_directory
+  Scenario: Basic orb pack
+    Given a file named "src/@orb.yml" with:
+    """
+    commands:
+        test:
+          steps:
+            - run:
+                command: <<include(script.sh)>>
+    """
+    Given a file named "src/script.sh" with "echo Hello, world!"
+    When I run `circleci orb pack src`
+    Then the output should contain:
+    """
+    commands:
+        test:
+            steps:
+                - run:
+                    command: echo Hello, world!
+    """
+    And the exit status should be 0
+
+  @mocked_home_directory
+  Scenario: Missing @orb.yml for orb packing
+    When I run `circleci orb pack src`
+    Then the output should contain:
+    """
+    Error: @orb.yml file not found, are you sure this is the Orb root?
+    """
+    And the exit status should be 255
+
+  @mocked_home_directory
+  Scenario: Missing script for inclusion
+    Given a file named "src/@orb.yml" with:
+    """
+    commands:
+        test:
+          steps:
+            - run:
+                command: <<include(script.sh)>>
+    """
+    When I run `circleci orb pack src`
+    Then the output should contain:
+    """
+    Error: An unexpected error occurred: Could not open src/script.sh for inclusion in Orb
+    """
+    And the exit status should be 255

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/CircleCI-Public/circleci-cli/data"
-	yaml "gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v3"
 )
 
 // Config is used to represent the current state of a CLI instance.


### PR DESCRIPTION
 * New `orb pack` command, which behaves similar to the `config pack`, but with a stricter project structure.
 * Added `<<include([filepath])>>` syntax to Orb packing to include scripts and files.
 * Add ability to enforce directories walked with `NewTree()` (backwards-compatible)
 * Move everything to `yaml.v3` to consolidate (previously both `gopkg.in/yaml.v2` and `github.com/go-yaml/yaml` were being used)
 * Orb and orb usage example schema