### PR TITLE
[CIRCLE-30179] Create Private Orbs

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -1005,13 +1005,14 @@ func RenameNamespace(cl *graphql.Client, oldName, newName string) (*RenameNamesp
 	return renameNamespaceWithNsID(cl, getNamespaceResponse.RegistryNamespace.ID, newName)
 }
 
-func createOrbWithNsID(cl *graphql.Client, name string, namespaceID string) (*CreateOrbResponse, error) {
+func createOrbWithNsID(cl *graphql.Client, name string, namespaceID string, isPrivate bool) (*CreateOrbResponse, error) {
 	var response CreateOrbResponse
 
-	query := `mutation($name: String!, $registryNamespaceId: UUID!){
+	query := `mutation($name: String!, $registryNamespaceId: UUID!, $isPrivate: Boolean!){
 				createOrb(
 					name: $name,
-					registryNamespaceId: $registryNamespaceId
+					registryNamespaceId: $registryNamespaceId,
+					isPrivate: $isPrivate
 				){
 				    orb {
 				      id
@@ -1028,6 +1029,7 @@ func createOrbWithNsID(cl *graphql.Client, name string, namespaceID string) (*Cr
 
 	request.Var("name", name)
 	request.Var("registryNamespaceId", namespaceID)
+	request.Var("isPrivate", isPrivate)
 
 	err := cl.Run(request, &response)
 
@@ -1043,13 +1045,13 @@ func createOrbWithNsID(cl *graphql.Client, name string, namespaceID string) (*Cr
 }
 
 // CreateOrb creates (reserves) an orb within a namespace
-func CreateOrb(cl *graphql.Client, namespace string, name string) (*CreateOrbResponse, error) {
+func CreateOrb(cl *graphql.Client, namespace string, name string, isPrivate bool) (*CreateOrbResponse, error) {
 	response, err := GetNamespace(cl, namespace)
 	if err != nil {
 		return nil, err
 	}
 
-	return createOrbWithNsID(cl, name, response.RegistryNamespace.ID)
+	return createOrbWithNsID(cl, name, response.RegistryNamespace.ID, isPrivate)
 }
 
 // CreateImportedOrb creates (reserves) an imported orb within the provided namespace.

--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -44,7 +44,7 @@ type orbOptions struct {
 	listUncertified bool
 	listJSON        bool
 	listDetails     bool
-	selectPrivate   bool
+	private         bool
 	sortBy          string
 	// Allows user to skip y/n confirm when creating an orb
 	noPrompt bool
@@ -248,7 +248,7 @@ listing of the orb in the registry.`,
 		Use:   "create <namespace>/<orb>",
 		Short: "Create an orb in the specified namespace",
 		Long: `Create an orb in the specified namespace
-Please note that at this time all orbs created in the registry are world-readable.`,
+Please note that at this time all orbs created in the registry are world-readable unless set as private using the optional flag.`,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			if opts.integrationTesting {
 				opts.tty = createOrbTestUI{
@@ -263,7 +263,7 @@ Please note that at this time all orbs created in the registry are world-readabl
 		},
 		Args: cobra.ExactArgs(1),
 	}
-	orbCreate.PersistentFlags().BoolVarP(&opts.selectPrivate, "private", "", false, "target private orbs") // TODO: more detailed description
+	orbCreate.PersistentFlags().BoolVarP(&opts.private, "private", "", false, "Specify that this orb is for private use within your org, unlisted from the public registry.")
 
 	orbPack := &cobra.Command{
 		Use:   "pack <path>",
@@ -787,7 +787,7 @@ If you change your mind about the name, you will have to create a new orb with t
 	confirm := fmt.Sprintf("Are you sure you wish to create the orb: `%s/%s`", namespace, orbName)
 
 	if opts.noPrompt || opts.tty.askUserToConfirm(confirm) {
-		_, err = api.CreateOrb(opts.cl, namespace, orbName, opts.selectPrivate)
+		_, err = api.CreateOrb(opts.cl, namespace, orbName, opts.private)
 
 		if err != nil {
 			return err

--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -44,6 +44,7 @@ type orbOptions struct {
 	listUncertified bool
 	listJSON        bool
 	listDetails     bool
+	selectPrivate   bool
 	sortBy          string
 	// Allows user to skip y/n confirm when creating an orb
 	noPrompt bool
@@ -262,6 +263,7 @@ Please note that at this time all orbs created in the registry are world-readabl
 		},
 		Args: cobra.ExactArgs(1),
 	}
+	orbCreate.PersistentFlags().BoolVarP(&opts.selectPrivate, "private", "", false, "target private orbs") // TODO: more detailed description
 
 	orbPack := &cobra.Command{
 		Use:   "pack <path>",
@@ -766,7 +768,7 @@ func promoteOrb(opts orbOptions) error {
 func createOrb(opts orbOptions) error {
 	var err error
 
-	namespace, orb, err := references.SplitIntoOrbAndNamespace(opts.args[0])
+	namespace, orbName, err := references.SplitIntoOrbAndNamespace(opts.args[0])
 
 	if err != nil {
 		return err
@@ -779,13 +781,13 @@ You will not be able to change the name of this orb.
 
 If you change your mind about the name, you will have to create a new orb with the new name.
 
-`, namespace, orb)
+`, namespace, orbName)
 	}
 
-	confirm := fmt.Sprintf("Are you sure you wish to create the orb: `%s/%s`", namespace, orb)
+	confirm := fmt.Sprintf("Are you sure you wish to create the orb: `%s/%s`", namespace, orbName)
 
 	if opts.noPrompt || opts.tty.askUserToConfirm(confirm) {
-		_, err = api.CreateOrb(opts.cl, namespace, orb)
+		_, err = api.CreateOrb(opts.cl, namespace, orbName, opts.selectPrivate)
 
 		if err != nil {
 			return err
@@ -1284,7 +1286,7 @@ func initOrb(opts orbOptions) error {
 	}
 
 	// Push a dev version of the orb.
-	newOrb, err := api.CreateOrb(opts.cl, namespace, orbName)
+	newOrb, err := api.CreateOrb(opts.cl, namespace, orbName, false)
 	if err != nil {
 		return errors.Wrap(err, "Unable to create orb")
 	}

--- a/cmd/orb_test.go
+++ b/cmd/orb_test.go
@@ -964,7 +964,7 @@ See a full explanation and documentation on orbs here: https://circleci.com/docs
 					expectedOrbRequest := `{
             "query": "mutation($name: String!, $registryNamespaceId: UUID!, $isPrivate: Boolean!){\n\t\t\t\tcreateOrb(\n\t\t\t\t\tname: $name,\n\t\t\t\t\tregistryNamespaceId: $registryNamespaceId,\n\t\t\t\t\tisPrivate: $isPrivate\n\t\t\t\t){\n\t\t\t\t    orb {\n\t\t\t\t      id\n\t\t\t\t    }\n\t\t\t\t    errors {\n\t\t\t\t      message\n\t\t\t\t      type\n\t\t\t\t    }\n\t\t\t\t}\n}",
             "variables": {
-			  "isPrivate": false,
+              "isPrivate": false,
               "name": "foo-orb",
               "registryNamespaceId": "bb604b45-b6b0-4b81-ad80-796f15eddf87"
             }

--- a/cmd/orb_test.go
+++ b/cmd/orb_test.go
@@ -962,8 +962,9 @@ See a full explanation and documentation on orbs here: https://circleci.com/docs
 								   }`
 
 					expectedOrbRequest := `{
-            "query": "mutation($name: String!, $registryNamespaceId: UUID!){\n\t\t\t\tcreateOrb(\n\t\t\t\t\tname: $name,\n\t\t\t\t\tregistryNamespaceId: $registryNamespaceId\n\t\t\t\t){\n\t\t\t\t    orb {\n\t\t\t\t      id\n\t\t\t\t    }\n\t\t\t\t    errors {\n\t\t\t\t      message\n\t\t\t\t      type\n\t\t\t\t    }\n\t\t\t\t}\n}",
+            "query": "mutation($name: String!, $registryNamespaceId: UUID!, $isPrivate: Boolean!){\n\t\t\t\tcreateOrb(\n\t\t\t\t\tname: $name,\n\t\t\t\t\tregistryNamespaceId: $registryNamespaceId,\n\t\t\t\t\tisPrivate: $isPrivate\n\t\t\t\t){\n\t\t\t\t    orb {\n\t\t\t\t      id\n\t\t\t\t    }\n\t\t\t\t    errors {\n\t\t\t\t      message\n\t\t\t\t      type\n\t\t\t\t    }\n\t\t\t\t}\n}",
             "variables": {
+			  "isPrivate": false,
               "name": "foo-orb",
               "registryNamespaceId": "bb604b45-b6b0-4b81-ad80-796f15eddf87"
             }
@@ -1020,8 +1021,9 @@ You can now register versions of %s using %s`, "`bar-ns/foo-orb`", "`bar-ns/foo-
 					gqlErrors := `[ { "message": "ignored error" } ]`
 
 					expectedOrbRequest := `{
-            "query": "mutation($name: String!, $registryNamespaceId: UUID!){\n\t\t\t\tcreateOrb(\n\t\t\t\t\tname: $name,\n\t\t\t\t\tregistryNamespaceId: $registryNamespaceId\n\t\t\t\t){\n\t\t\t\t    orb {\n\t\t\t\t      id\n\t\t\t\t    }\n\t\t\t\t    errors {\n\t\t\t\t      message\n\t\t\t\t      type\n\t\t\t\t    }\n\t\t\t\t}\n}",
+            "query": "mutation($name: String!, $registryNamespaceId: UUID!, $isPrivate: Boolean!){\n\t\t\t\tcreateOrb(\n\t\t\t\t\tname: $name,\n\t\t\t\t\tregistryNamespaceId: $registryNamespaceId,\n\t\t\t\t\tisPrivate: $isPrivate\n\t\t\t\t){\n\t\t\t\t    orb {\n\t\t\t\t      id\n\t\t\t\t    }\n\t\t\t\t    errors {\n\t\t\t\t      message\n\t\t\t\t      type\n\t\t\t\t    }\n\t\t\t\t}\n}",
             "variables": {
+			  "isPrivate": false,
               "name": "foo-orb",
               "registryNamespaceId": "bb604b45-b6b0-4b81-ad80-796f15eddf87"
             }
@@ -1087,8 +1089,9 @@ You can now register versions of %s using %s`, "`bar-ns/foo-orb`", "`bar-ns/foo-
 								   }`
 
 						expectedOrbRequest := `{
-            "query": "mutation($name: String!, $registryNamespaceId: UUID!){\n\t\t\t\tcreateOrb(\n\t\t\t\t\tname: $name,\n\t\t\t\t\tregistryNamespaceId: $registryNamespaceId\n\t\t\t\t){\n\t\t\t\t    orb {\n\t\t\t\t      id\n\t\t\t\t    }\n\t\t\t\t    errors {\n\t\t\t\t      message\n\t\t\t\t      type\n\t\t\t\t    }\n\t\t\t\t}\n}",
+            "query": "mutation($name: String!, $registryNamespaceId: UUID!, $isPrivate: Boolean!){\n\t\t\t\tcreateOrb(\n\t\t\t\t\tname: $name,\n\t\t\t\t\tregistryNamespaceId: $registryNamespaceId,\n\t\t\t\t\tisPrivate: $isPrivate\n\t\t\t\t){\n\t\t\t\t    orb {\n\t\t\t\t      id\n\t\t\t\t    }\n\t\t\t\t    errors {\n\t\t\t\t      message\n\t\t\t\t      type\n\t\t\t\t    }\n\t\t\t\t}\n}",
             "variables": {
+			  "isPrivate": false,
               "name": "foo-orb",
               "registryNamespaceId": "bb604b45-b6b0-4b81-ad80-796f15eddf87"
             }
@@ -1153,8 +1156,9 @@ You can now register versions of %s using %s.`,
 						gqlErrors := `[ { "message": "ignored error" } ]`
 
 						expectedOrbRequest := `{
-            "query": "mutation($name: String!, $registryNamespaceId: UUID!){\n\t\t\t\tcreateOrb(\n\t\t\t\t\tname: $name,\n\t\t\t\t\tregistryNamespaceId: $registryNamespaceId\n\t\t\t\t){\n\t\t\t\t    orb {\n\t\t\t\t      id\n\t\t\t\t    }\n\t\t\t\t    errors {\n\t\t\t\t      message\n\t\t\t\t      type\n\t\t\t\t    }\n\t\t\t\t}\n}",
+            "query": "mutation($name: String!, $registryNamespaceId: UUID!, $isPrivate: Boolean!){\n\t\t\t\tcreateOrb(\n\t\t\t\t\tname: $name,\n\t\t\t\t\tregistryNamespaceId: $registryNamespaceId,\n\t\t\t\t\tisPrivate: $isPrivate\n\t\t\t\t){\n\t\t\t\t    orb {\n\t\t\t\t      id\n\t\t\t\t    }\n\t\t\t\t    errors {\n\t\t\t\t      message\n\t\t\t\t      type\n\t\t\t\t    }\n\t\t\t\t}\n}",
             "variables": {
+			  "isPrivate": false,
               "name": "foo-orb",
               "registryNamespaceId": "bb604b45-b6b0-4b81-ad80-796f15eddf87"
             }


### PR DESCRIPTION
This PR makes the following changes:
- orb commands now accept an optional `--private` flag
- `createOrb` now propagates a `selectPrivate` flag into the api-service mutation

This PR should not be merged until api-service has been updated to optionally accept the isPrivate flag: https://github.com/circleci/api-service/pull/789

Co-authored-by: @skimke <skimke@users.noreply.github.com>