### PR TITLE
Fixes unmarshalling for homebrew outdated v2 JSON

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -17,3 +17,4 @@ We are very grateful to the following people have helped us to build the CLI too
 - [Josef Šimánek](https://github.com/simi)
 - [Brady Sullivan](https://github.com/d1str0)
 - [Ashley Reid](https://github.com/akanix42)
+- [Joshu Coats](https://github.com/rhwlo)

--- a/update/update.go
+++ b/update/update.go
@@ -83,7 +83,7 @@ func checkFromHomebrew(check *Options) error {
 		return errors.Wrap(err, "failed to parse output of `brew outdated --json=v2`")
 	}
 
-	for _, o := range outdated {
+	for _, o := range outdated.Formulae {
 		if o.Name == "circleci" {
 			if len(o.InstalledVersions) > 0 {
 				check.Current = semver.MustParse(o.InstalledVersions[0])
@@ -104,23 +104,28 @@ func checkFromHomebrew(check *Options) error {
 // HomebrewOutdated wraps the JSON output from running `brew outdated --json=v2`
 // We're specifically looking for this kind of structured data from the command:
 //
-//   [
-//     {
-//       "name": "circleci",
-//       "installed_versions": [
-//         "0.1.1248"
-//       ],
-//       "current_version": "0.1.3923",
-//       "pinned": false,
-//       "pinned_version": null
-//     },
-//   ]
-type HomebrewOutdated []struct {
-	Name              string   `json:"name"`
-	InstalledVersions []string `json:"installed_versions"`
-	CurrentVersion    string   `json:"current_version"`
-	Pinned            bool     `json:"pinned"`
-	PinnedVersion     string   `json:"pinned_version"`
+//   {
+//     "formulae": [
+//       {
+//         "name": "circleci",
+//         "installed_versions": [
+//           "0.1.1248"
+//         ],
+//         "current_version": "0.1.3923",
+//         "pinned": false,
+//         "pinned_version": null
+//       }
+//     ],
+//     "casks": []
+//   }
+type HomebrewOutdated struct {
+	Formulae []struct {
+		Name              string   `json:"name"`
+		InstalledVersions []string `json:"installed_versions"`
+		CurrentVersion    string   `json:"current_version"`
+		Pinned            bool     `json:"pinned"`
+		PinnedVersion     string   `json:"pinned_version"`
+	} `json:"formulae"`
 }
 
 // Options contains everything we need to check for or perform updates of the CLI.


### PR DESCRIPTION
Fixes #462; from the Homebrew source, it looks like the output for `outdated --json=v2` nests the values that we’re looking for under the `formulae` key: https://github.com/Homebrew/brew/blob/484c2b4fab3eeadd477d902b0b95036cc463355f/Library/Homebrew/cmd/outdated.rb#L59-L72

- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/master/CONTRIBUTING.md).
- [x] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)
