### PR TITLE
[EXT-242] Upgrade Golang version in Dockerfile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ commands:
         default: https://github.com/goreleaser/goreleaser/releases/download/v0.127.0/goreleaser_amd64.deb
     steps:
       - restore_cache:
-          keys: [v4-goreleaser-]
+          keys: [v5-goreleaser-]
       - run:
           name: Install GoReleaser
           command: |
@@ -72,7 +72,7 @@ commands:
   gomod:
     steps:
       - restore_cache:
-          keys: ['v2-gomod-{{ arch }}-']
+          keys: ['v3-gomod-{{ arch }}-']
       - run:
           name: Download go module dependencies
           command: go mod download

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM circleci/golang:1.10.3
+FROM cimg/go:1.17
 
 ENV CIRCLECI_CLI_SKIP_UPDATE_CHECK true
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cimg/go:1.17
+FROM cimg/go:1.18.3
 
 ENV CIRCLECI_CLI_SKIP_UPDATE_CHECK true
 


### PR DESCRIPTION
The original image was based on a deprecated version of Ubuntu. Testing on 1.17

The goal is to update the base image in the public docker image, so that the depreciation notice in CircleCI is resolved.

Docker image: https://hub.docker.com/r/circleci/circleci-cli
Related Issue: https://github.com/CircleCI-Public/orb-tools-orb/issues/130#issuecomment-1082505567
Depreciation Warning: https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034
