### PR TITLE
[SECENG-577] Accept policy-id as flag instead of positional argument

### DIFF
--- a/cmd/policy/policy.go
+++ b/cmd/policy/policy.go
@@ -110,11 +110,12 @@ func NewCommand(config *settings.Config, preRunE validator) *cobra.Command {
 	}()
 
 	get := func() *cobra.Command {
+		var policyID string
 		cmd := &cobra.Command{
 			Short: "Get a policy",
-			Use:   "get <policyID>",
+			Use:   "get",
 			RunE: func(cmd *cobra.Command, args []string) error {
-				policy, err := policy.NewClient(*policyBaseURL, config).GetPolicy(*ownerID, args[0])
+				policy, err := policy.NewClient(*policyBaseURL, config).GetPolicy(*ownerID, policyID)
 				if err != nil {
 					return fmt.Errorf("failed to get policy: %v", err)
 				}
@@ -128,9 +129,13 @@ func NewCommand(config *settings.Config, preRunE validator) *cobra.Command {
 
 				return nil
 			},
-			Args:    cobra.ExactArgs(1),
-			Example: `policy get 60b7e1a5-c1d7-4422-b813-7a12d353d7c6 --owner-id 516425b2-e369-421b-838d-920e1f51b0f5`,
+			Args:    cobra.ExactArgs(0),
+			Example: `policy get --owner-id 516425b2-e369-421b-838d-920e1f51b0f5 --policy-id 60b7e1a5-c1d7-4422-b813-7a12d353d7c6`,
 		}
+
+		cmd.Flags().StringVar(&policyID, "policy-id", "", "the id policy to get")
+		cmd.MarkFlagRequired("policy-id")
+
 		return cmd
 	}()
 

--- a/cmd/policy/policy_test.go
+++ b/cmd/policy/policy_test.go
@@ -192,16 +192,16 @@ func TestGetPolicy(t *testing.T) {
 		{
 			Name:        "requires policy-id",
 			Args:        []string{"get", "--owner-id", "ownerID"},
-			ExpectedErr: "accepts 1 arg(s), received 0",
+			ExpectedErr: "required flag(s) \"policy-id\" not set",
 		},
 		{
 			Name:        "requires org-id",
-			Args:        []string{"get", "policyID"},
+			Args:        []string{"get", "--policy-id", "policyID"},
 			ExpectedErr: "required flag(s) \"owner-id\" not set",
 		},
 		{
 			Name:        "gets error response",
-			Args:        []string{"get", "policyID", "--owner-id", "ownerID"},
+			Args:        []string{"get", "--policy-id", "policyID", "--owner-id", "ownerID"},
 			ExpectedErr: "failed to get policy: unexpected status-code: 403 - Forbidden",
 			ServerHandler: func(w http.ResponseWriter, r *http.Request) {
 				assert.Equal(t, r.Method, "GET")
@@ -212,7 +212,7 @@ func TestGetPolicy(t *testing.T) {
 		},
 		{
 			Name: "successfully gets a policy",
-			Args: []string{"get", "60b7e1a5-c1d7-4422-b813-7a12d353d7c6", "--owner-id", "462d67f8-b232-4da4-a7de-0c86dd667d3f"},
+			Args: []string{"get", "--owner-id", "462d67f8-b232-4da4-a7de-0c86dd667d3f", "--policy-id", "60b7e1a5-c1d7-4422-b813-7a12d353d7c6"},
 			ServerHandler: func(w http.ResponseWriter, r *http.Request) {
 				assert.Equal(t, r.Method, "GET")
 				assert.Equal(t, r.URL.String(), "/api/v1/owner/462d67f8-b232-4da4-a7de-0c86dd667d3f/policy/60b7e1a5-c1d7-4422-b813-7a12d353d7c6")

--- a/cmd/policy/testdata/policy/get-expected-usage.txt
+++ b/cmd/policy/testdata/policy/get-expected-usage.txt
@@ -1,8 +1,11 @@
 Usage:
-  policy get <policyID> [flags]
+  policy get [flags]
 
 Examples:
-policy get 60b7e1a5-c1d7-4422-b813-7a12d353d7c6 --owner-id 516425b2-e369-421b-838d-920e1f51b0f5
+policy get --owner-id 516425b2-e369-421b-838d-920e1f51b0f5 --policy-id 60b7e1a5-c1d7-4422-b813-7a12d353d7c6
+
+Flags:
+      --policy-id string   the id policy to get
 
 Global Flags:
       --owner-id string          the id of the owner of a policy


### PR DESCRIPTION
# Checklist

=========

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have checked for similar issues and haven't found anything relevant.
- [ ] This is not a security issue (which should be reported here: https://circleci.com/security/)
- [ ] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/master/CONTRIBUTING.md).

## Changes

=======

- Accept policy-id as flag instead of positional argument
- Fixed tests
