### PR TITLE
[CIRCLE-32666] Orb create - change confirmation message for private orbs

### DIFF
--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -788,8 +788,13 @@ If you change your mind about the name, you will have to create a new orb with t
 			return err
 		}
 
+		confirmationString := "Please note that any versions you publish of this orb are world-readable."
+		if opts.private {
+			confirmationString = "This orb will not be listed on the registry and is usable only by org users."
+		}
+
 		fmt.Printf("Orb `%s` created.\n", opts.args[0])
-		fmt.Println("Please note that any versions you publish of this orb are world-readable.")
+		fmt.Println(confirmationString)
 		fmt.Printf("You can now register versions of `%s` using `circleci orb publish`.\n", opts.args[0])
 	}
 


### PR DESCRIPTION
Private orbs are not world-readable, but the create orb confirmation message for them contains:
```
Please note that any versions you publish of this orb are world-readable.
```
This PR changes the string for when the private flag was passed and the graphql request was successful.