### PR TITLE
Fix for successfully creating a private orb with orb dev kit

### DIFF
--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -1256,13 +1256,15 @@ func initOrb(opts orbOptions) error {
 	}()
 
 	if !gitAction {
-		_, err = api.CreateOrb(opts.cl, namespace, orbName, false)
+		_, err = api.CreateOrb(opts.cl, namespace, orbName, opts.private)
 		if err != nil {
 			return errors.Wrap(err, "Unable to create orb")
 		}
-		err = api.AddOrRemoveOrbCategorization(opts.cl, namespace, orbName, opts.args[1], api.Add)
-		if err != nil {
-			return err
+		for _, v := range categories {
+			err = api.AddOrRemoveOrbCategorization(opts.cl, namespace, orbName, v, api.Add)
+			if err != nil {
+				return err
+			}
 		}
 		err = finalizeOrbInit(ownerName, vcsProvider, vcsShort, namespace, orbName, "", &opts)
 		if err != nil {


### PR DESCRIPTION
When a user uses the orb development kit to create an orb, it does not respect the private orb argument passed. This only happens when a user says `no` setting up a git project.
This addresses both https://github.com/CircleCI-Public/circleci-cli/issues/601 and https://github.com/CircleCI-Public/circleci-cli/issues/599

- Updating the params for `CreateOrb` to read the `--private` orb argument passed.
- There is also an issue where choosing categories breaks the flow. Adding a fix for that rather than reading `opts.args[1]` irrespective of the categories passed