### PR TITLE
Escape `<<` in `<<include(file)>>` directives

### DIFF
--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -836,7 +836,7 @@ func inlineIncludes(node *yaml.Node, orbRoot string) error {
 	// Otherwise, we recurse into the children of the Node in search of
 	// a matching regex.
 	if node.Kind == yaml.ScalarNode && node.Value != "" {
-		v, err := process.IncludeFile(node.Value, orbRoot)
+		v, err := process.MaybeIncludeFile(node.Value, orbRoot)
 		if err != nil {
 			return err
 		}

--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -850,8 +850,9 @@ func inlineIncludes(node *yaml.Node, orbRoot string) error {
 			if err != nil {
 				return errors.New(fmt.Sprintf("Could not open %s for inclusion in Orb", filepath))
 			}
+			escaped := strings.ReplaceAll("<<", string(file), "\\<<")
 
-			node.Value = string(file)
+			node.Value = string(escaped)
 		}
 
 	} else {

--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -4,10 +4,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
-	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -15,6 +13,7 @@ import (
 	"github.com/CircleCI-Public/circleci-cli/api"
 	"github.com/CircleCI-Public/circleci-cli/client"
 	"github.com/CircleCI-Public/circleci-cli/filetree"
+	"github.com/CircleCI-Public/circleci-cli/process"
 	"github.com/CircleCI-Public/circleci-cli/prompt"
 	"github.com/CircleCI-Public/circleci-cli/references"
 	"github.com/CircleCI-Public/circleci-cli/settings"
@@ -833,28 +832,15 @@ func packOrb(opts orbOptions) error {
 
 // Travel down a YAML node, replacing values as we go.
 func inlineIncludes(node *yaml.Node, orbRoot string) error {
-	// View: https://regexr.com/582gb
-	includeRegex, err := regexp.Compile(`(?U)^<<\s*include\((.*\/*[^\/]+)\)\s*?>>$`)
-	if err != nil {
-		return err
-	}
-
 	// If we're dealing with a ScalarNode, we can replace the contents.
 	// Otherwise, we recurse into the children of the Node in search of
 	// a matching regex.
 	if node.Kind == yaml.ScalarNode && node.Value != "" {
-		includeMatches := includeRegex.FindStringSubmatch(node.Value)
-		if len(includeMatches) > 0 {
-			filepath := filepath.Join(orbRoot, includeMatches[1])
-			file, err := ioutil.ReadFile(filepath)
-			if err != nil {
-				return errors.New(fmt.Sprintf("Could not open %s for inclusion in Orb", filepath))
-			}
-			escaped := strings.ReplaceAll("<<", string(file), "\\<<")
-
-			node.Value = string(escaped)
+		v, err := process.IncludeFile(node.Value, orbRoot)
+		if err != nil {
+			return err
 		}
-
+		node.Value = v
 	} else {
 		// I am *slightly* worried about performance related to this approach, but don't have any
 		// larger Orbs to test against.

--- a/integration_tests/features/orb_pack.feature
+++ b/integration_tests/features/orb_pack.feature
@@ -43,6 +43,6 @@ Feature: Orb pack
     When I run `circleci orb pack src`
     Then the output should contain:
     """
-    Error: An unexpected error occurred: Could not open src/script.sh for inclusion in Orb
+    Error: An unexpected error occurred: could not open src/script.sh for inclusion
     """
     And the exit status should be 255

--- a/process/process.go
+++ b/process/process.go
@@ -1,0 +1,33 @@
+package process
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// IncludeFile replaces intsances of <<include(file)>> with the contents
+// of "file", escaping instances of "<<" within the file before returning.
+func IncludeFile(template string, root string) (string, error) {
+	// View: https://regexr.com/582gb
+	includeRegex, err := regexp.Compile(`(?U)^<<\s*include\((.*\/*[^\/]+)\)\s*?>>$`)
+	if err != nil {
+		return template, err
+	}
+
+	includeMatches := includeRegex.FindStringSubmatch(template)
+	if len(includeMatches) > 0 {
+		filepath := filepath.Join(root, includeMatches[1])
+		file, err := ioutil.ReadFile(filepath)
+		if err != nil {
+			return "", fmt.Errorf("could not open %s for inclusion", filepath)
+		}
+		escaped := strings.ReplaceAll("<<", string(file), "\\<<")
+
+		return escaped, nil
+	}
+
+	return template, nil
+}

--- a/process/process.go
+++ b/process/process.go
@@ -24,7 +24,7 @@ func IncludeFile(template string, root string) (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("could not open %s for inclusion", filepath)
 		}
-		escaped := strings.ReplaceAll("<<", string(file), "\\<<")
+		escaped := strings.ReplaceAll(string(file), "<<", "\\<<")
 
 		return escaped, nil
 	}

--- a/process/process.go
+++ b/process/process.go
@@ -8,18 +8,19 @@ import (
 	"strings"
 )
 
-// IncludeFile replaces intsances of <<include(file)>> with the contents
-// of "file", escaping instances of "<<" within the file before returning.
-func IncludeFile(template string, root string) (string, error) {
+// MaybeIncludeFile replaces intsances of <<include(file)>> with the contents
+// of "file", escaping instances of "<<" within the file before returning, when
+// the <<include()>> parameter is the string passed.
+func MaybeIncludeFile(s string, orbDirectory string) (string, error) {
 	// View: https://regexr.com/582gb
 	includeRegex, err := regexp.Compile(`(?U)^<<\s*include\((.*\/*[^\/]+)\)\s*?>>$`)
 	if err != nil {
-		return template, err
+		return s, err
 	}
 
-	includeMatches := includeRegex.FindStringSubmatch(template)
+	includeMatches := includeRegex.FindStringSubmatch(s)
 	if len(includeMatches) > 0 {
-		filepath := filepath.Join(root, includeMatches[1])
+		filepath := filepath.Join(orbDirectory, includeMatches[1])
 		file, err := ioutil.ReadFile(filepath)
 		if err != nil {
 			return "", fmt.Errorf("could not open %s for inclusion", filepath)
@@ -29,5 +30,5 @@ func IncludeFile(template string, root string) (string, error) {
 		return escaped, nil
 	}
 
-	return template, nil
+	return s, nil
 }


### PR DESCRIPTION
This allows the `<<include(file)>>` directives to escape any `<<` strings in the script itself, encouraging orb authors to write test-able scripts rather than injecting parameters directly into their scripts. e.g

```bash
# src/scripts/xyz.sh
echo << parameters.xyz >>
```

becomes

```bash
# rest of the orb
commands: |
  echo \<< parameters.xyz >>
```