### PR TITLE
Fix bug listing env vars

### DIFF
--- a/api/context_rest.go
+++ b/api/context_rest.go
@@ -22,7 +22,7 @@ type ContextRestClient struct {
 
 type listEnvironmentVariablesResponse struct {
 	Items []EnvironmentVariable
-	NextPageToken *string
+	NextPageToken *string `json:"next_page_token"`
 	client *ContextRestClient
 	params *listEnvironmentVariablesParams
 }


### PR DESCRIPTION
This caused only the first 20 environment variables to be printed,
rather than paging through if there were more.