### PR TITLE
Fix brew release script

### DIFF
--- a/.circleci/brew-deploy.sh
+++ b/.circleci/brew-deploy.sh
@@ -8,7 +8,7 @@ brew update
 brew install circleci
 
 VERSION=$("$DESTDIR"/circleci version)
-TAG="v$(ruby -e "puts '$VERSION'.split('+')[0]")"
-REVISION=$(git rev-parse "$(ruby -e "puts '$VERSION'.split('+')[1]")")
+TAG="v$(ruby -e "puts '$VERSION'.split(/[ +]/)[0]")"
+REVISION=$(git rev-parse "$(ruby -e "puts '$VERSION'.split(/[ +]/)[1]")")
 echo "Bumping circleci to $TAG+$REVISION"
 brew bump-formula-pr --strict --tag="$TAG" --revision="$REVISION" circleci


### PR DESCRIPTION
Our regex that pulls out the version number and commit hash got broken by https://github.com/circleci-public/circleci-cli/commit/39bbf290aff20f0bcec39a3e2a190158c3c12d15 last month:
```
fatal: ambiguous argument 'e30b234 (release)': unknown revision or path not in the working tree.
```