### PR TITLE
Add user token to 'list-orb' graphQL requests

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -1501,6 +1501,7 @@ query ListOrbs ($after: String!, $certifiedOnly: Boolean!) {
 
 	for {
 		request := graphql.NewRequest(query)
+		request.SetToken(cl.Token)
 		request.Var("after", currentCursor)
 		request.Var("certifiedOnly", !uncertified)
 


### PR DESCRIPTION
Ensure user token is passed downstream when making list-orb requests