### PR TITLE
Properly deserialize graphQL response when creating an imported orb

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -203,6 +203,15 @@ type CreateOrbResponse struct {
 	}
 }
 
+// ImportOrbResponse type matches the data shape of the GQL response for
+// creating an orb
+type ImportOrbResponse struct {
+	ImportOrb struct {
+		Orb    Orb
+		Errors GQLErrorsCollection
+	}
+}
+
 // NamespaceOrbResponse type matches the result from GQL.
 // So that we can use mapstructure to convert from nested maps to a strongly typed struct.
 type NamespaceOrbResponse struct {
@@ -830,10 +839,10 @@ func organizationNotFound(name string, vcs string) error {
 }
 
 func DeleteNamespaceAlias(cl *graphql.Client, name string) error {
-	var response struct{
-		DeleteNamespaceAlias struct{
+	var response struct {
+		DeleteNamespaceAlias struct {
 			Deleted bool
-			Errors GQLErrorsCollection
+			Errors  GQLErrorsCollection
 		}
 	}
 	query := `
@@ -1034,13 +1043,13 @@ func CreateOrb(cl *graphql.Client, namespace string, name string) (*CreateOrbRes
 }
 
 // CreateImportedOrb creates (reserves) an imported orb within the provided namespace.
-func CreateImportedOrb(cl *graphql.Client, namespace string, name string) (*CreateOrbResponse, error) {
+func CreateImportedOrb(cl *graphql.Client, namespace string, name string) (*ImportOrbResponse, error) {
 	res, err := GetNamespace(cl, namespace)
 	if err != nil {
 		return nil, err
 	}
 
-	var response CreateOrbResponse
+	var response ImportOrbResponse
 
 	query := `mutation($name: String!, $registryNamespaceId: UUID!){
 				importOrb(
@@ -1068,8 +1077,8 @@ func CreateImportedOrb(cl *graphql.Client, namespace string, name string) (*Crea
 		return nil, err
 	}
 
-	if len(response.CreateOrb.Errors) > 0 {
-		return nil, response.CreateOrb.Errors
+	if len(response.ImportOrb.Errors) > 0 {
+		return nil, response.ImportOrb.Errors
 	}
 
 	return &response, nil

--- a/cmd/orb_import_test.go
+++ b/cmd/orb_import_test.go
@@ -799,7 +799,7 @@ The following orb versions already exist:
 					}
 				}`
 
-			createOrbReq := `{
+			importOrbReq := `{
 					"query": "mutation($name: String!, $registryNamespaceId: UUID!){\n\t\t\t\timportOrb(\n\t\t\t\t\tname: $name,\n\t\t\t\t\tregistryNamespaceId: $registryNamespaceId\n\t\t\t\t){\n\t\t\t\t    orb {\n\t\t\t\t      id\n\t\t\t\t    }\n\t\t\t\t    errors {\n\t\t\t\t      message\n\t\t\t\t      type\n\t\t\t\t    }\n\t\t\t\t}\n}",
 					"variables": {
 					  "name": "orb",
@@ -807,8 +807,8 @@ The following orb versions already exist:
 					}
 				  }`
 
-			createOrbResp := `{
-					"createOrb": {
+			importOrbResp := `{
+					"importOrb": {
 						"errors": [{"message": "testerror"}]
 					}
 				}`
@@ -820,8 +820,8 @@ The following orb versions already exist:
 			})
 			cli.AppendPostHandler("", clitest.MockRequestResponse{
 				Status:   http.StatusOK,
-				Request:  createOrbReq,
-				Response: createOrbResp,
+				Request:  importOrbReq,
+				Response: importOrbResp,
 			})
 
 			err := applyPlan(opts, plan)


### PR DESCRIPTION
This PR fixes a bug where we weren't deserializing graphQL responses properly when importing orbs. The response struct name was changed to match that of the mutation being performed: `ImportOrb`