### PR TITLE
Add new 'admin delete-namespace' command

### DIFF
--- a/cmd/admin.go
+++ b/cmd/admin.go
@@ -83,6 +83,31 @@ Example:
 		panic(err)
 	}
 
+	deleteNamespaceCommand := &cobra.Command{
+		Use:   "delete-namespace <name>",
+		Short: "Delete a namespace",
+		Long: `Delete a namespace and its related orbs.
+
+	This command deletes a namespace, as well as any orbs that have been created in the namespace.`,
+		PreRunE: func(_ *cobra.Command, args []string) error {
+			return validateToken(nsOpts.cfg)
+		},
+		RunE: func(_ *cobra.Command, _ []string) error {
+			if nsOpts.integrationTesting {
+				nsOpts.tty = createNamespaceTestUI{
+					confirm: true,
+				}
+			}
+			return deleteNamespace(nsOpts)
+		},
+		Args:        cobra.ExactArgs(1),
+		Annotations: make(map[string]string),
+	}
+
+	deleteNamespaceCommand.Annotations["<name>"] = "The name of the namespace to delete"
+	deleteNamespaceCommand.Flags().BoolVar(&nsOpts.noPrompt, "no-prompt", false, "Disable prompt to bypass interactive UI.")
+	deleteNamespaceCommand.Flags().BoolVar(&nsOpts.integrationTesting, "integration-testing", false, "Enable test mode to bypass interactive UI.")
+
 	adminCommand := &cobra.Command{
 		Use:   "admin",
 		Short: "Administrative operations for a CircleCI Server installation.",
@@ -103,6 +128,7 @@ Example:
 	adminCommand.AddCommand(importOrbCommand)
 	adminCommand.AddCommand(renameCommand)
 	adminCommand.AddCommand(deleteAliasCommand)
+	adminCommand.AddCommand(deleteNamespaceCommand)
 
 	return adminCommand
 }

--- a/cmd/admin_test.go
+++ b/cmd/admin_test.go
@@ -120,6 +120,239 @@ var _ = Describe("Namespace integration tests", func() {
 		})
 	})
 
+	Describe("deleting namespace", func() {
+		BeforeEach(func() {
+			command = exec.Command(pathCLI,
+				"admin",
+				"delete-namespace",
+				"--skip-update-check",
+				"--token", token,
+				"--host", tempSettings.TestServer.URL(),
+				"--integration-testing",
+				"foo-ns",
+			)
+		})
+
+		It("fails when provided namespace does not exist", func() {
+			gqlRegistryNsResponse := `{
+				"registryNamespace": {
+					"id": ""
+				}
+			}`
+
+			expectedRegistryNsRequest := `{
+				"query": "\n\t\t\t\tquery($name: String!) {\n\t\t\t\t\tregistryNamespace(\n\t\t\t\t\t\tname: $name\n\t\t\t\t\t){\n\t\t\t\t\t\tid\n\t\t\t\t\t}\n\t\t\t }",
+				"variables": {
+				  "name": "foo-ns"
+				}
+			  }`
+
+			tempSettings.AppendPostHandler(token, clitest.MockRequestResponse{
+				Status:   http.StatusOK,
+				Request:  expectedRegistryNsRequest,
+				Response: gqlRegistryNsResponse})
+
+			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+
+			Expect(err).ShouldNot(HaveOccurred())
+			Eventually(session.Err).Should(gbytes.Say("Error: namespace check failed: the namespace 'foo-ns' does not exist. Did you misspell the namespace, or maybe you meant to create the namespace first?"))
+			Eventually(session).ShouldNot(gexec.Exit(0))
+		})
+
+		It("fails when list orbs returns an error", func() {
+			gqlRegistryNsResponse := `{
+				"registryNamespace": {
+					"id": "f13a9e13-538c-435c-8f61-78596661acd6"
+				}
+			}`
+
+			expectedRegistryNsRequest := `{
+				"query": "\n\t\t\t\tquery($name: String!) {\n\t\t\t\t\tregistryNamespace(\n\t\t\t\t\t\tname: $name\n\t\t\t\t\t){\n\t\t\t\t\t\tid\n\t\t\t\t\t}\n\t\t\t }",
+				"variables": {
+				  "name": "foo-ns"
+				}
+			  }`
+
+			gqlListNamespaceOrbsResponse := `{
+				"orbs": [
+					{"name": "test-orb-1"},
+					{"name": "test-orb-2"}
+				]
+			}`
+
+			expectedListOrbsRequest := `{
+				"query": "\nquery namespaceOrbs ($namespace: String, $after: String!, $view: OrbListViewType) {\n\tregistryNamespace(name: $namespace) {\n\t\tname\n                id\n\t\torbs(first: 20, after: $after, view: $view) {\n\t\t\tedges {\n\t\t\t\tcursor\n\t\t\t\tnode {\n\t\t\t\t\tversions {\n\t\t\t\t\t\tsource\n\t\t\t\t\t\tversion\n\t\t\t\t\t}\n\t\t\t\t\tname\n\t                                statistics {\n\t\t                           last30DaysBuildCount,\n\t\t                           last30DaysProjectCount,\n\t\t                           last30DaysOrganizationCount\n\t                               }\n\t\t\t\t}\n\t\t\t}\n\t\t\ttotalCount\n\t\t\tpageInfo {\n\t\t\t\thasNextPage\n\t\t\t}\n\t\t}\n\t}\n}\n",
+				"variables": {
+				  "after": "",
+				  "namespace": "foo-ns",
+				  "view": "PUBLIC_ONLY"
+				}
+			  }`
+
+			tempSettings.AppendPostHandler(token, clitest.MockRequestResponse{
+				Status:   http.StatusOK,
+				Request:  expectedRegistryNsRequest,
+				Response: gqlRegistryNsResponse})
+
+			tempSettings.AppendPostHandler(token, clitest.MockRequestResponse{
+				Status:   http.StatusOK,
+				Request:  expectedListOrbsRequest,
+				Response: gqlListNamespaceOrbsResponse})
+
+			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+
+			Expect(err).ShouldNot(HaveOccurred())
+			Eventually(session.Err).Should(gbytes.Say("unable to list orbs: No namespace found"))
+			Eventually(session).ShouldNot(gexec.Exit(0))
+		})
+
+		It("fails when delete namespace returns an error", func() {
+			gqlRegistryNsResponse := `{
+				"registryNamespace": {
+					"id": "f13a9e13-538c-435c-8f61-78596661acd6"
+				}
+			}`
+
+			expectedRegistryNsRequest := `{
+				"query": "\n\t\t\t\tquery($name: String!) {\n\t\t\t\t\tregistryNamespace(\n\t\t\t\t\t\tname: $name\n\t\t\t\t\t){\n\t\t\t\t\t\tid\n\t\t\t\t\t}\n\t\t\t }",
+				"variables": {
+				  "name": "foo-ns"
+				}
+			  }`
+
+			gqlListNamespaceOrbsResponse := `{
+				"registryNamespace": {
+					"id": "f13a9e13-538c-435c-8f61-78596661acd6",
+					"orbs": {
+						"edges": [
+							{
+								"node": {
+									"name": "test-orb-1"
+								}
+							}
+						]
+					}
+				}
+			}`
+
+			expectedListOrbsRequest := `{
+				"query": "\nquery namespaceOrbs ($namespace: String, $after: String!, $view: OrbListViewType) {\n\tregistryNamespace(name: $namespace) {\n\t\tname\n                id\n\t\torbs(first: 20, after: $after, view: $view) {\n\t\t\tedges {\n\t\t\t\tcursor\n\t\t\t\tnode {\n\t\t\t\t\tversions {\n\t\t\t\t\t\tsource\n\t\t\t\t\t\tversion\n\t\t\t\t\t}\n\t\t\t\t\tname\n\t                                statistics {\n\t\t                           last30DaysBuildCount,\n\t\t                           last30DaysProjectCount,\n\t\t                           last30DaysOrganizationCount\n\t                               }\n\t\t\t\t}\n\t\t\t}\n\t\t\ttotalCount\n\t\t\tpageInfo {\n\t\t\t\thasNextPage\n\t\t\t}\n\t\t}\n\t}\n}\n",
+				"variables": {
+				  "after": "",
+				  "namespace": "foo-ns",
+				  "view": "PUBLIC_ONLY"
+				}
+			  }`
+
+			gqlDeleteNamespaceResponse := `{
+				"deleteNamespaceAndRelatedOrbs": {
+					"deleted": false,
+					"errors": [{"message": "test"}]
+				}
+			}`
+
+			expectedDeleteNamespacerequest := `{
+				"query": "\nmutation($id: UUID!) {\n  deleteNamespaceAndRelatedOrbs(namespaceId: $id) {\n    deleted\n    errors {\n      type\n      message\n    }\n  }\n}\n",
+				"variables": {
+				  "id": "f13a9e13-538c-435c-8f61-78596661acd6"
+				}
+			  }`
+
+			tempSettings.AppendPostHandler(token, clitest.MockRequestResponse{
+				Status:   http.StatusOK,
+				Request:  expectedRegistryNsRequest,
+				Response: gqlRegistryNsResponse})
+
+			tempSettings.AppendPostHandler(token, clitest.MockRequestResponse{
+				Status:   http.StatusOK,
+				Request:  expectedListOrbsRequest,
+				Response: gqlListNamespaceOrbsResponse})
+
+			tempSettings.AppendPostHandler(token, clitest.MockRequestResponse{
+				Status:   http.StatusOK,
+				Request:  expectedDeleteNamespacerequest,
+				Response: gqlDeleteNamespaceResponse})
+
+			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+
+			Expect(err).ShouldNot(HaveOccurred())
+			Eventually(session.Err).Should(gbytes.Say("Error: test"))
+			Eventually(session).ShouldNot(gexec.Exit(0))
+		})
+
+		It("deletes namespace successfully", func() {
+			gqlRegistryNsResponse := `{
+				"registryNamespace": {
+					"id": "f13a9e13-538c-435c-8f61-78596661acd6"
+				}
+			}`
+
+			expectedRegistryNsRequest := `{
+				"query": "\n\t\t\t\tquery($name: String!) {\n\t\t\t\t\tregistryNamespace(\n\t\t\t\t\t\tname: $name\n\t\t\t\t\t){\n\t\t\t\t\t\tid\n\t\t\t\t\t}\n\t\t\t }",
+				"variables": {
+				  "name": "foo-ns"
+				}
+			  }`
+
+			gqlListNamespaceOrbsResponse := `{
+				"registryNamespace": {
+					"id": "f13a9e13-538c-435c-8f61-78596661acd6",
+					"orbs": {
+						"edges": [
+							{
+								"node": {
+									"name": "test-orb-1"
+								}
+							}
+						]
+					}
+				}
+			}`
+
+			expectedListOrbsRequest := `{
+				"query": "\nquery namespaceOrbs ($namespace: String, $after: String!, $view: OrbListViewType) {\n\tregistryNamespace(name: $namespace) {\n\t\tname\n                id\n\t\torbs(first: 20, after: $after, view: $view) {\n\t\t\tedges {\n\t\t\t\tcursor\n\t\t\t\tnode {\n\t\t\t\t\tversions {\n\t\t\t\t\t\tsource\n\t\t\t\t\t\tversion\n\t\t\t\t\t}\n\t\t\t\t\tname\n\t                                statistics {\n\t\t                           last30DaysBuildCount,\n\t\t                           last30DaysProjectCount,\n\t\t                           last30DaysOrganizationCount\n\t                               }\n\t\t\t\t}\n\t\t\t}\n\t\t\ttotalCount\n\t\t\tpageInfo {\n\t\t\t\thasNextPage\n\t\t\t}\n\t\t}\n\t}\n}\n",
+				"variables": {
+				  "after": "",
+				  "namespace": "foo-ns",
+				  "view": "PUBLIC_ONLY"
+				}
+			  }`
+
+			gqlDeleteNamespaceResponse := `{
+				"deleteNamespaceAndRelatedOrbs": {
+					"deleted": true
+				}
+			}`
+
+			expectedDeleteNamespacerequest := `{
+				"query": "\nmutation($id: UUID!) {\n  deleteNamespaceAndRelatedOrbs(namespaceId: $id) {\n    deleted\n    errors {\n      type\n      message\n    }\n  }\n}\n",
+				"variables": {
+				  "id": "f13a9e13-538c-435c-8f61-78596661acd6"
+				}
+			  }`
+
+			tempSettings.AppendPostHandler(token, clitest.MockRequestResponse{
+				Status:   http.StatusOK,
+				Request:  expectedRegistryNsRequest,
+				Response: gqlRegistryNsResponse})
+
+			tempSettings.AppendPostHandler(token, clitest.MockRequestResponse{
+				Status:   http.StatusOK,
+				Request:  expectedListOrbsRequest,
+				Response: gqlListNamespaceOrbsResponse})
+
+			tempSettings.AppendPostHandler(token, clitest.MockRequestResponse{
+				Status:   http.StatusOK,
+				Request:  expectedDeleteNamespacerequest,
+				Response: gqlDeleteNamespaceResponse})
+
+			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+
+			Expect(err).ShouldNot(HaveOccurred())
+			Eventually(session, time.Second*5).Should(gexec.Exit(0))
+		})
+	})
+
 	Describe("renaming a namespace", func() {
 		var (
 			gqlGetNsResponse      string

--- a/cmd/orb_import.go
+++ b/cmd/orb_import.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -200,4 +201,39 @@ func displayPlan(w io.Writer, plan orbImportPlan) {
 
 func isNamespace(ref string) bool {
 	return len(strings.Split(ref, "/")) == 1
+}
+
+func deleteNamespace(nsOpts namespaceOptions) error {
+	if len(nsOpts.args) == 0 {
+		return errors.New("namespace name must be provided")
+	}
+	namespaceArg := nsOpts.args[0]
+
+	nsResp, err := api.GetNamespace(nsOpts.cl, namespaceArg)
+	if err != nil {
+		return fmt.Errorf("namespace check failed: %s", err.Error())
+	}
+
+	// Currently, private orbs will not be included in the list of orbs to be deleted.
+	// This can be changed once we have 'listBothPublicAndPrivateOrbs' functionality.
+	orbs, err := api.ListNamespaceOrbs(nsOpts.cl, namespaceArg, false)
+	if err != nil {
+		return fmt.Errorf("unable to list orbs: %s", err.Error())
+	}
+
+	var b strings.Builder
+	b.WriteString("The following delete actions will be performed:\n")
+
+	b.WriteString(fmt.Sprintf("  Delete namespace: '%s'\n", namespaceArg))
+	for _, o := range orbs.Orbs {
+		b.WriteString(fmt.Sprintf("  Delete orb: '%s'\n", o.Name))
+	}
+
+	fmt.Println(b.String())
+
+	if !nsOpts.noPrompt && !nsOpts.tty.askUserToConfirm("Are you sure you would like to proceed?") {
+		return nil
+	}
+
+	return api.DeleteNamespace(nsOpts.cl, nsResp.RegistryNamespace.ID)
 }


### PR DESCRIPTION
**Changes made:**
- Add 'DeleteNamespace' function in the api package which calls out to our [new mutation](https://github.com/circleci/api-service/pull/837)
- Add new cmd resolver that parses the given namespace, prints out a deletion plan (much like importing orbs), and executes it when the prompt is confirmed

Co-authored-by: @halie-kastl <halie-kastl@users.noreply.github.com>

**Demo: (pointing to https://extensibility.eks-dev.sphereci.com)**

![delete-namespace-demo](https://user-images.githubusercontent.com/18508962/130285953-909be32a-82d1-4216-a07f-3870734ee4f4.gif)
