### PR TITLE
[CIRCLE-32122] use the correct delete alias cmd name in prompt

### DIFF
--- a/cmd/admin_test.go
+++ b/cmd/admin_test.go
@@ -168,8 +168,10 @@ var _ = Describe("Namespace integration tests", func() {
 			By("running the command")
 			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 			Expect(err).ShouldNot(HaveOccurred())
-			Eventually(session.Out, "5s").Should(gbytes.Say("`ns-0` renamed to `ns-1`"))
 			Eventually(session).Should(gexec.Exit(0))
+
+			stdout := session.Wait().Out.Contents()
+			Expect(string(stdout)).To(ContainSubstring("Namespace `ns-0` renamed to `ns-1`. `ns-0` is an alias for `ns-1` so existing usages will continue to work, unless you delete the `ns-0` alias with `delete-namespace-alias ns-0`"))
 		})
 
 		It("returns an error when renaming a namespace fails", func() {

--- a/cmd/namespace.go
+++ b/cmd/namespace.go
@@ -143,7 +143,7 @@ func renameNamespace(opts namespaceOptions) error {
 			return err
 		}
 
-		fmt.Printf("Namespace `%s` renamed to `%s`. `%s` is an alias for `%s` so existing usages will continue to work, unless you delete the %s alias with `namespace delete-alias %s`", oldName, newName, oldName, newName, oldName, oldName)
+		fmt.Printf("Namespace `%s` renamed to `%s`. `%s` is an alias for `%s` so existing usages will continue to work, unless you delete the `%s` alias with `delete-namespace-alias %s`", oldName, newName, oldName, newName, oldName, oldName)
 	}
 	return nil
 }


### PR DESCRIPTION
After successfully renaming a namespace alias, the prompt suggests the wrong cmd name for deleting namespace alias.
- Fix in `renameNamespace`
- Adds more specific string in tests