### PR TITLE
Remove mentions to X-team in our issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -13,5 +13,3 @@ Can you provide an example?
 **Which version of the CLI and OS are you using? Did this work in previous versions?**
 
 Please provide the output of `circleci version` and `circleci diagnostic`.
-
-**If you have any questions, feel free to ping us at @CircleCI-Public/x-team.**

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,5 +11,3 @@
 5. The `--debug` flag is often helpful for debugging HTTP client requests and responses.
 6. Format your code with [gofmt](https://golang.org/cmd/gofmt/).
 7. Make sure your code lints (`make lint`). Note: This requires Docker to run inside a local job.
-
-**If you have any questions, feel free to ping us at @CircleCI-Public/x-team.**


### PR DESCRIPTION
Remove mentions to the x-team as they no longer manage the CLI; the Ecosystem team now owns it, but we look at every PR and ticket, so no need for the extra @-mention. 