### PR TITLE
Add API bindings for the pipeline scheduling REST API

### DIFF
--- a/api/schedule.go
+++ b/api/schedule.go
@@ -1,0 +1,42 @@
+package api
+
+import (
+	"time"
+)
+
+type Timetable struct {
+	PerHour    uint     `json:"per-hour"`
+	HoursOfDay []uint   `json:"hours-of-day"`
+	DaysOfWeek []string `json:"days-of-week"`
+}
+
+type Actor struct {
+	ID    string `json:"id"`
+	Login string `json:"login"`
+	Name  string `json:"name"`
+}
+
+type Schedule struct {
+	ID          string            `json:"id"`
+	ProjectSlug string            `json:"project-slug"`
+	Name        string            `json:"name"`
+	Description string            `json:"description,omitempty"`
+	Timetable   Timetable         `json:"timetable"`
+	Actor       Actor             `json:"actor"`
+	Parameters  map[string]string `json:"parameters"`
+	CreatedAt   time.Time         `json:"created-at"`
+	UpdatedAt   time.Time         `json:"updated-at"`
+}
+
+type ScheduleInterface interface {
+	Schedules(vcs, org, project string) (*[]Schedule, error)
+	ScheduleByID(scheduleID string) (*Schedule, error)
+	ScheduleByName(vcs, org, project, name string) (*Schedule, error)
+	DeleteSchedule(scheduleID string) error
+	CreateSchedule(vcs, org, project, name, description string,
+		useSchedulingSystem bool, timetable Timetable,
+		parameters map[string]string) (*Schedule, error)
+	UpdateSchedule(scheduleID, name, description string,
+		useSchedulingSystem bool, timetable Timetable,
+		parameters map[string]string) (*Schedule, error)
+}

--- a/api/schedule_rest.go
+++ b/api/schedule_rest.go
@@ -1,0 +1,487 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/CircleCI-Public/circleci-cli/api/header"
+	"github.com/CircleCI-Public/circleci-cli/settings"
+	"github.com/CircleCI-Public/circleci-cli/version"
+	"github.com/pkg/errors"
+)
+
+// Communicates with the CircleCI REST API to ask questions about
+// schedules. It satisfies api.ScheduleInterface.
+type ScheduleRestClient struct {
+	token  string
+	server string
+	client *http.Client
+}
+
+type listSchedulesResponse struct {
+	Items         []Schedule
+	NextPageToken *string `json:"next_page_token"`
+	client        *ScheduleRestClient
+	params        *listSchedulesParams
+}
+
+type listSchedulesParams struct {
+	PageToken *string
+}
+
+// Creates a new schedule in the supplied project.
+func (c *ScheduleRestClient) CreateSchedule(vcs, org, project, name, description string,
+	useSchedulingSystem bool, timetable Timetable, parameters map[string]string) (*Schedule, error) {
+
+	req, err := c.newCreateScheduleRequest(vcs, org, project, name, description, useSchedulingSystem, timetable, parameters)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.client.Do(req)
+
+	if err != nil {
+		return nil, err
+	}
+
+	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	defer resp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != 201 {
+		var dest errorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		return nil, errors.New(*dest.Message)
+	}
+
+	var schedule Schedule
+	if err := json.Unmarshal(bodyBytes, &schedule); err != nil {
+		return nil, err
+	}
+
+	return &schedule, nil
+}
+
+// Updates an existing schedule.
+func (c *ScheduleRestClient) UpdateSchedule(scheduleID, name, description string,
+	useSchedulingSystem bool, timetable Timetable, parameters map[string]string) (*Schedule, error) {
+
+	req, err := c.newUpdateScheduleRequest(scheduleID, name, description, useSchedulingSystem, timetable, parameters)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.client.Do(req)
+
+	if err != nil {
+		return nil, err
+	}
+
+	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	defer resp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != 200 {
+		var dest errorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		return nil, errors.New(*dest.Message)
+	}
+
+	var schedule Schedule
+	if err := json.Unmarshal(bodyBytes, &schedule); err != nil {
+		return nil, err
+	}
+
+	return &schedule, nil
+}
+
+// Deletes the schedule with the given ID.
+func (c *ScheduleRestClient) DeleteSchedule(scheduleID string) error {
+	req, err := c.newDeleteScheduleRequest(scheduleID)
+
+	if err != nil {
+		return err
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	defer resp.Body.Close()
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != 200 {
+		var dest errorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return err
+		}
+		return errors.New(*dest.Message)
+	}
+	return nil
+}
+
+// Returns all of the schedules for a given project. Note that
+// pagination is not currently supported - we get all pages of
+// schedules and return them all.
+func (c *ScheduleRestClient) Schedules(vcs, org, project string) (*[]Schedule, error) {
+	schedules, err := c.listAllSchedules(vcs, org, project, &listSchedulesParams{})
+	return &schedules, err
+}
+
+// Returns the schedule with the given ID.
+func (c *ScheduleRestClient) ScheduleByID(scheduleID string) (*Schedule, error) {
+	req, err := c.newGetScheduleRequest(scheduleID)
+
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	defer resp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != 200 {
+		var dest errorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		return nil, errors.New(*dest.Message)
+	}
+
+	schedule := Schedule{}
+	if err := json.Unmarshal(bodyBytes, &schedule); err != nil {
+		return nil, err
+	}
+
+	return &schedule, err
+}
+
+// Finds a single schedule by its name and returns it.
+func (c *ScheduleRestClient) ScheduleByName(vcs, org, project, name string) (*Schedule, error) {
+	params := &listSchedulesParams{}
+	for {
+		resp, err := c.listSchedules(vcs, org, project, params)
+		if err != nil {
+			return nil, err
+		}
+		for _, schedule := range resp.Items {
+			if schedule.Name == name {
+				return &schedule, nil
+			}
+		}
+		if resp.NextPageToken == nil {
+			return nil, nil
+		}
+		params.PageToken = resp.NextPageToken
+	}
+}
+
+// Fetches all pages of the schedule list API and returns a single
+// list with all the schedules.
+func (c *ScheduleRestClient) listAllSchedules(vcs, org, project string, params *listSchedulesParams) (schedules []Schedule, err error) {
+	var resp *listSchedulesResponse
+	for {
+		resp, err = c.listSchedules(vcs, org, project, params)
+		if err != nil {
+			return nil, err
+		}
+
+		schedules = append(schedules, resp.Items...)
+
+		if resp.NextPageToken == nil {
+			break
+		}
+
+		params.PageToken = resp.NextPageToken
+	}
+	return schedules, nil
+}
+
+// Fetches and returns one page of schedules.
+func (c *ScheduleRestClient) listSchedules(vcs, org, project string, params *listSchedulesParams) (*listSchedulesResponse, error) {
+	req, err := c.newListSchedulesRequest(vcs, org, project, params)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	defer resp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != 200 {
+		var dest errorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+
+		}
+		return nil, errors.New(*dest.Message)
+
+	}
+
+	dest := listSchedulesResponse{
+		client: c,
+		params: params,
+	}
+	if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+		return nil, err
+	}
+	return &dest, nil
+}
+
+// Builds a request to fetch a schedule by ID.
+func (c *ScheduleRestClient) newGetScheduleRequest(scheduleID string) (*http.Request, error) {
+	queryURL, err := url.Parse(c.server)
+	if err != nil {
+		return nil, err
+	}
+
+	queryURL, err = queryURL.Parse(fmt.Sprintf("schedule/%s", scheduleID))
+	if err != nil {
+		return nil, err
+	}
+
+	return c.newHTTPRequest("GET", queryURL.String(), nil)
+}
+
+// Builds a request to create a new schedule.
+func (c *ScheduleRestClient) newCreateScheduleRequest(vcs, org, project, name, description string,
+	useSchedulingSystem bool, timetable Timetable, parameters map[string]string) (*http.Request, error) {
+
+	var err error
+	queryURL, err := url.Parse(c.server)
+	if err != nil {
+		return nil, err
+	}
+	queryURL, err = queryURL.Parse(fmt.Sprintf("project/%s/%s/%s/schedule", vcs, org, project))
+	if err != nil {
+		return nil, err
+	}
+
+	actor := "current"
+	if useSchedulingSystem {
+		actor = "system"
+	}
+
+	var bodyReader io.Reader
+
+	var body = struct {
+		Name             string            `json:"name"`
+		Description      string            `json:"description,omitempty"`
+		AttributionActor string            `json:"attribution-actor"`
+		Parameters       map[string]string `json:"parameters"`
+		Timetable        Timetable         `json:"timetable"`
+	}{
+		Name:             name,
+		Description:      description,
+		AttributionActor: actor,
+		Parameters:       parameters,
+		Timetable:        timetable,
+	}
+	buf, err := json.Marshal(body)
+
+	if err != nil {
+		return nil, err
+	}
+
+	bodyReader = bytes.NewReader(buf)
+
+	return c.newHTTPRequest("POST", queryURL.String(), bodyReader)
+}
+
+// Builds a request to update an existing schedule.
+func (c *ScheduleRestClient) newUpdateScheduleRequest(scheduleID, name, description string,
+	useSchedulingSystem bool, timetable Timetable, parameters map[string]string) (*http.Request, error) {
+
+	var err error
+	queryURL, err := url.Parse(c.server)
+	if err != nil {
+		return nil, err
+	}
+	queryURL, err = queryURL.Parse(fmt.Sprintf("schedule/%s", scheduleID))
+	if err != nil {
+		return nil, err
+	}
+
+	actor := "current"
+	if useSchedulingSystem {
+		actor = "system"
+	}
+
+	var bodyReader io.Reader
+
+	var body = struct {
+		Name             string            `json:"name,omitempty"`
+		Description      string            `json:"description,omitempty"`
+		AttributionActor string            `json:"attribution-actor,omitempty"`
+		Parameters       map[string]string `json:"parameters,omitempty"`
+		Timetable        Timetable         `json:"timetable,omitempty"`
+	}{
+		Name:             name,
+		Description:      description,
+		AttributionActor: actor,
+		Parameters:       parameters,
+		Timetable:        timetable,
+	}
+	buf, err := json.Marshal(body)
+
+	if err != nil {
+		return nil, err
+	}
+
+	bodyReader = bytes.NewReader(buf)
+
+	return c.newHTTPRequest("PATCH", queryURL.String(), bodyReader)
+}
+
+// Builds a request to delete an existing schedule.
+func (c *ScheduleRestClient) newDeleteScheduleRequest(scheduleID string) (*http.Request, error) {
+	var err error
+	queryURL, err := url.Parse(c.server)
+	if err != nil {
+		return nil, err
+	}
+	queryURL, err = queryURL.Parse(fmt.Sprintf("schedule/%s", scheduleID))
+	if err != nil {
+		return nil, err
+	}
+	return c.newHTTPRequest("DELETE", queryURL.String(), nil)
+}
+
+// Builds a requeest to list schedules according to params.
+func (c *ScheduleRestClient) newListSchedulesRequest(vcs, org, project string, params *listSchedulesParams) (*http.Request, error) {
+	var err error
+	queryURL, err := url.Parse(c.server)
+	if err != nil {
+		return nil, err
+	}
+	queryURL, err = queryURL.Parse(fmt.Sprintf("project/%s/%s/%s/schedule", vcs, org, project))
+	if err != nil {
+		return nil, err
+	}
+
+	urlParams := url.Values{}
+	if params.PageToken != nil {
+		urlParams.Add("page-token", *params.PageToken)
+	}
+
+	queryURL.RawQuery = urlParams.Encode()
+
+	return c.newHTTPRequest("GET", queryURL.String(), nil)
+}
+
+// Returns a new blank API request with boilerplate headers.
+func (c *ScheduleRestClient) newHTTPRequest(method, url string, body io.Reader) (*http.Request, error) {
+	req, err := http.NewRequest(method, url, body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("circle-token", c.token)
+	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("User-Agent", version.UserAgent())
+	commandStr := header.GetCommandStr()
+	if commandStr != "" {
+		req.Header.Add("Circleci-Cli-Command", commandStr)
+	}
+	return req, nil
+}
+
+// Verifies that the REST API exists and has the necessary endpoints
+// to interact with schedules.
+func (c *ScheduleRestClient) EnsureExists() error {
+	queryURL, err := url.Parse(c.server)
+	if err != nil {
+		return err
+	}
+	queryURL, err = queryURL.Parse("openapi.json")
+	if err != nil {
+		return err
+	}
+	req, err := c.newHTTPRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != 200 {
+		return errors.New("API v2 test request failed.")
+	}
+
+	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	defer resp.Body.Close()
+	if err != nil {
+		return err
+	}
+	var respBody struct {
+		Paths struct {
+			ScheduleEndpoint interface{} `json:"/schedule"`
+		}
+	}
+	if err := json.Unmarshal(bodyBytes, &respBody); err != nil {
+		return err
+	}
+
+	if respBody.Paths.ScheduleEndpoint == nil {
+		return errors.New("No schedule endpoint exists")
+	}
+
+	return nil
+}
+
+// Returns a new client satisfying the api.ScheduleInterface interface
+// via the REST API.
+func NewScheduleRestClient(config settings.Config) (*ScheduleRestClient, error) {
+	// Ensure server ends with a slash
+	if !strings.HasSuffix(config.RestEndpoint, "/") {
+		config.RestEndpoint += "/"
+	}
+	serverURL, err := url.Parse(config.Host)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err = serverURL.Parse(config.RestEndpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	client := &ScheduleRestClient{
+		token:  config.Token,
+		server: serverURL.String(),
+		client: config.HTTPClient,
+	}
+
+	return client, nil
+}

--- a/api/schedule_test.go
+++ b/api/schedule_test.go
@@ -1,0 +1,206 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/CircleCI-Public/circleci-cli/mock"
+)
+
+// Returns a static mock schedule.
+func mockSchedule() Schedule {
+	return Schedule{
+		ID:          "07f08dea-de06-48d4-9b47-9639229b7d24",
+		ProjectSlug: "github/test-org/test-project",
+		Name:        "test-schedule",
+		Description: "A test schedule",
+		Timetable: Timetable{
+			PerHour:    1,
+			HoursOfDay: []uint{4, 8, 15, 16, 23},
+			DaysOfWeek: []string{"MON", "THU", "SAT"},
+		},
+		Actor: Actor{
+			ID:    "807d18e2-a8e2-4b1e-8a54-18da6e0cc478",
+			Login: "test-actor",
+			Name:  "T. Actor",
+		},
+		Parameters: map[string]string{
+			"test": "parameter",
+		},
+	}
+}
+
+// Returns the string representation of the static mock schedule.
+func mockScheduleString() string {
+	schedule := mockSchedule()
+	rv, err := json.Marshal(schedule)
+	if err != nil {
+		panic("Failed to serialise mock schedule")
+	}
+	return string(rv)
+}
+
+// Takes a number of schedules and formats them as if they were
+// returned as a page of our paginated API. No next page tokens
+// included at this point.
+func formatListResponse(schedules []Schedule) string {
+	schedule := mockSchedule()
+	var resp = struct {
+		Items         []Schedule `json:"items"`
+		NextPageToken string     `json:"next_page_token,omitempty"`
+	}{
+		Items: []Schedule{schedule},
+	}
+	serialized, err := json.Marshal(resp)
+	if err != nil {
+		panic("Failed to serialise mock list response")
+	}
+	return string(serialized)
+}
+
+func TestSchedules(t *testing.T) {
+	mockFn := func(r *http.Request) (*http.Response, error) {
+		if r.URL.String() != "https://circleci.com/api/v2/project/github/test-org/test-project/schedule" {
+			panic(fmt.Sprintf("unexpected url: %s", r.URL.String()))
+		}
+		if r.Method != "GET" {
+			panic(fmt.Sprintf("unexpected method: %s", r.Method))
+		}
+		return mock.NewHTTPResponse(200, formatListResponse([]Schedule{mockSchedule()})), nil
+	}
+	httpClient := mock.NewHTTPClient(mockFn)
+	restClient := ScheduleRestClient{
+		server: "https://circleci.com/api/v2/",
+		client: httpClient,
+	}
+
+	t.Run("Get all schedules for a project", func(t *testing.T) {
+		schedules, err := restClient.Schedules("github", "test-org", "test-project")
+		assert.NilError(t, err)
+		assert.DeepEqual(t, mockSchedule(), (*schedules)[0])
+	})
+}
+
+func TestScheduleByID(t *testing.T) {
+	mockFn := func(r *http.Request) (*http.Response, error) {
+		if r.URL.String() != "https://circleci.com/api/v2/schedule/07f08dea-de06-48d4-9b47-9639229b7d24" {
+			panic(fmt.Sprintf("unexpected url: %s", r.URL.String()))
+		}
+		if r.Method != "GET" {
+			panic(fmt.Sprintf("unexpected method: %s", r.Method))
+		}
+		return mock.NewHTTPResponse(200, mockScheduleString()), nil
+	}
+	httpClient := mock.NewHTTPClient(mockFn)
+	restClient := ScheduleRestClient{
+		server: "https://circleci.com/api/v2/",
+		client: httpClient,
+	}
+
+	t.Run("Get a schedule by ID", func(t *testing.T) {
+		schedule := mockSchedule()
+		gotten, err := restClient.ScheduleByID(schedule.ID)
+		assert.NilError(t, err)
+		assert.DeepEqual(t, schedule, *gotten)
+	})
+}
+
+func TestScheduleByName(t *testing.T) {
+	mockFn := func(r *http.Request) (*http.Response, error) {
+		if r.URL.String() != "https://circleci.com/api/v2/project/github/test-org/test-project/schedule" {
+			panic(fmt.Sprintf("unexpected url: %s", r.URL.String()))
+		}
+		if r.Method != "GET" {
+			panic(fmt.Sprintf("unexpected method: %s", r.Method))
+		}
+		return mock.NewHTTPResponse(200, formatListResponse([]Schedule{mockSchedule()})), nil
+	}
+	httpClient := mock.NewHTTPClient(mockFn)
+	restClient := ScheduleRestClient{
+		server: "https://circleci.com/api/v2/",
+		client: httpClient,
+	}
+
+	t.Run("Get a schedule by name", func(t *testing.T) {
+		schedule := mockSchedule()
+		gotten, err := restClient.ScheduleByName("github", "test-org", "test-project", schedule.Name)
+		assert.NilError(t, err)
+		assert.DeepEqual(t, schedule, *gotten)
+	})
+}
+
+func TestDeleteSchedule(t *testing.T) {
+	mockFn := func(r *http.Request) (*http.Response, error) {
+		if r.URL.String() != "https://circleci.com/api/v2/schedule/07f08dea-de06-48d4-9b47-9639229b7d24" {
+			panic(fmt.Sprintf("unexpected url: %s", r.URL.String()))
+		}
+		if r.Method != "DELETE" {
+			panic(fmt.Sprintf("unexpected method: %s", r.Method))
+		}
+		return mock.NewHTTPResponse(200, "{\"message\": \"okay\"}"), nil
+	}
+	httpClient := mock.NewHTTPClient(mockFn)
+	restClient := ScheduleRestClient{
+		server: "https://circleci.com/api/v2/",
+		client: httpClient,
+	}
+
+	t.Run("Delete a schedule", func(t *testing.T) {
+		err := restClient.DeleteSchedule("07f08dea-de06-48d4-9b47-9639229b7d24")
+		assert.NilError(t, err)
+	})
+}
+
+func TestCreateSchedule(t *testing.T) {
+	mockFn := func(r *http.Request) (*http.Response, error) {
+		if r.URL.String() != "https://circleci.com/api/v2/project/github/test-org/test-project/schedule" {
+			panic(fmt.Sprintf("unexpected url: %s", r.URL.String()))
+		}
+		if r.Method != "POST" {
+			panic(fmt.Sprintf("unexpected method: %s", r.Method))
+		}
+		return mock.NewHTTPResponse(201, mockScheduleString()), nil
+	}
+	httpClient := mock.NewHTTPClient(mockFn)
+	restClient := ScheduleRestClient{
+		server: "https://circleci.com/api/v2/",
+		client: httpClient,
+	}
+
+	t.Run("Create a schedule", func(t *testing.T) {
+		schedule := mockSchedule()
+		created, err := restClient.CreateSchedule("github", "test-org", "test-project",
+			schedule.Name, schedule.Description, true, schedule.Timetable, schedule.Parameters)
+		assert.NilError(t, err)
+		assert.DeepEqual(t, schedule, *created)
+	})
+}
+
+func TestUpdateSchedule(t *testing.T) {
+	mockFn := func(r *http.Request) (*http.Response, error) {
+		if r.URL.String() != "https://circleci.com/api/v2/schedule/07f08dea-de06-48d4-9b47-9639229b7d24" {
+			panic(fmt.Sprintf("unexpected url: %s", r.URL.String()))
+		}
+		if r.Method != "PATCH" {
+			panic(fmt.Sprintf("unexpected method: %s", r.Method))
+		}
+		return mock.NewHTTPResponse(200, mockScheduleString()), nil
+	}
+	httpClient := mock.NewHTTPClient(mockFn)
+	restClient := ScheduleRestClient{
+		server: "https://circleci.com/api/v2/",
+		client: httpClient,
+	}
+
+	t.Run("Update a schedule", func(t *testing.T) {
+		schedule := mockSchedule()
+		updated, err := restClient.UpdateSchedule(schedule.ID, schedule.Name, schedule.Description,
+			false, schedule.Timetable, schedule.Parameters)
+		assert.NilError(t, err)
+		assert.DeepEqual(t, schedule, *updated)
+	})
+}


### PR DESCRIPTION
This is actually meant to be used in the CircleCI terraform provider,
which uses the CLI as a library. As such I'm not adding any
CLI-user-visible way of interacting with schedules as part of this.