### PR TITLE
Fix the brew deploy script

### DIFF
--- a/.circleci/brew-deploy.sh
+++ b/.circleci/brew-deploy.sh
@@ -1,11 +1,8 @@
 #!/bin/sh
 set -e
 
-# Remove the original circleci-agent from /usr/local/bin for homebrew
-rm /usr/local/bin/circleci
 # Install the latest circleci from homebrew
 brew update
-brew install circleci
 
 VERSION=$("$DESTDIR"/circleci version)
 TAG="v$(ruby -e "puts '$VERSION'.split(/[ +]/)[0]")"


### PR DESCRIPTION
- The postinstall phase for the `circleci` formula is failing on the Mac machine instances because it can't find a `circleci` user.
- We don't need the package installed to bump the version, so stop installing it.