### PR TITLE
[CIRCLE-13071] Add orb import command to CLI

### DIFF
--- a/clitest/clitest.go
+++ b/clitest/clitest.go
@@ -111,7 +111,7 @@ func (tempSettings *TempSettings) AppendPostHandler(authToken string, combineHan
 						gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 						err = req.Body.Close()
 						gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-						gomega.Expect(body).Should(gomega.MatchJSON(handler.Request), "JSON Mismatch")
+						gomega.Expect(handler.Request).Should(gomega.MatchJSON(body), "JSON Mismatch")
 					},
 					ghttp.RespondWith(handler.Status, responseBody),
 				),

--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -260,6 +260,17 @@ Please note that at this time all orbs created in the registry are world-readabl
 		Args: cobra.ExactArgs(1),
 	}
 
+	importOrbCommand := &cobra.Command{
+		Use:   "import <namespace>[/<orb>[@<version>]]",
+		Short: "(Server only) Import an orb version from circleci.com into a CircleCI Server installation",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return importOrb(opts)
+		},
+		Args:   cobra.MinimumNArgs(1),
+		Hidden: true,
+	}
+	importOrbCommand.Flags().BoolVar(&opts.integrationTesting, "integration-testing", false, "Enable test mode to bypass interactive UI.")
+
 	orbPack := &cobra.Command{
 		Use:   "pack <path>",
 		Short: "Pack an Orb with local scripts.",
@@ -335,6 +346,7 @@ Please note that at this time all orbs created in the registry are world-readabl
 
 	orbCommand.AddCommand(listCommand)
 	orbCommand.AddCommand(orbCreate)
+	orbCommand.AddCommand(importOrbCommand)
 	orbCommand.AddCommand(validateCommand)
 	orbCommand.AddCommand(processCommand)
 	orbCommand.AddCommand(publishCommand)

--- a/cmd/orb_import.go
+++ b/cmd/orb_import.go
@@ -1,0 +1,199 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/CircleCI-Public/circleci-cli/api"
+	"github.com/CircleCI-Public/circleci-cli/api/graphql"
+)
+
+type orbImportPlan struct {
+	NewNamespaces           []string
+	NewOrbs                 []api.Orb
+	NewVersions             []api.OrbVersion
+	AlreadyExistingVersions []api.OrbVersion
+}
+
+func (o orbImportPlan) isEmpty() bool {
+	n := len(o.NewNamespaces)
+	n += len(o.NewOrbs)
+	n += len(o.NewVersions)
+	return n == 0
+}
+
+func importOrb(opts orbOptions) error {
+	defer func() {
+		if r := recover(); r != nil {
+			fmt.Printf("error: %v\n", r)
+		}
+	}()
+
+	vs, err := versionsToImport(opts)
+	if err != nil {
+		return err
+	}
+
+	plan, err := generateImportPlan(opts, vs)
+	if err != nil {
+		return err
+	}
+
+	displayPlan(os.Stdout, plan)
+	if !opts.noPrompt && !plan.isEmpty() && !opts.tty.askUserToConfirm("Are you sure you would like to proceed?") {
+		return nil
+	}
+
+	return applyPlan(opts, plan)
+}
+
+func versionsToImport(opts orbOptions) ([]api.OrbVersion, error) {
+	cloudClient := graphql.NewClient("https://circleci.com", "graphql-unstable", "", opts.cfg.Debug)
+
+	if opts.integrationTesting {
+		cloudClient = opts.cl
+	}
+
+	var orbVersions []api.OrbVersion
+	for _, ref := range opts.args {
+		if !isNamespace(ref) {
+			version, err := api.OrbInfo(cloudClient, ref)
+			if err != nil {
+				return nil, fmt.Errorf("orb info: %s", err.Error())
+			}
+
+			orbVersions = append(orbVersions, *version)
+			continue
+		}
+
+		// TODO: support an `--all-versions` flag that gets all versions instead of latest version per orb?
+		// Note: fetching all orb versions may not be possible. The best we could do is fetch an arbitrarily large number.
+		// Otherwise, do some other operation that grabs orb source data from a single namespace.
+		obv, err := api.ListNamespaceOrbVersions(cloudClient, ref)
+		if err != nil {
+			return nil, fmt.Errorf("list namespace orb versions: %s", err.Error())
+		}
+
+		orbVersions = append(orbVersions, obv...)
+	}
+
+	return orbVersions, nil
+}
+
+func generateImportPlan(opts orbOptions, orbVersions []api.OrbVersion) (orbImportPlan, error) {
+	uniqueNamespaces := map[string]bool{}
+	uniqueOrbs := map[string]api.Orb{}
+
+	// Dedupe namespaces and orbs.
+	for _, o := range orbVersions {
+		ns, orbName := o.Orb.Namespace.Name, o.Orb.Name
+		uniqueNamespaces[ns] = true
+		uniqueOrbs[orbName] = o.Orb
+	}
+
+	var plan orbImportPlan
+	for ns := range uniqueNamespaces {
+		ok, err := api.NamespaceExists(opts.cl, ns)
+		if err != nil {
+			return orbImportPlan{}, fmt.Errorf("namespace check failed: %s", err.Error())
+		}
+
+		if !ok {
+			plan.NewNamespaces = append(plan.NewNamespaces, ns)
+		}
+	}
+
+	for _, orb := range uniqueOrbs {
+		ok, err := api.OrbExists(opts.cl, orb.Namespace.Name, orb.Shortname())
+		if err != nil {
+			return orbImportPlan{}, fmt.Errorf("orb id check failed: %s", err.Error())
+		}
+
+		if !ok {
+			plan.NewOrbs = append(plan.NewOrbs, orb)
+		}
+	}
+
+	for _, o := range orbVersions {
+		_, err := api.OrbInfo(opts.cl, fmt.Sprintf("%s@%s", o.Orb.Name, o.Version))
+		if _, ok := err.(*api.ErrOrbVersionNotExists); ok {
+			plan.NewVersions = append(plan.NewVersions, o)
+			continue
+		}
+		if err != nil {
+			return orbImportPlan{}, fmt.Errorf("orb info check failed: %s", err.Error())
+		}
+
+		plan.AlreadyExistingVersions = append(plan.AlreadyExistingVersions, o)
+	}
+
+	return plan, nil
+}
+
+func applyPlan(opts orbOptions, plan orbImportPlan) error {
+	for _, ns := range plan.NewNamespaces {
+		_, err := api.CreateImportedNamespace(opts.cl, ns)
+		if err != nil {
+			return fmt.Errorf("unable to create '%s' namespace: %s", ns, err.Error())
+		}
+	}
+
+	for _, o := range plan.NewOrbs {
+		_, err := api.CreateImportedOrb(opts.cl, o.Namespace.Name, o.Shortname())
+		if err != nil {
+			return fmt.Errorf("unable to create '%s' orb: %s", o.Name, err.Error())
+		}
+	}
+
+	for _, v := range plan.NewVersions {
+		resp, err := api.OrbID(opts.cl, v.Orb.Namespace.Name, v.Orb.Shortname())
+		if err != nil {
+			return fmt.Errorf("unable to get orb info at %s: %s", v.Orb.Name, err.Error())
+		}
+
+		_, err = api.OrbImportVersion(opts.cl, v.Source, resp.Orb.ID, v.Version)
+		if err != nil {
+			return fmt.Errorf("unable to publish '%s@%s' with source: %s", v.Orb.Name, v.Version, err.Error())
+		}
+	}
+
+	return nil
+}
+
+func displayPlan(w io.Writer, plan orbImportPlan) {
+	var b strings.Builder
+	b.WriteString("The following actions will be performed:\n")
+
+	for _, ns := range plan.NewNamespaces {
+		b.WriteString(fmt.Sprintf("  Create namespace '%s'\n", ns))
+	}
+
+	for _, o := range plan.NewOrbs {
+		b.WriteString(fmt.Sprintf("  Create orb '%s'\n", o.Name))
+	}
+
+	for _, v := range plan.NewVersions {
+		b.WriteString(fmt.Sprintf("  Import version '%s@%s'\n", v.Orb.Name, v.Version))
+	}
+
+	for i, e := range plan.AlreadyExistingVersions {
+		if i == 0 {
+			b.WriteString("\nThe following orb versions already exist:\n")
+		}
+		b.WriteString(fmt.Sprintf("  ('%s@%s')\n", e.Orb.Name, e.Version))
+	}
+
+	b.WriteString("\n")
+
+	if plan.isEmpty() {
+		b.WriteString("Nothing to do!\n")
+	}
+
+	fmt.Fprint(w, b.String())
+}
+
+func isNamespace(ref string) bool {
+	return len(strings.Split(ref, "/")) == 1
+}

--- a/cmd/orb_import_test.go
+++ b/cmd/orb_import_test.go
@@ -1,0 +1,980 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/CircleCI-Public/circleci-cli/api"
+	"github.com/CircleCI-Public/circleci-cli/api/graphql"
+	"github.com/CircleCI-Public/circleci-cli/clitest"
+	"github.com/CircleCI-Public/circleci-cli/settings"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Import unit testing", func() {
+	var (
+		cli    *clitest.TempSettings
+		client *graphql.Client
+	)
+	BeforeEach(func() {
+		cli = clitest.WithTempSettings()
+		client = cli.NewFakeClient("graphql-unstable", "")
+	})
+
+	AfterEach(func() {
+		cli.Close()
+	})
+
+	Describe("When fetching all 'versionsToImport'", func() {
+		It("should fail when fetching orb info", func() {
+			opts := orbOptions{
+				cl:                 client,
+				cfg:                &settings.Config{},
+				args:               []string{"namespace1/orb@0.0.1"},
+				integrationTesting: true,
+			}
+
+			infoReq := `{
+				"query": "query($orbVersionRef: String!) {\n\t\t\t    orbVersion(orbVersionRef: $orbVersionRef) {\n\t\t\t        id\n                                version\n                                orb {\n                                    id\n                                    createdAt\n\t\t\t\t\t\t\t\t\tname\n\t\t\t\t\t\t\t\t\tnamespace {\n\t\t\t\t\t\t\t\t\t  name\n\t\t\t\t\t\t\t\t\t}\n                                    categories {\n                                      id\n                                      name\n                                    }\n\t                            statistics {\n\t\t                        last30DaysBuildCount,\n\t\t                        last30DaysProjectCount,\n\t\t                        last30DaysOrganizationCount\n\t                            }\n                                    versions(count: 200) {\n                                        createdAt\n                                        version\n                                    }\n                                }\n                                source\n                                createdAt\n\t\t\t    }\n\t\t      }",
+				"variables": {
+				  "orbVersionRef": "namespace1/orb@0.0.1"
+				}
+			  }`
+			infoResp := `{}`
+
+			cli.AppendPostHandler("", clitest.MockRequestResponse{
+				Status:   http.StatusOK,
+				Request:  infoReq,
+				Response: infoResp,
+			})
+
+			_, err := versionsToImport(opts)
+			Expect(err).To(MatchError("orb info: no Orb 'namespace1/orb@0.0.1' was found; please check that the Orb reference is correct"))
+		})
+
+		It("should successfully fetch an orb version", func() {
+			opts := orbOptions{
+				cl:                 client,
+				cfg:                &settings.Config{},
+				args:               []string{"namespace1/orb@0.0.1"},
+				integrationTesting: true,
+			}
+
+			infoReq := `{
+				"query": "query($orbVersionRef: String!) {\n\t\t\t    orbVersion(orbVersionRef: $orbVersionRef) {\n\t\t\t        id\n                                version\n                                orb {\n                                    id\n                                    createdAt\n\t\t\t\t\t\t\t\t\tname\n\t\t\t\t\t\t\t\t\tnamespace {\n\t\t\t\t\t\t\t\t\t  name\n\t\t\t\t\t\t\t\t\t}\n                                    categories {\n                                      id\n                                      name\n                                    }\n\t                            statistics {\n\t\t                        last30DaysBuildCount,\n\t\t                        last30DaysProjectCount,\n\t\t                        last30DaysOrganizationCount\n\t                            }\n                                    versions(count: 200) {\n                                        createdAt\n                                        version\n                                    }\n                                }\n                                source\n                                createdAt\n\t\t\t    }\n\t\t      }",
+				"variables": {
+				  "orbVersionRef": "namespace1/orb@0.0.1"
+				}
+			  }`
+
+			infoResp := `{
+					"orbVersion": {
+						"id": "bb604b45-b6b0-4b81-ad80-796f15eddf87",
+						"version": "0.0.1",
+						"orb": {
+								"id": "bb604b45-b6b0-4b81-ad80-796f15eddf87",
+								"createdAt": "2018-09-24T08:53:37.086Z",
+								"name": "namespace1/orb",
+								"namespace": {
+									"name": "namespace1"
+								},
+								"versions": [
+									{
+										"version": "0.0.1",
+										"createdAt": "2018-10-11T22:12:19.477Z"
+									}
+								]
+						},
+						"source": "description: somesource",
+						"createdAt": "2018-09-24T08:53:37.086Z"
+					}
+				}`
+
+			cli.AppendPostHandler("", clitest.MockRequestResponse{
+				Status:   http.StatusOK,
+				Request:  infoReq,
+				Response: infoResp,
+			})
+
+			v, err := versionsToImport(opts)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(v).To(Equal([]api.OrbVersion{
+				{
+					ID:      "bb604b45-b6b0-4b81-ad80-796f15eddf87",
+					Version: "0.0.1",
+					Source:  "description: somesource",
+					Orb: api.Orb{
+						ID:        "bb604b45-b6b0-4b81-ad80-796f15eddf87",
+						Name:      "namespace1/orb",
+						Namespace: api.Namespace{Name: "namespace1"},
+						Versions: []api.OrbVersion{
+							{Version: "0.0.1", CreatedAt: "2018-10-11T22:12:19.477Z"},
+						},
+						CreatedAt:      "2018-09-24T08:53:37.086Z",
+						HighestVersion: "0.0.1",
+					},
+					CreatedAt: "2018-09-24T08:53:37.086Z",
+				},
+			}))
+		})
+
+		It("should fail when no namespace is found", func() {
+			opts := orbOptions{
+				cl:                 client,
+				cfg:                &settings.Config{},
+				args:               []string{"namespace1"},
+				integrationTesting: true,
+			}
+
+			infoReq := `{
+					"query": "\nquery namespaceOrbs ($namespace: String, $after: String!) {\n\t\tregistryNamespace(name: $namespace) {\n\t\t\tname\n\t\t\tid\n\t\t\torbs(first: 20, after: $after) {\n\t\t\t\tedges {\n\t\t\t\t\tcursor\n\t\t\t\t\tnode {\n\t\t\t\t\t\tversions(count: 1) {\n\t\t\t\t\t\t\tsource\n\t\t\t\t\t\t\tid\n\t\t\t\t\t\t\tversion\n\t\t\t\t\t\t\tcreatedAt\n\t\t\t\t\t\t}\n\t\t\t\t\t\tname\n\t\t\t\t\t\tid\n\t\t\t\t\t\tcreatedAt\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t\tpageInfo {\n\t\t\t\t\thasNextPage\n\t\t\t\t}\n\t\t\t}\n\t\t}\n\t}\n",
+					"variables": {
+					  "after": "",
+					  "namespace": "namespace1"
+					}
+				  }	`
+
+			infoResp := `{}`
+
+			cli.AppendPostHandler("", clitest.MockRequestResponse{
+				Status:   http.StatusOK,
+				Request:  infoReq,
+				Response: infoResp,
+			})
+
+			_, err := versionsToImport(opts)
+			Expect(err).To(MatchError("list namespace orb versions: No namespace found"))
+		})
+
+		It("should successfully fetch all orb versions in a namespace", func() {
+			opts := orbOptions{
+				cl:                 client,
+				cfg:                &settings.Config{},
+				args:               []string{"namespace1"},
+				integrationTesting: true,
+			}
+
+			listReq := `{
+					"query": "\nquery namespaceOrbs ($namespace: String, $after: String!) {\n\t\tregistryNamespace(name: $namespace) {\n\t\t\tname\n\t\t\tid\n\t\t\torbs(first: 20, after: $after) {\n\t\t\t\tedges {\n\t\t\t\t\tcursor\n\t\t\t\t\tnode {\n\t\t\t\t\t\tversions(count: 1) {\n\t\t\t\t\t\t\tsource\n\t\t\t\t\t\t\tid\n\t\t\t\t\t\t\tversion\n\t\t\t\t\t\t\tcreatedAt\n\t\t\t\t\t\t}\n\t\t\t\t\t\tname\n\t\t\t\t\t\tid\n\t\t\t\t\t\tcreatedAt\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t\tpageInfo {\n\t\t\t\t\thasNextPage\n\t\t\t\t}\n\t\t\t}\n\t\t}\n\t}\n",
+					"variables": {
+					  "after": "",
+					  "namespace": "namespace1"
+					}
+				  }	`
+
+			listResp := `{
+					"registryNamespace": {
+						"name": "namespace1",
+						"id": "bb604b45-b6b0-4b81-ad80-796f15eddf87",
+						"orbs": {
+							"edges": [
+								{
+									"node": {
+										"name": "namespace1/orb",
+										"versions": [
+											{
+												"source": "description: somesource",
+												"id": "bb604b45-b6b0-4b81-ad80-796f15eddf87",
+												"version": "0.0.1",
+												"createdAt": "2018-09-24T08:53:37.086Z"
+											},
+											{
+												"source": "description: someothersource",
+												"id": "bb604b45-b6b0-4b81-ad80-796f15eddf87",
+												"version": "0.0.2",
+												"createdAt": "2018-09-24T08:53:37.086Z"
+											}
+										]
+									}
+								}
+							]
+						}
+					}
+				}`
+
+			cli.AppendPostHandler("", clitest.MockRequestResponse{
+				Status:   http.StatusOK,
+				Request:  listReq,
+				Response: listResp,
+			})
+
+			v, err := versionsToImport(opts)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(v).To(Equal([]api.OrbVersion{
+				{
+					ID:      "bb604b45-b6b0-4b81-ad80-796f15eddf87",
+					Version: "0.0.1",
+					Source:  "description: somesource",
+					Orb: api.Orb{
+						Name:      "namespace1/orb",
+						Namespace: api.Namespace{Name: "namespace1"},
+					},
+					CreatedAt: "2018-09-24T08:53:37.086Z",
+				},
+				{
+					ID:      "bb604b45-b6b0-4b81-ad80-796f15eddf87",
+					Version: "0.0.2",
+					Source:  "description: someothersource",
+					Orb: api.Orb{
+						Name:      "namespace1/orb",
+						Namespace: api.Namespace{Name: "namespace1"},
+					},
+					CreatedAt: "2018-09-24T08:53:37.086Z",
+				},
+			}))
+		})
+
+		It("should successfully fetch all orb versions from multiple arguments", func() {
+			opts := orbOptions{
+				cl:                 client,
+				cfg:                &settings.Config{},
+				args:               []string{"namespace1", "namespace2/orb2@3.3.3"},
+				integrationTesting: true,
+			}
+
+			listReq := `{
+					"query": "\nquery namespaceOrbs ($namespace: String, $after: String!) {\n\t\tregistryNamespace(name: $namespace) {\n\t\t\tname\n\t\t\tid\n\t\t\torbs(first: 20, after: $after) {\n\t\t\t\tedges {\n\t\t\t\t\tcursor\n\t\t\t\t\tnode {\n\t\t\t\t\t\tversions(count: 1) {\n\t\t\t\t\t\t\tsource\n\t\t\t\t\t\t\tid\n\t\t\t\t\t\t\tversion\n\t\t\t\t\t\t\tcreatedAt\n\t\t\t\t\t\t}\n\t\t\t\t\t\tname\n\t\t\t\t\t\tid\n\t\t\t\t\t\tcreatedAt\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t\tpageInfo {\n\t\t\t\t\thasNextPage\n\t\t\t\t}\n\t\t\t}\n\t\t}\n\t}\n",
+					"variables": {
+					  "after": "",
+					  "namespace": "namespace1"
+					}
+				  }	`
+
+			listResp := `{
+					"registryNamespace": {
+						"name": "namespace1",
+						"id": "bb604b45-b6b0-4b81-ad80-796f15eddf87",
+						"orbs": {
+							"edges": [
+								{
+									"node": {
+										"name": "namespace1/orb",
+										"versions": [
+											{
+												"source": "description: somesource",
+												"id": "bb604b45-b6b0-4b81-ad80-796f15eddf87",
+												"version": "0.0.1",
+												"createdAt": "2018-09-24T08:53:37.086Z"
+											},
+											{
+												"source": "description: someothersource",
+												"id": "bb604b45-b6b0-4b81-ad80-796f15eddf87",
+												"version": "0.0.2",
+												"createdAt": "2018-09-24T08:53:37.086Z"
+											}
+										]
+									}
+								}
+							]
+						}
+					}
+				}`
+
+			infoReq := `{
+				"query": "query($orbVersionRef: String!) {\n\t\t\t    orbVersion(orbVersionRef: $orbVersionRef) {\n\t\t\t        id\n                                version\n                                orb {\n                                    id\n                                    createdAt\n\t\t\t\t\t\t\t\t\tname\n\t\t\t\t\t\t\t\t\tnamespace {\n\t\t\t\t\t\t\t\t\t  name\n\t\t\t\t\t\t\t\t\t}\n                                    categories {\n                                      id\n                                      name\n                                    }\n\t                            statistics {\n\t\t                        last30DaysBuildCount,\n\t\t                        last30DaysProjectCount,\n\t\t                        last30DaysOrganizationCount\n\t                            }\n                                    versions(count: 200) {\n                                        createdAt\n                                        version\n                                    }\n                                }\n                                source\n                                createdAt\n\t\t\t    }\n\t\t      }",
+				"variables": {
+				  "orbVersionRef": "namespace2/orb2@3.3.3"
+				}
+			  }`
+
+			infoResp := `{
+					"orbVersion": {
+						"id": "bb604b45-b6b0-4b81-ad80-796f15eddf87",
+						"version": "3.3.3",
+						"orb": {
+								"id": "bb604b45-b6b0-4b81-ad80-796f15eddf87",
+								"createdAt": "2018-09-24T08:53:37.086Z",
+								"name": "namespace2/orb2",
+								"namespace": {
+									"name": "namespace2"
+								},
+								"versions": [
+									{
+										"version": "3.3.3",
+										"createdAt": "2018-10-11T22:12:19.477Z"
+									}
+								]
+						},
+						"source": "description: somesource",
+						"createdAt": "2018-09-24T08:53:37.086Z"
+					}
+				}`
+
+			cli.AppendPostHandler("", clitest.MockRequestResponse{
+				Status:   http.StatusOK,
+				Request:  listReq,
+				Response: listResp,
+			})
+			cli.AppendPostHandler("", clitest.MockRequestResponse{
+				Status:   http.StatusOK,
+				Request:  infoReq,
+				Response: infoResp,
+			})
+
+			v, err := versionsToImport(opts)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(v).To(Equal([]api.OrbVersion{
+				{
+					ID:      "bb604b45-b6b0-4b81-ad80-796f15eddf87",
+					Version: "0.0.1",
+					Source:  "description: somesource",
+					Orb: api.Orb{
+						Name:      "namespace1/orb",
+						Namespace: api.Namespace{Name: "namespace1"},
+					},
+					CreatedAt: "2018-09-24T08:53:37.086Z",
+				},
+				{
+					ID:      "bb604b45-b6b0-4b81-ad80-796f15eddf87",
+					Version: "0.0.2",
+					Source:  "description: someothersource",
+					Orb: api.Orb{
+						Name:      "namespace1/orb",
+						Namespace: api.Namespace{Name: "namespace1"},
+					},
+					CreatedAt: "2018-09-24T08:53:37.086Z",
+				},
+				{
+					ID:      "bb604b45-b6b0-4b81-ad80-796f15eddf87",
+					Version: "3.3.3",
+					Source:  "description: somesource",
+					Orb: api.Orb{
+						ID:        "bb604b45-b6b0-4b81-ad80-796f15eddf87",
+						Name:      "namespace2/orb2",
+						Namespace: api.Namespace{Name: "namespace2"},
+						Versions: []api.OrbVersion{
+							{Version: "3.3.3", CreatedAt: "2018-10-11T22:12:19.477Z"},
+						},
+						CreatedAt:      "2018-09-24T08:53:37.086Z",
+						HighestVersion: "3.3.3",
+					},
+					CreatedAt: "2018-09-24T08:53:37.086Z",
+				},
+			}))
+		})
+	})
+
+	Describe("When testing 'generateImportPlan'", func() {
+		var opts orbOptions
+
+		BeforeEach(func() {
+			opts = orbOptions{
+				cl:                 client,
+				cfg:                &settings.Config{},
+				args:               []string{"namespace1/orb@0.0.1"},
+				integrationTesting: true,
+			}
+		})
+		It("should generate a plan with all resources", func() {
+			vs := []api.OrbVersion{
+				{
+					ID:      "bb604b45-b6b0-4b81-ad80-796f15eddf87",
+					Version: "0.0.1",
+					Source:  "description: somesource",
+					Orb: api.Orb{
+						Name:      "namespace1/orb",
+						Namespace: api.Namespace{Name: "namespace1"},
+					},
+					CreatedAt: "2018-09-24T08:53:37.086Z",
+				},
+			}
+
+			nsReq := `{
+					"query": "\n\t\t\t\tquery($name: String!) {\n\t\t\t\t\tregistryNamespace(\n\t\t\t\t\t\tname: $name\n\t\t\t\t\t){\n\t\t\t\t\t\tid\n\t\t\t\t\t}\n\t\t\t }",
+					"variables": {
+					  "name": "namespace1"
+					}
+				  }`
+
+			nsResp := `{}`
+
+			orbExistsReq := `{
+					"query": "\n\tquery ($name: String!, $namespace: String) {\n\t\torb(name: $name) {\n\t\t  id\n\t\t}\n\t\tregistryNamespace(name: $namespace) {\n\t\t\tid\n\t\t  }\n\t  }\n\t  ",
+					"variables": {
+					  "name": "namespace1/orb",
+					  "namespace": "namespace1"
+					}
+				  }`
+
+			orbExistsResp := `{}`
+
+			orbInfoReq := `{
+				"query": "query($orbVersionRef: String!) {\n\t\t\t    orbVersion(orbVersionRef: $orbVersionRef) {\n\t\t\t        id\n                                version\n                                orb {\n                                    id\n                                    createdAt\n\t\t\t\t\t\t\t\t\tname\n\t\t\t\t\t\t\t\t\tnamespace {\n\t\t\t\t\t\t\t\t\t  name\n\t\t\t\t\t\t\t\t\t}\n                                    categories {\n                                      id\n                                      name\n                                    }\n\t                            statistics {\n\t\t                        last30DaysBuildCount,\n\t\t                        last30DaysProjectCount,\n\t\t                        last30DaysOrganizationCount\n\t                            }\n                                    versions(count: 200) {\n                                        createdAt\n                                        version\n                                    }\n                                }\n                                source\n                                createdAt\n\t\t\t    }\n\t\t      }",
+				"variables": {
+				  "orbVersionRef": "namespace1/orb@0.0.1"
+				}
+			  }`
+
+			orbInfoResp := `{}`
+
+			cli.AppendPostHandler("", clitest.MockRequestResponse{
+				Status:   http.StatusOK,
+				Request:  nsReq,
+				Response: nsResp,
+			})
+			cli.AppendPostHandler("", clitest.MockRequestResponse{
+				Status:   http.StatusOK,
+				Request:  orbExistsReq,
+				Response: orbExistsResp,
+			})
+			cli.AppendPostHandler("", clitest.MockRequestResponse{
+				Status:   http.StatusOK,
+				Request:  orbInfoReq,
+				Response: orbInfoResp,
+			})
+
+			plan, err := generateImportPlan(opts, vs)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(plan).To(Equal(orbImportPlan{
+				NewNamespaces: []string{"namespace1"},
+				NewOrbs: []api.Orb{
+					{Name: "namespace1/orb", Namespace: api.Namespace{Name: "namespace1"}},
+				},
+				NewVersions: []api.OrbVersion{
+					{
+						ID:        "bb604b45-b6b0-4b81-ad80-796f15eddf87",
+						Version:   "0.0.1",
+						Orb:       api.Orb{Name: "namespace1/orb", Namespace: api.Namespace{Name: "namespace1"}},
+						Source:    "description: somesource",
+						CreatedAt: "2018-09-24T08:53:37.086Z",
+					},
+				},
+			}))
+		})
+
+		It("should generate a plan with overlapping orbs and namespaces", func() {
+			vs := []api.OrbVersion{
+				{
+					ID:      "bb604b45-b6b0-4b81-ad80-796f15eddf87",
+					Version: "0.0.1",
+					Source:  "description: somesource",
+					Orb: api.Orb{
+						Name:      "namespace1/orb",
+						Namespace: api.Namespace{Name: "namespace1"},
+					},
+					CreatedAt: "2018-09-24T08:53:37.086Z",
+				},
+				{
+					ID:      "bb604b45-b6b0-4b81-ad80-796f15eddf87",
+					Version: "0.0.2",
+					Source:  "description: somesource",
+					Orb: api.Orb{
+						Name:      "namespace1/orb",
+						Namespace: api.Namespace{Name: "namespace1"},
+					},
+					CreatedAt: "2018-09-24T08:53:37.086Z",
+				},
+			}
+
+			nsReq := `{
+					"query": "\n\t\t\t\tquery($name: String!) {\n\t\t\t\t\tregistryNamespace(\n\t\t\t\t\t\tname: $name\n\t\t\t\t\t){\n\t\t\t\t\t\tid\n\t\t\t\t\t}\n\t\t\t }",
+					"variables": {
+					  "name": "%s"
+					}
+				  }`
+
+			nsResp := `{}`
+
+			orbExistsReq := `{
+					"query": "\n\tquery ($name: String!, $namespace: String) {\n\t\torb(name: $name) {\n\t\t  id\n\t\t}\n\t\tregistryNamespace(name: $namespace) {\n\t\t\tid\n\t\t  }\n\t  }\n\t  ",
+					"variables": {
+					  "name": "%s",
+					  "namespace": "%s"
+					}
+				  }`
+
+			orbExistsResp := `{}`
+
+			orbInfoReq := `{
+				"query": "query($orbVersionRef: String!) {\n\t\t\t    orbVersion(orbVersionRef: $orbVersionRef) {\n\t\t\t        id\n                                version\n                                orb {\n                                    id\n                                    createdAt\n\t\t\t\t\t\t\t\t\tname\n\t\t\t\t\t\t\t\t\tnamespace {\n\t\t\t\t\t\t\t\t\t  name\n\t\t\t\t\t\t\t\t\t}\n                                    categories {\n                                      id\n                                      name\n                                    }\n\t                            statistics {\n\t\t                        last30DaysBuildCount,\n\t\t                        last30DaysProjectCount,\n\t\t                        last30DaysOrganizationCount\n\t                            }\n                                    versions(count: 200) {\n                                        createdAt\n                                        version\n                                    }\n                                }\n                                source\n                                createdAt\n\t\t\t    }\n\t\t      }",
+				"variables": {
+				  "orbVersionRef": "%s"
+				}
+			  }`
+
+			orbInfoResp := `{}`
+
+			cli.AppendPostHandler("", clitest.MockRequestResponse{
+				Status:   http.StatusOK,
+				Request:  fmt.Sprintf(nsReq, "namespace1"),
+				Response: nsResp,
+			})
+			cli.AppendPostHandler("", clitest.MockRequestResponse{
+				Status:   http.StatusOK,
+				Request:  fmt.Sprintf(orbExistsReq, "namespace1/orb", "namespace1"),
+				Response: orbExistsResp,
+			})
+			cli.AppendPostHandler("", clitest.MockRequestResponse{
+				Status:   http.StatusOK,
+				Request:  fmt.Sprintf(orbInfoReq, "namespace1/orb@0.0.1"),
+				Response: orbInfoResp,
+			})
+			cli.AppendPostHandler("", clitest.MockRequestResponse{
+				Status:   http.StatusOK,
+				Request:  fmt.Sprintf(orbInfoReq, "namespace1/orb@0.0.2"),
+				Response: orbInfoResp,
+			})
+
+			plan, err := generateImportPlan(opts, vs)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(plan).To(Equal(orbImportPlan{
+				NewNamespaces: []string{"namespace1"},
+				NewOrbs: []api.Orb{
+					{Name: "namespace1/orb", Namespace: api.Namespace{Name: "namespace1"}},
+				},
+				NewVersions: []api.OrbVersion{
+					{
+						ID:        "bb604b45-b6b0-4b81-ad80-796f15eddf87",
+						Version:   "0.0.1",
+						Orb:       api.Orb{Name: "namespace1/orb", Namespace: api.Namespace{Name: "namespace1"}},
+						Source:    "description: somesource",
+						CreatedAt: "2018-09-24T08:53:37.086Z",
+					},
+					{
+						ID:        "bb604b45-b6b0-4b81-ad80-796f15eddf87",
+						Version:   "0.0.2",
+						Orb:       api.Orb{Name: "namespace1/orb", Namespace: api.Namespace{Name: "namespace1"}},
+						Source:    "description: somesource",
+						CreatedAt: "2018-09-24T08:53:37.086Z",
+					},
+				},
+			}))
+		})
+
+		It("should generate an action plan when some resources exist", func() {
+			vs := []api.OrbVersion{
+				{
+					ID:      "bb604b45-b6b0-4b81-ad80-796f15eddf87",
+					Version: "0.0.1",
+					Source:  "description: somesource",
+					Orb: api.Orb{
+						Name:      "namespace1/orb",
+						Namespace: api.Namespace{Name: "namespace1"},
+					},
+					CreatedAt: "2018-09-24T08:53:37.086Z",
+				},
+			}
+
+			nsReq := `{
+					"query": "\n\t\t\t\tquery($name: String!) {\n\t\t\t\t\tregistryNamespace(\n\t\t\t\t\t\tname: $name\n\t\t\t\t\t){\n\t\t\t\t\t\tid\n\t\t\t\t\t}\n\t\t\t }",
+					"variables": {
+					  "name": "%s"
+					}
+				  }`
+
+			nsResp := `{
+					"registryNamespace": {
+						"id": "someid"
+					}
+				}`
+
+			orbExistsReq := `{
+					"query": "\n\tquery ($name: String!, $namespace: String) {\n\t\torb(name: $name) {\n\t\t  id\n\t\t}\n\t\tregistryNamespace(name: $namespace) {\n\t\t\tid\n\t\t  }\n\t  }\n\t  ",
+					"variables": {
+					  "name": "%s",
+					  "namespace": "%s"
+					}
+				  }`
+
+			orbExistsResp := `{
+					"orb": {
+						"id": "someid"
+					}
+				}`
+
+			orbInfoReq := `{
+				"query": "query($orbVersionRef: String!) {\n\t\t\t    orbVersion(orbVersionRef: $orbVersionRef) {\n\t\t\t        id\n                                version\n                                orb {\n                                    id\n                                    createdAt\n\t\t\t\t\t\t\t\t\tname\n\t\t\t\t\t\t\t\t\tnamespace {\n\t\t\t\t\t\t\t\t\t  name\n\t\t\t\t\t\t\t\t\t}\n                                    categories {\n                                      id\n                                      name\n                                    }\n\t                            statistics {\n\t\t                        last30DaysBuildCount,\n\t\t                        last30DaysProjectCount,\n\t\t                        last30DaysOrganizationCount\n\t                            }\n                                    versions(count: 200) {\n                                        createdAt\n                                        version\n                                    }\n                                }\n                                source\n                                createdAt\n\t\t\t    }\n\t\t      }",
+				"variables": {
+				  "orbVersionRef": "%s"
+				}
+			  }`
+
+			orbInfoResp := `{
+					"orbVersion": {
+						"id": "someid"
+					}
+				}`
+
+			cli.AppendPostHandler("", clitest.MockRequestResponse{
+				Status:   http.StatusOK,
+				Request:  fmt.Sprintf(nsReq, "namespace1"),
+				Response: nsResp,
+			})
+			cli.AppendPostHandler("", clitest.MockRequestResponse{
+				Status:   http.StatusOK,
+				Request:  fmt.Sprintf(orbExistsReq, "namespace1/orb", "namespace1"),
+				Response: orbExistsResp,
+			})
+			cli.AppendPostHandler("", clitest.MockRequestResponse{
+				Status:   http.StatusOK,
+				Request:  fmt.Sprintf(orbInfoReq, "namespace1/orb@0.0.1"),
+				Response: orbInfoResp,
+			})
+
+			plan, err := generateImportPlan(opts, vs)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(plan).To(Equal(orbImportPlan{
+				AlreadyExistingVersions: []api.OrbVersion{
+					{
+						ID:        "bb604b45-b6b0-4b81-ad80-796f15eddf87",
+						Version:   "0.0.1",
+						Orb:       api.Orb{Name: "namespace1/orb", Namespace: api.Namespace{Name: "namespace1"}},
+						Source:    "description: somesource",
+						CreatedAt: "2018-09-24T08:53:37.086Z",
+					},
+				},
+			}))
+		})
+	})
+
+	Describe("When testing 'displayPlan'", func() {
+		It("prints out plan correctly to the provided writer", func() {
+			plan := orbImportPlan{
+				NewNamespaces: []string{"namespace1"},
+				NewOrbs: []api.Orb{
+					{Name: "namespace1/orb", Namespace: api.Namespace{Name: "namespace1"}},
+				},
+				NewVersions: []api.OrbVersion{
+					{
+						ID:        "bb604b45-b6b0-4b81-ad80-796f15eddf87",
+						Version:   "0.0.1",
+						Orb:       api.Orb{Name: "namespace1/orb", Namespace: api.Namespace{Name: "namespace1"}},
+						Source:    "description: somesource",
+						CreatedAt: "2018-09-24T08:53:37.086Z",
+					},
+					{
+						ID:        "bb604b45-b6b0-4b81-ad80-796f15eddf87",
+						Version:   "0.0.2",
+						Orb:       api.Orb{Name: "namespace1/orb", Namespace: api.Namespace{Name: "namespace1"}},
+						Source:    "description: somesource",
+						CreatedAt: "2018-09-24T08:53:37.086Z",
+					},
+				},
+				AlreadyExistingVersions: []api.OrbVersion{
+					{
+						ID:        "bb604b45-b6b0-4b81-ad80-796f15eddf87",
+						Version:   "0.0.3",
+						Orb:       api.Orb{Name: "namespace1/orb", Namespace: api.Namespace{Name: "namespace1"}},
+						Source:    "description: somesource",
+						CreatedAt: "2018-09-24T08:53:37.086Z",
+					},
+				},
+			}
+
+			var b bytes.Buffer
+			displayPlan(&b, plan)
+
+			expOutput := `The following actions will be performed:
+  Create namespace 'namespace1'
+  Create orb 'namespace1/orb'
+  Import version 'namespace1/orb@0.0.1'
+  Import version 'namespace1/orb@0.0.2'
+
+The following orb versions already exist:
+  ('namespace1/orb@0.0.3')
+
+`
+			actual, err := ioutil.ReadAll(&b)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(fmt.Sprintf("%s", actual)).To(Equal(expOutput))
+		})
+	})
+
+	Describe("When testing 'applyPlan'", func() {
+		var opts orbOptions
+
+		BeforeEach(func() {
+			opts = orbOptions{
+				cl:                 client,
+				cfg:                &settings.Config{},
+				args:               []string{"namespace1/orb@0.0.1"},
+				integrationTesting: true,
+			}
+		})
+
+		It("errors when creating an imported namespace", func() {
+			plan := orbImportPlan{
+				NewNamespaces: []string{"namespace1"},
+			}
+
+			createNSReq := `{
+					"query": "\n\t\t\tmutation($name: String!) {\n\t\t\t\timportNamespace(\n\t\t\t\t\tname: $name,\n\t\t\t\t) {\n\t\t\t\t\tnamespace {\n\t\t\t\t\t\tid\n\t\t\t\t\t}\n\t\t\t\t\terrors {\n\t\t\t\t\t\tmessage\n\t\t\t\t\t\ttype\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t}",
+					"variables": {
+					  "name": "namespace1"
+					}
+				  }`
+
+			createNSResp := `{
+					"importNamespace": {
+						"errors": [{"message": "testerror"}]
+					}
+				}`
+
+			cli.AppendPostHandler("", clitest.MockRequestResponse{
+				Status:   http.StatusOK,
+				Request:  createNSReq,
+				Response: createNSResp,
+			})
+
+			err := applyPlan(opts, plan)
+			Expect(err).To(MatchError("unable to create 'namespace1' namespace: testerror"))
+		})
+
+		It("successfully creates a namespace", func() {
+			plan := orbImportPlan{
+				NewNamespaces: []string{"namespace1"},
+			}
+
+			createNSReq := `{
+					"query": "\n\t\t\tmutation($name: String!) {\n\t\t\t\timportNamespace(\n\t\t\t\t\tname: $name,\n\t\t\t\t) {\n\t\t\t\t\tnamespace {\n\t\t\t\t\t\tid\n\t\t\t\t\t}\n\t\t\t\t\terrors {\n\t\t\t\t\t\tmessage\n\t\t\t\t\t\ttype\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t}",
+					"variables": {
+					  "name": "namespace1"
+					}
+				  }`
+
+			createNSResp := `{}`
+
+			cli.AppendPostHandler("", clitest.MockRequestResponse{
+				Status:   http.StatusOK,
+				Request:  createNSReq,
+				Response: createNSResp,
+			})
+
+			err := applyPlan(opts, plan)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		It("errors when creating an orb and namespace id fetch fails", func() {
+			plan := orbImportPlan{
+				NewOrbs: []api.Orb{
+					{
+						Name:      "namespace1/orb",
+						Namespace: api.Namespace{Name: "namespace1"},
+					},
+				},
+			}
+
+			getNSReq := `{
+					"query": "\n\t\t\t\tquery($name: String!) {\n\t\t\t\t\tregistryNamespace(\n\t\t\t\t\t\tname: $name\n\t\t\t\t\t){\n\t\t\t\t\t\tid\n\t\t\t\t\t}\n\t\t\t }",
+					"variables": {
+					  "name": "namespace1"
+					}
+				  }`
+
+			getNSResp := `{}`
+
+			cli.AppendPostHandler("", clitest.MockRequestResponse{
+				Status:   http.StatusOK,
+				Request:  getNSReq,
+				Response: getNSResp,
+			})
+
+			err := applyPlan(opts, plan)
+			Expect(err).To(MatchError("unable to create 'namespace1/orb' orb: the namespace 'namespace1' does not exist. Did you misspell the namespace, or maybe you meant to create the namespace first?"))
+		})
+
+		It("errors when creating an orb", func() {
+			plan := orbImportPlan{
+				NewOrbs: []api.Orb{
+					{
+						Name:      "namespace1/orb",
+						Namespace: api.Namespace{Name: "namespace1"},
+					},
+				},
+			}
+
+			getNSReq := `{
+					"query": "\n\t\t\t\tquery($name: String!) {\n\t\t\t\t\tregistryNamespace(\n\t\t\t\t\t\tname: $name\n\t\t\t\t\t){\n\t\t\t\t\t\tid\n\t\t\t\t\t}\n\t\t\t }",
+					"variables": {
+					  "name": "namespace1"
+					}
+				  }`
+
+			getNSResp := `{
+					"registryNamespace": {
+						"id": "someid1"
+					}
+				}`
+
+			createOrbReq := `{
+					"query": "mutation($name: String!, $registryNamespaceId: UUID!){\n\t\t\t\timportOrb(\n\t\t\t\t\tname: $name,\n\t\t\t\t\tregistryNamespaceId: $registryNamespaceId\n\t\t\t\t){\n\t\t\t\t    orb {\n\t\t\t\t      id\n\t\t\t\t    }\n\t\t\t\t    errors {\n\t\t\t\t      message\n\t\t\t\t      type\n\t\t\t\t    }\n\t\t\t\t}\n}",
+					"variables": {
+					  "name": "orb",
+					  "registryNamespaceId": "someid1"
+					}
+				  }`
+
+			createOrbResp := `{
+					"createOrb": {
+						"errors": [{"message": "testerror"}]
+					}
+				}`
+
+			cli.AppendPostHandler("", clitest.MockRequestResponse{
+				Status:   http.StatusOK,
+				Request:  getNSReq,
+				Response: getNSResp,
+			})
+			cli.AppendPostHandler("", clitest.MockRequestResponse{
+				Status:   http.StatusOK,
+				Request:  createOrbReq,
+				Response: createOrbResp,
+			})
+
+			err := applyPlan(opts, plan)
+			Expect(err).To(MatchError("unable to create 'namespace1/orb' orb: testerror"))
+		})
+
+		It("creates an orb successfully", func() {
+			plan := orbImportPlan{
+				NewOrbs: []api.Orb{
+					{
+						Name: "namespace1/orb",
+
+						Namespace: api.Namespace{Name: "namespace1"},
+					},
+				},
+			}
+
+			getNSReq := `{
+					"query": "\n\t\t\t\tquery($name: String!) {\n\t\t\t\t\tregistryNamespace(\n\t\t\t\t\t\tname: $name\n\t\t\t\t\t){\n\t\t\t\t\t\tid\n\t\t\t\t\t}\n\t\t\t }",
+					"variables": {
+					  "name": "namespace1"
+					}
+				  }`
+
+			getNSResp := `{
+					"registryNamespace": {
+						"id": "someid1"
+					}
+				}`
+
+			createOrbReq := `{
+					"query": "mutation($name: String!, $registryNamespaceId: UUID!){\n\t\t\t\timportOrb(\n\t\t\t\t\tname: $name,\n\t\t\t\t\tregistryNamespaceId: $registryNamespaceId\n\t\t\t\t){\n\t\t\t\t    orb {\n\t\t\t\t      id\n\t\t\t\t    }\n\t\t\t\t    errors {\n\t\t\t\t      message\n\t\t\t\t      type\n\t\t\t\t    }\n\t\t\t\t}\n}",
+					"variables": {
+					  "name": "orb",
+					  "registryNamespaceId": "someid1"
+					}
+				  }`
+
+			createOrbResp := `{}`
+
+			cli.AppendPostHandler("", clitest.MockRequestResponse{
+				Status:   http.StatusOK,
+				Request:  getNSReq,
+				Response: getNSResp,
+			})
+			cli.AppendPostHandler("", clitest.MockRequestResponse{
+				Status:   http.StatusOK,
+				Request:  createOrbReq,
+				Response: createOrbResp,
+			})
+
+			err := applyPlan(opts, plan)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		It("fails to publish an orb version with source", func() {
+			plan := orbImportPlan{
+				NewVersions: []api.OrbVersion{
+					{
+						Version: "0.0.1",
+						Orb:     api.Orb{Name: "namespace1/orb", Namespace: api.Namespace{Name: "namespace1"}},
+					},
+				},
+			}
+
+			orbIDReq := `{
+					"query": "\n\tquery ($name: String!, $namespace: String) {\n\t\torb(name: $name) {\n\t\t  id\n\t\t}\n\t\tregistryNamespace(name: $namespace) {\n\t\t  id\n\t\t}\n\t  }\n\t  ",
+					"variables": {
+					  "name": "namespace1/orb",
+					  "namespace": "namespace1"
+					}
+				  }`
+
+			orbIDResp := `{
+					"orb": {"id": "orbid1"}
+				}`
+
+			orbPublishReq := `{
+					"query": "\n\t\tmutation($config: String!, $orbId: UUID!, $version: String!) {\n\t\t\timportOrbVersion(\n\t\t\t\torbId: $orbId,\n\t\t\t\torbYaml: $config,\n\t\t\t\tversion: $version\n\t\t\t) {\n\t\t\t\torb {\n\t\t\t\t\tversion\n\t\t\t\t}\n\t\t\t\terrors { message }\n\t\t\t}\n\t\t}\n\t",
+					"variables": {
+					  "config": "",
+					  "orbId": "orbid1",
+					  "version": "0.0.1"
+					}
+				  }`
+
+			orbPublishResp := `{
+					"publishOrb": {
+						"errors": [{"message": "testerror"}]
+					}
+				}`
+
+			cli.AppendPostHandler("", clitest.MockRequestResponse{
+				Status:   http.StatusOK,
+				Request:  orbIDReq,
+				Response: orbIDResp,
+			})
+			cli.AppendPostHandler("", clitest.MockRequestResponse{
+				Status:   http.StatusOK,
+				Request:  orbPublishReq,
+				Response: orbPublishResp,
+			})
+
+			err := applyPlan(opts, plan)
+			Expect(err).To(MatchError("unable to publish 'namespace1/orb@0.0.1' with source: testerror"))
+		})
+
+		It("fails to publish an orb version with source", func() {
+			plan := orbImportPlan{
+				NewVersions: []api.OrbVersion{
+					{
+						Version: "0.0.1",
+						Orb:     api.Orb{Name: "namespace1/orb", Namespace: api.Namespace{Name: "namespace1"}},
+					},
+				},
+			}
+
+			orbIDReq := `{
+					"query": "\n\tquery ($name: String!, $namespace: String) {\n\t\torb(name: $name) {\n\t\t  id\n\t\t}\n\t\tregistryNamespace(name: $namespace) {\n\t\t  id\n\t\t}\n\t  }\n\t  ",
+					"variables": {
+					  "name": "namespace1/orb",
+					  "namespace": "namespace1"
+					}
+				  }`
+
+			orbIDResp := `{
+					"orb": {"id": "orbid1"}
+				}`
+
+			orbPublishReq := `{
+					"query": "\n\t\tmutation($config: String!, $orbId: UUID!, $version: String!) {\n\t\t\timportOrbVersion(\n\t\t\t\torbId: $orbId,\n\t\t\t\torbYaml: $config,\n\t\t\t\tversion: $version\n\t\t\t) {\n\t\t\t\torb {\n\t\t\t\t\tversion\n\t\t\t\t}\n\t\t\t\terrors { message }\n\t\t\t}\n\t\t}\n\t",
+					"variables": {
+					  "config": "",
+					  "orbId": "orbid1",
+					  "version": "0.0.1"
+					}
+				  }`
+
+			orbPublishResp := `{}`
+
+			cli.AppendPostHandler("", clitest.MockRequestResponse{
+				Status:   http.StatusOK,
+				Request:  orbIDReq,
+				Response: orbIDResp,
+			})
+			cli.AppendPostHandler("", clitest.MockRequestResponse{
+				Status:   http.StatusOK,
+				Request:  orbPublishReq,
+				Response: orbPublishResp,
+			})
+
+			err := applyPlan(opts, plan)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+	})
+})

--- a/cmd/orb_test.go
+++ b/cmd/orb_test.go
@@ -2378,7 +2378,10 @@ foo.bar/account/api`))
                                 orb {
                                     id
                                     createdAt
-                                    name
+									name
+									namespace {
+									  name
+									}
                                     categories {
                                       id
                                       name


### PR DESCRIPTION
As part of our efforts to add support for orbs in server installs, a new `orb import` command will be added to our CLI. The command supports one or more arguments and accepts specific orb references or entire namespaces.

Sample: `circleci orb import {namespace} {orb-ref}`

The import command can be broken down into four stages:
1. Fetch all available orb versions from the list of provided arguments.
2. Validate existing namespaces/orbs/versions on the server install to generate an import plan.
3. Display the import plan to the caller (detailing all changes that will be made) and wait for user confirmation.
4. Apply the import plan by creating all the resources via requests to `api-service`.

This PR applies the following changes:
- Adds `NamespaceExists`, `OrbExists`, `OrbPublishWithSource`, and `ListNamespaceOrbVersions` graphQL calls
- Adds `importOrb` to the parent orb command, currently with `Hidden: true`
- Due to complexity of this call, broke out unit tests into its own file.

TODOs:
1. Since this command is intended to be used by server-admins, we should have a permission check up front, instead of relying on checks downstream (like api-service)
2. Investigate adding support for `--all-versions` flag when importing entire namespaces.