### PR TITLE
[CIRCLE-29501] Add commands to manage runner types

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,6 +93,7 @@ jobs:
   test_windows:
     executor: windows/default
     steps:
+      - run: git config --global core.autocrlf false
       - checkout
       - run: setx GOPATH %USERPROFILE%\go
       - run: go get gotest.tools/gotestsum

--- a/api/rest/client.go
+++ b/api/rest/client.go
@@ -1,0 +1,111 @@
+package rest
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+type Client struct {
+	baseURL     *url.URL
+	circleToken string
+	client      *http.Client
+}
+
+func New(host, endpoint, circleToken string) *Client {
+	// Ensure endpoint ends with a slash
+	if !strings.HasSuffix(endpoint, "/") {
+		endpoint += "/"
+	}
+
+	u, _ := url.Parse(host)
+	return &Client{
+		baseURL:     u.ResolveReference(&url.URL{Path: endpoint}),
+		circleToken: circleToken,
+		client: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+	}
+}
+
+func (c *Client) NewRequest(method string, u *url.URL, payload interface{}) (req *http.Request, err error) {
+	var r io.Reader
+	if payload != nil {
+		buf := &bytes.Buffer{}
+		r = buf
+		err = json.NewEncoder(buf).Encode(payload)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	req, err = http.NewRequest(method, c.baseURL.ResolveReference(u).String(), r)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Circle-Token", c.circleToken)
+	req.Header.Set("Accept-Type", "application/json")
+	req.Header.Set("User-Agent", "circleci-cli")
+	if payload != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	return req, nil
+}
+
+func (c *Client) DoRequest(req *http.Request, resp interface{}) (statusCode int, err error) {
+	httpResp, err := c.client.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer httpResp.Body.Close()
+
+	if httpResp.StatusCode >= 300 {
+		httpError := struct {
+			Message string `json:"message"`
+		}{}
+		err = json.NewDecoder(httpResp.Body).Decode(&httpError)
+		if err != nil {
+			return httpResp.StatusCode, err
+		}
+		return httpResp.StatusCode, &HTTPError{Code: httpResp.StatusCode, Err: errors.New(httpError.Message)}
+	}
+
+	if resp != nil {
+		if !strings.Contains(httpResp.Header.Get("Content-Type"), "application/json") {
+			return httpResp.StatusCode, errors.New("wrong content type received")
+		}
+
+		err = json.NewDecoder(httpResp.Body).Decode(resp)
+		if err != nil {
+			return httpResp.StatusCode, err
+		}
+	}
+	return httpResp.StatusCode, nil
+}
+
+type HTTPError struct {
+	Code int
+	Err  error
+}
+
+func (e *HTTPError) Error() string {
+	if e.Code == 0 {
+		e.Code = http.StatusInternalServerError
+	}
+	if e.Err != nil {
+		return fmt.Sprintf("%v (%d-%s)", e.Err, e.Code, http.StatusText(e.Code))
+	}
+	return fmt.Sprintf("response %d (%s)", e.Code, http.StatusText(e.Code))
+}
+
+func (e *HTTPError) Unwrap() error {
+	return e.Err
+}

--- a/api/rest/client_test.go
+++ b/api/rest/client_test.go
@@ -1,0 +1,169 @@
+package rest
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+)
+
+func TestClient_DoRequest(t *testing.T) {
+	t.Run("PUT with req and resp", func(t *testing.T) {
+		fix := &fixture{}
+		c, cleanup := fix.Run(http.StatusCreated, `{"key": "value"}`)
+		defer cleanup()
+
+		t.Run("Check result", func(t *testing.T) {
+			r, err := c.NewRequest("PUT", &url.URL{Path: "my/endpoint"}, struct {
+				A string
+				B int
+			}{
+				A: "aaa",
+				B: 123,
+			})
+			assert.NilError(t, err)
+
+			resp := make(map[string]interface{})
+			statusCode, err := c.DoRequest(r, &resp)
+			assert.NilError(t, err)
+			assert.Equal(t, statusCode, http.StatusCreated)
+			assert.Check(t, cmp.DeepEqual(resp, map[string]interface{}{
+				"key": "value",
+			}))
+		})
+
+		t.Run("Check request", func(t *testing.T) {
+			assert.Check(t, cmp.Equal(fix.URL(), url.URL{Path: "/api/v2/my/endpoint"}))
+			assert.Check(t, cmp.Equal(fix.Method(), "PUT"))
+			assert.Check(t, cmp.DeepEqual(fix.Header(), http.Header{
+				"Accept-Encoding": {"gzip"},
+				"Accept-Type":     {"application/json"},
+				"Circle-Token":    {"fake-token"},
+				"Content-Length":  {"20"},
+				"Content-Type":    {"application/json"},
+				"User-Agent":      {"circleci-cli"},
+			}))
+			assert.Check(t, cmp.Equal(fix.Body(), `{"A":"aaa","B":123}`+"\n"))
+		})
+	})
+
+	t.Run("GET with error status", func(t *testing.T) {
+		fix := &fixture{}
+		c, cleanup := fix.Run(http.StatusBadRequest, `{"message": "the error message"}`)
+		defer cleanup()
+
+		t.Run("Check result", func(t *testing.T) {
+			r, err := c.NewRequest("GET", &url.URL{Path: "my/error/endpoint"}, nil)
+			assert.NilError(t, err)
+
+			resp := make(map[string]interface{})
+			statusCode, err := c.DoRequest(r, &resp)
+			assert.Error(t, err, "the error message (400-Bad Request)")
+			assert.Equal(t, statusCode, http.StatusBadRequest)
+			assert.Check(t, cmp.DeepEqual(resp, map[string]interface{}{}))
+		})
+
+		t.Run("Check request", func(t *testing.T) {
+			assert.Check(t, cmp.Equal(fix.URL(), url.URL{Path: "/api/v2/my/error/endpoint"}))
+			assert.Check(t, cmp.Equal(fix.Method(), "GET"))
+			assert.Check(t, cmp.DeepEqual(fix.Header(), http.Header{
+				"Accept-Encoding": {"gzip"},
+				"Accept-Type":     {"application/json"},
+				"Circle-Token":    {"fake-token"},
+				"User-Agent":      {"circleci-cli"},
+			}))
+			assert.Check(t, cmp.Equal(fix.Body(), ""))
+		})
+	})
+
+	t.Run("GET with resp only", func(t *testing.T) {
+		fix := &fixture{}
+		c, cleanup := fix.Run(http.StatusCreated, `{"a": "abc", "b": true}`)
+		defer cleanup()
+
+		t.Run("Check result", func(t *testing.T) {
+			r, err := c.NewRequest("GET", &url.URL{Path: "path"}, nil)
+			assert.NilError(t, err)
+
+			resp := make(map[string]interface{})
+			statusCode, err := c.DoRequest(r, &resp)
+			assert.NilError(t, err)
+			assert.Equal(t, statusCode, http.StatusCreated)
+			assert.Check(t, cmp.DeepEqual(resp, map[string]interface{}{
+				"a": "abc",
+				"b": true,
+			}))
+		})
+
+		t.Run("Check request", func(t *testing.T) {
+			assert.Check(t, cmp.Equal(fix.URL(), url.URL{Path: "/api/v2/path"}))
+			assert.Check(t, cmp.Equal(fix.Method(), "GET"))
+			assert.Check(t, cmp.DeepEqual(fix.Header(), http.Header{
+				"Accept-Encoding": {"gzip"},
+				"Accept-Type":     {"application/json"},
+				"Circle-Token":    {"fake-token"},
+				"User-Agent":      {"circleci-cli"},
+			}))
+			assert.Check(t, cmp.Equal(fix.Body(), ""))
+		})
+	})
+}
+
+type fixture struct {
+	mu     sync.Mutex
+	url    url.URL
+	method string
+	header http.Header
+	body   bytes.Buffer
+}
+
+func (f *fixture) URL() url.URL {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.url
+}
+
+func (f *fixture) Method() string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.method
+}
+
+func (f *fixture) Header() http.Header {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.header
+}
+
+func (f *fixture) Body() string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.body.String()
+}
+
+func (f *fixture) Run(statusCode int, respBody string) (c *Client, cleanup func()) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		f.mu.Lock()
+		defer f.mu.Unlock()
+
+		defer r.Body.Close()
+		_, _ = io.Copy(&f.body, r.Body)
+		f.url = *r.URL
+		f.header = r.Header
+		f.method = r.Method
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(statusCode)
+		_, _ = io.WriteString(w, respBody)
+	})
+	server := httptest.NewServer(mux)
+
+	return New(server.URL, "api/v2", "fake-token"), server.Close
+}

--- a/api/runner/runner.go
+++ b/api/runner/runner.go
@@ -1,0 +1,116 @@
+package runner
+
+import (
+	"net/url"
+	"time"
+
+	"github.com/CircleCI-Public/circleci-cli/api/rest"
+)
+
+type Runner struct {
+	rc *rest.Client
+}
+
+func New(rc *rest.Client) *Runner {
+	return &Runner{rc: rc}
+}
+
+type ResourceClass struct {
+	ID            string `json:"id"`
+	ResourceClass string `json:"resource_class"`
+	Description   string `json:"description"`
+}
+
+func (r *Runner) CreateResourceClass(resourceClass, desc string) (rc *ResourceClass, err error) {
+	req, err := r.rc.NewRequest("POST", &url.URL{Path: "runner/resource"}, struct {
+		ResourceClass string `json:"resource_class"`
+		Description   string `json:"description"`
+	}{
+		ResourceClass: resourceClass,
+		Description:   desc,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	rc = &ResourceClass{}
+	_, err = r.rc.DoRequest(req, rc)
+	return rc, err
+}
+
+func (r *Runner) GetResourceClassesByNamespace(namespace string) ([]ResourceClass, error) {
+	query := url.Values{}
+	query.Add("namespace", namespace)
+	req, err := r.rc.NewRequest("GET", &url.URL{Path: "runner/resource", RawQuery: query.Encode()}, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := struct {
+		Items []ResourceClass `json:"items"`
+	}{}
+	_, err = r.rc.DoRequest(req, &resp)
+	return resp.Items, err
+}
+
+func (r *Runner) DeleteResourceClass(id string) error {
+	req, err := r.rc.NewRequest("DELETE", &url.URL{Path: "runner/resource/" + url.QueryEscape(id)}, nil)
+	if err != nil {
+		return err
+	}
+
+	_, err = r.rc.DoRequest(req, nil)
+	return err
+}
+
+type Token struct {
+	ID            string    `json:"id"`
+	Token         string    `json:"token"`
+	ResourceClass string    `json:"resource_class"`
+	Nickname      string    `json:"nickname"`
+	CreatedAt     time.Time `json:"created_at"`
+}
+
+func (r *Runner) CreateToken(resourceClass, nickname string) (token *Token, err error) {
+	t := struct {
+		ResourceClass string `json:"resource_class"`
+		Nickname      string `json:"nickname"`
+	}{
+		ResourceClass: resourceClass,
+		Nickname:      nickname,
+	}
+
+	req, err := r.rc.NewRequest("POST", &url.URL{Path: "runner/token"}, t)
+	if err != nil {
+		return nil, err
+	}
+
+	token = &Token{}
+	_, err = r.rc.DoRequest(req, token)
+	return token, err
+}
+
+func (r *Runner) GetRunnerTokensByResourceClass(resourceClass string) ([]Token, error) {
+	query := url.Values{}
+	query.Add("resource-class", resourceClass)
+	req, err := r.rc.NewRequest("GET", &url.URL{Path: "runner/token", RawQuery: query.Encode()}, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := struct {
+		Items []Token `json:"items"`
+	}{}
+	_, err = r.rc.DoRequest(req, &resp)
+	return resp.Items, err
+}
+
+func (r *Runner) DeleteToken(id string) error {
+	req, err := r.rc.NewRequest("DELETE", &url.URL{Path: "runner/token/" + url.QueryEscape(id)}, nil)
+	if err != nil {
+		return err
+	}
+
+	_, err = r.rc.DoRequest(req, nil)
+	return err
+}

--- a/api/runner/runner_test.go
+++ b/api/runner/runner_test.go
@@ -1,0 +1,306 @@
+package runner
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+
+	"github.com/CircleCI-Public/circleci-cli/api/rest"
+)
+
+func TestRunner_CreateResourceClass(t *testing.T) {
+	fix := fixture{}
+	runner, cleanup := fix.Run(
+		http.StatusOK,
+		`
+{
+	"id": "2bc0df8e-d258-4ae8-9c2b-3793f004725f",
+	"resource_class": "the-namespace/the-resource-class",
+	"description": "the-description"
+}`,
+	)
+	defer cleanup()
+
+	t.Run("Check resource-class is created", func(t *testing.T) {
+		rc, err := runner.CreateResourceClass("the-namespace/the-resource-class", "the-description")
+		assert.NilError(t, err)
+		assert.Check(t, cmp.DeepEqual(rc, &ResourceClass{
+			ID:            "2bc0df8e-d258-4ae8-9c2b-3793f004725f",
+			ResourceClass: "the-namespace/the-resource-class",
+			Description:   "the-description",
+		}))
+	})
+
+	t.Run("Check request", func(t *testing.T) {
+		assert.Check(t, cmp.Equal(fix.URL(), url.URL{Path: "/api/v2/runner/resource"}))
+		assert.Check(t, cmp.Equal(fix.method, "POST"))
+		assert.Check(t, cmp.DeepEqual(fix.Header(), http.Header{
+			"Accept-Encoding": {"gzip"},
+			"Accept-Type":     {"application/json"},
+			"Circle-Token":    {"fake-token"},
+			"Content-Length":  {"86"},
+			"Content-Type":    {"application/json"},
+			"User-Agent":      {"circleci-cli"},
+		}))
+		assert.Check(t, cmp.Equal(fix.Body(), `{"resource_class":"the-namespace/the-resource-class","description":"the-description"}`+"\n"))
+	})
+}
+
+func TestRunner_GetResourceClassesByNamespace(t *testing.T) {
+	fix := fixture{}
+	runner, cleanup := fix.Run(
+		http.StatusOK,
+		`
+{
+	"items": [
+		{"id": "7101f2a4-1617-4ef9-8fd4-f72de73896bd", "resource_class": "the-namespace/the-resource-class-1", "description": "the-description-1"},
+		{"id": "b2713ad1-13b9-44f6-9b0d-1bf5f38571db", "resource_class": "the-namespace/the-resource-class-2", "description": "the-description-2"}
+	]
+}`,
+	)
+	defer cleanup()
+
+	t.Run("Check resource-class list results", func(t *testing.T) {
+		rcs, err := runner.GetResourceClassesByNamespace("the-namespace")
+		assert.NilError(t, err)
+		assert.Check(t, cmp.DeepEqual(rcs, []ResourceClass{
+			{
+				ID:            "7101f2a4-1617-4ef9-8fd4-f72de73896bd",
+				ResourceClass: "the-namespace/the-resource-class-1",
+				Description:   "the-description-1",
+			},
+			{
+				ID:            "b2713ad1-13b9-44f6-9b0d-1bf5f38571db",
+				ResourceClass: "the-namespace/the-resource-class-2",
+				Description:   "the-description-2",
+			},
+		}))
+	})
+
+	t.Run("Check request", func(t *testing.T) {
+		assert.Check(t, cmp.Equal(fix.URL(), url.URL{Path: "/api/v2/runner/resource", RawQuery: "namespace=the-namespace"}))
+		assert.Check(t, cmp.Equal(fix.method, "GET"))
+		assert.Check(t, cmp.DeepEqual(fix.Header(), http.Header{
+			"Accept-Encoding": {"gzip"},
+			"Accept-Type":     {"application/json"},
+			"Circle-Token":    {"fake-token"},
+			"User-Agent":      {"circleci-cli"},
+		}))
+		assert.Check(t, cmp.Equal(fix.Body(), ``))
+	})
+}
+
+func TestRunner_DeleteResourceClass(t *testing.T) {
+	fix := fixture{}
+	runner, cleanup := fix.Run(http.StatusOK, ``)
+	defer cleanup()
+
+	t.Run("Check resource-class is deleted", func(t *testing.T) {
+		err := runner.DeleteResourceClass("51628548-4627-4813-9f9b-8cc9637ac879")
+		assert.NilError(t, err)
+	})
+
+	t.Run("Check request", func(t *testing.T) {
+		assert.Check(t, cmp.Equal(fix.URL(), url.URL{Path: "/api/v2/runner/resource/51628548-4627-4813-9f9b-8cc9637ac879"}))
+		assert.Check(t, cmp.Equal(fix.method, "DELETE"))
+		assert.Check(t, cmp.DeepEqual(fix.Header(), http.Header{
+			"Accept-Encoding": {"gzip"},
+			"Accept-Type":     {"application/json"},
+			"Circle-Token":    {"fake-token"},
+			"User-Agent":      {"circleci-cli"},
+		}))
+		assert.Check(t, cmp.Equal(fix.Body(), ``))
+	})
+}
+
+func TestRunner_CreateToken(t *testing.T) {
+	fix := fixture{}
+	runner, cleanup := fix.Run(
+		http.StatusOK,
+		`
+{
+	"id": "2bc0df8e-d258-4ae8-9c2b-3793f004725f",
+	"resource_class": "the-namespace/the-resource-class",
+	"nickname": "the-nickname",
+	"created_at": "2020-10-01T09:55:00.000000Z"
+}`,
+	)
+	defer cleanup()
+
+	t.Run("Check token is created", func(t *testing.T) {
+		token, err := runner.CreateToken("the-namespace/the-resource-class", "the-nickname")
+		assert.NilError(t, err)
+		assert.Check(t, cmp.DeepEqual(token, &Token{
+			ID:            "2bc0df8e-d258-4ae8-9c2b-3793f004725f",
+			ResourceClass: "the-namespace/the-resource-class",
+			Nickname:      "the-nickname",
+			CreatedAt:     time.Date(2020, 10, 1, 9, 55, 0, 0, time.UTC),
+		}))
+	})
+
+	t.Run("Check request", func(t *testing.T) {
+		assert.Check(t, cmp.Equal(fix.URL(), url.URL{Path: "/api/v2/runner/token"}))
+		assert.Check(t, cmp.Equal(fix.method, "POST"))
+		assert.Check(t, cmp.DeepEqual(fix.Header(), http.Header{
+			"Accept-Encoding": {"gzip"},
+			"Accept-Type":     {"application/json"},
+			"Circle-Token":    {"fake-token"},
+			"Content-Length":  {"80"},
+			"Content-Type":    {"application/json"},
+			"User-Agent":      {"circleci-cli"},
+		}))
+		assert.Check(t, cmp.Equal(fix.Body(), `{"resource_class":"the-namespace/the-resource-class","nickname":"the-nickname"}`+"\n"))
+	})
+}
+
+func TestRunner_GetRunnerTokensByResourceClass(t *testing.T) {
+	fix := fixture{}
+	runner, cleanup := fix.Run(
+		http.StatusOK,
+		`
+{
+	"items": [
+		{
+			"id": "9e12ad09-527d-482c-b7ce-1a2fd20d1b9b",
+			"resource_class": "the-namespace/the-resource-class",
+			"nickname": "the-nickname-1",
+			"created_at": "2020-10-01T09:55:00.000000Z"
+		},
+		{
+			"id": "8618c56e-4abf-48a6-89fa-f75a845d1196",
+			"resource_class": "the-namespace/the-resource-class",
+			"nickname": "the-nickname-2",
+			"created_at": "2020-10-01T09:55:00.000000Z"
+		},
+		{
+			"id": "a3117e42-12ce-4027-8fde-5ce39e174dfe",
+			"resource_class": "the-namespace/the-resource-class",
+			"nickname": "the-nickname-3",
+			"created_at": "2020-10-01T09:55:00.000000Z"
+		}
+	]
+}`,
+	)
+	defer cleanup()
+
+	t.Run("Check token list", func(t *testing.T) {
+		token, err := runner.GetRunnerTokensByResourceClass("the-namespace/the-resource-class")
+		assert.NilError(t, err)
+		assert.Check(t, cmp.DeepEqual(token, []Token{
+			{
+				ID:            "9e12ad09-527d-482c-b7ce-1a2fd20d1b9b",
+				ResourceClass: "the-namespace/the-resource-class",
+				Nickname:      "the-nickname-1",
+				CreatedAt:     time.Date(2020, 10, 1, 9, 55, 0, 0, time.UTC),
+			},
+			{
+				ID:            "8618c56e-4abf-48a6-89fa-f75a845d1196",
+				ResourceClass: "the-namespace/the-resource-class",
+				Nickname:      "the-nickname-2",
+				CreatedAt:     time.Date(2020, 10, 1, 9, 55, 0, 0, time.UTC),
+			},
+			{
+				ID:            "a3117e42-12ce-4027-8fde-5ce39e174dfe",
+				ResourceClass: "the-namespace/the-resource-class",
+				Nickname:      "the-nickname-3",
+				CreatedAt:     time.Date(2020, 10, 1, 9, 55, 0, 0, time.UTC),
+			},
+		}))
+	})
+
+	t.Run("Check request", func(t *testing.T) {
+		assert.Check(t, cmp.Equal(fix.URL(), url.URL{Path: "/api/v2/runner/token", RawQuery: "resource-class=the-namespace%2Fthe-resource-class"}))
+		assert.Check(t, cmp.Equal(fix.method, "GET"))
+		assert.Check(t, cmp.DeepEqual(fix.Header(), http.Header{
+			"Accept-Encoding": {"gzip"},
+			"Accept-Type":     {"application/json"},
+			"Circle-Token":    {"fake-token"},
+			"User-Agent":      {"circleci-cli"},
+		}))
+		assert.Check(t, cmp.Equal(fix.Body(), ""))
+	})
+}
+
+func TestRunner_DeleteToken(t *testing.T) {
+	fix := fixture{}
+	runner, cleanup := fix.Run(http.StatusOK, ``)
+	defer cleanup()
+
+	t.Run("Check token is deleted", func(t *testing.T) {
+		err := runner.DeleteToken("ca5341fd-9b4d-4704-b16e-1b496d6012f2")
+		assert.NilError(t, err)
+	})
+
+	t.Run("Check request", func(t *testing.T) {
+		assert.Check(t, cmp.Equal(fix.URL(), url.URL{Path: "/api/v2/runner/token/ca5341fd-9b4d-4704-b16e-1b496d6012f2"}))
+		assert.Check(t, cmp.Equal(fix.method, "DELETE"))
+		assert.Check(t, cmp.DeepEqual(fix.Header(), http.Header{
+			"Accept-Encoding": {"gzip"},
+			"Accept-Type":     {"application/json"},
+			"Circle-Token":    {"fake-token"},
+			"User-Agent":      {"circleci-cli"},
+		}))
+		assert.Check(t, cmp.Equal(fix.Body(), ``))
+	})
+}
+
+type fixture struct {
+	mu     sync.Mutex
+	url    url.URL
+	method string
+	header http.Header
+	body   bytes.Buffer
+}
+
+func (f *fixture) URL() url.URL {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.url
+}
+
+func (f *fixture) Method() string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.method
+}
+
+func (f *fixture) Header() http.Header {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.header
+}
+
+func (f *fixture) Body() string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.body.String()
+}
+
+func (f *fixture) Run(statusCode int, respBody string) (r *Runner, cleanup func()) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		f.mu.Lock()
+		defer f.mu.Unlock()
+
+		defer r.Body.Close()
+		_, _ = io.Copy(&f.body, r.Body)
+		f.url = *r.URL
+		f.header = r.Header
+		f.method = r.Method
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(statusCode)
+		_, _ = io.WriteString(w, respBody)
+	})
+	server := httptest.NewServer(mux)
+
+	return New(rest.New(server.URL, "api/v2", "fake-token")), server.Close
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,11 +4,13 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/spf13/cobra"
+
+	"github.com/CircleCI-Public/circleci-cli/cmd/runner"
 	"github.com/CircleCI-Public/circleci-cli/data"
 	"github.com/CircleCI-Public/circleci-cli/md_docs"
 	"github.com/CircleCI-Public/circleci-cli/settings"
 	"github.com/CircleCI-Public/circleci-cli/version"
-	"github.com/spf13/cobra"
 )
 
 var defaultEndpoint = "graphql-unstable"
@@ -103,12 +105,17 @@ func MakeCommands() *cobra.Command {
 	rootCmd.SetUsageTemplate(usageTemplate)
 	rootCmd.DisableAutoGenTag = true
 
+	validator := func(_ *cobra.Command, _ []string) error {
+		return validateToken(rootOptions)
+	}
+
 	rootCmd.AddCommand(newOpenCommand())
 	rootCmd.AddCommand(newTestsCommand())
 	rootCmd.AddCommand(newContextCommand(rootOptions))
 	rootCmd.AddCommand(newQueryCommand(rootOptions))
 	rootCmd.AddCommand(newConfigCommand(rootOptions))
 	rootCmd.AddCommand(newOrbCommand(rootOptions))
+	rootCmd.AddCommand(runner.NewCommand(rootOptions, validator))
 	rootCmd.AddCommand(newLocalCommand(rootOptions))
 	rootCmd.AddCommand(newBuildCommand(rootOptions))
 	rootCmd.AddCommand(newVersionCommand(rootOptions))

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -15,7 +15,7 @@ var _ = Describe("Root", func() {
 	Describe("subcommands", func() {
 		It("can create commands", func() {
 			commands := cmd.MakeCommands()
-			Expect(len(commands.Commands())).To(Equal(17))
+			Expect(len(commands.Commands())).To(Equal(18))
 		})
 	})
 

--- a/cmd/runner/config.go
+++ b/cmd/runner/config.go
@@ -1,0 +1,45 @@
+package runner
+
+import (
+	"io"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/CircleCI-Public/circleci-cli/api/runner"
+)
+
+type AgentConfig struct {
+	API    APIConfig    `yaml:"api"`
+	Runner RunnerConfig `yaml:"runner"`
+}
+
+func NewAgentConfig(t runner.Token) *AgentConfig {
+	return &AgentConfig{
+		API: APIConfig{
+			AuthToken: t.Token,
+		},
+		Runner: RunnerConfig{
+			Name:                    t.Nickname,
+			ResourceClass:           t.ResourceClass,
+			CommandPrefix:           []string{"/opt/circleci/launch-task"},
+			WorkingDirectory:        "/opt/circleci/workdir/%s",
+			CleanupWorkingDirectory: true,
+		},
+	}
+}
+
+func (c *AgentConfig) WriteYaml(w io.Writer) error {
+	return yaml.NewEncoder(w).Encode(c)
+}
+
+type APIConfig struct {
+	AuthToken string `yaml:"auth_token"`
+}
+
+type RunnerConfig struct {
+	Name                    string   `yaml:"name"`
+	ResourceClass           string   `yaml:"resource_class"`
+	CommandPrefix           []string `yaml:"command_prefix,flow"`
+	WorkingDirectory        string   `yaml:"working_directory"`
+	CleanupWorkingDirectory bool     `yaml:"cleanup_working_directory"`
+}

--- a/cmd/runner/config_test.go
+++ b/cmd/runner/config_test.go
@@ -1,0 +1,27 @@
+package runner
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/golden"
+
+	"github.com/CircleCI-Public/circleci-cli/api/runner"
+)
+
+func TestAgentConfig_WriteYaml(t *testing.T) {
+	token := runner.Token{
+		ID:            "da73786c-ebbc-4c07-849a-5590f7eef509",
+		Token:         "1a34e5519976717fb808ad8900cadbecc686facee3f9ca56c5ba1ad30e50cab7e5fa328409065c64",
+		ResourceClass: "the-namespace/the-resource-class",
+		Nickname:      "the-nickname",
+		CreatedAt:     time.Date(2020, 03, 04, 16, 13, 53, 00, time.UTC),
+	}
+
+	b := bytes.Buffer{}
+	err := NewAgentConfig(token).WriteYaml(&b)
+	assert.NilError(t, err)
+	golden.Assert(t, b.String(), "expected-config.yaml")
+}

--- a/cmd/runner/resource_class.go
+++ b/cmd/runner/resource_class.go
@@ -1,0 +1,79 @@
+package runner
+
+import (
+	"os"
+
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+
+	"github.com/CircleCI-Public/circleci-cli/api/runner"
+)
+
+func newResourceClassCommand(r *runner.Runner, preRunE validator) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "resource-class",
+		Short: "Operate on runner resource-classes",
+	}
+
+	cmd.AddCommand(&cobra.Command{
+		Use:     "create <resource-class> <description>",
+		Short:   "Create a resource-class",
+		Args:    cobra.ExactArgs(2),
+		PreRunE: preRunE,
+		RunE: func(_ *cobra.Command, args []string) error {
+			rc, err := r.CreateResourceClass(args[0], args[1])
+			if err != nil {
+				return err
+			}
+			table := newResourceClassTable()
+			defer table.Render()
+			appendResourceClass(table, *rc)
+			return nil
+		},
+	})
+
+	cmd.AddCommand(&cobra.Command{
+		Use:     "delete <resource-class>",
+		Short:   "Delete a resource-class",
+		Aliases: []string{"rm"},
+		Args:    cobra.ExactArgs(1),
+		PreRunE: preRunE,
+		RunE: func(_ *cobra.Command, args []string) error {
+			return r.DeleteResourceClass(args[0])
+		},
+	})
+
+	cmd.AddCommand(&cobra.Command{
+		Use:     "list <namespace>",
+		Short:   "List resource-classes for a namespace",
+		Aliases: []string{"ls"},
+		Args:    cobra.ExactArgs(1),
+		PreRunE: preRunE,
+		RunE: func(_ *cobra.Command, args []string) error {
+			rcs, err := r.GetResourceClassesByNamespace(args[0])
+			if err != nil {
+				return err
+			}
+
+			table := newResourceClassTable()
+			defer table.Render()
+			for _, rc := range rcs {
+				appendResourceClass(table, rc)
+			}
+
+			return nil
+		},
+	})
+
+	return cmd
+}
+
+func newResourceClassTable() *tablewriter.Table {
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeader([]string{"ID", "Resource Class", "Description"})
+	return table
+}
+
+func appendResourceClass(table *tablewriter.Table, rc runner.ResourceClass) {
+	table.Append([]string{rc.ID, rc.ResourceClass, rc.Description})
+}

--- a/cmd/runner/runner.go
+++ b/cmd/runner/runner.go
@@ -1,0 +1,23 @@
+package runner
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/CircleCI-Public/circleci-cli/api/rest"
+	"github.com/CircleCI-Public/circleci-cli/api/runner"
+	"github.com/CircleCI-Public/circleci-cli/settings"
+)
+
+func NewCommand(config *settings.Config, preRunE validator) *cobra.Command {
+	r := runner.New(rest.New(config.Host, config.RestEndpoint, config.Token))
+	cmd := &cobra.Command{
+		Use:    "runner",
+		Short:  "Operate on runners",
+		Hidden: true,
+	}
+	cmd.AddCommand(newResourceClassCommand(r, preRunE))
+	cmd.AddCommand(newTokenCommand(r, preRunE))
+	return cmd
+}
+
+type validator func(cmd *cobra.Command, args []string) error

--- a/cmd/runner/testdata/expected-config.yaml
+++ b/cmd/runner/testdata/expected-config.yaml
@@ -1,0 +1,8 @@
+api:
+    auth_token: 1a34e5519976717fb808ad8900cadbecc686facee3f9ca56c5ba1ad30e50cab7e5fa328409065c64
+runner:
+    name: the-nickname
+    resource_class: the-namespace/the-resource-class
+    command_prefix: [/opt/circleci/launch-task]
+    working_directory: /opt/circleci/workdir/%s
+    cleanup_working_directory: true

--- a/cmd/runner/testdata/runner-expected-usage.txt
+++ b/cmd/runner/testdata/runner-expected-usage.txt
@@ -1,0 +1,8 @@
+Usage:
+  runner [command]
+
+Available Commands:
+  resource-class Operate on runner resource-classes
+  token          Operate on runner tokens
+
+Use "runner [command] --help" for more information about a command.

--- a/cmd/runner/testdata/runner/resource-class-expected-usage.txt
+++ b/cmd/runner/testdata/runner/resource-class-expected-usage.txt
@@ -1,0 +1,9 @@
+Usage:
+  runner resource-class [command]
+
+Available Commands:
+  create      Create a resource-class
+  delete      Delete a resource-class
+  list        List resource-classes for a namespace
+
+Use "runner resource-class [command] --help" for more information about a command.

--- a/cmd/runner/testdata/runner/resource-class/create-expected-usage.txt
+++ b/cmd/runner/testdata/runner/resource-class/create-expected-usage.txt
@@ -1,0 +1,2 @@
+Usage:
+  runner resource-class create <resource-class> <description>

--- a/cmd/runner/testdata/runner/resource-class/delete-expected-usage.txt
+++ b/cmd/runner/testdata/runner/resource-class/delete-expected-usage.txt
@@ -1,0 +1,5 @@
+Usage:
+  runner resource-class delete <resource-class>
+
+Aliases:
+  delete, rm

--- a/cmd/runner/testdata/runner/resource-class/list-expected-usage.txt
+++ b/cmd/runner/testdata/runner/resource-class/list-expected-usage.txt
@@ -1,0 +1,5 @@
+Usage:
+  runner resource-class list <namespace>
+
+Aliases:
+  list, ls

--- a/cmd/runner/testdata/runner/token-expected-usage.txt
+++ b/cmd/runner/testdata/runner/token-expected-usage.txt
@@ -1,0 +1,9 @@
+Usage:
+  runner token [command]
+
+Available Commands:
+  create      Create a token for a resource-class
+  delete      Delete a token
+  list        List tokens for a resource-class
+
+Use "runner token [command] --help" for more information about a command.

--- a/cmd/runner/testdata/runner/token/create-expected-usage.txt
+++ b/cmd/runner/testdata/runner/token/create-expected-usage.txt
@@ -1,0 +1,5 @@
+Usage:
+  runner token create <resource-class> <nickname> [flags]
+
+Flags:
+      --config   'true' to emit a CircleCI runner config template with the token

--- a/cmd/runner/testdata/runner/token/delete-expected-usage.txt
+++ b/cmd/runner/testdata/runner/token/delete-expected-usage.txt
@@ -1,0 +1,5 @@
+Usage:
+  runner token delete <token-id>
+
+Aliases:
+  delete, rm

--- a/cmd/runner/testdata/runner/token/list-expected-usage.txt
+++ b/cmd/runner/testdata/runner/token/list-expected-usage.txt
@@ -1,0 +1,5 @@
+Usage:
+  runner token list <resource-class>
+
+Aliases:
+  list, ls

--- a/cmd/runner/token.go
+++ b/cmd/runner/token.go
@@ -1,0 +1,81 @@
+package runner
+
+import (
+	"os"
+	"time"
+
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+
+	"github.com/CircleCI-Public/circleci-cli/api/runner"
+)
+
+func newTokenCommand(r *runner.Runner, preRunE validator) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "token",
+		Short: "Operate on runner tokens",
+	}
+
+	createOpts := struct {
+		config bool
+	}{}
+	createCmd := &cobra.Command{
+		Use:     "create <resource-class> <nickname>",
+		Short:   "Create a token for a resource-class",
+		Args:    cobra.ExactArgs(2),
+		PreRunE: preRunE,
+		RunE: func(_ *cobra.Command, args []string) error {
+			token, err := r.CreateToken(args[0], args[1])
+			if err != nil {
+				return err
+			}
+
+			if createOpts.config {
+				return NewAgentConfig(*token).WriteYaml(os.Stdout)
+			}
+
+			table := tablewriter.NewWriter(os.Stdout)
+			defer table.Render()
+			table.SetHeader([]string{"ID", "Token", "Nickname", "Created At"})
+			table.Append([]string{token.ID, token.Token, token.Nickname, token.CreatedAt.Format(time.RFC3339)})
+			return nil
+		},
+	}
+	createCmd.Flags().BoolVar(&createOpts.config, "config", false, "'true' to emit a CircleCI runner config template with the token")
+	cmd.AddCommand(createCmd)
+
+	cmd.AddCommand(&cobra.Command{
+		Use:     "delete <token-id>",
+		Short:   "Delete a token",
+		Aliases: []string{"rm"},
+		Args:    cobra.ExactArgs(1),
+		PreRunE: preRunE,
+		RunE: func(_ *cobra.Command, args []string) error {
+			return r.DeleteToken(args[0])
+		},
+	})
+
+	cmd.AddCommand(&cobra.Command{
+		Use:     "list <resource-class>",
+		Aliases: []string{"ls"},
+		Short:   "List tokens for a resource-class",
+		Args:    cobra.ExactArgs(1),
+		PreRunE: preRunE,
+		RunE: func(_ *cobra.Command, args []string) error {
+			tokens, err := r.GetRunnerTokensByResourceClass(args[0])
+			if err != nil {
+				return err
+			}
+
+			table := tablewriter.NewWriter(os.Stdout)
+			defer table.Render()
+			table.SetHeader([]string{"ID", "Nickname", "Created At"})
+			for _, token := range tokens {
+				table.Append([]string{token.ID, token.Nickname, token.CreatedAt.Format(time.RFC3339)})
+			}
+			return nil
+		},
+	})
+
+	return cmd
+}

--- a/cmd/runner/usage_test.go
+++ b/cmd/runner/usage_test.go
@@ -1,0 +1,28 @@
+package runner
+
+import (
+	"fmt"
+	"testing"
+
+	"gotest.tools/v3/golden"
+
+	"github.com/spf13/cobra"
+
+	"github.com/CircleCI-Public/circleci-cli/settings"
+)
+
+func TestUsage(t *testing.T) {
+	preRunE := func(cmd *cobra.Command, args []string) error { return nil }
+	cmd := NewCommand(&settings.Config{}, preRunE)
+	testSubCommandUsage(t, cmd.Name(), cmd)
+}
+
+func testSubCommandUsage(t *testing.T, prefix string, parent *cobra.Command) {
+	t.Helper()
+	t.Run(parent.Name(), func(t *testing.T) {
+		golden.Assert(t, parent.UsageString(), fmt.Sprintf("%s-expected-usage.txt", prefix))
+		for _, cmd := range parent.Commands() {
+			testSubCommandUsage(t, fmt.Sprintf("%s/%s", prefix, cmd.Name()), cmd)
+		}
+	})
+}


### PR DESCRIPTION
Commands added:
- `circleci runner resource-class create <resource-class> <description>`
- `circleci runner resource-class delete <resource-class>`
- `circleci runner resource-class list <namespace>`
- `circleci runner token create [--config] <resource-class> <nickname>`
- `circleci runner token delete <token-id>`
- `circleci runner token list <resource-class>`

Aliases of `delete` to `rm` and `list` to `ls` have been added.