### PR TITLE
Switch to cimg/go image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ orbs:
 executors:
   go:
     docker:
-      - image: circleci/golang:1.17
+      - image: cimg/go:1.18
     environment:
       CGO_ENABLED: 0
   mac:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ orbs:
 executors:
   go:
     docker:
-      - image: cimg/go:1.18
+      - image: cimg/go:1.17
     environment:
       CGO_ENABLED: 0
   mac:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ orbs:
 executors:
   go:
     docker:
-      - image: cimg/go:1.17
+      - image: cimg/go:1.19
     environment:
       CGO_ENABLED: 0
   mac:


### PR DESCRIPTION
This is the first PR we need to in order to move the circleci cli to go 1.18 since the old circleci convenience images will not get 1.18