### PR TITLE
fix: duplicate output for circleci config process

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -171,7 +171,6 @@ func processConfig(opts configOptions, flags *pflag.FlagSet) error {
 		return err
 	}
 
-	fmt.Println(response.OutputYaml)
 	fmt.Print(response.OutputYaml)
 	return nil
 }


### PR DESCRIPTION
The command  `circleci config process` gave a duplicated output. This fixes it.

See #642 