### PR TITLE
Add HTTP header indicating the command name being run

### DIFF
--- a/api/graphql/client.go
+++ b/api/graphql/client.go
@@ -54,7 +54,10 @@ func NewRequest(query string) *Request {
 	}
 
 	request.Header.Set("User-Agent", version.UserAgent())
-	request.Header.Set("Circleci-Cli-Command", header.GetCommandStr())
+	commandStr := header.GetCommandStr()
+	if commandStr != "" {
+		request.Header.Set("Circleci-Cli-Command", commandStr)
+	}
 	return request
 }
 

--- a/api/graphql/client.go
+++ b/api/graphql/client.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/CircleCI-Public/circleci-cli/api/header"
 	"github.com/CircleCI-Public/circleci-cli/version"
 	"github.com/pkg/errors"
 )
@@ -53,6 +54,7 @@ func NewRequest(query string) *Request {
 	}
 
 	request.Header.Set("User-Agent", version.UserAgent())
+	request.Header.Set("Circleci-Cli-Command", header.GetCommandStr())
 	return request
 }
 

--- a/api/header/global.go
+++ b/api/header/global.go
@@ -1,7 +1,7 @@
 package header
 
 // When the CLI is initialized, we set this to a string of the current CLI subcommand
-// (e.g. `orb list`) with no args or flags, so we include it as a header in API requests.
+// (e.g. `circleci orb list`) with no args or flags, so we include it as a header in API requests.
 var cliCommandStr string = ""
 
 func SetCommandStr(commandStr string) {

--- a/api/header/global.go
+++ b/api/header/global.go
@@ -1,0 +1,13 @@
+package header
+
+// When the CLI is initialized, we set this to a string of the current CLI subcommand
+// (e.g. `orb list`) with no args or flags, so we include it as a header in API requests.
+var cliCommandStr string = ""
+
+func SetCommandStr(commandStr string) {
+	cliCommandStr = commandStr
+}
+
+func GetCommandStr() string {
+	return cliCommandStr
+}

--- a/api/rest/client.go
+++ b/api/rest/client.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/CircleCI-Public/circleci-cli/api/header"
 	"github.com/CircleCI-Public/circleci-cli/version"
 )
 
@@ -55,6 +56,7 @@ func (c *Client) NewRequest(method string, u *url.URL, payload interface{}) (req
 	req.Header.Set("Circle-Token", c.circleToken)
 	req.Header.Set("Accept-Type", "application/json")
 	req.Header.Set("User-Agent", version.UserAgent())
+	req.Header.Set("Circleci-Cli-Command", header.GetCommandStr())
 	if payload != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}

--- a/api/rest/client.go
+++ b/api/rest/client.go
@@ -56,7 +56,10 @@ func (c *Client) NewRequest(method string, u *url.URL, payload interface{}) (req
 	req.Header.Set("Circle-Token", c.circleToken)
 	req.Header.Set("Accept-Type", "application/json")
 	req.Header.Set("User-Agent", version.UserAgent())
-	req.Header.Set("Circleci-Cli-Command", header.GetCommandStr())
+	commandStr := header.GetCommandStr()
+	if commandStr != "" {
+		req.Header.Set("Circleci-Cli-Command", commandStr)
+	}
 	if payload != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -42,7 +42,7 @@ func Execute() {
 	}
 }
 
-// Returns a string (e.g. "context list") indicating what
+// Returns a string (e.g. "circleci context list") indicating what
 // subcommand is being called, without any args or flags,
 // for API headers.
 func CommandStr() string {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -49,7 +49,7 @@ func CommandStr() string {
 	command := MakeCommands()
 	subCmd, _, err := command.Find(os.Args[1:])
 	if err != nil {
-		return ""
+		return "unknown"
 	}
 	parentNames := []string{subCmd.Name()}
 	subCmd.VisitParents(func(parent *cobra.Command) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,9 +3,11 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 
+	"github.com/CircleCI-Public/circleci-cli/api/header"
 	"github.com/CircleCI-Public/circleci-cli/cmd/runner"
 	"github.com/CircleCI-Public/circleci-cli/data"
 	"github.com/CircleCI-Public/circleci-cli/md_docs"
@@ -33,10 +35,27 @@ var rootTokenFromFlag string
 // by main.main(). It only needs to happen once to
 // the rootCmd.
 func Execute() {
+	header.SetCommandStr(CommandStr())
 	command := MakeCommands()
 	if err := command.Execute(); err != nil {
 		os.Exit(-1)
 	}
+}
+
+// Returns a string (e.g. "context list") indicating what
+// subcommand is being called, without any args or flags,
+// for API headers.
+func CommandStr() string {
+	command := MakeCommands()
+	subCmd, _, err := command.Find(os.Args[1:])
+	if err != nil {
+		return ""
+	}
+	parentNames := []string{subCmd.Name()}
+	subCmd.VisitParents(func(parent *cobra.Command) {
+		parentNames = append([]string{parent.Name()}, parentNames...)
+	})
+	return strings.Join(parentNames, " ")
 }
 
 func hasAnnotations(cmd *cobra.Command) bool {


### PR DESCRIPTION
When making calls to our API, we'll now include a header `Circleci-Cli-Command` set to the current command being called, with no args or flags (e.g. `circleci orb list`).

This gives us some more server-side usage data for commands like `circleci local execute` that make the same API calls as other commands. It does not add any usage data for non-API-based commands like `circleci open` and `circleci setup`.