### PR TITLE
feat: allow keeping local exec containers

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -16,6 +16,7 @@ func newLocalExecuteCommand(config *settings.Config) *cobra.Command {
 	}
 
 	local.AddFlagsForDocumentation(buildCommand.Flags())
+	buildCommand.Flags().Bool("rm", true, "remove containers automatically")
 	buildCommand.Flags().StringP("org-slug", "o", "", "organization slug (for example: github/example-org), used when a config depends on private orbs belonging to that org")
 
 	return buildCommand

--- a/local/local_test.go
+++ b/local/local_test.go
@@ -17,12 +17,12 @@ var _ = Describe("build", func() {
 		It("can generate a command line", func() {
 			home, err := os.UserHomeDir()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(generateDockerCommand("/config/path", "docker-image-name", "/current/directory", "extra-1", "extra-2")).To(ConsistOf(
+			Expect(generateDockerCommand("/config/path", "docker-image-name", "/current/directory", true, "extra-1", "extra-2")).To(ConsistOf(
 				"docker",
 				"run",
 				"--interactive",
 				"--tty",
-				"--rm",
+				"--rm=true",
 				"--volume", "/var/run/docker.sock:/var/run/docker.sock",
 				"--volume", "/config/path:/tmp/local_build_config.yml",
 				"--volume", "/current/directory:/current/directory",


### PR DESCRIPTION
When running a job locally, it would be nice to keep the containers in some case to do after-run analysis, just as you would with remote SSH. It seems that this is not working as I would like it to, because the picard image also needs to implement this feature. As I could not find it on GitHub, I assume it is a private repo. Can you add the feature there as well? This PR is more of a POC and I will improve it once it is technically possible to implement this.
Until then, I will unfortunately still have to use SSH on the remote.