### PR TITLE
remove "analytics events added" from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,5 @@
 # Checklist
+
 =========
 
 - [ ] I have performed a self-review of my own code
@@ -8,30 +9,30 @@
 - [ ] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/master/CONTRIBUTING.md).
 
 ## Changes
+
 =======
 
 - Put itemized changes here, preferably in imperative mood, i.e. "Add
   `functionA` to `fileB`"
 
 ## Rationale
+
 =========
 
 What was the overarching product goal of this PR as well as any pertinent
 history of changes
 
 ## Considerations
+
 ==============
 
 Why you made some of the technical decisions that you made, especially if the
 reasoning is not immediately obvious
 
-## Analytics Events Added
-======================
-
-- `event-name` 
-
 ## Screenshots
+
 ============
+
 <h4>Before</h4>
 Image or [gif](https://giphy.com/apps/giphycapture)
 


### PR DESCRIPTION
Also some markdown auto-formatting changes that got applied.

# Checklist
=========

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)
- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/master/CONTRIBUTING.md).

## Changes
=======

Follow-up PR on #708 to remove "Analytics Events added" section

## Rationale
=========

See above

## Considerations
==============

N/A

## Analytics Events Added
======================

N/A

## Screenshots
============

N/A