### PR TITLE
[JIRA EXT-294] Orb Tools 11 Support

### DIFF
--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -76,6 +76,7 @@ type createOrbTestUI struct {
 
 type orbProtectTemplateRelease struct {
 	ZipUrl string `json:"zipball_url"`
+	Name string `json:"name"`
 }
 
 func (ui createOrbTestUI) askUserToConfirm(message string) bool {
@@ -1060,7 +1061,7 @@ func initOrb(opts orbOptions) error {
 
 	fmt.Printf("Downloading Orb Project Template into %s\n", orbPath)
 	httpClient := http.Client{}
-	req, err := httpClient.Get("https://api.github.com/repos/CircleCI-Public/Orb-Project-Template/tags")
+	req, err := httpClient.Get("https://api.github.com/repos/CircleCI-Public/Orb-Template/tags")
 	if err != nil {
 		return errors.Wrap(err, "Unexpected error")
 	}
@@ -1075,15 +1076,26 @@ func initOrb(opts orbOptions) error {
 		return errors.Wrap(err, "Unexpected error")
 	}
 
-	latestTag := tags[0].ZipUrl
-	resp, err := http.Get(latestTag)
+	// filter out any non-release tags
+	releaseTags:= []orbProtectTemplateRelease{}
+	validTagRegex := regexp.MustCompile(`^v\d+\.\d+\.\d+$`)
+	for _, tag := range tags {
+		matched := validTagRegex.MatchString(tag.Name)
+		if matched {
+			releaseTags = append(releaseTags, tag)
+		}
+	}
+
+
+	latestRelease := releaseTags[0]
+	resp, err := http.Get(latestRelease.ZipUrl)
 	if err != nil {
 		return err
 	}
 	defer resp.Body.Close()
 
 	// Create the file
-	out, err := os.Create(filepath.Join(os.TempDir(), "orb-project-template.zip"))
+	out, err := os.Create(filepath.Join(os.TempDir(), "orb-template.zip"))
 	if err != nil {
 		return err
 	}
@@ -1095,7 +1107,7 @@ func initOrb(opts orbOptions) error {
 		return err
 	}
 
-	err = unzipToOrbPath(filepath.Join(os.TempDir(), "orb-project-template.zip"), orbPath)
+	err = unzipToOrbPath(filepath.Join(os.TempDir(), "orb-template.zip"), orbPath)
 	if err != nil {
 		return err
 	}
@@ -1297,13 +1309,24 @@ func initOrb(opts orbOptions) error {
 		return y[0]
 	}()
 
-	circleConfig, err := ioutil.ReadFile(path.Join(orbPath, ".circleci", "config.yml"))
+	circleConfig1, err := ioutil.ReadFile(path.Join(orbPath, ".circleci", "config.yml"))
 	if err != nil {
 		return err
 	}
 
-	circle := string(circleConfig)
-	err = ioutil.WriteFile(path.Join(orbPath, ".circleci", "config.yml"), []byte(orbTemplate(circle, projectName, ownerName, orbName, namespace)), 0644)
+	config1String := string(circleConfig1)
+	err = ioutil.WriteFile(path.Join(orbPath, ".circleci", "config.yml"), []byte(orbTemplate(config1String, projectName, ownerName, orbName, namespace)), 0644)
+	if err != nil {
+		return err
+	}
+
+	circleConfig2, err := ioutil.ReadFile(path.Join(orbPath, ".circleci", "test-deploy.yml"))
+	if err != nil {
+		return err
+	}
+
+	config2String := string(circleConfig2)
+	err = ioutil.WriteFile(path.Join(orbPath, ".circleci", "test-deploy.yml"), []byte(orbTemplate(config2String, projectName, ownerName, orbName, namespace)), 0644)
 	if err != nil {
 		return err
 	}
@@ -1312,8 +1335,20 @@ func initOrb(opts orbOptions) error {
 	if err != nil {
 		return err
 	}
+
 	readmeString := string(readme)
 	err = ioutil.WriteFile(path.Join(orbPath, "README.md"), []byte(orbTemplate(readmeString, projectName, ownerName, orbName, namespace)), 0644)
+	if err != nil {
+		return err
+	}
+
+	orbRoot, err := ioutil.ReadFile(path.Join(orbPath, "src",  "@orb.yml"))
+	if err != nil {
+		return err
+	}
+
+	orbRootString := string(orbRoot)
+	err = ioutil.WriteFile(path.Join(orbPath, "src", "@orb.yml"), []byte(orbTemplate(orbRootString, projectName, ownerName, orbName, namespace)), 0644)
 	if err != nil {
 		return err
 	}
@@ -1401,9 +1436,11 @@ func initOrb(opts orbOptions) error {
 		return err
 	}
 
-	fmt.Printf("An initial commit has been created - please run \033[1;34m'git push origin %v'\033[0m to publish your first commit!\n", gitBranch)
+	fmt.Printf("An initial commit has been created - please run the following commands in a separate terminal window. \n")
+	fmt.Printf("\033[1;34m'git branch -M %v'\033[0m\n", gitBranch)
+	fmt.Printf("\033[1;34m'git push origin %v'\033[0m\n", gitBranch)
 	yprompt = &survey.Confirm{
-		Message: "I have pushed to my git repository using the above command",
+		Message: "I have pushed to my git repository using the above commands",
 	}
 	// We don't use this anywhere, but AskOne will fail if we don't give it a
 	// place to put the result.

--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -1077,7 +1077,7 @@ func initOrb(opts orbOptions) error {
 	}
 
 	// filter out any non-release tags
-	releaseTags:= []orbProtectTemplateRelease{}
+	releaseTags := []orbProtectTemplateRelease{}
 	validTagRegex := regexp.MustCompile(`^v\d+\.\d+\.\d+$`)
 	for _, tag := range tags {
 		matched := validTagRegex.MatchString(tag.Name)

--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -1309,24 +1309,24 @@ func initOrb(opts orbOptions) error {
 		return y[0]
 	}()
 
-	circleConfig1, err := ioutil.ReadFile(path.Join(orbPath, ".circleci", "config.yml"))
+	circleConfigSetup, err := ioutil.ReadFile(path.Join(orbPath, ".circleci", "config.yml"))
 	if err != nil {
 		return err
 	}
 
-	config1String := string(circleConfig1)
-	err = ioutil.WriteFile(path.Join(orbPath, ".circleci", "config.yml"), []byte(orbTemplate(config1String, projectName, ownerName, orbName, namespace)), 0644)
+	configSetupString := string(circleConfigSetup)
+	err = ioutil.WriteFile(path.Join(orbPath, ".circleci", "config.yml"), []byte(orbTemplate(configSetupString, projectName, ownerName, orbName, namespace)), 0644)
 	if err != nil {
 		return err
 	}
 
-	circleConfig2, err := ioutil.ReadFile(path.Join(orbPath, ".circleci", "test-deploy.yml"))
+	circleConfigDeploy, err := ioutil.ReadFile(path.Join(orbPath, ".circleci", "test-deploy.yml"))
 	if err != nil {
 		return err
 	}
 
-	config2String := string(circleConfig2)
-	err = ioutil.WriteFile(path.Join(orbPath, ".circleci", "test-deploy.yml"), []byte(orbTemplate(config2String, projectName, ownerName, orbName, namespace)), 0644)
+	configDeployString := string(circleConfigDeploy)
+	err = ioutil.WriteFile(path.Join(orbPath, ".circleci", "test-deploy.yml"), []byte(orbTemplate(configDeployString, projectName, ownerName, orbName, namespace)), 0644)
 	if err != nil {
 		return err
 	}

--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -311,7 +311,7 @@ Please note that at this time all orbs created in the registry are world-readabl
 
 	orbInit := &cobra.Command{
 		Use:   "init <path>",
-		Short: "Initialize a new orb.",
+		Short: "Initialize a new orb project.",
 		Long:  ``,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return initOrb(opts)


### PR DESCRIPTION
**Note: This PR is ready for review but please do not merge until this message has been removed**

These changes to the CLI enable users to use the `circleci orb init` command to create their orb based on the new Orb Tools 11 pipeline.
Orb Tools 11 Docs: https://github.com/circleci/circleci-docs/pull/6560
Release Notes: https://github.com/CircleCI-Public/orb-tools-orb/releases/tag/v11.0.0

# CLI Changes

- The orb template repository URL has been changed to move to a new repo.
    - This was required to ensure that we did not affect current users of the CLI as the CLI will currently download the latest tag from the original repo. It also gave us a chance to better "clean up" the existing tag structure
- The latest _semver_ tag will be downloaded from the new Orb Template
    - Tags that do not follow `vX.Y.Z` exactly are ignored in the CLI
- More automated templating
    - Orb tools 11 uses two config files with dynamic config, both are now supported by the templatizing
    - The `@orb.yml` file is now also templatized to include your GitHub URL automatically.
- Message to set branch
    - We currently require that users run a git command separately in a new window to push their code.
    - If their git client is still set to `master` this will result in error.
    - Added a second command to have the user manually set the `main` branch before pushing.
    - Fixes #646 
 
# Orb Development Changes

These changes are implemented in the new orb project template and orb-tools v11 orb which is configured by the above CLI changes.

Existing orbs can migrate to Orb Tools 11 via: https://github.com/CircleCI-Public/orb-tools-orb/blob/master/MIGRATION.md

## Notable changes:

- **Removed the 30 day limit**
  - Previously, the configuration relied on calling a `dev:alpha` tagged version of the orb for testing. Due to "dev" tags on CircleCI being ephemeral with a 30-day life span, if it had been over 30 days since the orb was last published this would result in an error in the CircleCI pipeline. Users would have to manually publish their orb locally to re-start the ci pipeline
  - The new dynamic configuration system allows us to publish the dev version of the orb _before_ calling it for testing. This means that the 30 day limit is no longer an issue.
- **Adopting Tag/Release based publishing**
  - Publishing previously required a special text flag to be added to the commit message and a new version was published on every merge to the main branch.
  - The new tag/release based publishing system will simply publish your orb when you opt to push a versioned tag or use GitHub's [releases](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases) feature, which will create a tag and give you an opportunity to create a change log via [release notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes).
- **Review system**
  - The new "review" job can automatically detect opportunities to improve best-practices and provide native JUNIT output which will be displayed in the CircleCI UI.
  - Modeled after _shellcheck_, it is easy to skip any "review check" by supplying its "RC" code in the "exclude" parameter of the job.
- **Simplified/Improved PR Commenting**
  - Automatically comment on the PR associated with a commit when each new orb version is published (dev or production.)
  - The comment will include a link to the Orb Registry to preview dev versions of the orb, and a live link to the production version of the orb.

# Local Testing

After going through the `orb init` command with these changes:

1. The orb was created: 
<img width="390" alt="image" src="https://user-images.githubusercontent.com/33272306/160864518-8ede727f-e15d-4508-b048-e0f10d299d9f.png">

2. The repo is created and the projects is followed
<img width="911" alt="image" src="https://user-images.githubusercontent.com/33272306/160864770-9fa96c75-42d0-4cdb-9d79-2e1d705188a8.png">

3. A new side effect that is known/expected/documented is that users will need to enable Dynamic Config
<img width="1264" alt="image" src="https://user-images.githubusercontent.com/33272306/160864971-b9b8e424-83e5-4427-9192-2be2d6f31563.png">

But the configs have been properly generated and modified. Once dynamic config is enabled, you are good to go. A Jira ticket has been filed as well to improve API access around this so we can enable it on-follow.