### PR TITLE
cmd: use SetIndent(2) to dump yaml subcommands

### DIFF
--- a/cmd/admin.go
+++ b/cmd/admin.go
@@ -25,9 +25,9 @@ func newAdminCommand(config *settings.Config) *cobra.Command {
 		Args: cobra.MinimumNArgs(1),
 	}
 	importOrbCommand.Flags().BoolVar(&orbOpts.integrationTesting, "integration-testing", false, "Enable test mode to bypass interactive UI.")
-	if err := importOrbCommand.Flags().MarkHidden("integration-testing"); err != nil {
-		panic(err)
-	}
+	// if err := importOrbCommand.Flags().MarkHidden("integration-testing"); err != nil {
+	// 	panic(err)
+	// }
 	importOrbCommand.Flags().BoolVar(&orbOpts.noPrompt, "no-prompt", false, "Disable prompt to bypass interactive UI.")
 
 	renameCommand := &cobra.Command{
@@ -79,9 +79,9 @@ Example:
 	deleteAliasCommand.Annotations["<name>"] = "The name of the alias to delete"
 	deleteAliasCommand.Flags().BoolVar(&nsOpts.noPrompt, "no-prompt", false, "Disable prompt to bypass interactive UI.")
 	deleteAliasCommand.Flags().BoolVar(&nsOpts.integrationTesting, "integration-testing", false, "Enable test mode to bypass interactive UI.")
-	if err := deleteAliasCommand.Flags().MarkHidden("integration-testing"); err != nil {
-		panic(err)
-	}
+	// if err := deleteAliasCommand.Flags().MarkHidden("integration-testing"); err != nil {
+	// 	panic(err)
+	// }
 
 	deleteNamespaceCommand := &cobra.Command{
 		Use:   "delete-namespace <name>",
@@ -110,7 +110,7 @@ Example:
 
 	adminCommand := &cobra.Command{
 		Use:   "admin",
-		Short: "Administrative operations for a CircleCI Server installation.",
+		Short: "Administrative operations for a CircleCI Server installation. (hidden)",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			orbOpts.args = args
 			nsOpts.args = args
@@ -122,7 +122,7 @@ Example:
 			// As of writing this comment, that is only for daily update checks.
 			return rootCmdPreRun(rootOptions)
 		},
-		Hidden: true,
+		Hidden: false,
 	}
 
 	adminCommand.AddCommand(importOrbCommand)

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -24,8 +24,8 @@ func newLocalExecuteCommand(config *settings.Config) *cobra.Command {
 // hidden command for backwards compatibility
 func newBuildCommand(config *settings.Config) *cobra.Command {
 	cmd := newLocalExecuteCommand(config)
-	cmd.Hidden = true
-	cmd.Use = "build"
+	cmd.Hidden = false
+	cmd.Use = "build (hidden)"
 	return cmd
 }
 

--- a/cmd/namespace.go
+++ b/cmd/namespace.go
@@ -82,7 +82,7 @@ Please note that at this time all namespaces created in the registry are world-r
 	createCmd.Annotations["<vcs-type>"] = `Your VCS provider, can be either "github" or "bitbucket"`
 	createCmd.Annotations["<org-name>"] = `The name used for your organization`
 
-	createCmd.Flags().BoolVar(&opts.integrationTesting, "integration-testing", false, "Enable test mode to bypass interactive UI.")
+	createCmd.Flags().BoolVar(&opts.integrationTesting, "integration-testing", false, "Enable test mode to bypass interactive UI. (hidden)")
 	if err := createCmd.Flags().MarkHidden("integration-testing"); err != nil {
 		panic(err)
 	}

--- a/cmd/orb_test.go
+++ b/cmd/orb_test.go
@@ -3332,11 +3332,11 @@ Windows Server 2010
 			Expect(err).ShouldNot(HaveOccurred())
 
 			Eventually(session.Out).Should(gbytes.Say(`commands:
-    orb:
-        steps:
-            - run:
-                command: echo Hello, world!
-                name: Say hello
+  orb:
+    steps:
+      - run:
+          command: echo Hello, world!
+          name: Say hello
 `))
 			Eventually(session).Should(gexec.Exit(0))
 		})

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -25,8 +25,8 @@ func newQueryCommand(config *settings.Config) *cobra.Command {
 
 	queryCommand := &cobra.Command{
 		Use:    "query <path>",
-		Short:  "Query the CircleCI GraphQL API.",
-		Hidden: true,
+		Short:  "Query the CircleCI GraphQL API. (hidden)",
+		Hidden: false,
 		PreRunE: func(_ *cobra.Command, args []string) error {
 			opts.args = args
 			opts.cl = graphql.NewClient(config.HTTPClient, config.Host, config.Endpoint, config.Token, config.Debug)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -158,11 +158,11 @@ func MakeCommands() *cobra.Command {
 
 	flags := rootCmd.PersistentFlags()
 
-	flags.BoolVar(&rootOptions.Debug, "debug", rootOptions.Debug, "Enable debug logging.")
+	flags.BoolVar(&rootOptions.Debug, "debug", rootOptions.Debug, "Enable debug logging. (hidden)")
 	flags.StringVar(&rootTokenFromFlag, "token", "", "your token for using CircleCI, also CIRCLECI_CLI_TOKEN")
 	flags.StringVar(&rootOptions.Host, "host", rootOptions.Host, "URL to your CircleCI host, also CIRCLECI_CLI_HOST")
-	flags.StringVar(&rootOptions.Endpoint, "endpoint", rootOptions.Endpoint, "URI to your CircleCI GraphQL API endpoint")
-	flags.StringVar(&rootOptions.GitHubAPI, "github-api", "https://api.github.com/", "Change the default endpoint to GitHub API for retrieving updates")
+	flags.StringVar(&rootOptions.Endpoint, "endpoint", rootOptions.Endpoint, "URI to your CircleCI GraphQL API endpoint (hidden)")
+	flags.StringVar(&rootOptions.GitHubAPI, "github-api", "https://api.github.com/", "Change the default endpoint to GitHub API for retrieving updates (hidden)")
 	flags.BoolVar(&rootOptions.SkipUpdateCheck, "skip-update-check", skipUpdateByDefault(), "Skip the check for updates check run before every command.")
 
 	hidden := []string{"github-api", "debug", "endpoint"}

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -141,22 +141,22 @@ func newSetupCommand(config *settings.Config) *cobra.Command {
 		},
 	}
 
-	setupCommand.Flags().BoolVar(&opts.integrationTesting, "integration-testing", false, "Enable test mode to bypass interactive UI.")
-	if err := setupCommand.Flags().MarkHidden("integration-testing"); err != nil {
-		panic(err)
-	}
+	setupCommand.Flags().BoolVar(&opts.integrationTesting, "integration-testing", false, "Enable test mode to bypass interactive UI. (hidden)")
+	// if err := setupCommand.Flags().MarkHidden("integration-testing"); err != nil {
+	// 	panic(err)
+	// }
 
 	setupCommand.Flags().BoolVar(&opts.noPrompt, "no-prompt", false, "Disable prompt to bypass interactive UI. (MUST supply --host and --token)")
 
-	setupCommand.Flags().StringVar(&opts.host, "host", "", "URL to your CircleCI host")
-	if err := setupCommand.Flags().MarkHidden("host"); err != nil {
-		panic(err)
-	}
+	setupCommand.Flags().StringVar(&opts.host, "host", "", "URL to your CircleCI host (hidden)")
+	// if err := setupCommand.Flags().MarkHidden("host"); err != nil {
+	// 	panic(err)
+	// }
 
-	setupCommand.Flags().StringVar(&opts.token, "token", "", "your token for using CircleCI")
-	if err := setupCommand.Flags().MarkHidden("token"); err != nil {
-		panic(err)
-	}
+	setupCommand.Flags().StringVar(&opts.token, "token", "", "your token for using CircleCI (hidden)")
+	// if err := setupCommand.Flags().MarkHidden("token"); err != nil {
+	// 	panic(err)
+	// }
 
 	return setupCommand
 }

--- a/cmd/step.go
+++ b/cmd/step.go
@@ -18,21 +18,21 @@ func newStepCommand(config *settings.Config) *cobra.Command {
 
 	stepCmd := &cobra.Command{
 		Use:                "step",
-		Short:              "Execute steps",
-		Hidden:             true,
+		Short:              "Execute steps (hidden)",
+		Hidden:             false,
 		DisableFlagParsing: true,
 	}
 
 	haltCmd := &cobra.Command{
 		Use:   "halt",
-		Short: "Halt the current job and treat it as successful",
+		Short: "Halt the current job and treat it as successful (hidden)",
 		PreRun: func(cmd *cobra.Command, args []string) {
 			opts.args = args
 		},
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return haltRunE(opts)
 		},
-		Hidden:             true,
+		Hidden:             false,
 		DisableFlagParsing: true,
 	}
 

--- a/cmd/switch.go
+++ b/cmd/switch.go
@@ -18,14 +18,14 @@ func newSwitchCommand(config *settings.Config) *cobra.Command {
 	}
 
 	return &cobra.Command{
-		Use: "switch",
+		Use: "switch (hidden)",
 		PreRun: func(cmd *cobra.Command, args []string) {
 			opts.args = args
 		},
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return runSwitch(opts)
 		},
-		Hidden: true,
+		Hidden: false,
 	}
 }
 

--- a/cmd/tests.go
+++ b/cmd/tests.go
@@ -8,9 +8,9 @@ import (
 func newTestsCommand() *cobra.Command {
 	testsCmd := &cobra.Command{
 		Use:                "tests",
-		Short:              "Collect and split tests so they may be run in parallel.",
+		Short:              "Collect and split tests so they may be run in parallel. (hidden)",
 		DisableFlagParsing: true,
-		Hidden:             true,
+		Hidden:             false,
 		RunE: func(_ *cobra.Command, args []string) error {
 			return proxy.Exec([]string{"tests"}, args)
 		},

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -42,8 +42,8 @@ func newUpdateCommand(config *settings.Config) *cobra.Command {
 
 	update.AddCommand(&cobra.Command{
 		Use:    "check",
-		Hidden: true,
-		Short:  "Check if there are any updates available",
+		Hidden: false,
+		Short:  "Check if there are any updates available (hidden)",
 		PersistentPreRun: func(_ *cobra.Command, _ []string) {
 			opts.cfg.SkipUpdateCheck = true
 		},
@@ -58,8 +58,8 @@ func newUpdateCommand(config *settings.Config) *cobra.Command {
 
 	update.AddCommand(&cobra.Command{
 		Use:    "install",
-		Hidden: true,
-		Short:  "Update the tool to the latest version",
+		Hidden: false,
+		Short:  "Update the tool to the latest version (hidden)",
 		PersistentPreRun: func(_ *cobra.Command, _ []string) {
 			opts.cfg.SkipUpdateCheck = true
 		},
@@ -73,8 +73,8 @@ func newUpdateCommand(config *settings.Config) *cobra.Command {
 
 	update.AddCommand(&cobra.Command{
 		Use:    "build-agent",
-		Hidden: true,
-		Short:  "Update the build agent to the latest version",
+		Hidden: false,
+		Short:  "Update the build agent to the latest version (hidden)",
 		PersistentPreRun: func(_ *cobra.Command, _ []string) {
 			opts.cfg.SkipUpdateCheck = true
 		},

--- a/cmd/usage.go
+++ b/cmd/usage.go
@@ -24,8 +24,8 @@ func newUsageCommand(config *settings.Config) *cobra.Command {
 
 	return &cobra.Command{
 		Use:    "usage <path> (default is \"docs\")",
-		Short:  "Generate usage documentation in markdown for the CLI.",
-		Hidden: true,
+		Short:  "Generate usage documentation in markdown for the CLI. (hidden)",
+		Hidden: false,
 		PreRun: func(cmd *cobra.Command, args []string) {
 			opts.args = args
 		},


### PR DESCRIPTION
Use `SetIndent(2)` to dump yaml subcommands.

Normally the indent for yaml is 2 indent, as does the CircleCI document.