### PR TITLE
Apple m1 support

### DIFF
--- a/.circleci/pack.sh
+++ b/.circleci/pack.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-
 set -o errexit
 set -o pipefail
 set -o nounset
@@ -15,7 +14,7 @@ trap error SIGINT
 function get_arch_type() {
     if [[ $(uname -m) == "i686" ]]; then
         echo "386"
-    elif [[ $(uname -m) == "x86_64" ]]; then
+    elif [[ $(uname -m) == "x86_64" || $(uname -m) == "arm64" ]]; then
         echo "amd64"
     fi
 }
@@ -32,7 +31,6 @@ ARCH="$(get_arch_base)_$(get_arch_type)"
 CMD="bin/$ARCH/packr2"
 
 command -v "$CMD"
-
 ./"$CMD" build
 
 exit 0

--- a/.circleci/pack.sh
+++ b/.circleci/pack.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 set -o errexit
 set -o pipefail
 set -o nounset
@@ -28,9 +29,11 @@ function get_arch_base() {
 }
 
 ARCH="$(get_arch_base)_$(get_arch_type)"
+
 CMD="bin/$ARCH/packr2"
 
 command -v "$CMD"
+
 ./"$CMD" build
 
 exit 0

--- a/go.mod
+++ b/go.mod
@@ -68,7 +68,7 @@ require (
 	github.com/xanzy/ssh-agent v0.2.1 // indirect
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 // indirect
 	golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb // indirect
-	golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f // indirect
+	golang.org/x/sys v0.0.0-20220422013727-9388b58f7150 // indirect
 	golang.org/x/text v0.3.3 // indirect
 	golang.org/x/tools v0.0.0-20190624222133-a101b041ded4 // indirect
 	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 // indirect

--- a/go.sum
+++ b/go.sum
@@ -473,8 +473,9 @@ golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx3WQ/1ib8I44HXV5yTA=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220422013727-9388b58f7150 h1:xHms4gcpe1YE7A3yIllJXP16CMAGuqwO2lX1mTyyRRc=
+golang.org/x/sys v0.0.0-20220422013727-9388b58f7150/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=


### PR DESCRIPTION
I'm currently using a 2021 Mac Book pro with an Apple M1 Pro chip using go 1.18 and I cannot get the project to run tests or build without these changes. 

Upgrading golang.org/x/sys was necessary otherwise a "go:linkname must refer to declared function or variable" would be thrown. 