### PR TITLE
Remove slack webhook configuration in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,6 @@ version: 2.1
 orbs:
   codecov: codecov/codecov@1.1.3
   shellcheck: circleci/shellcheck@1.2.0
-  slack: circleci/slack@0.1.14
   windows: circleci/windows@2.2.0
 
 executors:
@@ -82,12 +81,6 @@ commands:
           paths:
             - /go/pkg/mod  # Linux
             - ~/go/pkg/mod # macOS
-  # Wrap the slack/status command to only notify on failures
-  slack-notify-on-failure:
-    steps:
-      - slack/status:
-          fail_only: "true"
-          only_for_branch: "master"
 
 jobs:
   test_windows:
@@ -115,7 +108,6 @@ jobs:
           echo 'export PATH="/usr/local/opt/go@1.12/bin:$PATH"' >> ~/.bash_profile
       - gomod
       - run: make test
-      - slack-notify-on-failure
   build:
     executor: go
     steps:
@@ -149,7 +141,6 @@ jobs:
       - checkout
       - gomod
       - run: make test
-      - slack-notify-on-failure
 
   coverage:
     executor: go
@@ -165,7 +156,6 @@ jobs:
           destination: coverage.txt
       - codecov/upload:
           file: coverage.txt
-      - slack-notify-on-failure
 
   docs:
     executor: go
@@ -179,7 +169,6 @@ jobs:
           destination: docs
       - run: ./.circleci/generate-docs.sh
       - run: ./.circleci/deploy-gh-pages.sh
-      - slack-notify-on-failure
 
   lint:
     executor: go
@@ -188,7 +177,6 @@ jobs:
       - run: make install-lint
       - run: make build
       - run: make lint
-      - slack-notify-on-failure
 
   deploy-test:
     executor: go
@@ -215,7 +203,6 @@ jobs:
       - build-docker-image
       - build-alpine-image
       - deploy-save-cache-workspace-and-artifacts
-      - slack-notify-on-failure
 
   deploy:
     executor: go
@@ -253,7 +240,6 @@ jobs:
             docker tag      circleci/circleci-cli:0.1.$CIRCLE_BUILD_NUM-alpine circleci/circleci-cli:alpine
             docker push     circleci/circleci-cli:alpine
       - deploy-save-cache-workspace-and-artifacts
-      - slack-notify-on-failure
 
   snap:
     docker:
@@ -273,7 +259,6 @@ jobs:
             mkdir .snapcraft
             echo $SNAPCRAFT_LOGIN_FILE | base64 --decode --ignore-garbage > .snapcraft/snapcraft.cfg
             snapcraft push *.snap --release stable
-      - slack-notify-on-failure
 
   brew-deploy:
     executor: mac
@@ -292,7 +277,6 @@ jobs:
           git config --global user.name "$GH_NAME" > /dev/null 2>&1
       - run: brew --version
       - run: ./.circleci/brew-deploy.sh
-      - slack-notify-on-failure
 
   chocolatey-deploy:
     executor: windows/default


### PR DESCRIPTION
We need to roll the `SLACK_WEBHOOK` environment variable. Because this webhook was configured with an old method, Bear and I couldn't detect exactly which of the 54 configurations the variable pointed to.

As as result, we are instead going to remove slack notification commands from all jobs and we'll add them back at
a later time if necessary.

https://circleci.slack.com/archives/C01ULMLG820/p1618590142465600