### PR TITLE
Only pass pipelineValuesJson if non-empty, revert pipelineValues

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -523,34 +523,31 @@ func ConfigQuery(cl *graphql.Client, configPath string, orgSlug string, params p
 		return nil, err
 	}
 
+	// GraphQL isn't forwards-compatible, so we are unusually selective here about
+	// passing only non-empty fields on to the API, to minimize user impact if the
+	// backend is out of date.
+	var fieldAddendums string
 	if orgSlug != "" {
-		query = `query ValidateConfig ($config: String!, $pipelineParametersJson: String, $pipelineValuesJson: String, $orgSlug: String) {
-					buildConfig(configYaml: $config, pipelineParametersJson: $pipelineParametersJson, pipelineValuesJson: $pipelineValuesJson, orgSlug: $orgSlug) {
-						valid,
-						errors { message },
-						sourceYaml,
-						outputYaml
-					}
-				}`
-	} else {
-		query = `query ValidateConfig ($config: String!, $pipelineParametersJson: String, $pipelineValuesJson: String) {
-					buildConfig(configYaml: $config, pipelineParametersJson: $pipelineParametersJson, pipelineValuesJson: $pipelineValuesJson) {
-						valid,
-						errors { message },
-						sourceYaml,
-						outputYaml
-					}
-				}`
+		fieldAddendums += ", orgSlug: $orgSlug"
 	}
+	if len(params) > 0 {
+		fieldAddendums += ", pipelineParametersJson: $pipelineParametersJson"
+	}
+	query = fmt.Sprintf(
+		`query ValidateConfig ($config: String!, $pipelineParametersJson: String, $pipelineValues: [StringKeyVal!], $orgSlug: String) {
+			buildConfig(configYaml: $config, pipelineValues: $pipelineValues %s) {
+				valid,
+				errors { message },
+				sourceYaml,
+				outputYaml
+			}
+		}`,
+		fieldAddendums)
 
 	request := graphql.NewRequest(query)
 	request.Var("config", config)
 	if values != nil {
-		pipelineValues, err := json.Marshal(values)
-		if err != nil {
-			return nil, fmt.Errorf("unable to serialize pipeline values: %s", err.Error())
-		}
-		request.Var("pipelineValuesJson", string(pipelineValues))
+		request.Var("pipelineValues", pipeline.PrepareForGraphQL(values))
 	}
 	if params != nil {
 		pipelineParameters, err := json.Marshal(params)

--- a/api/api.go
+++ b/api/api.go
@@ -535,7 +535,7 @@ func ConfigQuery(cl *graphql.Client, configPath string, orgSlug string, params p
 	}
 	query = fmt.Sprintf(
 		`query ValidateConfig ($config: String!, $pipelineParametersJson: String, $pipelineValues: [StringKeyVal!], $orgSlug: String) {
-			buildConfig(configYaml: $config, pipelineValues: $pipelineValues %s) {
+			buildConfig(configYaml: $config, pipelineValues: $pipelineValues%s) {
 				valid,
 				errors { message },
 				sourceYaml,

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -171,7 +171,6 @@ func processConfig(opts configOptions, flags *pflag.FlagSet) error {
 		return err
 	}
 
-	fmt.Println(response.OutputYaml)
 	fmt.Print(response.OutputYaml)
 	return nil
 }

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -166,21 +166,18 @@ var _ = Describe("Config", func() {
 				Expect(err).ToNot(HaveOccurred())
 				stdin.Close()
 
-				query := `query ValidateConfig ($config: String!, $pipelineParametersJson: String, $pipelineValuesJson: String) {
-					buildConfig(configYaml: $config, pipelineParametersJson: $pipelineParametersJson, pipelineValuesJson: $pipelineValuesJson) {
-						valid,
-						errors { message },
-						sourceYaml,
-						outputYaml
-					}
-				}`
+				query := `query ValidateConfig ($config: String!, $pipelineParametersJson: String, $pipelineValues: [StringKeyVal!], $orgSlug: String) {
+			buildConfig(configYaml: $config, pipelineValues: $pipelineValues) {
+				valid,
+				errors { message },
+				sourceYaml,
+				outputYaml
+			}
+		}`
 
 				r := graphql.NewRequest(query)
 				r.Variables["config"] = config
-
-				pipelineValues, err := json.Marshal(pipeline.LocalPipelineValues())
-				Expect(err).ToNot(HaveOccurred())
-				r.Variables["pipelineValuesJson"] = string(pipelineValues)
+				r.Variables["pipelineValues"] = pipeline.PrepareForGraphQL(pipeline.LocalPipelineValues())
 
 				req, err := r.Encode()
 				Expect(err).ShouldNot(HaveOccurred())
@@ -246,21 +243,18 @@ var _ = Describe("Config", func() {
 				Expect(err).ToNot(HaveOccurred())
 				stdin.Close()
 
-				query := `query ValidateConfig ($config: String!, $pipelineParametersJson: String, $pipelineValuesJson: String) {
-					buildConfig(configYaml: $config, pipelineParametersJson: $pipelineParametersJson, pipelineValuesJson: $pipelineValuesJson) {
-						valid,
-						errors { message },
-						sourceYaml,
-						outputYaml
-					}
-				}`
+				query := `query ValidateConfig ($config: String!, $pipelineParametersJson: String, $pipelineValues: [StringKeyVal!], $orgSlug: String) {
+			buildConfig(configYaml: $config, pipelineValues: $pipelineValues, pipelineParametersJson: $pipelineParametersJson) {
+				valid,
+				errors { message },
+				sourceYaml,
+				outputYaml
+			}
+		}`
 
 				r := graphql.NewRequest(query)
 				r.Variables["config"] = config
-
-				pipelineValues, err := json.Marshal(pipeline.LocalPipelineValues())
-				Expect(err).ToNot(HaveOccurred())
-				r.Variables["pipelineValuesJson"] = string(pipelineValues)
+				r.Variables["pipelineValues"] = pipeline.PrepareForGraphQL(pipeline.LocalPipelineValues())
 
 				pipelineParams, err := json.Marshal(pipeline.Parameters{
 					"foo": "test",
@@ -313,22 +307,19 @@ var _ = Describe("Config", func() {
 				Expect(err).ToNot(HaveOccurred())
 				stdin.Close()
 
-				query := `query ValidateConfig ($config: String!, $pipelineParametersJson: String, $pipelineValuesJson: String, $orgSlug: String) {
-					buildConfig(configYaml: $config, pipelineParametersJson: $pipelineParametersJson, pipelineValuesJson: $pipelineValuesJson, orgSlug: $orgSlug) {
-						valid,
-						errors { message },
-						sourceYaml,
-						outputYaml
-					}
-				}`
+				query := `query ValidateConfig ($config: String!, $pipelineParametersJson: String, $pipelineValues: [StringKeyVal!], $orgSlug: String) {
+			buildConfig(configYaml: $config, pipelineValues: $pipelineValues, orgSlug: $orgSlug) {
+				valid,
+				errors { message },
+				sourceYaml,
+				outputYaml
+			}
+		}`
 
 				r := graphql.NewRequest(query)
 				r.Variables["config"] = config
 				r.Variables["orgSlug"] = orgSlug
-
-				pipelineValues, err := json.Marshal(pipeline.LocalPipelineValues())
-				Expect(err).ToNot(HaveOccurred())
-				r.Variables["pipelineValuesJson"] = string(pipelineValues)
+				r.Variables["pipelineValues"] = pipeline.PrepareForGraphQL(pipeline.LocalPipelineValues())
 
 				req, err := r.Encode()
 				Expect(err).ShouldNot(HaveOccurred())


### PR DESCRIPTION
This partially reverts and refines https://github.com/CircleCI-Public/circleci-cli/pull/637.

When we switched to passing `pipelineParametersJson` and `pipelineValuesJson` in the call to the `buildConfig` API, it made the CLI not backwards-compatible with older versions of api-service. (Really, it's api-service's fault for not being forward-compatible.) As a result, some Server automated tests are broken and blocking the next release.

The changes here are:
* When a user doesn't specifically pass `--pipeline-parameters`, we don't pass the pipelineParametersJson field at all
* Instead of passing the new `pipelineValuesJson` field, we pass the legacy `pipelineValues` field instead
  * This isn't terrible because type dynamism was not something we immediately needed for pipeline values, only pipeline parameters