### PR TITLE
[CIRCLE-28191] Info message when failing to import orb

### DIFF
--- a/cmd/orb_import.go
+++ b/cmd/orb_import.go
@@ -155,7 +155,11 @@ func applyPlan(opts orbOptions, plan orbImportPlan) error {
 
 		_, err = api.OrbImportVersion(opts.cl, v.Source, resp.Orb.ID, v.Version)
 		if err != nil {
-			return fmt.Errorf("unable to publish '%s@%s' with source: %s", v.Orb.Name, v.Version, err.Error())
+			additionalMessage := ""
+			if strings.HasPrefix(err.Error(), "ERROR IN CONFIG FILE") {
+				additionalMessage = "\nThis can be caused by an orb using syntax that is not supported on your server version."
+			}
+			return fmt.Errorf("unable to publish '%s@%s': %s%s", v.Orb.Name, v.Version, err.Error(), additionalMessage)
 		}
 	}
 

--- a/cmd/orb_import_test.go
+++ b/cmd/orb_import_test.go
@@ -910,7 +910,7 @@ The following orb versions already exist:
 
 			orbPublishResp := `{
 					"publishOrb": {
-						"errors": [{"message": "testerror"}]
+						"errors": [{"message": "ERROR IN CONFIG FILE:\ntesterror"}]
 					}
 				}`
 
@@ -926,7 +926,7 @@ The following orb versions already exist:
 			})
 
 			err := applyPlan(opts, plan)
-			Expect(err).To(MatchError("unable to publish 'namespace1/orb@0.0.1' with source: testerror"))
+			Expect(err).To(MatchError("unable to publish 'namespace1/orb@0.0.1': ERROR IN CONFIG FILE:\ntesterror\nThis can be caused by an orb using syntax that is not supported on your server version."))
 		})
 
 		It("fails to publish an orb version with source", func() {


### PR DESCRIPTION
Under normal circumstances, an imported orb should be valid syntax. If it isn't,
it may be that there is new syntax on cloud that is not yet supported on (this)
server. Make that clearer if it happens.