### PR TITLE
Don't panic on bad semver versions

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -181,7 +181,14 @@ func prepare() {
 }
 
 func rootCmdPreRun(rootOptions *settings.Config) error {
-	return checkForUpdates(rootOptions)
+	// If an error occurs checking for updates, we should print the error but
+	// not break the CLI entirely.
+	err := checkForUpdates(rootOptions)
+	if err != nil {
+		fmt.Printf("Error checking for updates: %s\n", err)
+		fmt.Printf("Please contact support.\n\n")
+	}
+	return nil
 }
 
 func validateToken(rootOptions *settings.Config) error {

--- a/update/update.go
+++ b/update/update.go
@@ -91,14 +91,18 @@ func checkFromHomebrew(check *Options) error {
 	for _, o := range outdated.Formulae {
 		if o.Name == "circleci" {
 			if len(o.InstalledVersions) > 0 {
-				current, err := semver.Parse(o.InstalledVersions[0])
+				// homebrew versions may have a revision number appended, like
+				// `1.2.3_<revision_number>`. This is not valid semver, but we
+				// can make it valid by replacing the underscore with a hyphen.
+				current, err := semver.Parse(strings.Replace(o.InstalledVersions[0], "_", "-"))
 				if err != nil {
 					return errors.Wrap(err, "failed to parse current version from `brew outdated --json=v2`")
 				}
 				check.Current = current
 			}
 
-			latest, err := semver.Parse(o.CurrentVersion)
+			// see above regarding homebrew / revision numbers
+			latest, err := semver.Parse(strings.Replace(o.CurrentVersion, "_", "-"))
 			if err != nil {
 				return errors.Wrap(err, "failed to  parse latest version from `brew outdated --json=v2`")
 			}

--- a/update/update.go
+++ b/update/update.go
@@ -81,7 +81,7 @@ func ParseHomebrewVersion(homebrewVesion string) (semver.Version, error) {
 	version, err := semver.Parse(withRevisionAsTag)
 
 	if err != nil {
-		return semver.Version{}, fmt.Errorf("failed to parse current version from %s: %w", homebrewVesion, err)
+		return semver.Version{}, fmt.Errorf("failed to parse current version from %s: %s", homebrewVesion, err)
 	}
 
 	return version, nil

--- a/update/update_suite_test.go
+++ b/update/update_suite_test.go
@@ -1,0 +1,13 @@
+package update_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestUpdate(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Update Suite")
+}

--- a/update/update_test.go
+++ b/update/update_test.go
@@ -1,0 +1,31 @@
+package update_test
+
+import (
+	"github.com/CircleCI-Public/circleci-cli/update"
+	"github.com/blang/semver"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Homebrew Version Parsing", func() {
+
+	It("Should parse simple versions", func() {
+		version, err := update.ParseHomebrewVersion("1.0.0")
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(version.String()).To(Equal("1.0.0"))
+	})
+
+	It("Should parse strings with revisions", func() {
+		version, err := update.ParseHomebrewVersion("0.1.15410_1")
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(version.String()).To(Equal("0.1.15410-1"))
+		Expect(version.Pre).To(HaveLen(1))
+		Expect(version.Pre[0]).To(Equal(semver.PRVersion{VersionNum: 1, IsNum: true}))
+	})
+
+	It("Should can deal with garbage", func() {
+		_, err := update.ParseHomebrewVersion("asdad.1231.-_")
+		Expect(err).To(MatchError(MatchRegexp("failed to parse current version")))
+		Expect(err).To(MatchError(MatchRegexp("asdad.1231.-_")))
+	})
+})


### PR DESCRIPTION
Homebrew versions may look like `0.1.1234_5` if there is a revision made
to the homebrew formula. This won't parse with semver.MustParse, so the
update check panics in this case.

This makes two changes. First, if we can't parse a version as semver,
return an error with normal go error handling, rather than using
`MustParse` and panicking. Second, change `rootCmdPreRun` to print
errors, then throw them away and continue along. This way, if the
check-for-upgrade piece of the CLI is broken, the CLI is still usable.