### PR TITLE
Send fabricated pipeline values when processing config or executing jobs.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -16,3 +16,4 @@ We are very grateful to the following people have helped us to build the CLI too
 - [Daniel Ruthardt](https://github.com/DanielRuthardt)
 - [Josef Šimánek](https://github.com/simi)
 - [Brady Sullivan](https://github.com/d1str0)
+- [Ashley Reid](https://github.com/akanix42)

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -141,7 +141,7 @@ func validateConfig(opts configOptions) error {
 }
 
 func processConfig(opts configOptions) error {
-	response, err := api.ConfigQuery(opts.cl, opts.args[0], nil)
+	response, err := api.ConfigQuery(opts.cl, opts.args[0], pipeline.FabricatedValues())
 
 	if err != nil {
 		return err

--- a/integration_tests/features/circleci_config.feature
+++ b/integration_tests/features/circleci_config.feature
@@ -38,7 +38,7 @@ Feature: Config checking
         steps: [checkout]
     """
     When I run `circleci config process --skip-update-check config.yml`
-    Then the output should contain exactly:
+    Then the output should match:
     """
     version: 2
     jobs:
@@ -46,6 +46,8 @@ Feature: Config checking
         machine: true
         steps:
         - checkout
+        environment:
+        - CIRCLE_COMPARE_URL: .*
     workflows:
       version: 2
       workflow:

--- a/local/local.go
+++ b/local/local.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/CircleCI-Public/circleci-cli/api"
 	"github.com/CircleCI-Public/circleci-cli/client"
+	"github.com/CircleCI-Public/circleci-cli/pipeline"
 	"github.com/CircleCI-Public/circleci-cli/settings"
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
@@ -42,7 +43,7 @@ func Execute(flags *pflag.FlagSet, cfg *settings.Config) error {
 
 	processedArgs, configPath := buildAgentArguments(flags)
 	cl := client.NewClient(cfg.Host, cfg.Endpoint, cfg.Token, cfg.Debug)
-	configResponse, err := api.ConfigQuery(cl, configPath, nil)
+	configResponse, err := api.ConfigQuery(cl, configPath, pipeline.FabricatedValues())
 
 	if err != nil {
 		return err


### PR DESCRIPTION
Fixes #442.

It takes what #405 did for `config validate` and applies it to `config process` and `local execute`.
The tests for #405 were removed, so I'm not sure if I should be adding any tests for this.