### PR TITLE
Add build support for linux/aarch64

### DIFF
--- a/.circleci/pack.sh
+++ b/.circleci/pack.sh
@@ -17,6 +17,8 @@ function get_arch_type() {
         echo "386"
     elif [[ $(uname -m) == "x86_64" ]]; then
         echo "amd64"
+    elif [[ $(uname -m) == "aarch64" ]]; then
+        echo "aarch64"
     fi
 }
 


### PR DESCRIPTION
This enables support for building linux/aarch64 commands.

To generate the `packr2` build I did:
```
go install github.com/gobuffalo/packr/v2/packr2@v2.8.3
cp $(which packr2) bin/linux_aarch64
```
