### PR TITLE
[CIRCLE-31080] Add no-prompt option to admin commands

### DIFF
--- a/cmd/admin.go
+++ b/cmd/admin.go
@@ -65,6 +65,11 @@ Example:
 			return validateToken(nsOpts.cfg)
 		},
 		RunE: func(_ *cobra.Command, _ []string) error {
+			if nsOpts.integrationTesting {
+				nsOpts.tty = createNamespaceTestUI{
+					confirm: true,
+				}
+			}
 			return deleteNamespaceAlias(nsOpts)
 		},
 		Args:        cobra.ExactArgs(1),
@@ -73,6 +78,10 @@ Example:
 
 	deleteAliasCommand.Annotations["<name>"] = "The name of the alias to delete"
 	deleteAliasCommand.Flags().BoolVar(&nsOpts.noPrompt, "no-prompt", false, "Disable prompt to bypass interactive UI.")
+	deleteAliasCommand.Flags().BoolVar(&nsOpts.integrationTesting, "integration-testing", false, "Enable test mode to bypass interactive UI.")
+	if err := deleteAliasCommand.Flags().MarkHidden("integration-testing"); err != nil {
+		panic(err)
+	}
 
 	adminCommand := &cobra.Command{
 		Use:   "admin",

--- a/cmd/admin.go
+++ b/cmd/admin.go
@@ -25,6 +25,10 @@ func newAdminCommand(config *settings.Config) *cobra.Command {
 		Args: cobra.MinimumNArgs(1),
 	}
 	importOrbCommand.Flags().BoolVar(&orbOpts.integrationTesting, "integration-testing", false, "Enable test mode to bypass interactive UI.")
+	if err := importOrbCommand.Flags().MarkHidden("integration-testing"); err != nil {
+		panic(err)
+	}
+	importOrbCommand.Flags().BoolVar(&orbOpts.noPrompt, "no-prompt", false, "Disable prompt to bypass interactive UI.")
 
 	renameCommand := &cobra.Command{
 		Use:   "rename-namespace <old-name> <new-name>",
@@ -68,6 +72,7 @@ Example:
 	}
 
 	deleteAliasCommand.Annotations["<name>"] = "The name of the alias to delete"
+	deleteAliasCommand.Flags().BoolVar(&nsOpts.noPrompt, "no-prompt", false, "Disable prompt to bypass interactive UI.")
 
 	adminCommand := &cobra.Command{
 		Use:   "admin",

--- a/cmd/admin_test.go
+++ b/cmd/admin_test.go
@@ -35,6 +35,7 @@ var _ = Describe("Namespace integration tests", func() {
 				"--skip-update-check",
 				"--token", token,
 				"--host", tempSettings.TestServer.URL(),
+				"--integration-testing",
 				"foo-ns",
 			)
 		})

--- a/cmd/namespace.go
+++ b/cmd/namespace.go
@@ -95,8 +95,12 @@ Please note that at this time all namespaces created in the registry are world-r
 
 func deleteNamespaceAlias(opts namespaceOptions) error {
 	aliasName := opts.args[0]
-	err := api.DeleteNamespaceAlias(opts.cl, aliasName)
-	return err
+	confirm := fmt.Sprintf("Are you sure you wish to delete the namespace alias %s? You should make sure that all configs and orbs that refer to it this way are updated to the new name first.", aliasName)
+	if opts.noPrompt || opts.tty.askUserToConfirm(confirm) {
+		err := api.DeleteNamespaceAlias(opts.cl, aliasName)
+		return err
+	}
+	return nil
 }
 
 func createNamespace(opts namespaceOptions) error {


### PR DESCRIPTION
Add --no-prompt option to admin commands to import orbs and delete namespace
aliases. We need these for use with automated integation tests of a server
install.