### PR TITLE
Runner subcommand respecting flags

### DIFF
--- a/cmd/runner/instance.go
+++ b/cmd/runner/instance.go
@@ -10,7 +10,7 @@ import (
 	"github.com/CircleCI-Public/circleci-cli/api/runner"
 )
 
-func newRunnerInstanceCommand(r *runner.Runner, preRunE validator) *cobra.Command {
+func newRunnerInstanceCommand(o *runnerOpts, preRunE validator) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "instance",
 		Short: "Operate on runner instances",
@@ -25,7 +25,7 @@ func newRunnerInstanceCommand(r *runner.Runner, preRunE validator) *cobra.Comman
 		Args:    cobra.ExactArgs(1),
 		PreRunE: preRunE,
 		RunE: func(_ *cobra.Command, args []string) error {
-			runners, err := r.GetRunnerInstances(args[0])
+			runners, err := o.r.GetRunnerInstances(args[0])
 			if err != nil {
 				return err
 			}

--- a/cmd/runner/resource_class.go
+++ b/cmd/runner/resource_class.go
@@ -9,7 +9,7 @@ import (
 	"github.com/CircleCI-Public/circleci-cli/api/runner"
 )
 
-func newResourceClassCommand(r *runner.Runner, preRunE validator) *cobra.Command {
+func newResourceClassCommand(o *runnerOpts, preRunE validator) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "resource-class",
 		Short: "Operate on runner resource-classes",
@@ -21,7 +21,7 @@ func newResourceClassCommand(r *runner.Runner, preRunE validator) *cobra.Command
 		Args:    cobra.ExactArgs(2),
 		PreRunE: preRunE,
 		RunE: func(_ *cobra.Command, args []string) error {
-			rc, err := r.CreateResourceClass(args[0], args[1])
+			rc, err := o.r.CreateResourceClass(args[0], args[1])
 			if err != nil {
 				return err
 			}
@@ -39,11 +39,11 @@ func newResourceClassCommand(r *runner.Runner, preRunE validator) *cobra.Command
 		Args:    cobra.ExactArgs(1),
 		PreRunE: preRunE,
 		RunE: func(_ *cobra.Command, args []string) error {
-			rc, err := r.GetResourceClassByName(args[0])
+			rc, err := o.r.GetResourceClassByName(args[0])
 			if err != nil {
 				return err
 			}
-			return r.DeleteResourceClass(rc.ID)
+			return o.r.DeleteResourceClass(rc.ID)
 		},
 	})
 
@@ -54,7 +54,7 @@ func newResourceClassCommand(r *runner.Runner, preRunE validator) *cobra.Command
 		Args:    cobra.ExactArgs(1),
 		PreRunE: preRunE,
 		RunE: func(_ *cobra.Command, args []string) error {
-			rcs, err := r.GetResourceClassesByNamespace(args[0])
+			rcs, err := o.r.GetResourceClassesByNamespace(args[0])
 			if err != nil {
 				return err
 			}

--- a/cmd/runner/runner.go
+++ b/cmd/runner/runner.go
@@ -8,16 +8,22 @@ import (
 	"github.com/CircleCI-Public/circleci-cli/settings"
 )
 
+type runnerOpts struct {
+	r *runner.Runner
+}
+
 func NewCommand(config *settings.Config, preRunE validator) *cobra.Command {
-	r := runner.New(rest.New(config.Host, config.RestEndpoint, config.Token))
+	var opts runnerOpts
 	cmd := &cobra.Command{
-		Use:    "runner",
-		Short:  "Operate on runners",
-		Hidden: true,
+		Use:   "runner",
+		Short: "Operate on runners",
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			opts.r = runner.New(rest.New(config.Host, config.RestEndpoint, config.Token))
+		},
 	}
-	cmd.AddCommand(newResourceClassCommand(r, preRunE))
-	cmd.AddCommand(newTokenCommand(r, preRunE))
-	cmd.AddCommand(newRunnerInstanceCommand(r, preRunE))
+	cmd.AddCommand(newResourceClassCommand(&opts, preRunE))
+	cmd.AddCommand(newTokenCommand(&opts, preRunE))
+	cmd.AddCommand(newRunnerInstanceCommand(&opts, preRunE))
 	return cmd
 }
 

--- a/cmd/runner/token.go
+++ b/cmd/runner/token.go
@@ -6,11 +6,9 @@ import (
 
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
-
-	"github.com/CircleCI-Public/circleci-cli/api/runner"
 )
 
-func newTokenCommand(r *runner.Runner, preRunE validator) *cobra.Command {
+func newTokenCommand(o *runnerOpts, preRunE validator) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "token",
 		Short: "Operate on runner tokens",
@@ -22,7 +20,7 @@ func newTokenCommand(r *runner.Runner, preRunE validator) *cobra.Command {
 		Args:    cobra.ExactArgs(2),
 		PreRunE: preRunE,
 		RunE: func(_ *cobra.Command, args []string) error {
-			token, err := r.CreateToken(args[0], args[1])
+			token, err := o.r.CreateToken(args[0], args[1])
 			if err != nil {
 				return err
 			}
@@ -37,7 +35,7 @@ func newTokenCommand(r *runner.Runner, preRunE validator) *cobra.Command {
 		Args:    cobra.ExactArgs(1),
 		PreRunE: preRunE,
 		RunE: func(_ *cobra.Command, args []string) error {
-			return r.DeleteToken(args[0])
+			return o.r.DeleteToken(args[0])
 		},
 	})
 
@@ -48,7 +46,7 @@ func newTokenCommand(r *runner.Runner, preRunE validator) *cobra.Command {
 		Args:    cobra.ExactArgs(1),
 		PreRunE: preRunE,
 		RunE: func(_ *cobra.Command, args []string) error {
-			tokens, err := r.GetRunnerTokensByResourceClass(args[0])
+			tokens, err := o.r.GetRunnerTokensByResourceClass(args[0])
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
When instantiating runner and client structs the flags are not parsed yet, so client ends up with the default values. 
This roughly fallows how other commands initialize and share instances.

Also I'm making runner command not hidden.