### PR TITLE
add nancy scan to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ orbs:
   shellcheck: circleci/shellcheck@1.2.0
   slack: circleci/slack@0.1.14
   windows: circleci/windows@2.2.0
+  nancy: sonatype-nexus-community/circleci-nancy-orb@0
 
 executors:
   go:
@@ -150,6 +151,13 @@ jobs:
       - gomod
       - run: make test
       - slack-notify-on-failure
+
+  scan:
+    executor: go
+    steps:
+      - checkout
+      - nancy/install-nancy
+      - nancy/run-nancy
 
   coverage:
     executor: go
@@ -326,6 +334,7 @@ workflows:
       - test_windows
       - coverage
       - lint
+      - scan
       - deploy-test
       - docs:
           requires:
@@ -350,6 +359,7 @@ workflows:
             - test_mac
             - coverage
             - lint
+            - scan
             - deploy-test
             - shellcheck/check
           filters:


### PR DESCRIPTION
This PR adds a job to run a scan using [nancy](https://github.com/sonatype-nexus-community/nancy)

possibly depends on PR #580 resolve CVE-2020-15114 in etcd v3.3.10+incompatible