### PR TITLE
[orb init] Change to use gitBranch instead of default master

### DIFF
--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -1338,6 +1338,13 @@ func initOrb(opts orbOptions) error {
 		return errors.Wrap(err, "Git error")
 	}
 
+	branchRef := fmt.Sprintf("refs/heads/%s", gitBranch)
+	head := plumbing.NewSymbolicReference(plumbing.HEAD, plumbing.ReferenceName(branchRef))
+	err = r.Storer.SetReference(head)
+	if err != nil {
+		return err
+	}
+
 	w, err := r.Worktree()
 	if err != nil {
 		return err


### PR DESCRIPTION
I encountered the same issue as #646

By default, it uses the local branch `master` even though we set other branch name such as `main`.

So I added a code to use the `gitBranch` name as the default local branch.

I locally installed the `circleci-cli` and confirmed it uses the given branch name when `An initial commit has been created - please run 'git push origin main' to publish your first commit!` message is shown:

```shell
❯ git branch
* main
```

It was `master` before.