### PR TITLE
`getRemoteUrl`: Address git error level difference in Windows

### DIFF
--- a/git/git_test.go
+++ b/git/git_test.go
@@ -56,7 +56,7 @@ var _ = Describe("Dealing with git", func() {
 				// This test will fail if the current working directory has git remote
 				// named 'peristeronic'.
 				_, err := getRemoteUrl("peristeronic")
-				Expect(err).To(MatchError("Error finding the peristeronic git remote: fatal: No such remote 'peristeronic'"))
+				Expect(err.Error()).To(MatchRegexp(`Error finding the peristeronic git remote`))
 			})
 
 			It("can read git output", func() {


### PR DESCRIPTION
There's a test that only fails for Windows because its level of error is `error`, not `fatal`.
On Windows, the message is:
`error: No such remote <remoteName>`
not
`fatal: No such remote <remoteName>`

Likely due to `git` version differences that include/exclude these changes: https://github.com/git/git/commit/9144ba4cf52bb0e891d7c10a331fc32c1d3e8f64