### PR TITLE
🐛 fix: brewdeploy script

### DIFF
--- a/.circleci/brew-deploy.sh
+++ b/.circleci/brew-deploy.sh
@@ -2,8 +2,6 @@
 set -e
 
 # Install the latest circleci from homebrew
-git -C /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core fetch --unshallow
-git -C /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask fetch --unshallow
 brew update
 
 VERSION=$("$DESTDIR"/circleci version)


### PR DESCRIPTION
This PR essentially changes commit [7b3e17](https://github.com/CircleCI-Public/circleci-cli/commit/7b3e17e34e55a11e869d74062ff1144ea4154bc3)'s change to `.circleci/brew-deploy.sh`. CircleCI job was failing with:
```bash
#!/bin/bash --login -eo pipefail
./.circleci/brew-deploy.sh
fatal: --unshallow on a complete repository does not make sense

Exited with code exit status 128
CircleCI received exit code 128
```

Tested this by ssh'ing into the Mac runner, which worked:
```bash
==> replace "v0.1.17429" with "v0.1.17497"
==> replace "18585af7414a80633aade2f03f33d8ec5551c962" with "77066e803c166cbad4634eccfd3626eed
M       Formula/circleci.rb
Switched to a new branch 'bump-circleci-0.1.17497'
[bump-circleci-0.1.17497 55af3aff6e8] circleci 0.1.17497
 1 file changed, 2 insertions(+), 2 deletions(-)
remote: 
remote: Create a pull request for 'bump-circleci-0.1.17497' on GitHub by visiting:        
remote:      https://github.com/circleci-deploy-bot/homebrew-core/pull/new/bump-circleci-0.1.17497        
remote: 
To https://github.com/circleci-deploy-bot/homebrew-core.git
 * [new branch]              bump-circleci-0.1.17497 -> bump-circleci-0.1.17497
Branch 'bump-circleci-0.1.17497' set up to track remote branch 'bump-circleci-0.1.17497' from 'https://******@github.com/circleci-deploy-bot/homebrew-core.git'.
```