### PR TITLE
[CIRCLE-32051] CLI Commands now optionally accept --org-slug flags

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -513,28 +513,44 @@ func WhoamiQuery(cl *graphql.Client) (*WhoamiResponse, error) {
 }
 
 // ConfigQuery calls the GQL API to validate and process config
-func ConfigQuery(cl *graphql.Client, configPath string, pipelineValues pipeline.Values) (*ConfigResponse, error) {
+func ConfigQuery(cl *graphql.Client, configPath string, orgSlug string, pipelineValues pipeline.Values) (*ConfigResponse, error) {
 	var response BuildConfigResponse
+	var query string
 
 	config, err := loadYaml(configPath)
 	if err != nil {
 		return nil, err
 	}
 
-	query := `
-		query ValidateConfig ($config: String!, $pipelineValues: [StringKeyVal!]) {
-			buildConfig(configYaml: $config, pipelineValues: $pipelineValues) {
-				valid,
-				errors { message },
-				sourceYaml,
-				outputYaml
-			}
-		}`
+	if orgSlug != "" {
+	    query = `
+		    query ValidateConfig ($config: String!, $pipelineValues: [StringKeyVal!], $orgSlug: String!) {
+			    buildConfig(configYaml: $config, pipelineValues: $pipelineValues, orgSlug: $orgSlug) {
+				    valid,
+				    errors { message },
+				    sourceYaml,
+				    outputYaml
+			    }
+		    }`
+	} else {
+	    query = `
+		    query ValidateConfig ($config: String!, $pipelineValues: [StringKeyVal!]) {
+			    buildConfig(configYaml: $config, pipelineValues: $pipelineValues) {
+				    valid,
+				    errors { message },
+				    sourceYaml,
+				    outputYaml
+			    }
+		    }`
+	}
 
 	request := graphql.NewRequest(query)
 	request.Var("config", config)
 	if pipelineValues != nil {
 		request.Var("pipelineValues", pipeline.PrepareForGraphQL(pipelineValues))
+	}
+	if orgSlug != "" {
+		request.Var("orgSlug", orgSlug)
 	}
 	request.SetToken(cl.Token)
 

--- a/api/api.go
+++ b/api/api.go
@@ -523,25 +523,23 @@ func ConfigQuery(cl *graphql.Client, configPath string, orgSlug string, pipeline
 	}
 
 	if orgSlug != "" {
-	    query = `
-		    query ValidateConfig ($config: String!, $pipelineValues: [StringKeyVal!], $orgSlug: String!) {
-			    buildConfig(configYaml: $config, pipelineValues: $pipelineValues, orgSlug: $orgSlug) {
-				    valid,
-				    errors { message },
-				    sourceYaml,
-				    outputYaml
-			    }
-		    }`
+		query = `query ValidateConfig ($config: String!, $pipelineValues: [StringKeyVal!], $orgSlug: String) {
+					buildConfig(configYaml: $config, pipelineValues: $pipelineValues, orgSlug: $orgSlug) {
+						valid,
+						errors { message },
+						sourceYaml,
+						outputYaml
+					}
+				}`
 	} else {
-	    query = `
-		    query ValidateConfig ($config: String!, $pipelineValues: [StringKeyVal!]) {
-			    buildConfig(configYaml: $config, pipelineValues: $pipelineValues) {
-				    valid,
-				    errors { message },
-				    sourceYaml,
-				    outputYaml
-			    }
-		    }`
+		query = `query ValidateConfig ($config: String!, $pipelineValues: [StringKeyVal!]) {
+					buildConfig(configYaml: $config, pipelineValues: $pipelineValues) {
+						valid,
+						errors { message },
+						sourceYaml,
+						outputYaml
+					}
+				}`
 	}
 
 	request := graphql.NewRequest(query)

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -17,10 +17,12 @@ func newLocalExecuteCommand(config *settings.Config) *cobra.Command {
 	}
 
 	local.AddFlagsForDocumentation(buildCommand.Flags())
+	buildCommand.Flags().StringP("org-slug", "o", "", "organization slug (for example: github/example-org), used when a config depends on private orbs belonging to that org")
 
 	return buildCommand
 }
 
+// hidden command for backwards compatibility
 func newBuildCommand(config *settings.Config) *cobra.Command {
 	cmd := newLocalExecuteCommand(config)
 	cmd.Hidden = true

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -7,7 +7,6 @@ import (
 )
 
 func newLocalExecuteCommand(config *settings.Config) *cobra.Command {
-
 	buildCommand := &cobra.Command{
 		Use:   "execute",
 		Short: "Run a job in a container on the local machine",

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -12,8 +12,8 @@ import (
 	"github.com/CircleCI-Public/circleci-cli/settings"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
 	"github.com/spf13/pflag"
+	"gopkg.in/yaml.v3"
 )
 
 type configOptions struct {

--- a/local/local.go
+++ b/local/local.go
@@ -42,8 +42,9 @@ func UpdateBuildAgent() error {
 func Execute(flags *pflag.FlagSet, cfg *settings.Config) error {
 
 	processedArgs, configPath := buildAgentArguments(flags)
+	orgSlug, _ := flags.GetString("org-slug")
 	cl := graphql.NewClient(cfg.Host, cfg.Endpoint, cfg.Token, cfg.Debug)
-	configResponse, err := api.ConfigQuery(cl, configPath, pipeline.FabricatedValues())
+	configResponse, err := api.ConfigQuery(cl, configPath, orgSlug, pipeline.FabricatedValues())
 
 	if err != nil {
 		return err
@@ -102,7 +103,7 @@ func Execute(flags *pflag.FlagSet, cfg *settings.Config) error {
 }
 
 // The `local execute` command proxies execution to the picard docker container,
-// and ultimately to `build-agent`. We want to pass all arguments passed to the
+// and ultimately to `build-agent`. We want to pass most arguments passed to the
 // `local execute` command on to build-agent
 // These options are here to retain a mock of the flags used by `build-agent`.
 // They don't reflect the entire structure or available flags, only those which
@@ -123,7 +124,8 @@ func AddFlagsForDocumentation(flags *pflag.FlagSet) {
 
 // Given the full set of flags that were passed to this command, return the path
 // to the config file, and the list of supplied args _except_ for the `--config`
-// or `-c` argument.
+// or `-c` argument, and except for --debug and --org-slug which are consumed by
+// this program.
 // The `build-agent` can only deal with config version 2.0. In order to feed
 // version 2.0 config to it, we need to process the supplied config file using the
 // GraphQL API, and feed the result of that into `build-agent`. The first step of
@@ -135,7 +137,7 @@ func buildAgentArguments(flags *pflag.FlagSet) ([]string, string) {
 
 	// build a list of all supplied flags, that we will pass on to build-agent
 	flags.Visit(func(flag *pflag.Flag) {
-		if flag.Name != "config" && flag.Name != "debug" {
+		if flag.Name != "org-slug" && flag.Name != "config" && flag.Name != "debug" {
 			result = append(result, unparseFlag(flags, flag)...)
 		}
 	})

--- a/local/local.go
+++ b/local/local.go
@@ -40,7 +40,6 @@ func UpdateBuildAgent() error {
 }
 
 func Execute(flags *pflag.FlagSet, cfg *settings.Config) error {
-
 	processedArgs, configPath := buildAgentArguments(flags)
 	orgSlug, _ := flags.GetString("org-slug")
 	cl := graphql.NewClient(cfg.Host, cfg.Endpoint, cfg.Token, cfg.Debug)


### PR DESCRIPTION
This PR completes the functionality provided by: https://github.com/circleci/api-service/pull/793

For configs that use private orbs, we now require that users provide an org-slug for the following commands:
1. `circleci config validate`
2. `circleci config process`
3. `circleci local execute`

Co-authored-by: @cayennes 