### PR TITLE
Update 'process config' to properly pass pipeline parameters + values

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -132,7 +132,7 @@ func validateConfig(opts configOptions, flags *pflag.FlagSet) error {
 
 	orgSlug, _ := flags.GetString("org-slug")
 
-	_, err := api.ConfigQuery(opts.cl, path, orgSlug, pipeline.LocalPipelineVars(map[string]string{}))
+	_, err := api.ConfigQuery(opts.cl, path, orgSlug, nil, pipeline.LocalPipelineValues())
 	if err != nil {
 		return err
 	}
@@ -150,7 +150,7 @@ func processConfig(opts configOptions, flags *pflag.FlagSet) error {
 	orgSlug, _ := flags.GetString("org-slug")
 	paramsYaml, _ := flags.GetString("pipeline-parameters")
 
-	var params map[string]string
+	var params pipeline.Parameters
 
 	if len(paramsYaml) > 0 {
 		// The 'src' value can be a filepath, or a yaml string. If the file cannot be read sucessfully,
@@ -166,12 +166,12 @@ func processConfig(opts configOptions, flags *pflag.FlagSet) error {
 		}
 	}
 
-	response, err := api.ConfigQuery(opts.cl, opts.args[0], orgSlug, pipeline.LocalPipelineVars(params))
-
+	response, err := api.ConfigQuery(opts.cl, opts.args[0], orgSlug, params, pipeline.LocalPipelineValues())
 	if err != nil {
 		return err
 	}
 
+	fmt.Println(response.OutputYaml)
 	fmt.Print(response.OutputYaml)
 	return nil
 }

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -1,6 +1,7 @@
 package cmd_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -165,8 +166,8 @@ var _ = Describe("Config", func() {
 				Expect(err).ToNot(HaveOccurred())
 				stdin.Close()
 
-				query := `query ValidateConfig ($config: String!, $pipelineValues: [StringKeyVal!]) {
-					buildConfig(configYaml: $config, pipelineValues: $pipelineValues) {
+				query := `query ValidateConfig ($config: String!, $pipelineParametersJson: String, $pipelineValuesJson: String) {
+					buildConfig(configYaml: $config, pipelineParametersJson: $pipelineParametersJson, pipelineValuesJson: $pipelineValuesJson) {
 						valid,
 						errors { message },
 						sourceYaml,
@@ -176,7 +177,10 @@ var _ = Describe("Config", func() {
 
 				r := graphql.NewRequest(query)
 				r.Variables["config"] = config
-				r.Variables["pipelineValues"] = pipeline.PrepareForGraphQL(pipeline.LocalPipelineVars(map[string]string{}))
+
+				pipelineValues, err := json.Marshal(pipeline.LocalPipelineValues())
+				Expect(err).ToNot(HaveOccurred())
+				r.Variables["pipelineValuesJson"] = string(pipelineValues)
 
 				req, err := r.Encode()
 				Expect(err).ShouldNot(HaveOccurred())
@@ -222,6 +226,72 @@ var _ = Describe("Config", func() {
 			})
 		})
 
+		Describe("validating configs with pipeline parameters", func() {
+			config := "version: 2.1"
+			var expReq string
+
+			BeforeEach(func() {
+				command = exec.Command(pathCLI,
+					"config", "process",
+					"--skip-update-check",
+					"--token", token,
+					"--host", tempSettings.TestServer.URL(),
+					"--pipeline-parameters", `{"foo": "test", "bar": true, "baz": 10}`,
+					"-",
+				)
+
+				stdin, err := command.StdinPipe()
+				Expect(err).ToNot(HaveOccurred())
+				_, err = io.WriteString(stdin, config)
+				Expect(err).ToNot(HaveOccurred())
+				stdin.Close()
+
+				query := `query ValidateConfig ($config: String!, $pipelineParametersJson: String, $pipelineValuesJson: String) {
+					buildConfig(configYaml: $config, pipelineParametersJson: $pipelineParametersJson, pipelineValuesJson: $pipelineValuesJson) {
+						valid,
+						errors { message },
+						sourceYaml,
+						outputYaml
+					}
+				}`
+
+				r := graphql.NewRequest(query)
+				r.Variables["config"] = config
+
+				pipelineValues, err := json.Marshal(pipeline.LocalPipelineValues())
+				Expect(err).ToNot(HaveOccurred())
+				r.Variables["pipelineValuesJson"] = string(pipelineValues)
+
+				pipelineParams, err := json.Marshal(pipeline.Parameters{
+					"foo": "test",
+					"bar": true,
+					"baz": 10,
+				})
+				Expect(err).ToNot(HaveOccurred())
+				r.Variables["pipelineParametersJson"] = string(pipelineParams)
+
+				req, err := r.Encode()
+				Expect(err).ShouldNot(HaveOccurred())
+				expReq = req.String()
+			})
+
+			It("returns successfully when validating a config", func() {
+				expResp := `{
+					"buildConfig": {}
+				}`
+
+				tempSettings.AppendPostHandler(token, clitest.MockRequestResponse{
+					Status:   http.StatusOK,
+					Request:  expReq,
+					Response: expResp,
+				})
+
+				session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+				Expect(err).ShouldNot(HaveOccurred())
+				Eventually(session).Should(gexec.Exit(0))
+			})
+		})
+
 		Describe("validating configs with private orbs", func() {
 			config := "version: 2.1"
 			orgSlug := "circleci"
@@ -243,8 +313,8 @@ var _ = Describe("Config", func() {
 				Expect(err).ToNot(HaveOccurred())
 				stdin.Close()
 
-				query := `query ValidateConfig ($config: String!, $pipelineValues: [StringKeyVal!], $orgSlug: String) {
-					buildConfig(configYaml: $config, pipelineValues: $pipelineValues, orgSlug: $orgSlug) {
+				query := `query ValidateConfig ($config: String!, $pipelineParametersJson: String, $pipelineValuesJson: String, $orgSlug: String) {
+					buildConfig(configYaml: $config, pipelineParametersJson: $pipelineParametersJson, pipelineValuesJson: $pipelineValuesJson, orgSlug: $orgSlug) {
 						valid,
 						errors { message },
 						sourceYaml,
@@ -254,8 +324,11 @@ var _ = Describe("Config", func() {
 
 				r := graphql.NewRequest(query)
 				r.Variables["config"] = config
-				r.Variables["pipelineValues"] = pipeline.PrepareForGraphQL(pipeline.LocalPipelineVars(map[string]string{}))
 				r.Variables["orgSlug"] = orgSlug
+
+				pipelineValues, err := json.Marshal(pipeline.LocalPipelineValues())
+				Expect(err).ToNot(HaveOccurred())
+				r.Variables["pipelineValuesJson"] = string(pipelineValues)
 
 				req, err := r.Encode()
 				Expect(err).ShouldNot(HaveOccurred())

--- a/local/local.go
+++ b/local/local.go
@@ -43,7 +43,7 @@ func Execute(flags *pflag.FlagSet, cfg *settings.Config) error {
 	processedArgs, configPath := buildAgentArguments(flags)
 	orgSlug, _ := flags.GetString("org-slug")
 	cl := graphql.NewClient(cfg.HTTPClient, cfg.Host, cfg.Endpoint, cfg.Token, cfg.Debug)
-	configResponse, err := api.ConfigQuery(cl, configPath, orgSlug, pipeline.LocalPipelineVars(map[string]string{}))
+	configResponse, err := api.ConfigQuery(cl, configPath, orgSlug, nil, pipeline.LocalPipelineValues())
 
 	if err != nil {
 		return err

--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -10,9 +10,12 @@ import (
 // CircleCI provides various `<< pipeline.x >>` values to be used in your config, but sometimes we need to fabricate those values when validating config.
 type Values map[string]string
 
+// Static typing is bypassed using an empty interface here due to pipeline parameters supporting multiple types.
+type Parameters map[string]interface{}
+
 // vars should contain any pipeline parameters that should be accessible via
 // << pipeline.parameters.foo >>
-func LocalPipelineVars(vars map[string]string) Values {
+func LocalPipelineValues() Values {
 	revision := git.Revision()
 	gitUrl := "https://github.com/CircleCI-Public/circleci-cli"
 	projectType := "github"
@@ -38,10 +41,6 @@ func LocalPipelineVars(vars map[string]string) Values {
 		"git.branch":        git.Branch(),
 		"git.revision":      revision,
 		"git.base_revision": revision,
-	}
-
-	for paramName, paramValue := range vars {
-		vals[fmt.Sprintf("parameters.%s", paramName)] = paramValue
 	}
 
 	return vals


### PR DESCRIPTION
Addresses the issue of pipeline parameters being properly coerced when a non-string type is used.

https://github.com/CircleCI-Public/circleci-cli/issues/631

Changes made:
- Preserve the original type of all parameters and values by passing a JSON-encoded string downstream