### PR TITLE
Unhide `orb pack`

### DIFF
--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -254,8 +254,7 @@ Please note that at this time all orbs created in the registry are world-readabl
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return packOrb(opts)
 		},
-		Args:   cobra.ExactArgs(1),
-		Hidden: true,
+		Args: cobra.ExactArgs(1),
 	}
 
 	orbCreate.Flags().BoolVar(&opts.integrationTesting, "integration-testing", false, "Enable test mode to bypass interactive UI.")


### PR DESCRIPTION
Unhides the `orb pack` command - merge this when we feel comfortable with the functionality!