### PR TITLE
[CIRCLE-32386] OrbPublish and OrbPromote now function through an orb's name + namespace instead of its ID

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -625,8 +625,9 @@ func OrbImportVersion(cl *graphql.Client, orbSrc string, orbID string, orbVersio
 	return &response.ImportOrbVersion.Orb, nil
 }
 
-// OrbPublishByID publishes a new version of an orb by id
-func OrbPublishByID(cl *graphql.Client, configPath string, orbID string, orbVersion string) (*Orb, error) {
+// OrbPublishByName publishes a new version of an orb using the provided orb's name and namespace, returning any
+// error encountered.
+func OrbPublishByName(cl *graphql.Client, configPath, orbName, namespaceName, orbVersion string) (*Orb, error) {
 	var response OrbPublishResponse
 
 	config, err := loadYaml(configPath)
@@ -635,9 +636,10 @@ func OrbPublishByID(cl *graphql.Client, configPath string, orbID string, orbVers
 	}
 
 	query := `
-		mutation($config: String!, $orbId: UUID!, $version: String!) {
+		mutation($config: String!, $orbName: String, $namespaceName: String, $version: String!) {
 			publishOrb(
-				orbId: $orbId,
+				orbName: $orbName,
+				namespaceName: $namespaceName,
 				orbYaml: $config,
 				version: $version
 			) {
@@ -653,7 +655,8 @@ func OrbPublishByID(cl *graphql.Client, configPath string, orbID string, orbVers
 	request.SetToken(cl.Token)
 
 	request.Var("config", config)
-	request.Var("orbId", orbID)
+	request.Var("orbName", orbName)
+	request.Var("namespaceName", namespaceName)
 	request.Var("version", orbVersion)
 
 	err = cl.Run(request, &response)
@@ -1118,12 +1121,6 @@ func incrementVersion(version string, segment string) (string, error) {
 
 // OrbIncrementVersion accepts an orb and segment to increment the orb.
 func OrbIncrementVersion(cl *graphql.Client, configPath string, namespace string, orb string, segment string) (*Orb, error) {
-	// TODO(zzak): We can squash OrbID and OrbLatestVersion to a single query
-	id, err := OrbID(cl, namespace, orb)
-	if err != nil {
-		return nil, err
-	}
-
 	v, err := OrbLatestVersion(cl, namespace, orb)
 	if err != nil {
 		return nil, err
@@ -1134,7 +1131,7 @@ func OrbIncrementVersion(cl *graphql.Client, configPath string, namespace string
 		return nil, err
 	}
 
-	response, err := OrbPublishByID(cl, configPath, id.Orb.ID, v2)
+	response, err := OrbPublishByName(cl, configPath, orb, namespace, v2)
 	if err != nil {
 		return nil, err
 	}
@@ -1175,16 +1172,9 @@ func OrbLatestVersion(cl *graphql.Client, namespace string, orb string) (string,
 	return response.Orb.Versions[0].Version, nil
 }
 
-// OrbPromote takes an orb and a development version and increments a semantic release with the given segment.
-func OrbPromote(cl *graphql.Client, namespace string, orb string, label string, segment string) (*Orb, error) {
-	// TODO(zzak): We can squash OrbID and OrbLatestVersion to a single query
-	id, err := OrbID(cl, namespace, orb)
-
-	if err != nil {
-		return nil, err
-	}
-
-	v, err := OrbLatestVersion(cl, namespace, orb)
+// OrbPromoteByName utilizes the given orb's name, namespace, development version, and segment to increment a semantic release.
+func OrbPromoteByName(cl *graphql.Client, namespaceName, orbName, label, segment string) (*Orb, error) {
+	v, err := OrbLatestVersion(cl, namespaceName, orbName)
 	if err != nil {
 		return nil, err
 	}
@@ -1197,9 +1187,10 @@ func OrbPromote(cl *graphql.Client, namespace string, orb string, label string, 
 	var response OrbPromoteResponse
 
 	query := `
-		mutation($orbId: UUID!, $devVersion: String!, $semanticVersion: String!) {
+		mutation($orbName: String, $namespaceName: String, $devVersion: String!, $semanticVersion: String!) {
 			promoteOrb(
-				orbId: $orbId,
+				orbName: $orbName,
+				namespaceName: $namespaceName,
 				devVersion: $devVersion,
 				semanticVersion: $semanticVersion
 			) {
@@ -1215,7 +1206,8 @@ func OrbPromote(cl *graphql.Client, namespace string, orb string, label string, 
 	request := graphql.NewRequest(query)
 	request.SetToken(cl.Token)
 
-	request.Var("orbId", id.Orb.ID)
+	request.Var("orbName", orbName)
+	request.Var("namespaceName", namespaceName)
 	request.Var("devVersion", label)
 	request.Var("semanticVersion", v2)
 

--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -647,12 +647,7 @@ func publishOrb(opts orbOptions) error {
 		return err
 	}
 
-	id, err := api.OrbID(opts.cl, namespace, orb)
-	if err != nil {
-		return err
-	}
-
-	_, err = api.OrbPublishByID(opts.cl, path, id.Orb.ID, version)
+	_, err = api.OrbPublishByName(opts.cl, path, orb, namespace, version)
 	if err != nil {
 		return err
 	}
@@ -755,7 +750,7 @@ func promoteOrb(opts orbOptions) error {
 		return fmt.Errorf("The version '%s' must be a dev version (the string should begin `dev:`)", version)
 	}
 
-	response, err := api.OrbPromote(opts.cl, namespace, orb, version, segment)
+	response, err := api.OrbPromoteByName(opts.cl, namespace, orb, version, segment)
 	if err != nil {
 		return err
 	}
@@ -1286,7 +1281,7 @@ func initOrb(opts orbOptions) error {
 	}
 
 	// Push a dev version of the orb.
-	newOrb, err := api.CreateOrb(opts.cl, namespace, orbName, false)
+	_, err = api.CreateOrb(opts.cl, namespace, orbName, false)
 	if err != nil {
 		return errors.Wrap(err, "Unable to create orb")
 	}
@@ -1307,7 +1302,7 @@ func initOrb(opts orbOptions) error {
 		return errors.Wrap(err, "Unable to write packed orb")
 	}
 
-	_, err = api.OrbPublishByID(opts.cl, tempOrbFile, newOrb.CreateOrb.Orb.ID, "dev:alpha")
+	_, err = api.OrbPublishByName(opts.cl, tempOrbFile, orbName, namespace, "dev:alpha")
 	if err != nil {
 		return err
 	}

--- a/cmd/orb_test.go
+++ b/cmd/orb_test.go
@@ -380,20 +380,6 @@ See a full explanation and documentation on orbs here: https://circleci.com/docs
 				It("works", func() {
 					By("setting up a mock server")
 
-					gqlOrbIDResponse := `{
-    											"orb": {
-      												"id": "bb604b45-b6b0-4b81-ad80-796f15eddf87"
-    											}
-  				}`
-
-					expectedOrbIDRequest := `{
-            "query": "\n\tquery ($name: String!, $namespace: String) {\n\t\torb(name: $name) {\n\t\t  id\n\t\t}\n\t\tregistryNamespace(name: $namespace) {\n\t\t  id\n\t\t}\n\t  }\n\t  ",
-            "variables": {
-              "name": "my/orb",
-              "namespace": "my"
-            }
-          }`
-
 					gqlPublishResponse := `{
 					"publishOrb": {
 						"errors": [],
@@ -404,18 +390,15 @@ See a full explanation and documentation on orbs here: https://circleci.com/docs
 				}`
 
 					expectedPublishRequest := `{
-					"query": "\n\t\tmutation($config: String!, $orbId: UUID!, $version: String!) {\n\t\t\tpublishOrb(\n\t\t\t\torbId: $orbId,\n\t\t\t\torbYaml: $config,\n\t\t\t\tversion: $version\n\t\t\t) {\n\t\t\t\torb {\n\t\t\t\t\tversion\n\t\t\t\t}\n\t\t\t\terrors { message }\n\t\t\t}\n\t\t}\n\t",
-					"variables": {
-						"config": "some orb",
-						"orbId": "bb604b45-b6b0-4b81-ad80-796f15eddf87",
-						"version": "0.0.1"
-					}
-				}`
+						"query": "\n\t\tmutation($config: String!, $orbName: String, $namespaceName: String, $version: String!) {\n\t\t\tpublishOrb(\n\t\t\t\torbName: $orbName,\n\t\t\t\tnamespaceName: $namespaceName,\n\t\t\t\torbYaml: $config,\n\t\t\t\tversion: $version\n\t\t\t) {\n\t\t\t\torb {\n\t\t\t\t\tversion\n\t\t\t\t}\n\t\t\t\terrors { message }\n\t\t\t}\n\t\t}\n\t",
+						"variables": {
+						  "config": "some orb",
+						  "namespaceName": "my",
+						  "orbName": "orb",
+						  "version": "0.0.1"
+						}
+					  }`
 
-					tempSettings.AppendPostHandler(token, clitest.MockRequestResponse{
-						Status:   http.StatusOK,
-						Request:  expectedOrbIDRequest,
-						Response: gqlOrbIDResponse})
 					tempSettings.AppendPostHandler(token, clitest.MockRequestResponse{
 						Status:   http.StatusOK,
 						Request:  expectedPublishRequest,
@@ -433,20 +416,6 @@ See a full explanation and documentation on orbs here: https://circleci.com/docs
 				It("prints all errors returned by the GraphQL API", func() {
 					By("setting up a mock server")
 
-					gqlOrbIDResponse := `{
-    											"orb": {
-      												"id": "bb604b45-b6b0-4b81-ad80-796f15eddf87"
-    											}
-  				}`
-
-					expectedOrbIDRequest := `{
-            "query": "\n\tquery ($name: String!, $namespace: String) {\n\t\torb(name: $name) {\n\t\t  id\n\t\t}\n\t\tregistryNamespace(name: $namespace) {\n\t\t  id\n\t\t}\n\t  }\n\t  ",
-            "variables": {
-              "name": "my/orb",
-              "namespace": "my"
-            }
-          }`
-
 					gqlPublishResponse := `{
 					"publishOrb": {
 								"errors": [
@@ -458,18 +427,15 @@ See a full explanation and documentation on orbs here: https://circleci.com/docs
 				}`
 
 					expectedPublishRequest := `{
-					"query": "\n\t\tmutation($config: String!, $orbId: UUID!, $version: String!) {\n\t\t\tpublishOrb(\n\t\t\t\torbId: $orbId,\n\t\t\t\torbYaml: $config,\n\t\t\t\tversion: $version\n\t\t\t) {\n\t\t\t\torb {\n\t\t\t\t\tversion\n\t\t\t\t}\n\t\t\t\terrors { message }\n\t\t\t}\n\t\t}\n\t",
-					"variables": {
-						"config": "some orb",
-						"orbId": "bb604b45-b6b0-4b81-ad80-796f15eddf87",
-						"version": "0.0.1"
-					}
-				}`
+						"query": "\n\t\tmutation($config: String!, $orbName: String, $namespaceName: String, $version: String!) {\n\t\t\tpublishOrb(\n\t\t\t\torbName: $orbName,\n\t\t\t\tnamespaceName: $namespaceName,\n\t\t\t\torbYaml: $config,\n\t\t\t\tversion: $version\n\t\t\t) {\n\t\t\t\torb {\n\t\t\t\t\tversion\n\t\t\t\t}\n\t\t\t\terrors { message }\n\t\t\t}\n\t\t}\n\t",
+						"variables": {
+						  "config": "some orb",
+						  "namespaceName": "my",
+						  "orbName": "orb",
+						  "version": "0.0.1"
+						}
+					  }`
 
-					tempSettings.AppendPostHandler(token, clitest.MockRequestResponse{
-						Status:   http.StatusOK,
-						Request:  expectedOrbIDRequest,
-						Response: gqlOrbIDResponse})
 					tempSettings.AppendPostHandler(token, clitest.MockRequestResponse{
 						Status:   http.StatusOK,
 						Request:  expectedPublishRequest,
@@ -500,20 +466,6 @@ See a full explanation and documentation on orbs here: https://circleci.com/docs
 				It("works", func() {
 					By("setting up a mock server")
 
-					gqlOrbIDResponse := `{
-    											"orb": {
-      												"id": "bb604b45-b6b0-4b81-ad80-796f15eddf87"
-    											}
-  				}`
-
-					expectedOrbIDRequest := `{
-            "query": "\n\tquery ($name: String!, $namespace: String) {\n\t\torb(name: $name) {\n\t\t  id\n\t\t}\n\t\tregistryNamespace(name: $namespace) {\n\t\t  id\n\t\t}\n\t  }\n\t  ",
-            "variables": {
-              "name": "my/orb",
-              "namespace": "my"
-            }
-          }`
-
 					gqlPublishResponse := `{
 					"publishOrb": {
 						"errors": [],
@@ -524,18 +476,15 @@ See a full explanation and documentation on orbs here: https://circleci.com/docs
 				}`
 
 					expectedPublishRequest := `{
-					"query": "\n\t\tmutation($config: String!, $orbId: UUID!, $version: String!) {\n\t\t\tpublishOrb(\n\t\t\t\torbId: $orbId,\n\t\t\t\torbYaml: $config,\n\t\t\t\tversion: $version\n\t\t\t) {\n\t\t\t\torb {\n\t\t\t\t\tversion\n\t\t\t\t}\n\t\t\t\terrors { message }\n\t\t\t}\n\t\t}\n\t",
-					"variables": {
-						"config": "some orb",
-						"orbId": "bb604b45-b6b0-4b81-ad80-796f15eddf87",
-						"version": "dev:foo"
-					}
-				}`
+						"query": "\n\t\tmutation($config: String!, $orbName: String, $namespaceName: String, $version: String!) {\n\t\t\tpublishOrb(\n\t\t\t\torbName: $orbName,\n\t\t\t\tnamespaceName: $namespaceName,\n\t\t\t\torbYaml: $config,\n\t\t\t\tversion: $version\n\t\t\t) {\n\t\t\t\torb {\n\t\t\t\t\tversion\n\t\t\t\t}\n\t\t\t\terrors { message }\n\t\t\t}\n\t\t}\n\t",
+						"variables": {
+						  "config": "some orb",
+						  "namespaceName": "my",
+						  "orbName": "orb",
+						  "version": "dev:foo"
+						}
+					  }`
 
-					tempSettings.AppendPostHandler(token, clitest.MockRequestResponse{
-						Status:   http.StatusOK,
-						Request:  expectedOrbIDRequest,
-						Response: gqlOrbIDResponse})
 					tempSettings.AppendPostHandler(token, clitest.MockRequestResponse{
 						Status:   http.StatusOK,
 						Request:  expectedPublishRequest,
@@ -553,20 +502,6 @@ See a full explanation and documentation on orbs here: https://circleci.com/docs
 				It("prints all errors returned by the GraphQL API", func() {
 					By("setting up a mock server")
 
-					gqlOrbIDResponse := `{
-    											"orb": {
-      												"id": "bb604b45-b6b0-4b81-ad80-796f15eddf87"
-    											}
-  				}`
-
-					expectedOrbIDRequest := `{
-            "query": "\n\tquery ($name: String!, $namespace: String) {\n\t\torb(name: $name) {\n\t\t  id\n\t\t}\n\t\tregistryNamespace(name: $namespace) {\n\t\t  id\n\t\t}\n\t  }\n\t  ",
-            "variables": {
-              "name": "my/orb",
-              "namespace": "my"
-            }
-          }`
-
 					gqlPublishResponse := `{
 					"publishOrb": {
 								"errors": [
@@ -578,18 +513,15 @@ See a full explanation and documentation on orbs here: https://circleci.com/docs
 				}`
 
 					expectedPublishRequest := `{
-					"query": "\n\t\tmutation($config: String!, $orbId: UUID!, $version: String!) {\n\t\t\tpublishOrb(\n\t\t\t\torbId: $orbId,\n\t\t\t\torbYaml: $config,\n\t\t\t\tversion: $version\n\t\t\t) {\n\t\t\t\torb {\n\t\t\t\t\tversion\n\t\t\t\t}\n\t\t\t\terrors { message }\n\t\t\t}\n\t\t}\n\t",
-					"variables": {
-						"config": "some orb",
-						"orbId": "bb604b45-b6b0-4b81-ad80-796f15eddf87",
-						"version": "dev:foo"
-					}
-				}`
+						"query": "\n\t\tmutation($config: String!, $orbName: String, $namespaceName: String, $version: String!) {\n\t\t\tpublishOrb(\n\t\t\t\torbName: $orbName,\n\t\t\t\tnamespaceName: $namespaceName,\n\t\t\t\torbYaml: $config,\n\t\t\t\tversion: $version\n\t\t\t) {\n\t\t\t\torb {\n\t\t\t\t\tversion\n\t\t\t\t}\n\t\t\t\terrors { message }\n\t\t\t}\n\t\t}\n\t",
+						"variables": {
+						  "config": "some orb",
+						  "namespaceName": "my",
+						  "orbName": "orb",
+						  "version": "dev:foo"
+						}
+					  }`
 
-					tempSettings.AppendPostHandler(token, clitest.MockRequestResponse{
-						Status:   http.StatusOK,
-						Request:  expectedOrbIDRequest,
-						Response: gqlOrbIDResponse})
 					tempSettings.AppendPostHandler(token, clitest.MockRequestResponse{
 						Status:   http.StatusOK,
 						Request:  expectedPublishRequest,
@@ -620,20 +552,6 @@ See a full explanation and documentation on orbs here: https://circleci.com/docs
 				It("works", func() {
 					By("setting up a mock server")
 
-					gqlOrbIDResponse := `{
-    											"orb": {
-      												"id": "bb604b45-b6b0-4b81-ad80-796f15eddf87"
-    											}
-  				}`
-
-					expectedOrbIDRequest := `{
-            "query": "\n\tquery ($name: String!, $namespace: String) {\n\t\torb(name: $name) {\n\t\t  id\n\t\t}\n\t\tregistryNamespace(name: $namespace) {\n\t\t  id\n\t\t}\n\t  }\n\t  ",
-            "variables": {
-              "name": "my/orb",
-              "namespace": "my"
-            }
-          }`
-
 					gqlVersionResponse := `{
 					"orb": {
 						"versions": [
@@ -659,18 +577,15 @@ See a full explanation and documentation on orbs here: https://circleci.com/docs
 				}`
 
 					expectedPublishRequest := `{
-					"query": "\n\t\tmutation($config: String!, $orbId: UUID!, $version: String!) {\n\t\t\tpublishOrb(\n\t\t\t\torbId: $orbId,\n\t\t\t\torbYaml: $config,\n\t\t\t\tversion: $version\n\t\t\t) {\n\t\t\t\torb {\n\t\t\t\t\tversion\n\t\t\t\t}\n\t\t\t\terrors { message }\n\t\t\t}\n\t\t}\n\t",
-					"variables": {
-						"config": "some orb",
-						"orbId": "bb604b45-b6b0-4b81-ad80-796f15eddf87",
-						"version": "0.1.0"
-					}
-				}`
+						"query": "\n\t\tmutation($config: String!, $orbName: String, $namespaceName: String, $version: String!) {\n\t\t\tpublishOrb(\n\t\t\t\torbName: $orbName,\n\t\t\t\tnamespaceName: $namespaceName,\n\t\t\t\torbYaml: $config,\n\t\t\t\tversion: $version\n\t\t\t) {\n\t\t\t\torb {\n\t\t\t\t\tversion\n\t\t\t\t}\n\t\t\t\terrors { message }\n\t\t\t}\n\t\t}\n\t",
+						"variables": {
+						  "config": "some orb",
+						  "namespaceName": "my",
+						  "orbName": "orb",
+						  "version": "0.1.0"
+						}
+					  }`
 
-					tempSettings.AppendPostHandler(token, clitest.MockRequestResponse{
-						Status:   http.StatusOK,
-						Request:  expectedOrbIDRequest,
-						Response: gqlOrbIDResponse})
 					tempSettings.AppendPostHandler(token, clitest.MockRequestResponse{
 						Status:   http.StatusOK,
 						Request:  expectedVersionRequest,
@@ -691,20 +606,6 @@ See a full explanation and documentation on orbs here: https://circleci.com/docs
 
 				It("prints all errors returned by the GraphQL API", func() {
 					By("setting up a mock server")
-
-					gqlOrbIDResponse := `{
-    											"orb": {
-      												"id": "bb604b45-b6b0-4b81-ad80-796f15eddf87"
-    											}
-  				}`
-
-					expectedOrbIDRequest := `{
-            "query": "\n\tquery ($name: String!, $namespace: String) {\n\t\torb(name: $name) {\n\t\t  id\n\t\t}\n\t\tregistryNamespace(name: $namespace) {\n\t\t  id\n\t\t}\n\t  }\n\t  ",
-            "variables": {
-              "name": "my/orb",
-              "namespace": "my"
-            }
-          }`
 
 					gqlVersionResponse := `{
 					"orb": {
@@ -732,18 +633,15 @@ See a full explanation and documentation on orbs here: https://circleci.com/docs
 				}`
 
 					expectedPublishRequest := `{
-					"query": "\n\t\tmutation($config: String!, $orbId: UUID!, $version: String!) {\n\t\t\tpublishOrb(\n\t\t\t\torbId: $orbId,\n\t\t\t\torbYaml: $config,\n\t\t\t\tversion: $version\n\t\t\t) {\n\t\t\t\torb {\n\t\t\t\t\tversion\n\t\t\t\t}\n\t\t\t\terrors { message }\n\t\t\t}\n\t\t}\n\t",
-					"variables": {
-						"config": "some orb",
-						"orbId": "bb604b45-b6b0-4b81-ad80-796f15eddf87",
-						"version": "0.1.0"
-					}
-				}`
+						"query": "\n\t\tmutation($config: String!, $orbName: String, $namespaceName: String, $version: String!) {\n\t\t\tpublishOrb(\n\t\t\t\torbName: $orbName,\n\t\t\t\tnamespaceName: $namespaceName,\n\t\t\t\torbYaml: $config,\n\t\t\t\tversion: $version\n\t\t\t) {\n\t\t\t\torb {\n\t\t\t\t\tversion\n\t\t\t\t}\n\t\t\t\terrors { message }\n\t\t\t}\n\t\t}\n\t",
+						"variables": {
+						  "config": "some orb",
+						  "namespaceName": "my",
+						  "orbName": "orb",
+						  "version": "0.1.0"
+						}
+					  }`
 
-					tempSettings.AppendPostHandler(token, clitest.MockRequestResponse{
-						Status:   http.StatusOK,
-						Request:  expectedOrbIDRequest,
-						Response: gqlOrbIDResponse})
 					tempSettings.AppendPostHandler(token, clitest.MockRequestResponse{
 						Status:   http.StatusOK,
 						Request:  expectedVersionRequest,
@@ -778,20 +676,6 @@ See a full explanation and documentation on orbs here: https://circleci.com/docs
 				It("works", func() {
 					By("setting up a mock server")
 
-					gqlOrbIDResponse := `{
-    											"orb": {
-      												"id": "bb604b45-b6b0-4b81-ad80-796f15eddf87"
-    											}
-  				}`
-
-					expectedOrbIDRequest := `{
-            "query": "\n\tquery ($name: String!, $namespace: String) {\n\t\torb(name: $name) {\n\t\t  id\n\t\t}\n\t\tregistryNamespace(name: $namespace) {\n\t\t  id\n\t\t}\n\t  }\n\t  ",
-            "variables": {
-              "name": "my/orb",
-              "namespace": "my"
-            }
-          }`
-
 					gqlVersionResponse := `{
 					"orb": {
 						"versions": [
@@ -818,18 +702,15 @@ See a full explanation and documentation on orbs here: https://circleci.com/docs
 				}`
 
 					expectedPromoteRequest := `{
-                                        "query": "\n\t\tmutation($orbId: UUID!, $devVersion: String!, $semanticVersion: String!) {\n\t\t\tpromoteOrb(\n\t\t\t\torbId: $orbId,\n\t\t\t\tdevVersion: $devVersion,\n\t\t\t\tsemanticVersion: $semanticVersion\n\t\t\t) {\n\t\t\t\torb {\n\t\t\t\t\tversion\n\t\t\t\t\tsource\n\t\t\t\t}\n\t\t\t\terrors { message }\n\t\t\t}\n\t\t}\n\t",
-					"variables": {
-						"orbId": "bb604b45-b6b0-4b81-ad80-796f15eddf87",
-						"devVersion": "dev:foo",
-						"semanticVersion": "0.1.0"
-					}
-				}`
+						"query": "\n\t\tmutation($orbName: String, $namespaceName: String, $devVersion: String!, $semanticVersion: String!) {\n\t\t\tpromoteOrb(\n\t\t\t\torbName: $orbName,\n\t\t\t\tnamespaceName: $namespaceName,\n\t\t\t\tdevVersion: $devVersion,\n\t\t\t\tsemanticVersion: $semanticVersion\n\t\t\t) {\n\t\t\t\torb {\n\t\t\t\t\tversion\n\t\t\t\t\tsource\n\t\t\t\t}\n\t\t\t\terrors { message }\n\t\t\t}\n\t\t}\n\t",
+						"variables": {
+						  "devVersion": "dev:foo",
+						  "namespaceName": "my",
+						  "orbName": "orb",
+						  "semanticVersion": "0.1.0"
+						}
+					  }`
 
-					tempSettings.AppendPostHandler(token, clitest.MockRequestResponse{
-						Status:   http.StatusOK,
-						Request:  expectedOrbIDRequest,
-						Response: gqlOrbIDResponse})
 					tempSettings.AppendPostHandler(token, clitest.MockRequestResponse{
 						Status:   http.StatusOK,
 						Request:  expectedVersionRequest,
@@ -850,20 +731,6 @@ See a full explanation and documentation on orbs here: https://circleci.com/docs
 
 				It("prints all errors returned by the GraphQL API", func() {
 					By("setting up a mock server")
-
-					gqlOrbIDResponse := `{
-    											"orb": {
-      												"id": "bb604b45-b6b0-4b81-ad80-796f15eddf87"
-    											}
-  				}`
-
-					expectedOrbIDRequest := `{
-            "query": "\n\tquery ($name: String!, $namespace: String) {\n\t\torb(name: $name) {\n\t\t  id\n\t\t}\n\t\tregistryNamespace(name: $namespace) {\n\t\t  id\n\t\t}\n\t  }\n\t  ",
-            "variables": {
-              "name": "my/orb",
-              "namespace": "my"
-            }
-          }`
 
 					gqlVersionResponse := `{
 					"orb": {
@@ -891,18 +758,15 @@ See a full explanation and documentation on orbs here: https://circleci.com/docs
 				}`
 
 					expectedPromoteRequest := `{
-                                        "query": "\n\t\tmutation($orbId: UUID!, $devVersion: String!, $semanticVersion: String!) {\n\t\t\tpromoteOrb(\n\t\t\t\torbId: $orbId,\n\t\t\t\tdevVersion: $devVersion,\n\t\t\t\tsemanticVersion: $semanticVersion\n\t\t\t) {\n\t\t\t\torb {\n\t\t\t\t\tversion\n\t\t\t\t\tsource\n\t\t\t\t}\n\t\t\t\terrors { message }\n\t\t\t}\n\t\t}\n\t",
-					"variables": {
-						"orbId": "bb604b45-b6b0-4b81-ad80-796f15eddf87",
-						"devVersion": "dev:foo",
-						"semanticVersion": "0.1.0"
-					}
-				}`
+						"query": "\n\t\tmutation($orbName: String, $namespaceName: String, $devVersion: String!, $semanticVersion: String!) {\n\t\t\tpromoteOrb(\n\t\t\t\torbName: $orbName,\n\t\t\t\tnamespaceName: $namespaceName,\n\t\t\t\tdevVersion: $devVersion,\n\t\t\t\tsemanticVersion: $semanticVersion\n\t\t\t) {\n\t\t\t\torb {\n\t\t\t\t\tversion\n\t\t\t\t\tsource\n\t\t\t\t}\n\t\t\t\terrors { message }\n\t\t\t}\n\t\t}\n\t",
+						"variables": {
+						  "devVersion": "dev:foo",
+						  "namespaceName": "my",
+						  "orbName": "orb",
+						  "semanticVersion": "0.1.0"
+						}
+					  }`
 
-					tempSettings.AppendPostHandler(token, clitest.MockRequestResponse{
-						Status:   http.StatusOK,
-						Request:  expectedOrbIDRequest,
-						Response: gqlOrbIDResponse})
 					tempSettings.AppendPostHandler(token, clitest.MockRequestResponse{
 						Status:   http.StatusOK,
 						Request:  expectedVersionRequest,


### PR DESCRIPTION
This PR includes the following changes:
- Adds `OrbPublishByName` and `OrbPromoteByName` functions
- Removes `OrbPublishByID` and `OrbPromoteByID` functions
- Removes unnecessary `OrbId` calls