### PR TITLE
added update policy command

### DIFF
--- a/api/policy/policy.go
+++ b/api/policy/policy.go
@@ -110,7 +110,6 @@ func (c Client) CreatePolicy(ownerID string, policy CreationRequest) (interface{
 	return &response, nil
 }
 
-
 type UpdateRequest struct {
 	Name    *string `json:"name,omitempty"`
 	Context *string `json:"context,omitempty"`
@@ -118,6 +117,7 @@ type UpdateRequest struct {
 	Active  *bool   `json:"active,omitempty"`
 }
 
+// UpdatePolicy calls the UPDATE policy API in the policy-service. It updates a policy in the policy-service matching the given owner-id and policy-id.
 func (c Client) UpdatePolicy(ownerID string, policyID string, policy UpdateRequest) (interface{}, error) {
 	data, err := json.Marshal(policy)
 	if err != nil {

--- a/api/policy/policy.go
+++ b/api/policy/policy.go
@@ -103,6 +103,52 @@ func (c Client) CreatePolicy(ownerID string, policy CreationRequest) (interface{
 	return &response, nil
 }
 
+type UpdateRequest struct {
+	Name    *string `json:"name,omitempty"`
+	Context *string `json:"context,omitempty"`
+	Content *string `json:"content,omitempty"`
+	Active  *bool   `json:"active,omitempty"`
+}
+
+func (c Client) UpdatePolicy(ownerID string, policyID string, policy UpdateRequest) (interface{}, error) {
+	data, err := json.Marshal(policy)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode policy payload: %w", err)
+	}
+
+	req, err := http.NewRequest(
+		"PATCH",
+		fmt.Sprintf("%s/api/v1/owner/%s/policy/%s", c.serverUrl, ownerID, policyID),
+		bytes.NewReader(data),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to construct request: %v", err)
+	}
+
+	req.Header.Set("Content-Length", strconv.Itoa(len(data)))
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get response from policy-service: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		var response httpError
+		if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+			return nil, fmt.Errorf("unexpected status-code: %d", resp.StatusCode)
+		}
+		return nil, fmt.Errorf("unexpected status-code: %d - %s", resp.StatusCode, response.Error)
+	}
+
+	var response interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
 func (c Client) GetPolicy(ownerID string, policyID string) (interface{}, error) {
 	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/owner/%s/policy/%s", c.serverUrl, ownerID, policyID), nil)
 	if err != nil {

--- a/cmd/policy/policy.go
+++ b/cmd/policy/policy.go
@@ -158,7 +158,6 @@ func NewCommand(config *settings.Config, preRunE validator) *cobra.Command {
 
 	update := func() *cobra.Command {
 		var policyPath string
-		var policyID string
 		var active bool
 		var context string
 		var name string
@@ -166,7 +165,7 @@ func NewCommand(config *settings.Config, preRunE validator) *cobra.Command {
 
 		cmd := &cobra.Command{
 			Short: "Update a policy",
-			Use:   "update",
+			Use:   "update <policyID>",
 			RunE: func(cmd *cobra.Command, args []string) error {
 
 				if !(cmd.Flag("policy").Changed ||
@@ -201,7 +200,7 @@ func NewCommand(config *settings.Config, preRunE validator) *cobra.Command {
 					updateRequest.Name = &name
 				}
 
-				result, err := client.UpdatePolicy(*ownerID, policyID, updateRequest)
+				result, err := client.UpdatePolicy(*ownerID, args[0], updateRequest)
 				if err != nil {
 					return fmt.Errorf("failed to update policy: %w", err)
 				}
@@ -215,17 +214,14 @@ func NewCommand(config *settings.Config, preRunE validator) *cobra.Command {
 
 				return nil
 			},
-			Args:    cobra.ExactArgs(0),
-			Example: `policy update --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --policy-id e9e300d1-5bab-4704-b610-addbd6e03b0b --name policy_name --active --policy ./policy.rego`,
+			Args:    cobra.ExactArgs(1),
+			Example: `policy update e9e300d1-5bab-4704-b610-addbd6e03b0b --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --name policy_name --active --policy ./policy.rego`,
 		}
 
-		cmd.Flags().StringVar(&policyID, "policy-id", "", "id of the policy to update")
 		cmd.Flags().StringVar(&name, "name", "", "set name of the given policy-id")
 		cmd.Flags().StringVar(&context, "context", "", "policy context (if set, must be config)")
 		cmd.Flags().BoolVar(&active, "active", false, "set policy active state (to deactivate, use --active=false)")
 		cmd.Flags().StringVar(&policyPath, "policy", "", "path to rego file containing the updated policy")
-
-		cmd.MarkFlagRequired("policy-id")
 
 		return cmd
 	}()

--- a/cmd/policy/policy.go
+++ b/cmd/policy/policy.go
@@ -194,10 +194,6 @@ func NewCommand(config *settings.Config, preRunE validator) *cobra.Command {
 				}
 
 				if cmd.Flag("context").Changed {
-					if context != "config" {
-						return fmt.Errorf("context must be set to \"config\"")
-
-					}
 					updateRequest.Context = &context
 				}
 

--- a/cmd/policy/policy.go
+++ b/cmd/policy/policy.go
@@ -57,7 +57,7 @@ func NewCommand(config *settings.Config, preRunE validator) *cobra.Command {
 				return nil
 			},
 			Args:    cobra.ExactArgs(0),
-			Example: `policy list --owner-id 516425b2-e369-421b-838d-920e1f51b0f5 --active true`,
+			Example: `policy list --owner-id 516425b2-e369-421b-838d-920e1f51b0f5 --active=true`,
 		}
 
 		cmd.Flags().BoolVar(&active, "active", false, "(OPTIONAL) filter policies based on active status (true or false)")
@@ -150,6 +150,85 @@ func NewCommand(config *settings.Config, preRunE validator) *cobra.Command {
 			Args:    cobra.ExactArgs(1),
 			Example: `policy delete 60b7e1a5-c1d7-4422-b813-7a12d353d7c6 --owner-id 516425b2-e369-421b-838d-920e1f51b0f5`,
 		}
+
+		return cmd
+	}()
+
+	update := func() *cobra.Command {
+		var policyPath string
+		var policyID string
+		var active bool
+		var context string
+		var name string
+		var updateRequest policy.UpdateRequest
+
+		cmd := &cobra.Command{
+			Short: "Update a policy",
+			Use:   "update",
+			RunE: func(cmd *cobra.Command, args []string) error {
+
+				if !(cmd.Flag("policy").Changed ||
+					cmd.Flag("active").Changed ||
+					cmd.Flag("context").Changed ||
+					cmd.Flag("name").Changed) {
+					return fmt.Errorf("one of policy, active, context, or name must be set")
+				}
+
+				if cmd.Flag("policy").Changed {
+					policyData, err := os.ReadFile(policyPath)
+					if err != nil {
+						return fmt.Errorf("failed to read policy file: %w", err)
+					}
+
+					content := string(policyData)
+
+					updateRequest.Content = &content
+				}
+
+				client := policy.NewClient(*policyBaseURL, config)
+
+				if cmd.Flag("active").Changed {
+					updateRequest.Active = &active
+				}
+
+				if cmd.Flag("context").Changed {
+					if context != "config" {
+						return fmt.Errorf("context must be set to \"config\"")
+
+					}
+					updateRequest.Context = &context
+				}
+
+				if cmd.Flag("name").Changed {
+					updateRequest.Name = &name
+				}
+
+				result, err := client.UpdatePolicy(*ownerID, policyID, updateRequest)
+				if err != nil {
+					return fmt.Errorf("failed to update policy: %w", err)
+				}
+
+				enc := json.NewEncoder(cmd.OutOrStdout())
+				enc.SetIndent("", "  ")
+
+				if err := enc.Encode(result); err != nil {
+					return fmt.Errorf("failed to encode result to stdout: %w", err)
+				}
+
+				return nil
+			},
+			Args:    cobra.ExactArgs(0),
+			Example: `policy update --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --policy-id e9e300d1-5bab-4704-b610-addbd6e03b0b --name policy_name --active --policy ./policy.rego`,
+		}
+
+		cmd.Flags().StringVar(&policyID, "policy-id", "", "id of the policy to update")
+		cmd.Flags().StringVar(&name, "name", "", "set name of the given policy-id")
+		cmd.Flags().StringVar(&context, "context", "", "policy context (if set, must be config)")
+		cmd.Flags().BoolVar(&active, "active", false, "set policy active state (to deactivate, use --active=false)")
+		cmd.Flags().StringVar(&policyPath, "policy", "", "path to rego file containing the updated policy")
+
+		cmd.MarkFlagRequired("policy-id")
+
 		return cmd
 	}()
 
@@ -157,6 +236,7 @@ func NewCommand(config *settings.Config, preRunE validator) *cobra.Command {
 	cmd.AddCommand(create)
 	cmd.AddCommand(get)
 	cmd.AddCommand(delete)
+	cmd.AddCommand(update)
 
 	return cmd
 }

--- a/cmd/policy/policy_test.go
+++ b/cmd/policy/policy_test.go
@@ -377,7 +377,7 @@ func TestUpdatePolicy(t *testing.T) {
 			ExpectedErr: "accepts 1 arg(s), received 0",
 		},
 		{
-			Name: "sends appropiate desired request",
+			Name: "sends appropriate desired request",
 			Args: []string{"update", "test-policy-id", "--owner-id", "test-org", "--active", "--name", "test-policy", "--policy", "./testdata/test.rego"},
 			ServerHandler: func(w http.ResponseWriter, r *http.Request) {
 				var body map[string]interface{}
@@ -414,7 +414,7 @@ func TestUpdatePolicy(t *testing.T) {
 			ExpectedOutput: "{}\n",
 		},
 		{
-			Name: "sends appropiate desired request with only name",
+			Name: "sends appropriate desired request with only name",
 			Args: []string{"update", "test-policy-id", "--owner-id", "test-org", "--name", "test-policy"},
 			ServerHandler: func(w http.ResponseWriter, r *http.Request) {
 				var body map[string]interface{}
@@ -430,7 +430,7 @@ func TestUpdatePolicy(t *testing.T) {
 			ExpectedOutput: "{}\n",
 		},
 		{
-			Name: "sends appropiate desired request with only policy path",
+			Name: "sends appropriate desired request with only policy path",
 			Args: []string{"update", "test-policy-id", "--owner-id", "test-org", "--policy", "./testdata/test.rego"},
 			ServerHandler: func(w http.ResponseWriter, r *http.Request) {
 				var body map[string]interface{}
@@ -446,7 +446,7 @@ func TestUpdatePolicy(t *testing.T) {
 			ExpectedOutput: "{}\n",
 		},
 		{
-			Name: "sends appropiate desired request - deactivate policy",
+			Name: "sends appropriate desired request - deactivate policy",
 			Args: []string{"update", "test-policy-id", "--owner-id", "test-org", "--active=false", "--name", "test-policy", "--policy", "./testdata/test.rego"},
 			ServerHandler: func(w http.ResponseWriter, r *http.Request) {
 				var body map[string]interface{}

--- a/cmd/policy/policy_test.go
+++ b/cmd/policy/policy_test.go
@@ -463,11 +463,6 @@ func TestUpdatePolicy(t *testing.T) {
 			Args:        []string{"update", "--owner-id", "test-org", "--policy-id", "test-policy-id"},
 			ExpectedErr: "one of policy, active, context, or name must be set",
 		},
-		{
-			Name:        "context must be set to config",
-			Args:        []string{"update", "--owner-id", "test-org", "--policy-id", "test-policy-id", "--context", "test"},
-			ExpectedErr: "context must be set to \"config\"",
-		},
 	}
 
 	for _, tc := range testcases {

--- a/cmd/policy/policy_test.go
+++ b/cmd/policy/policy_test.go
@@ -367,13 +367,18 @@ func TestUpdatePolicy(t *testing.T) {
 		ExpectedErr    string
 	}{
 		{
-			Name:        "requires owner-id and name and policy and policy-id and active flag",
-			Args:        []string{"update"},
-			ExpectedErr: "required flag(s) \"owner-id\", \"policy-id\" not set",
+			Name:        "requires owner-id flag",
+			Args:        []string{"update", "testID"},
+			ExpectedErr: "required flag(s) \"owner-id\" not set",
+		},
+		{
+			Name:        "requires policy id",
+			Args:        []string{"update", "--owner-id", "test-org"},
+			ExpectedErr: "accepts 1 arg(s), received 0",
 		},
 		{
 			Name: "sends appropiate desired request",
-			Args: []string{"update", "--owner-id", "test-org", "--policy-id", "test-policy-id", "--active", "--name", "test-policy", "--policy", "./testdata/test.rego"},
+			Args: []string{"update", "test-policy-id", "--owner-id", "test-org", "--active", "--name", "test-policy", "--policy", "./testdata/test.rego"},
 			ServerHandler: func(w http.ResponseWriter, r *http.Request) {
 				var body map[string]interface{}
 				assert.NilError(t, json.NewDecoder(r.Body).Decode(&body))
@@ -391,7 +396,7 @@ func TestUpdatePolicy(t *testing.T) {
 		},
 		{
 			Name: "explicitly set config",
-			Args: []string{"update", "--owner-id", "test-org", "--policy-id", "test-policy-id", "--active", "--name", "test-policy", "--policy", "./testdata/test.rego", "--context", "config"},
+			Args: []string{"update", "test-policy-id", "--owner-id", "test-org", "--active", "--name", "test-policy", "--policy", "./testdata/test.rego", "--context", "config"},
 			ServerHandler: func(w http.ResponseWriter, r *http.Request) {
 				var body map[string]interface{}
 				assert.NilError(t, json.NewDecoder(r.Body).Decode(&body))
@@ -410,7 +415,7 @@ func TestUpdatePolicy(t *testing.T) {
 		},
 		{
 			Name: "sends appropiate desired request with only name",
-			Args: []string{"update", "--owner-id", "test-org", "--policy-id", "test-policy-id", "--name", "test-policy"},
+			Args: []string{"update", "test-policy-id", "--owner-id", "test-org", "--name", "test-policy"},
 			ServerHandler: func(w http.ResponseWriter, r *http.Request) {
 				var body map[string]interface{}
 				assert.NilError(t, json.NewDecoder(r.Body).Decode(&body))
@@ -426,7 +431,7 @@ func TestUpdatePolicy(t *testing.T) {
 		},
 		{
 			Name: "sends appropiate desired request with only policy path",
-			Args: []string{"update", "--owner-id", "test-org", "--policy-id", "test-policy-id", "--policy", "./testdata/test.rego"},
+			Args: []string{"update", "test-policy-id", "--owner-id", "test-org", "--policy", "./testdata/test.rego"},
 			ServerHandler: func(w http.ResponseWriter, r *http.Request) {
 				var body map[string]interface{}
 				assert.NilError(t, json.NewDecoder(r.Body).Decode(&body))
@@ -442,7 +447,7 @@ func TestUpdatePolicy(t *testing.T) {
 		},
 		{
 			Name: "sends appropiate desired request - deactivate policy",
-			Args: []string{"update", "--owner-id", "test-org", "--policy-id", "test-policy-id", "--active=false", "--name", "test-policy", "--policy", "./testdata/test.rego"},
+			Args: []string{"update", "test-policy-id", "--owner-id", "test-org", "--active=false", "--name", "test-policy", "--policy", "./testdata/test.rego"},
 			ServerHandler: func(w http.ResponseWriter, r *http.Request) {
 				var body map[string]interface{}
 				assert.NilError(t, json.NewDecoder(r.Body).Decode(&body))
@@ -459,8 +464,8 @@ func TestUpdatePolicy(t *testing.T) {
 			ExpectedOutput: "{}\n",
 		},
 		{
-			Name:        "requires owner-id and name and policy and policy-id and active flag",
-			Args:        []string{"update", "--owner-id", "test-org", "--policy-id", "test-policy-id"},
+			Name:        "check at least one field is changed",
+			Args:        []string{"update", "test-policy-id", "--owner-id", "test-org"},
 			ExpectedErr: "one of policy, active, context, or name must be set",
 		},
 	}

--- a/cmd/policy/policy_test.go
+++ b/cmd/policy/policy_test.go
@@ -53,6 +53,16 @@ func TestListPolicies(t *testing.T) {
 			ExpectedOutput: "[]\n",
 		},
 		{
+			Name: "no active is set",
+			Args: []string{"list", "--owner-id", "ownerID"},
+			ServerHandler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, r.Method, "GET")
+				assert.Equal(t, r.URL.String(), "/api/v1/owner/ownerID/policy")
+				w.Write([]byte("[]"))
+			},
+			ExpectedOutput: "[]\n",
+		},
+		{
 			Name:        "gets error response",
 			Args:        []string{"list", "--owner-id", "ownerID"},
 			ExpectedErr: "failed to list policies: unexpected status-code: 403 - Forbidden",
@@ -307,6 +317,156 @@ func TestDeletePolicy(t *testing.T) {
 				w.WriteHeader(http.StatusNoContent)
 			},
 			ExpectedOutput: "Deleted Successfully\n",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.Name, func(t *testing.T) {
+			if tc.ServerHandler == nil {
+				tc.ServerHandler = func(w http.ResponseWriter, r *http.Request) {}
+			}
+
+			svr := httptest.NewServer(tc.ServerHandler)
+			defer svr.Close()
+
+			cmd, stdout, _ := makeCMD()
+
+			cmd.SetArgs(append(tc.Args, "--policy-base-url", svr.URL))
+
+			err := cmd.Execute()
+			if tc.ExpectedErr == "" {
+				assert.NilError(t, err)
+			} else {
+				assert.Error(t, err, tc.ExpectedErr)
+				return
+			}
+
+			assert.Equal(t, stdout.String(), tc.ExpectedOutput)
+		})
+	}
+}
+
+func TestUpdatePolicy(t *testing.T) {
+	makeCMD := func() (*cobra.Command, *bytes.Buffer, *bytes.Buffer) {
+		config := &settings.Config{Token: "testtoken", HTTPClient: http.DefaultClient}
+		cmd := NewCommand(config, nil)
+
+		stdout := new(bytes.Buffer)
+		stderr := new(bytes.Buffer)
+		cmd.SetOut(stdout)
+		cmd.SetErr(stderr)
+
+		return cmd, stdout, stderr
+	}
+
+	testcases := []struct {
+		Name           string
+		Args           []string
+		ServerHandler  http.HandlerFunc
+		ExpectedOutput string
+		ExpectedErr    string
+	}{
+		{
+			Name:        "requires owner-id and name and policy and policy-id and active flag",
+			Args:        []string{"update"},
+			ExpectedErr: "required flag(s) \"owner-id\", \"policy-id\" not set",
+		},
+		{
+			Name: "sends appropiate desired request",
+			Args: []string{"update", "--owner-id", "test-org", "--policy-id", "test-policy-id", "--active", "--name", "test-policy", "--policy", "./testdata/test.rego"},
+			ServerHandler: func(w http.ResponseWriter, r *http.Request) {
+				var body map[string]interface{}
+				assert.NilError(t, json.NewDecoder(r.Body).Decode(&body))
+				assert.Equal(t, r.URL.Path, "/api/v1/owner/test-org/policy/test-policy-id")
+				assert.DeepEqual(t, body, map[string]interface{}{
+					"content": string("package test"),
+					"name":    string("test-policy"),
+					"active":  bool(true),
+				})
+
+				w.WriteHeader(200)
+				io.WriteString(w, "{}")
+			},
+			ExpectedOutput: "{}\n",
+		},
+		{
+			Name: "explicitly set config",
+			Args: []string{"update", "--owner-id", "test-org", "--policy-id", "test-policy-id", "--active", "--name", "test-policy", "--policy", "./testdata/test.rego", "--context", "config"},
+			ServerHandler: func(w http.ResponseWriter, r *http.Request) {
+				var body map[string]interface{}
+				assert.NilError(t, json.NewDecoder(r.Body).Decode(&body))
+				assert.Equal(t, r.URL.Path, "/api/v1/owner/test-org/policy/test-policy-id")
+				assert.DeepEqual(t, body, map[string]interface{}{
+					"content": string("package test"),
+					"name":    string("test-policy"),
+					"active":  bool(true),
+					"context": string("config"),
+				})
+
+				w.WriteHeader(200)
+				io.WriteString(w, "{}")
+			},
+			ExpectedOutput: "{}\n",
+		},
+		{
+			Name: "sends appropiate desired request with only name",
+			Args: []string{"update", "--owner-id", "test-org", "--policy-id", "test-policy-id", "--name", "test-policy"},
+			ServerHandler: func(w http.ResponseWriter, r *http.Request) {
+				var body map[string]interface{}
+				assert.NilError(t, json.NewDecoder(r.Body).Decode(&body))
+				assert.Equal(t, r.URL.Path, "/api/v1/owner/test-org/policy/test-policy-id")
+				assert.DeepEqual(t, body, map[string]interface{}{
+					"name": string("test-policy"),
+				})
+
+				w.WriteHeader(200)
+				io.WriteString(w, "{}")
+			},
+			ExpectedOutput: "{}\n",
+		},
+		{
+			Name: "sends appropiate desired request with only policy path",
+			Args: []string{"update", "--owner-id", "test-org", "--policy-id", "test-policy-id", "--policy", "./testdata/test.rego"},
+			ServerHandler: func(w http.ResponseWriter, r *http.Request) {
+				var body map[string]interface{}
+				assert.NilError(t, json.NewDecoder(r.Body).Decode(&body))
+				assert.Equal(t, r.URL.Path, "/api/v1/owner/test-org/policy/test-policy-id")
+				assert.DeepEqual(t, body, map[string]interface{}{
+					"content": string("package test"),
+				})
+
+				w.WriteHeader(200)
+				io.WriteString(w, "{}")
+			},
+			ExpectedOutput: "{}\n",
+		},
+		{
+			Name: "sends appropiate desired request - deactivate policy",
+			Args: []string{"update", "--owner-id", "test-org", "--policy-id", "test-policy-id", "--active=false", "--name", "test-policy", "--policy", "./testdata/test.rego"},
+			ServerHandler: func(w http.ResponseWriter, r *http.Request) {
+				var body map[string]interface{}
+				assert.NilError(t, json.NewDecoder(r.Body).Decode(&body))
+				assert.Equal(t, r.URL.Path, "/api/v1/owner/test-org/policy/test-policy-id")
+				assert.DeepEqual(t, body, map[string]interface{}{
+					"content": string("package test"),
+					"name":    string("test-policy"),
+					"active":  bool(false),
+				})
+
+				w.WriteHeader(200)
+				io.WriteString(w, "{}")
+			},
+			ExpectedOutput: "{}\n",
+		},
+		{
+			Name:        "requires owner-id and name and policy and policy-id and active flag",
+			Args:        []string{"update", "--owner-id", "test-org", "--policy-id", "test-policy-id"},
+			ExpectedErr: "one of policy, active, context, or name must be set",
+		},
+		{
+			Name:        "context must be set to config",
+			Args:        []string{"update", "--owner-id", "test-org", "--policy-id", "test-policy-id", "--context", "test"},
+			ExpectedErr: "context must be set to \"config\"",
 		},
 	}
 

--- a/cmd/policy/testdata/policy-expected-usage.txt
+++ b/cmd/policy/testdata/policy-expected-usage.txt
@@ -3,8 +3,10 @@ Usage:
 
 Available Commands:
   create      create policy
+  delete      Delete a policy
   get         Get a policy
   list        List all policies
+  update      Update a policy
 
 Flags:
       --owner-id string          the id of the owner of a policy

--- a/cmd/policy/testdata/policy/delete-expected-usage.txt
+++ b/cmd/policy/testdata/policy/delete-expected-usage.txt
@@ -1,11 +1,8 @@
 Usage:
-  policy list [flags]
+  policy delete <policyID> [flags]
 
 Examples:
-policy list --owner-id 516425b2-e369-421b-838d-920e1f51b0f5 --active=true
-
-Flags:
-      --active   (OPTIONAL) filter policies based on active status (true or false)
+policy delete 60b7e1a5-c1d7-4422-b813-7a12d353d7c6 --owner-id 516425b2-e369-421b-838d-920e1f51b0f5
 
 Global Flags:
       --owner-id string          the id of the owner of a policy

--- a/cmd/policy/testdata/policy/update-expected-usage.txt
+++ b/cmd/policy/testdata/policy/update-expected-usage.txt
@@ -1,0 +1,16 @@
+Usage:
+  policy update [flags]
+
+Examples:
+policy update --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --policy-id e9e300d1-5bab-4704-b610-addbd6e03b0b --name policy_name --active --policy ./policy.rego
+
+Flags:
+      --active             set policy active state (to deactivate, use --active=false)
+      --context string     policy context (if set, must be config)
+      --name string        set name of the given policy-id
+      --policy string      path to rego file containing the updated policy
+      --policy-id string   id of the policy to update
+
+Global Flags:
+      --owner-id string          the id of the owner of a policy
+      --policy-base-url string   base url for policy api (default "https://internal.circleci.com")

--- a/cmd/policy/testdata/policy/update-expected-usage.txt
+++ b/cmd/policy/testdata/policy/update-expected-usage.txt
@@ -1,15 +1,14 @@
 Usage:
-  policy update [flags]
+  policy update <policyID> [flags]
 
 Examples:
-policy update --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --policy-id e9e300d1-5bab-4704-b610-addbd6e03b0b --name policy_name --active --policy ./policy.rego
+policy update e9e300d1-5bab-4704-b610-addbd6e03b0b --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --name policy_name --active --policy ./policy.rego
 
 Flags:
-      --active             set policy active state (to deactivate, use --active=false)
-      --context string     policy context (if set, must be config)
-      --name string        set name of the given policy-id
-      --policy string      path to rego file containing the updated policy
-      --policy-id string   id of the policy to update
+      --active           set policy active state (to deactivate, use --active=false)
+      --context string   policy context (if set, must be config)
+      --name string      set name of the given policy-id
+      --policy string    path to rego file containing the updated policy
 
 Global Flags:
       --owner-id string          the id of the owner of a policy


### PR DESCRIPTION
# Checklist

=========

- [ x] I have performed a self-review of my own code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [ x] I have checked for similar issues and haven't found anything relevant.
- [ x] This is not a security issue (which should be reported here: https://circleci.com/security/)
- [x ] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/master/CONTRIBUTING.md).

## Changes

=======

- Added `policy update` command in `cmd/policy/policy.go` (and added appropriate tests)
- Added code to update policy in policy-service in `api/policy/policy.go` (and added appropriate tests)
- Added usage text for testing in `cmd/policy/testdata`

## Rationale

=========

Add the ability to update a policy from the Circle CLI tool

## Considerations

==============

* The `cobra` library used to parse commands does not allow boolean values to be set to nil. To reduce the risk of a user accidentally disabling or enabling a policy, this flag was set to required with a `true` default value. The user will always need to include the `--active` flag (or could set it to `--active=false` if needed).

## Screenshots

============

<h4>Before</h4>
Image or [gif](https://giphy.com/apps/giphycapture)

<h4>After</h4>
Image or gif where change can be clearly seen

## **Here are some helpful tips you can follow when submitting a pull request:**

1. Fork [the repository](https://github.com/CircleCI-Public/circleci-cli) and create your branch from `master`.
2. Run `make build` in the repository root.
3. If you've fixed a bug or added code that should be tested, add tests!
4. Ensure the test suite passes (`make test`).
5. The `--debug` flag is often helpful for debugging HTTP client requests and responses.
6. Format your code with [gofmt](https://golang.org/cmd/gofmt/).
7. Make sure your code lints (`make lint`). Note: This requires Docker to run inside a local job.
