### PR TITLE
Validate that a circle token has been set before running context commands

### DIFF
--- a/cmd/context.go
+++ b/cmd/context.go
@@ -20,8 +20,9 @@ func newContextCommand(config *settings.Config) *cobra.Command {
 
 	var cl *client.Client
 
-	initClient := func(cmd *cobra.Command, args []string) {
+	initClient := func(cmd *cobra.Command, args []string) error {
 		cl = client.NewClient(config.Host, config.Endpoint, config.Token, config.Debug)
+		return validateToken(config)
 	}
 
 	command := &cobra.Command{
@@ -32,7 +33,7 @@ func newContextCommand(config *settings.Config) *cobra.Command {
 	listCommand := &cobra.Command{
 		Short:  "List all contexts",
 		Use:    "list <vcs-type> <org-name>",
-		PreRun: initClient,
+		PreRunE: initClient,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return listContexts(cl, args[0], args[1])
 		},
@@ -42,7 +43,7 @@ func newContextCommand(config *settings.Config) *cobra.Command {
 	showContextCommand := &cobra.Command{
 		Short:  "Show a context",
 		Use:    "show <vcs-type> <org-name> <context-name>",
-		PreRun: initClient,
+		PreRunE: initClient,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return showContext(cl, args[0], args[1], args[2])
 		},
@@ -52,7 +53,7 @@ func newContextCommand(config *settings.Config) *cobra.Command {
 	storeCommand := &cobra.Command{
 		Short:  "Store a new environment variable in the named context. The value is read from stdin.",
 		Use:    "store-secret <vcs-type> <org-name> <context-name> <secret name>",
-		PreRun: initClient,
+		PreRunE: initClient,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return storeEnvVar(cl, args[0], args[1], args[2], args[3])
 		},
@@ -62,7 +63,7 @@ func newContextCommand(config *settings.Config) *cobra.Command {
 	removeCommand := &cobra.Command{
 		Short:  "Remove an environment variable from the named context",
 		Use:    "remove-secret <vcs-type> <org-name> <context-name> <secret name>",
-		PreRun: initClient,
+		PreRunE: initClient,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return removeEnvVar(cl, args[0], args[1], args[2], args[3])
 		},
@@ -72,7 +73,7 @@ func newContextCommand(config *settings.Config) *cobra.Command {
 	createContextCommand := &cobra.Command{
 		Short:  "Create a new context",
 		Use:    "create <vcs-type> <org-name> <context-name>",
-		PreRun: initClient,
+		PreRunE: initClient,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return createContext(cl, args[0], args[1], args[2])
 		},
@@ -83,7 +84,7 @@ func newContextCommand(config *settings.Config) *cobra.Command {
 	deleteContextCommand := &cobra.Command{
 		Short:  "Delete the named context",
 		Use:    "delete <vcs-type> <org-name> <context-name>",
-		PreRun: initClient,
+		PreRunE: initClient,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return deleteContext(cl, force, args[0], args[1], args[2])
 		},

--- a/cmd/context_test.go
+++ b/cmd/context_test.go
@@ -1,0 +1,42 @@
+package cmd_test
+
+import (
+	"os/exec"
+
+	"github.com/CircleCI-Public/circleci-cli/clitest"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+	"github.com/onsi/gomega/gexec"
+)
+
+var _ = Describe("Context integration tests", func() {
+	Describe("when listing contexts without a token", func() {
+		var (
+			command      *exec.Cmd
+			tempSettings *clitest.TempSettings
+		)
+
+		BeforeEach(func() {
+			tempSettings = clitest.WithTempSettings()
+			command = commandWithHome(pathCLI, tempSettings.Home,
+				"context", "list", "github", "foo",
+				"--skip-update-check",
+				"--token", "",
+			)
+		})
+
+		It("instructs the user to run 'circleci setup' and create a new token", func() {
+			By("running the command")
+			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+
+			Expect(err).ShouldNot(HaveOccurred())
+			Eventually(session.Err).Should(gbytes.Say(`Error: please set a token with 'circleci setup'
+You can create a new personal API token here:
+https://circleci.com/account/api`))
+			Eventually(session).Should(clitest.ShouldFail())
+		})
+	})
+
+	// TODO: add integration tests for happy path cases
+})

--- a/integration_tests/features/contexts.feature
+++ b/integration_tests/features/contexts.feature
@@ -1,0 +1,16 @@
+
+# Aruba reference
+# https://gist.github.com/bdunn313/4199906
+
+Feature: Context integration tests
+
+  @mocked_home_directory
+  Scenario: when listing contexts without a token
+    When I run `circleci context list github foo --skip-update-check --token ""`
+    Then the output should contain:
+    """
+    Error: please set a token with 'circleci setup'
+    You can create a new personal API token here:
+    https://circleci.com/account/api`
+    """
+    And the exit status should be 0

--- a/integration_tests/features/contexts.feature
+++ b/integration_tests/features/contexts.feature
@@ -11,6 +11,6 @@ Feature: Context integration tests
     """
     Error: please set a token with 'circleci setup'
     You can create a new personal API token here:
-    https://circleci.com/account/api`
+    https://circleci.com/account/api
     """
-    And the exit status should be 0
+    And the exit status should be 255


### PR DESCRIPTION
This shows a more helpful error message in the case that a circle token has never been set, but not when the token is set and authn/authz fails.

This uses a function `validateToken` that other commands already use, so we probably just forgot to use it here.