### PR TITLE
WIP Clojure integration test suite

### DIFF
--- a/cli-integration-tests/project.clj
+++ b/cli-integration-tests/project.clj
@@ -1,0 +1,6 @@
+(defproject cli-integration-tests "0.1.0-SNAPSHOT"
+  :dependencies
+  [[org.clojure/clojure "1.10.1"]
+   [amperity/greenlight "0.6.0"]]
+
+  :main circleci.cli.test.main)

--- a/cli-integration-tests/src/circleci/cli/test/main.clj
+++ b/cli-integration-tests/src/circleci/cli/test/main.clj
@@ -5,11 +5,12 @@
 (defn -main
   "Main entrypoint to run all of the integration tests."
   [& args]
-  (runner/run-tests!
-   ;; Component system, which currently contains nothing
-   (constantly {})
-   ;; All the tests we want to run
-   (runner/find-tests)
-   ;; Options, like parallelism
-   {})
-  (shutdown-agents))
+  (if (runner/run-tests!
+       ;; Component system, which currently contains nothing
+       (constantly {})
+       ;; All the tests we want to run
+       (runner/find-tests)
+       ;; Options, like parallelism
+       {})
+    (shutdown-agents)
+    (System/exit 1)))

--- a/cli-integration-tests/src/circleci/cli/test/main.clj
+++ b/cli-integration-tests/src/circleci/cli/test/main.clj
@@ -1,6 +1,36 @@
 (ns circleci.cli.test.main
+  ;; Make sure all test namespaces are required here so the tests are compiled / registered
   (:require [circleci.cli.test.validate]
             [greenlight.runner :as runner]))
+
+;; Quick intro to Greenlight:
+;;
+;; A "test" is a call to greenlight.test/deftest, and roughly represents one use
+;; case or scenario, in which many things can happen. It contains many _steps_ which will
+;; run in order, and potentially clean themselves up in reverse order during the
+;; teardown phase. If a test fails, other tests will still run.
+;;
+;; A "step" represents roughly one operation / unit of work in a Greenlight test.
+;; It will execute some arbitrary behavior, while potentially making one or more
+;; assertions using the built-in clojure.test framework.
+;; If any of a step's assertions fails or an exception is thrown, the whole test halts,
+;; no more steps are executed, and the existing steps that ran so far are cleaned up.
+;; A step could either be an intermediate task (provisioning a resource we'll need later)
+;; or the ultimate task that tests the thing we want to test.
+;;
+;; Behind the scenes, a step is just a map that contains keys that start with :greenlight.step/...
+;; This tells Greenlight how to run the step, some metadata about how to refer to the step when
+;; printing the test results, and also how to pass context around between steps (a feature
+;; we aren't taking advantage of yet).
+;;
+;; Greenlight steps are meant to be composable, in that you can use helper functions to create
+;; steps to avoid re-iterating implementation details, especially for common operations
+;; and intermediate provisioning steps. You can also construct step maps in-line during a deftest
+;; if needed.
+;;
+;; In this codebase, the test suites live in `circleci.cli.test.*`, which use steps defined
+;; either in that same namespace or in `circleci.cli.test.util`. The runner that invokes
+;; Greenlight on all the different test suites lives here.
 
 (defn -main
   "Main entrypoint to run all of the integration tests."

--- a/cli-integration-tests/src/circleci/cli/test/main.clj
+++ b/cli-integration-tests/src/circleci/cli/test/main.clj
@@ -1,0 +1,15 @@
+(ns circleci.cli.test.main
+  (:require [circleci.cli.test.validate]
+            [greenlight.runner :as runner]))
+
+(defn -main
+  "Main entrypoint to run all of the integration tests."
+  [& args]
+  (runner/run-tests!
+   ;; Component system, which currently contains nothing
+   (constantly {})
+   ;; All the tests we want to run
+   (runner/find-tests)
+   ;; Options, like parallelism
+   {})
+  (shutdown-agents))

--- a/cli-integration-tests/src/circleci/cli/test/util.clj
+++ b/cli-integration-tests/src/circleci/cli/test/util.clj
@@ -56,7 +56,7 @@
     result))
 
 (defn shell!
-  "Convenience function to create a step that runs a CLI command and validates its output."
+  "Convenience function to create a step that runs a shell command and validates its output."
   [args verify-opts]
   #::step
   {:title (str/join " " args)

--- a/cli-integration-tests/src/circleci/cli/test/util.clj
+++ b/cli-integration-tests/src/circleci/cli/test/util.clj
@@ -23,38 +23,52 @@
     (catch Exception e
       (printf "WARN: couldn't delete %s: %s\n" filename e))))
 
-(defn shell!
-  "Reusable step that runs a shell command and validates its output."
+(defn run-shell!
+  "Run a shell command and validate its output."
   [args
    {:keys [exit exit-nonzero out-contains err-contains]}]
+  (let [result (apply sh args)
+        out (String. (:out result))
+        err (:err result)
+        exited-as-expected?
+        (if exit-nonzero
+          (is (not= 0 (:exit result)))
+          (is (= (or exit 0) (:exit result))))
+        printed-as-expected?
+        (if out-contains
+          (is (str/includes? out out-contains))
+          true)
+        errored-as-expected?
+        (if err-contains
+          (is (str/includes? err err-contains))
+          true)]
+    ;; If any of our assertions fails, dump everything we know so it's easy to inspect
+    (when-not (and exited-as-expected? printed-as-expected? errored-as-expected?)
+      (println "EXITED WITH" (:exit result))
+      (println "STDOUT:")
+      (println out)
+      (println "--------")
+      (println "STDERR:")
+      (println err)
+      (println "--------"))
+
+
+    result))
+
+(defn shell!
+  "Convenience function to create a step that runs a CLI command and validates its output."
+  [args verify-opts]
   #::step
   {:title (str/join " " args)
    :name 'shell!
    :test (fn [_]
-           (let [result (apply sh args)
-                 out (String. (:out result))
-                 err (:err result)
-                 exited-as-expected?
-                 (if exit-nonzero
-                   (is (not= 0 (:exit result)))
-                   (is (= (or exit 0) (:exit result))))]
-             (when-not exited-as-expected?
-               (println "EXITED WITH" (:exit result))
-               (println "STDOUT:")
-               (println out)
-               (println "--------")
-               (println "STDERR:")
-               (println err)
-               (println "--------"))
-             (when out-contains
-               (is (str/includes? out out-contains)))
-             (when err-contains
-               (is (str/includes? err err-contains)))))})
+           (run-shell! args verify-opts))})
 
 (defn cli!
-  "Reusable step that runs a CLI command and validates its output."
+  "Convenience function to create a step that runs a CLI command and validates its output."
   [args verify-opts]
   ;; Add --skip-update-check because we don't need it in CI
   ;; and the update spinner adds a bunch of spam to the output
-  (shell! (into ["circleci" "--skip-update-check"] args)
-          verify-opts))
+  (shell!
+   (into ["circleci" "--skip-update-check"] args)
+   verify-opts))

--- a/cli-integration-tests/src/circleci/cli/test/util.clj
+++ b/cli-integration-tests/src/circleci/cli/test/util.clj
@@ -1,5 +1,7 @@
 (ns circleci.cli.test.util
   (:require [clojure.java.io :as io]
+            [clojure.java.shell :refer [sh]]
+            [clojure.string :as str]
             [clojure.test :refer :all]
             [greenlight.step :as step :refer [defstep]]))
 
@@ -20,3 +22,39 @@
     (io/delete-file filename)
     (catch Exception e
       (printf "WARN: couldn't delete %s: %s\n" filename e))))
+
+(defn shell!
+  "Reusable step that runs a shell command and validates its output."
+  [args
+   {:keys [exit exit-nonzero out-contains err-contains]}]
+  #::step
+  {:title (str/join " " args)
+   :name 'shell!
+   :test (fn [_]
+           (let [result (apply sh args)
+                 out (String. (:out result))
+                 err (:err result)
+                 exited-as-expected?
+                 (if exit-nonzero
+                   (is (not= 0 (:exit result)))
+                   (is (= (or exit 0) (:exit result))))]
+             (when-not exited-as-expected?
+               (println "EXITED WITH" (:exit result))
+               (println "STDOUT:")
+               (println out)
+               (println "--------")
+               (println "STDERR:")
+               (println err)
+               (println "--------"))
+             (when out-contains
+               (is (str/includes? out out-contains)))
+             (when err-contains
+               (is (str/includes? err err-contains)))))})
+
+(defn cli!
+  "Reusable step that runs a CLI command and validates its output."
+  [args verify-opts]
+  ;; Add --skip-update-check because we don't need it in CI
+  ;; and the update spinner adds a bunch of spam to the output
+  (shell! (into ["circleci" "--skip-update-check"] args)
+          verify-opts))

--- a/cli-integration-tests/src/circleci/cli/test/util.clj
+++ b/cli-integration-tests/src/circleci/cli/test/util.clj
@@ -1,0 +1,22 @@
+(ns circleci.cli.test.util
+  (:require [clojure.java.io :as io]
+            [clojure.test :refer :all]
+            [greenlight.step :as step :refer [defstep]]))
+
+(defn add-file!
+  "Reusable step that adds a file to the filesystem, then cleans it up afterwards."
+  [filename content]
+  #::step
+  {:title (str "Create " filename)
+   :name 'add-file!
+   :test (fn [_]
+           (step/register-cleanup! :local/file filename)
+           (io/make-parents filename)
+           (spit filename content))})
+
+(defmethod step/clean! :local/file
+  [_ _ filename]
+  (try
+    (io/delete-file filename)
+    (catch Exception e
+      (printf "WARN: couldn't delete %s: %s\n" filename e))))

--- a/cli-integration-tests/src/circleci/cli/test/validate.clj
+++ b/cli-integration-tests/src/circleci/cli/test/validate.clj
@@ -1,0 +1,12 @@
+(ns circleci.cli.test.validate
+  (:require [circleci.cli.test.util :as util]
+            [greenlight.test :refer [deftest]]
+            [greenlight.step :as step :refer [defstep]]))
+
+(deftest validate-good-config
+  "Validate config that is valid"
+  (util/add-file! "config.yml" "
+jobs:
+  build:
+    machine: true
+    steps: [checkout]"))

--- a/cli-integration-tests/src/circleci/cli/test/validate.clj
+++ b/cli-integration-tests/src/circleci/cli/test/validate.clj
@@ -3,6 +3,23 @@
             [greenlight.test :refer [deftest]]
             [greenlight.step :as step :refer [defstep]]))
 
+;; Quick intro to Greenlight:
+;;
+;; A "test" is a call to greenlight.test/deftest, and roughly corresponds to
+;; one use case, in which many things can happen. It contains many steps which will
+;; run and potentially clean themselves up in reverse order during the teardown phase.
+;; If a test fails, other tests will still run.
+;;
+;; A "step" is a map containing various :greenlight.step/* keys, and represents
+;; roughly one operation in a test scenario. It will execute some arbitrary behavior and
+;; make zero or more assertions using the built-in clojure.test framework.
+;; If any of those assertions fail, the test halts, no more steps are executed,
+;; and the existing steps that ran so far are cleaned up in reverse order.
+;;
+;; Here we define our tests, which contain many steps. So far all of the steps
+;; are constructed by calling helper functions in the util namespace, but we could
+;; also manually construct step maps here if needed.
+
 (deftest validate-good-config
   "Validating good config says it is valid"
   (util/add-file! "config.yml" "
@@ -23,5 +40,5 @@ jobs:
   build:
     steps: [checkout]")
   (util/cli! ["config" "validate" "-c" "config.yml"]
-             {:exit-nonzero 1
+             {:exit-nonzero true
               :err-contains "A job must have one of `docker`, `machine`, `macos` or `executor`"}))

--- a/cli-integration-tests/src/circleci/cli/test/validate.clj
+++ b/cli-integration-tests/src/circleci/cli/test/validate.clj
@@ -4,9 +4,24 @@
             [greenlight.step :as step :refer [defstep]]))
 
 (deftest validate-good-config
-  "Validate config that is valid"
+  "Validating good config says it is valid"
   (util/add-file! "config.yml" "
+version: 2.1
 jobs:
   build:
     machine: true
-    steps: [checkout]"))
+    steps: [checkout]")
+  (util/cli! ["config" "validate" "-c" "config.yml"]
+             {:out-contains "Config file at config.yml is valid."}))
+
+
+(deftest validate-bad-config
+  "Validating bad config says it is not valid"
+  (util/add-file! "config.yml" "
+version: 2.1
+jobs:
+  build:
+    steps: [checkout]")
+  (util/cli! ["config" "validate" "-c" "config.yml"]
+             {:exit-nonzero 1
+              :err-contains "A job must have one of `docker`, `machine`, `macos` or `executor`"}))

--- a/cli-integration-tests/src/circleci/cli/test/validate.clj
+++ b/cli-integration-tests/src/circleci/cli/test/validate.clj
@@ -3,22 +3,6 @@
             [greenlight.test :refer [deftest]]
             [greenlight.step :as step :refer [defstep]]))
 
-;; Quick intro to Greenlight:
-;;
-;; A "test" is a call to greenlight.test/deftest, and roughly corresponds to
-;; one use case, in which many things can happen. It contains many steps which will
-;; run and potentially clean themselves up in reverse order during the teardown phase.
-;; If a test fails, other tests will still run.
-;;
-;; A "step" is a map containing various :greenlight.step/* keys, and represents
-;; roughly one operation in a test scenario. It will execute some arbitrary behavior and
-;; make zero or more assertions using the built-in clojure.test framework.
-;; If any of those assertions fail, the test halts, no more steps are executed,
-;; and the existing steps that ran so far are cleaned up in reverse order.
-;;
-;; Here we define our tests, which contain many steps. So far all of the steps
-;; are constructed by calling helper functions in the util namespace, but we could
-;; also manually construct step maps here if needed.
 
 (deftest validate-good-config
   "Validating good config says it is valid"


### PR DESCRIPTION
A sample of what it would look like if we built out a Clojure-based integration test suite using the [Greenlight](https://github.com/amperity/greenlight) testing framework.

Greenlight is a bit overkill, in that I don't foresee us taking advantage of these features:
* Managing stateful clients using `component`
* Writing reusable steps with "context inputs / outputs" to pass values around between them (this is mostly useful if there are randomly-generated id's / references you need to keep track of during the test)

But it does provide these features, that I think are useful to us:
* A "teardown" system that lets us ensure things get cleaned up on the way out, even in failure cases
* Easy to write helper functions that DRY the implementation of certain types of tests and provisioning steps
* The output of a test run is descriptive, colorful, an clearly points to which steps are failing if any

Here's what it looks like when you run the tests (happy path):
![image](https://user-images.githubusercontent.com/4122172/108117113-5c695180-7051-11eb-967d-eab61fc037ad.png)

And in the sad path:
![image](https://user-images.githubusercontent.com/4122172/108117263-8884d280-7051-11eb-820a-d82dd9f1754f.png)
