### PR TITLE
resolve CVE-2020-15114 in etcd v3.3.10+incompatible

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,4 +31,7 @@ require (
 	gotest.tools/v3 v3.0.2
 )
 
+// fix vulnerability: CVE-2020-15114 in etcd v3.3.10+incompatible
+replace github.com/coreos/etcd => github.com/coreos/etcd v3.3.24+incompatible
+
 go 1.14

--- a/go.sum
+++ b/go.sum
@@ -21,7 +21,7 @@ github.com/briandowns/spinner v0.0.0-20181018151057-dd69c579ff20/go.mod h1:hw/JE
 github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMeY4+DwBQ=
 github.com/cockroachdb/cockroach-go v0.0.0-20181001143604-e0a95dfd547c/go.mod h1:XGLbWH/ujMcbPbhZq52Nv6UrCghb1yGn//133kEsvDk=
 github.com/codegangsta/negroni v1.0.0/go.mod h1:v0y3T5G7Y1UlFfyxFn/QLRU4a2EuNau2iZY63YTKWo0=
-github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
+github.com/coreos/etcd v3.3.24+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=


### PR DESCRIPTION
While creating a PR to add a [nancy](https://github.com/sonatype-nexus-community/nancy) scan to CI, I ran into the vulnerability below (CVE-2020-15114):

https://ossindex.sonatype.org/vuln/bba60acb-c7b5-4621-af69-f4085a8301d0

This PR bumps the version of etcd to a newer, non-vulnerable version.

The version previously in use was:
```shell
$ go list -m all | grep 'github.com/coreos/etcd'
github.com/coreos/etcd v3.3.10+incompatible
```

relates to PR #581 add nancy scan to CI