### PR TITLE
Fix overly harsh auth requirements for listing contexts

### DIFF
--- a/api/context.go
+++ b/api/context.go
@@ -105,7 +105,9 @@ func CreateContext(cl *client.Client, vcsType, orgName, contextName string) erro
 }
 
 func ListContexts(cl *client.Client, orgName, vcsType string) (*ContextsQueryResponse, error) {
-
+	// In theory we can lookup the organization by name and its contexts in
+	// the same query, but using separate requests to circumvent a bug in
+	// the API
 	org, err := getOrganization(cl, orgName, vcsType)
 
 	if err != nil {

--- a/api/context.go
+++ b/api/context.go
@@ -106,9 +106,15 @@ func CreateContext(cl *client.Client, vcsType, orgName, contextName string) erro
 
 func ListContexts(cl *client.Client, orgName, vcsType string) (*ContextsQueryResponse, error) {
 
+	org, err := getOrganization(cl, orgName, vcsType)
+
+	if err != nil {
+		return nil, err
+	}
+
 	query := `
-	query ContextsQuery($orgName: String!, $vcsType: VCSType!) {
-		organization(name: $orgName, vcsType: $vcsType) {
+	query ContextsQuery($orgId: ID!) {
+		organization(id: $orgId) {
 			id
 			contexts {
 				edges {
@@ -151,11 +157,10 @@ func ListContexts(cl *client.Client, orgName, vcsType string) (*ContextsQueryRes
 	request := client.NewRequest(query)
 	request.SetToken(cl.Token)
 
-	request.Var("orgName", orgName)
-	request.Var("vcsType", strings.ToUpper(vcsType))
+	request.Var("orgId", org.Organization.ID)
 
 	var response ContextsQueryResponse
-	err := cl.Run(request, &response)
+	err = cl.Run(request, &response)
 	return &response, errors.Wrapf(improveVcsTypeError(err), "failed to load context list")
 }
 

--- a/api/context_test.go
+++ b/api/context_test.go
@@ -150,8 +150,13 @@ var _ = Describe("API", func() {
 			}
 
 			server, client := createSingleUseGraphQLServer(list, func(count uint64, req *graphQLRequst) {
-				Expect(req.Variables["orgName"]).To(Equal("test-org"))
-				Expect(req.Variables["vcsType"]).To(Equal("TEST-VCS"))
+				switch count {
+				case 1:
+					Expect(req.Variables["organizationName"]).To(Equal("test-org"))
+					Expect(req.Variables["organizationVcs"]).To(Equal("TEST-VCS"))
+				case 2:
+					Expect(req.Variables["orgId"]).To(Equal("C3D79A95-6BD5-40B4-9958-AB6BDC4CAD50"))
+				}
 			})
 			defer server.Close()
 


### PR DESCRIPTION
Our GraphQL API has a bug that prevents us from looking up an organization by name and listing its contexts in the same query. This impacts our `ListContexts` function that's used by most of the context-related commands. Until we have addressed the underlying backend issue, the CLI now resolves those via two separate requests as a quick fix.

Fixes #379 