### PR TITLE
`orb init` improvements

### DIFF
--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -1063,14 +1063,7 @@ func initOrb(opts orbOptions) error {
 		return err
 	}
 
-	nested, err := unzip(filepath.Join(os.TempDir(), "orb-project-template.zip"), filepath.Join(os.TempDir(), "orb-project-template"))
-	if err != nil {
-		return err
-	}
-	// This is neccesary because the zip downloaded from GitHub will have a
-	// directory with the actual template, rather than the template being
-	// top-level.
-	err = os.Rename(filepath.Join(os.TempDir(), "orb-project-template", nested), orbPath)
+	err = unzipToOrbPath(filepath.Join(os.TempDir(), "orb-project-template.zip"), orbPath)
 	if err != nil {
 		return err
 	}
@@ -1358,10 +1351,10 @@ func finalizeOrbInit(ownerName string, vcsProvider string, vcsShort string, name
 }
 
 // From https://stackoverflow.com/questions/20357223/easy-way-to-unzip-file-with-golang
-func unzip(src, dest string) (string, error) {
+func unzipToOrbPath(src, dest string) (error) {
 	r, err := zip.OpenReader(src)
 	if err != nil {
-		return "", err
+		return err
 	}
 	defer func() {
 		if err := r.Close(); err != nil {
@@ -1371,7 +1364,7 @@ func unzip(src, dest string) (string, error) {
 
 	err = os.MkdirAll(dest, 0755)
 	if err != nil {
-		return "", err
+		return err
 	}
 	// Closure to address file descriptors issue with all the deferred .Close() methods
 	extractAndWriteFile := func(f *zip.File) error {
@@ -1385,7 +1378,12 @@ func unzip(src, dest string) (string, error) {
 			}
 		}()
 
-		path := filepath.Join(dest, f.Name)
+		// This is neccesary because the zip downloaded from GitHub will have a
+		// directory with the actual template, rather than the template being
+		// top-level.
+		pathParts := strings.Split(f.Name, string(os.PathSeparator))
+		pathParts = append([]string{dest}, pathParts[1:]...)
+		path := filepath.Join(pathParts...)
 
 		if f.FileInfo().IsDir() {
 			err = os.MkdirAll(path, f.Mode())
@@ -1415,15 +1413,14 @@ func unzip(src, dest string) (string, error) {
 		return nil
 	}
 
-	nestedDir := r.File[0].Name
 	for _, f := range r.File {
 		err := extractAndWriteFile(f)
 		if err != nil {
-			return "", err
+			return err
 		}
 	}
 
-	return nestedDir, nil
+	return nil
 }
 
 func orbTemplate(fileContents string, projectName string, orgName string, orbName string, namespace string) string {

--- a/integration_tests/features/orb_pack.feature
+++ b/integration_tests/features/orb_pack.feature
@@ -22,6 +22,42 @@ Feature: Orb pack
     And the exit status should be 0
 
   @mocked_home_directory
+  Scenario: Orb pack with multiple includes fails
+    Given a file named "src/@orb.yml" with:
+    """
+    commands:
+        test:
+          steps:
+            - run:
+                command: <<include(script.sh)>> <<include(script.sh)>>
+    """
+    Given a file named "src/script.sh" with "echo Hello, world!"
+    When I run `circleci orb pack src`
+    Then the output should contain:
+    """
+    Error: An unexpected error occurred: multiple include statements: '<<include(script.sh)>> <<include(script.sh)>>'
+    """
+    And the exit status should be 255
+
+  @mocked_home_directory
+  Scenario: Orb pack with include statement in bigger string
+    Given a file named "src/@orb.yml" with:
+    """
+    commands:
+        test:
+          steps:
+            - run:
+                command: include <<include(script.sh)>>
+    """
+    Given a file named "src/script.sh" with "echo Hello, world!"
+    When I run `circleci orb pack src`
+    Then the output should contain:
+    """
+    Error: An unexpected error occurred: entire string must be include statement: 'include <<include(script.sh)>>'
+    """
+    And the exit status should be 255
+
+  @mocked_home_directory
   Scenario: Missing @orb.yml for orb packing
     When I run `circleci orb pack src`
     Then the output should contain:

--- a/process/process.go
+++ b/process/process.go
@@ -12,15 +12,25 @@ import (
 // of "file", escaping instances of "<<" within the file before returning, when
 // the <<include()>> parameter is the string passed.
 func MaybeIncludeFile(s string, orbDirectory string) (string, error) {
-	// View: https://regexr.com/582gb
-	includeRegex, err := regexp.Compile(`(?U)^<<\s*include\((.*\/*[^\/]+)\)\s*?>>$`)
-	if err != nil {
-		return s, err
+	// View: https://regexr.com/599mq
+	includeRegex := regexp.MustCompile(`<<[\s]*include\(([\w\/\.]+)\)?[\s]*>>`)
+
+	// only find up to 2 matches, because we throw an error if we find >1
+	includeMatches := includeRegex.FindAllStringSubmatch(s, 2)
+	if len(includeMatches) > 1 {
+		return "", fmt.Errorf("multiple include statements: '%s'", s)
 	}
 
-	includeMatches := includeRegex.FindStringSubmatch(s)
-	if len(includeMatches) > 0 {
-		filepath := filepath.Join(orbDirectory, includeMatches[1])
+	if len(includeMatches) == 1 {
+		match := includeMatches[0]
+		fullMatch, subMatch := match[0], match[1]
+
+		// throw an error if the entire string wasn't matched
+		if fullMatch != s {
+			return "", fmt.Errorf("entire string must be include statement: '%s'", s)
+		}
+
+		filepath := filepath.Join(orbDirectory, subMatch)
 		file, err := ioutil.ReadFile(filepath)
 		if err != nil {
 			return "", fmt.Errorf("could not open %s for inclusion", filepath)


### PR DESCRIPTION
Brings #493, #453, and snap detection when creating a git commit, under one PR.

Snap detection is necessary because of the way snaps are sandboxed. Normal installations allow the `git` library used to read the configuration and pull details, whereas a snap install disallows this and requires us to supply custom details.