### PR TITLE
Ensure that a user token is passed when fetching orb info

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -1424,6 +1424,7 @@ func OrbInfo(cl *graphql.Client, orbRef string) (*OrbVersion, error) {
 		      }`
 
 	request := graphql.NewRequest(query)
+	request.SetToken(cl.Token)
 	request.Var("orbVersionRef", ref)
 
 	err := cl.Run(request, &response)


### PR DESCRIPTION
This fixes a bug where `api-service` could not propagate a `user-id` downstream for authorization. 