### PR TITLE
Bump JSON version for brew outdated

### DIFF
--- a/update/update.go
+++ b/update/update.go
@@ -70,17 +70,17 @@ func checkFromHomebrew(check *Options) error {
 		return errors.Wrap(err, "Expected to find `brew` in your $PATH but wasn't able to find it")
 	}
 
-	command := exec.Command(brew, "outdated", "--json=v1") // #nosec
+	command := exec.Command(brew, "outdated", "--json=v2") // #nosec
 	out, err := command.Output()
 	if err != nil {
-		return errors.Wrap(err, "failed to check for updates. `brew outdated --json=v1` returned an error")
+		return errors.Wrap(err, "failed to check for updates. `brew outdated --json=v2` returned an error")
 	}
 
 	var outdated HomebrewOutdated
 
 	err = json.Unmarshal(out, &outdated)
 	if err != nil {
-		return errors.Wrap(err, "failed to parse output of `brew outdated --json=v1`")
+		return errors.Wrap(err, "failed to parse output of `brew outdated --json=v2`")
 	}
 
 	for _, o := range outdated {
@@ -101,7 +101,7 @@ func checkFromHomebrew(check *Options) error {
 	return nil
 }
 
-// HomebrewOutdated wraps the JSON output from running `brew outdated --json=v1`
+// HomebrewOutdated wraps the JSON output from running `brew outdated --json=v2`
 // We're specifically looking for this kind of structured data from the command:
 //
 //   [


### PR DESCRIPTION
Prevents errors from being raised when attempting to use a deprecated API version with Homebrew.

    $ brew outdated --json=v1 ; echo $?
    Error: Calling brew outdated --json=v1 is deprecated! Use brew outdated --json=v2 instead.
    1

- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/master/CONTRIBUTING.md).
- [x] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)