### PR TITLE
Added `policy` command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ docs/
 out/
 vendor/
 .vscode
+.idea
 
 # For supporting generated config of 2.1 syntax for local testing
 .circleci/processed.yml

--- a/api/policy/policy.go
+++ b/api/policy/policy.go
@@ -1,0 +1,91 @@
+package policy
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/CircleCI-Public/circleci-cli/api/header"
+	"github.com/CircleCI-Public/circleci-cli/settings"
+	"github.com/CircleCI-Public/circleci-cli/version"
+)
+
+// Client communicates with the CircleCI policy-service to ask questions
+// about policies. It satisfies policy.ClientInterface.
+type Client struct {
+	serverUrl string
+	client    *http.Client
+}
+
+type httpError struct {
+	Error   string                 `json:"error"`
+	Context map[string]interface{} `json:"context,omitempty"`
+}
+
+func (c Client) ListPolicies(ownerID string, activeFilter *bool) (interface{}, error) {
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/api/v1/owner/%s/policy", c.serverUrl, ownerID), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to construct request: %v", err)
+	}
+
+	query := make(url.Values)
+	if activeFilter != nil {
+		query.Set("active", fmt.Sprint(*activeFilter))
+	}
+
+	req.URL.RawQuery = query.Encode()
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		var payload httpError
+		if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+			return nil, fmt.Errorf("unexected status-code: %d", resp.StatusCode)
+		}
+		return nil, fmt.Errorf("unexpected status-code: %d - %s", resp.StatusCode, payload.Error)
+	}
+
+	var body interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return nil, fmt.Errorf("failed to decode response body: %v", err)
+	}
+
+	return body, nil
+}
+
+// NewClient returns a new client satisfying the api.PolicyInterface interface via the REST API.
+func NewClient(baseURL string, config *settings.Config) *Client {
+	transport := config.HTTPClient.Transport
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+
+	config.HTTPClient.Transport = transportFunc(func(r *http.Request) (*http.Response, error) {
+		r.Header.Add("circle-token", config.Token)
+		r.Header.Add("Accept", "application/json")
+		r.Header.Add("Content-Type", "application/json")
+		r.Header.Add("User-Agent", version.UserAgent())
+		if commandStr := header.GetCommandStr(); commandStr != "" {
+			r.Header.Add("Circleci-Cli-Command", commandStr)
+		}
+		return transport.RoundTrip(r)
+	})
+
+	return &Client{
+		serverUrl: strings.TrimSuffix(baseURL, "/"),
+		client:    config.HTTPClient,
+	}
+}
+
+// transportFunc is utility type for declaring a http.RoundTripper as a function literal
+type transportFunc func(*http.Request) (*http.Response, error)
+
+func (fn transportFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}

--- a/api/policy/policy.go
+++ b/api/policy/policy.go
@@ -21,11 +21,14 @@ type Client struct {
 	client    *http.Client
 }
 
+// httpError represents error response json payload as sent by the policy-server: internal/error.go
 type httpError struct {
 	Error   string                 `json:"error"`
 	Context map[string]interface{} `json:"context,omitempty"`
 }
 
+// ListPolicies calls the view policy-service list policy API. If the active filter is nil, all policies are returned. If
+// activeFilter is not nil it will only return active or inactive policies based on the value of *activeFilter.
 func (c Client) ListPolicies(ownerID string, activeFilter *bool) (interface{}, error) {
 	req, err := http.NewRequest("GET", fmt.Sprintf("%s/api/v1/owner/%s/policy", c.serverUrl, ownerID), nil)
 	if err != nil {
@@ -62,12 +65,16 @@ func (c Client) ListPolicies(ownerID string, activeFilter *bool) (interface{}, e
 }
 
 // Creation types taken from policy-service: internal/policy/api.go
+
+// CreationRequest represents the json payload to create a Policy in the Policy-Service
 type CreationRequest struct {
 	Name    string `json:"name"`
 	Context string `json:"context"`
 	Content string `json:"content"`
 }
 
+// CreatePolicy call the Create Policy API in the Policy-Service. It creates a policy for the specified owner and returns the created
+// policy resonse as an interface{}.
 func (c Client) CreatePolicy(ownerID string, policy CreationRequest) (interface{}, error) {
 	data, err := json.Marshal(policy)
 	if err != nil {
@@ -103,6 +110,7 @@ func (c Client) CreatePolicy(ownerID string, policy CreationRequest) (interface{
 	return &response, nil
 }
 
+// GetPolicy calls the GET policy API in the policy-service. It fetches the policy from policy-service matching the given owner-id and policy-id.
 func (c Client) GetPolicy(ownerID string, policyID string) (interface{}, error) {
 	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/owner/%s/policy/%s", c.serverUrl, ownerID, policyID), nil)
 	if err != nil {
@@ -131,6 +139,8 @@ func (c Client) GetPolicy(ownerID string, policyID string) (interface{}, error) 
 	return body, nil
 }
 
+// DeletePolicy calls the Delete Policy API in the policy-service. It attempts to delete an a policy belonging the passed ownerID.
+// It returns an error if the call fails or the policy could not be deleted.
 func (c Client) DeletePolicy(ownerID string, policyID string) error {
 	req, err := http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/api/v1/owner/%s/policy/%s", c.serverUrl, ownerID, policyID), nil)
 	if err != nil {
@@ -154,7 +164,8 @@ func (c Client) DeletePolicy(ownerID string, policyID string) error {
 	return nil
 }
 
-// NewClient returns a new client satisfying the api.PolicyInterface interface via the REST API.
+// NewClient returns a new policy client that will use the provided settings.Config to automatically inject appropriate
+// Circle-Token authentication and other relevant CLI headers.
 func NewClient(baseURL string, config *settings.Config) *Client {
 	transport := config.HTTPClient.Transport
 	if transport == nil {
@@ -181,6 +192,7 @@ func NewClient(baseURL string, config *settings.Config) *Client {
 // transportFunc is utility type for declaring a http.RoundTripper as a function literal
 type transportFunc func(*http.Request) (*http.Response, error)
 
+// RoundTrip implements the http.RoundTripper interface
 func (fn transportFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return fn(req)
 }

--- a/api/policy/policy.go
+++ b/api/policy/policy.go
@@ -74,7 +74,7 @@ func (c Client) CreatePolicy(ownerID string, policy CreationRequest) (interface{
 		return nil, fmt.Errorf("failed to encode policy payload: %w", err)
 	}
 
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/api/v1/owner/%s/policy", c.serverUrl, ownerID), bytes.NewReader(data))
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/api/v1/owner/%s/policy", c.serverUrl, ownerID), bytes.NewReader(data))
 	if err != nil {
 		return nil, fmt.Errorf("failed to construct request: %v", err)
 	}
@@ -104,7 +104,7 @@ func (c Client) CreatePolicy(ownerID string, policy CreationRequest) (interface{
 }
 
 func (c Client) GetPolicy(ownerID string, policyID string) (interface{}, error) {
-	req, err := http.NewRequest("GET", fmt.Sprintf("%s/api/v1/owner/%s/policy/%s", c.serverUrl, ownerID, policyID), nil)
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/owner/%s/policy/%s", c.serverUrl, ownerID, policyID), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to construct request: %v", err)
 	}
@@ -129,6 +129,29 @@ func (c Client) GetPolicy(ownerID string, policyID string) (interface{}, error) 
 	}
 
 	return body, nil
+}
+
+func (c Client) DeletePolicy(ownerID string, policyID string) error {
+	req, err := http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/api/v1/owner/%s/policy/%s", c.serverUrl, ownerID, policyID), nil)
+	if err != nil {
+		return fmt.Errorf("failed to construct request: %v", err)
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		var payload httpError
+		if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+			return fmt.Errorf("unexected status-code: %d", resp.StatusCode)
+		}
+		return fmt.Errorf("unexpected status-code: %d - %s", resp.StatusCode, payload.Error)
+	}
+
+	return nil
 }
 
 // NewClient returns a new client satisfying the api.PolicyInterface interface via the REST API.

--- a/api/policy/policy.go
+++ b/api/policy/policy.go
@@ -8,7 +8,6 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/CircleCI-Public/circleci-cli/api/header"
 	"github.com/CircleCI-Public/circleci-cli/settings"
@@ -69,16 +68,7 @@ type CreationRequest struct {
 	Content string `json:"content"`
 }
 
-type CreationResponse struct {
-	DocumentVersion int        `json:"document_version"`
-	ID              string     `json:"id"`
-	Name            string     `json:"name"`
-	Context         string     `json:"context"`
-	Content         string     `json:"content"`
-	CreatedAt       *time.Time `json:"created_at"`
-}
-
-func (c Client) CreatePolicy(ownerID string, policy CreationRequest) (*CreationResponse, error) {
+func (c Client) CreatePolicy(ownerID string, policy CreationRequest) (interface{}, error) {
 	data, err := json.Marshal(policy)
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode policy payload: %w", err)
@@ -100,12 +90,12 @@ func (c Client) CreatePolicy(ownerID string, policy CreationRequest) (*CreationR
 	if resp.StatusCode != http.StatusCreated {
 		var response httpError
 		if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
-			return nil, fmt.Errorf("unexpected statuscode: %d", resp.StatusCode)
+			return nil, fmt.Errorf("unexpected status-code: %d", resp.StatusCode)
 		}
-		return nil, fmt.Errorf("unexpected statuscode: %d - %s", resp.StatusCode, response.Error)
+		return nil, fmt.Errorf("unexpected status-code: %d - %s", resp.StatusCode, response.Error)
 	}
 
-	var response CreationResponse
+	var response interface{}
 	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
 		return nil, fmt.Errorf("failed to parse response: %w", err)
 	}

--- a/api/policy/policy.go
+++ b/api/policy/policy.go
@@ -1,11 +1,14 @@
 package policy
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/CircleCI-Public/circleci-cli/api/header"
 	"github.com/CircleCI-Public/circleci-cli/settings"
@@ -36,6 +39,85 @@ func (c Client) ListPolicies(ownerID string, activeFilter *bool) (interface{}, e
 	}
 
 	req.URL.RawQuery = query.Encode()
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		var payload httpError
+		if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+			return nil, fmt.Errorf("unexected status-code: %d", resp.StatusCode)
+		}
+		return nil, fmt.Errorf("unexpected status-code: %d - %s", resp.StatusCode, payload.Error)
+	}
+
+	var body interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return nil, fmt.Errorf("failed to decode response body: %v", err)
+	}
+
+	return body, nil
+}
+
+// Creation types taken from policy-service: internal/policy/api.go
+type CreationRequest struct {
+	Name    string `json:"name"`
+	Context string `json:"context"`
+	Content string `json:"content"`
+}
+
+type CreationResponse struct {
+	DocumentVersion int        `json:"document_version"`
+	ID              string     `json:"id"`
+	Name            string     `json:"name"`
+	Context         string     `json:"context"`
+	Content         string     `json:"content"`
+	CreatedAt       *time.Time `json:"created_at"`
+}
+
+func (c Client) CreatePolicy(ownerID string, policy CreationRequest) (*CreationResponse, error) {
+	data, err := json.Marshal(policy)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode policy payload: %w", err)
+	}
+
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s/api/v1/owner/%s/policy", c.serverUrl, ownerID), bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("failed to construct request: %v", err)
+	}
+
+	req.Header.Set("Content-Length", strconv.Itoa(len(data)))
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get response from policy-service: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		var response httpError
+		if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+			return nil, fmt.Errorf("unexpected statuscode: %d", resp.StatusCode)
+		}
+		return nil, fmt.Errorf("unexpected statuscode: %d - %s", resp.StatusCode, response.Error)
+	}
+
+	var response CreationResponse
+	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+func (c Client) GetPolicy(ownerID string, policyID string) (interface{}, error) {
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/api/v1/owner/%s/policy/%s", c.serverUrl, ownerID, policyID), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to construct request: %v", err)
+	}
 
 	resp, err := c.client.Do(req)
 	if err != nil {

--- a/api/policy/policy_test.go
+++ b/api/policy/policy_test.go
@@ -1,0 +1,128 @@
+package policy
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/CircleCI-Public/circleci-cli/settings"
+	"github.com/CircleCI-Public/circleci-cli/version"
+)
+
+func TestClient_ListPolicies(t *testing.T) {
+	t.Run("expected request", func(t *testing.T) {
+		svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, r.Header.Get("circle-token"), "testtoken")
+			assert.Equal(t, r.Header.Get("accept"), "application/json")
+			assert.Equal(t, r.Header.Get("content-type"), "application/json")
+			assert.Equal(t, r.Header.Get("user-agent"), version.UserAgent())
+			assert.Equal(t, r.Header.Get("circle-token"), "testtoken")
+
+			assert.Equal(t, r.Method, "GET")
+			assert.Equal(t, r.URL.Path, "/api/v1/owner/ownerId/policy")
+
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("[]"))
+		}))
+		defer svr.Close()
+
+		config := &settings.Config{Token: "testtoken", HTTPClient: &http.Client{}}
+		client := NewClient(svr.URL, config)
+
+		_, err := client.ListPolicies("ownerId", nil)
+		assert.NilError(t, err)
+	})
+
+	t.Run("List Policies - Bad Request", func(t *testing.T) {
+		expectedResponse := `{"error": "active: query string not a boolean."}`
+
+		svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte(expectedResponse))
+		}))
+		defer svr.Close()
+
+		config := &settings.Config{Token: "testtoken", HTTPClient: &http.Client{}}
+		client := NewClient(svr.URL, config)
+
+		policies, err := client.ListPolicies("ownerId", nil)
+		assert.Equal(t, policies, nil)
+		assert.Error(t, err, "unexpected status-code: 400 - active: query string not a boolean.")
+	})
+
+	t.Run("List Policies - Forbidden", func(t *testing.T) {
+		expectedResponse := `{"error": "Forbidden"}`
+		svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+			w.Write([]byte(expectedResponse))
+		}))
+		defer svr.Close()
+
+		config := &settings.Config{Token: "testtoken", HTTPClient: &http.Client{}}
+		client := NewClient(svr.URL, config)
+
+		policies, err := client.ListPolicies("ownerId", nil)
+		assert.Equal(t, policies, nil)
+		assert.Error(t, err, "unexpected status-code: 403 - Forbidden")
+	})
+
+	t.Run("List Policies - no policies", func(t *testing.T) {
+		expectedResponse := "[]"
+
+		var expectedResponseValue interface{}
+		assert.NilError(t, json.Unmarshal([]byte(expectedResponse), &expectedResponseValue))
+
+		svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(expectedResponse))
+		}))
+		defer svr.Close()
+
+		config := &settings.Config{Token: "testtoken", HTTPClient: &http.Client{}}
+		client := NewClient(svr.URL, config)
+
+		policies, err := client.ListPolicies("ownerId", nil)
+		assert.DeepEqual(t, policies, expectedResponseValue)
+		assert.NilError(t, err)
+	})
+
+	t.Run("List Policies - some policies", func(t *testing.T) {
+		expectedResponse := `[
+			{
+				"id": "60b7e1a5-c1d7-4422-b813-7a12d353d7c6",
+				"name": "policy_1",
+				"owner_id": "462d67f8-b232-4da4-a7de-0c86dd667d3f",
+				"context": "config",
+				"active": false,
+				"created_at": "2022-05-31T14:15:10.86097Z",
+				"modified_at": null
+			},
+			{
+				"id": "a917a0ab-ceb6-482d-9a4e-f2f6b8bdfdcd",
+				"name": "policy_2",
+				"owner_id": "462d67f8-b232-4da4-a7de-0c86dd667d3f",
+				"context": "config",
+				"active": true,
+				"created_at": "2022-05-31T14:15:23.582383Z",
+				"modified_at": "2022-05-31T14:15:46.72321Z"
+			}
+		]`
+
+		var expectedResponseValue interface{}
+		assert.NilError(t, json.Unmarshal([]byte(expectedResponse), &expectedResponseValue))
+
+		svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(expectedResponse))
+		}))
+		defer svr.Close()
+
+		config := &settings.Config{Token: "testtoken", HTTPClient: &http.Client{}}
+		client := NewClient(svr.URL, config)
+
+		policies, err := client.ListPolicies("ownerId", nil)
+		assert.DeepEqual(t, policies, expectedResponseValue)
+		assert.NilError(t, err)
+	})
+}

--- a/api/policy/policy_test.go
+++ b/api/policy/policy_test.go
@@ -126,3 +126,106 @@ func TestClient_ListPolicies(t *testing.T) {
 		assert.NilError(t, err)
 	})
 }
+
+func TestClientGetPolicy(t *testing.T) {
+	t.Run("expected request", func(t *testing.T) {
+		svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, r.Header.Get("circle-token"), "testtoken")
+			assert.Equal(t, r.Header.Get("accept"), "application/json")
+			assert.Equal(t, r.Header.Get("content-type"), "application/json")
+			assert.Equal(t, r.Header.Get("user-agent"), version.UserAgent())
+			assert.Equal(t, r.Header.Get("circle-token"), "testtoken")
+
+			assert.Equal(t, r.Method, "GET")
+			assert.Equal(t, r.URL.Path, "/api/v1/owner/ownerId/policy/policyID")
+
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("[]"))
+		}))
+		defer svr.Close()
+
+		config := &settings.Config{Token: "testtoken", HTTPClient: &http.Client{}}
+		client := NewClient(svr.URL, config)
+
+		_, err := client.GetPolicy("ownerId", "policyID")
+		assert.NilError(t, err)
+	})
+
+	t.Run("Get Policy - Bad Request", func(t *testing.T) {
+		expectedResponse := `{"error": "PolicyID: must be a valid UUID."}`
+
+		svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte(expectedResponse))
+		}))
+		defer svr.Close()
+
+		config := &settings.Config{Token: "testtoken", HTTPClient: &http.Client{}}
+		client := NewClient(svr.URL, config)
+
+		policy, err := client.GetPolicy("ownerId", "policyID")
+		assert.Equal(t, policy, nil)
+		assert.Error(t, err, "unexpected status-code: 400 - PolicyID: must be a valid UUID.")
+	})
+
+	t.Run("Get Policy - Forbidden", func(t *testing.T) {
+		expectedResponse := `{"error": "Forbidden"}`
+		svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+			w.Write([]byte(expectedResponse))
+		}))
+		defer svr.Close()
+
+		config := &settings.Config{Token: "testtoken", HTTPClient: &http.Client{}}
+		client := NewClient(svr.URL, config)
+
+		policy, err := client.GetPolicy("ownerId", "policyID")
+		assert.Equal(t, policy, nil)
+		assert.Error(t, err, "unexpected status-code: 403 - Forbidden")
+	})
+
+	t.Run("Get Policy - Not Found", func(t *testing.T) {
+		expectedResponse := `{"error": "policy not found"}`
+		svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte(expectedResponse))
+		}))
+		defer svr.Close()
+
+		config := &settings.Config{Token: "testtoken", HTTPClient: &http.Client{}}
+		client := NewClient(svr.URL, config)
+
+		policy, err := client.GetPolicy("ownerId", "a917a0ab-ceb6-482d-9a4e-f2f6b8bdfdca")
+		assert.Equal(t, policy, nil)
+		assert.Error(t, err, "unexpected status-code: 404 - policy not found")
+	})
+
+	t.Run("Get Policy - successfully gets a policy", func(t *testing.T) {
+		expectedResponse := `{
+   			 "document_version": 1,
+   			 "id": "60b7e1a5-c1d7-4422-b813-7a12d353d7c6",
+   			 "name": "policy_1",
+   			 "owner_id": "462d67f8-b232-4da4-a7de-0c86dd667d3f",
+   			 "context": "config",
+   			 "content": "package test",
+   			 "active": false,
+   			 "created_at": "2022-05-31T14:15:10.86097Z",
+   			 "modified_at": null
+		}`
+
+		var expectedResponseValue interface{}
+		assert.NilError(t, json.Unmarshal([]byte(expectedResponse), &expectedResponseValue))
+
+		svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(expectedResponse))
+		}))
+		defer svr.Close()
+
+		config := &settings.Config{Token: "testtoken", HTTPClient: &http.Client{}}
+		client := NewClient(svr.URL, config)
+
+		policy, err := client.GetPolicy("462d67f8-b232-4da4-a7de-0c86dd667d3f", "60b7e1a5-c1d7-4422-b813-7a12d353d7c6")
+		assert.DeepEqual(t, policy, expectedResponseValue)
+		assert.NilError(t, err)
+	})
+}

--- a/cmd/policy/policy.go
+++ b/cmd/policy/policy.go
@@ -3,6 +3,7 @@ package policy
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -134,9 +135,28 @@ func NewCommand(config *settings.Config, preRunE validator) *cobra.Command {
 		return cmd
 	}()
 
+	delete := func() *cobra.Command {
+		cmd := &cobra.Command{
+			Short: "Delete a policy",
+			Use:   "delete <policyID>",
+			RunE: func(cmd *cobra.Command, args []string) error {
+				err := policy.NewClient(*policyBaseURL, config).DeletePolicy(*ownerID, args[0])
+				if err != nil {
+					return fmt.Errorf("failed to delete policy: %v", err)
+				}
+				io.WriteString(cmd.OutOrStdout(), "Deleted Successfully\n")
+				return nil
+			},
+			Args:    cobra.ExactArgs(1),
+			Example: `policy delete 60b7e1a5-c1d7-4422-b813-7a12d353d7c6 --owner-id 516425b2-e369-421b-838d-920e1f51b0f5`,
+		}
+		return cmd
+	}()
+
 	cmd.AddCommand(list)
 	cmd.AddCommand(create)
 	cmd.AddCommand(get)
+	cmd.AddCommand(delete)
 
 	return cmd
 }

--- a/cmd/policy/policy.go
+++ b/cmd/policy/policy.go
@@ -1,0 +1,72 @@
+package policy
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/CircleCI-Public/circleci-cli/api/policy"
+
+	"github.com/CircleCI-Public/circleci-cli/settings"
+)
+
+type validator func(cmd *cobra.Command, args []string) error
+
+func NewCommand(config *settings.Config, preRunE validator) *cobra.Command {
+	cmd := &cobra.Command{
+		Use: "policy",
+		Short: "Policies ensures security of build configs via security policy management framework. " +
+			"This group of commands allows the management of polices to be verified against build configs.",
+	}
+
+	policyBaseURL := cmd.PersistentFlags().String("policy-base-url", "https://internal.circleci.com", "base url for policy api")
+
+	list := func() *cobra.Command {
+		var ownerID string
+		var active bool
+
+		cmd := &cobra.Command{
+			Short:   "List all policies",
+			Use:     "list",
+			PreRunE: preRunE,
+			RunE: func(cmd *cobra.Command, args []string) error {
+				var flags struct {
+					OwnerID string
+					Active  *bool
+				}
+
+				flags.OwnerID = ownerID
+				if cmd.Flag("active").Changed {
+					flags.Active = &active
+				}
+
+				policies, err := policy.NewClient(*policyBaseURL, config).ListPolicies(flags.OwnerID, flags.Active)
+				if err != nil {
+					return fmt.Errorf("failed to list policies: %v", err)
+				}
+
+				enc := json.NewEncoder(cmd.OutOrStdout())
+				enc.SetIndent("", "  ")
+
+				if err := enc.Encode(policies); err != nil {
+					return fmt.Errorf("failed to output policies in json format: %v", err)
+				}
+
+				return nil
+			},
+			Args:    cobra.ExactArgs(0),
+			Example: `policy list --owner-id 516425b2-e369-421b-838d-920e1f51b0f5 --active true`,
+		}
+
+		cmd.Flags().StringVar(&ownerID, "owner-id", "", "the id of the owner of a policy")
+		cmd.Flags().BoolVar(&active, "active", false, "(OPTIONAL) filter policies based on active status (true or false)")
+		cmd.MarkFlagRequired("owner-id")
+
+		return cmd
+	}()
+
+	cmd.AddCommand(list)
+
+	return cmd
+}

--- a/cmd/policy/policy.go
+++ b/cmd/policy/policy.go
@@ -3,6 +3,7 @@ package policy
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 
@@ -15,33 +16,32 @@ type validator func(cmd *cobra.Command, args []string) error
 
 func NewCommand(config *settings.Config, preRunE validator) *cobra.Command {
 	cmd := &cobra.Command{
-		Use: "policy",
+		Use:               "policy",
+		PersistentPreRunE: preRunE,
 		Short: "Policies ensures security of build configs via security policy management framework. " +
 			"This group of commands allows the management of polices to be verified against build configs.",
 	}
 
 	policyBaseURL := cmd.PersistentFlags().String("policy-base-url", "https://internal.circleci.com", "base url for policy api")
+	ownerID := cmd.PersistentFlags().String("owner-id", "", "the id of the owner of a policy")
+	cmd.MarkPersistentFlagRequired("owner-id")
 
 	list := func() *cobra.Command {
-		var ownerID string
 		var active bool
 
 		cmd := &cobra.Command{
-			Short:   "List all policies",
-			Use:     "list",
-			PreRunE: preRunE,
+			Short: "List all policies",
+			Use:   "list",
 			RunE: func(cmd *cobra.Command, args []string) error {
 				var flags struct {
-					OwnerID string
-					Active  *bool
+					Active *bool
 				}
 
-				flags.OwnerID = ownerID
 				if cmd.Flag("active").Changed {
 					flags.Active = &active
 				}
 
-				policies, err := policy.NewClient(*policyBaseURL, config).ListPolicies(flags.OwnerID, flags.Active)
+				policies, err := policy.NewClient(*policyBaseURL, config).ListPolicies(*ownerID, flags.Active)
 				if err != nil {
 					return fmt.Errorf("failed to list policies: %v", err)
 				}
@@ -59,14 +59,82 @@ func NewCommand(config *settings.Config, preRunE validator) *cobra.Command {
 			Example: `policy list --owner-id 516425b2-e369-421b-838d-920e1f51b0f5 --active true`,
 		}
 
-		cmd.Flags().StringVar(&ownerID, "owner-id", "", "the id of the owner of a policy")
 		cmd.Flags().BoolVar(&active, "active", false, "(OPTIONAL) filter policies based on active status (true or false)")
-		cmd.MarkFlagRequired("owner-id")
 
 		return cmd
 	}()
 
+	create := func() *cobra.Command {
+		var policyPath string
+		var creationRequest policy.CreationRequest
+
+		cmd := &cobra.Command{
+			Short: "create policy",
+			Use:   "create",
+			RunE: func(cmd *cobra.Command, args []string) error {
+				policyData, err := os.ReadFile(policyPath)
+				if err != nil {
+					return fmt.Errorf("failed to read policy file: %w", err)
+				}
+
+				creationRequest.Content = string(policyData)
+
+				client := policy.NewClient(*policyBaseURL, config)
+
+				result, err := client.CreatePolicy(*ownerID, creationRequest)
+				if err != nil {
+					return fmt.Errorf("failed to create policy: %w", err)
+				}
+
+				enc := json.NewEncoder(cmd.OutOrStdout())
+				enc.SetIndent("", "  ")
+
+				if err := enc.Encode(result); err != nil {
+					return fmt.Errorf("failed to encode result to stdout: %w", err)
+				}
+
+				return nil
+			},
+		}
+
+		cmd.Flags().StringVar(&creationRequest.Name, "name", "", "name of policy to create")
+		cmd.Flags().StringVar(&creationRequest.Context, "context", "config", "policy context")
+		cmd.Flags().StringVar(&policyPath, "policy", "", "path to rego policy file")
+
+		cmd.MarkFlagRequired("name")
+		cmd.MarkFlagRequired("policy")
+
+		return cmd
+	}()
+
+	get := func() *cobra.Command {
+		cmd := &cobra.Command{
+			Short: "Get a policy",
+			Use:   "get <policyID>",
+			RunE: func(cmd *cobra.Command, args []string) error {
+				policy, err := policy.NewClient(*policyBaseURL, config).GetPolicy(*ownerID, args[0])
+				if err != nil {
+					return fmt.Errorf("failed to get policy: %v", err)
+				}
+
+				enc := json.NewEncoder(cmd.OutOrStdout())
+				enc.SetIndent("", "  ")
+
+				if err := enc.Encode(policy); err != nil {
+					return fmt.Errorf("failed to output policy in json format: %v", err)
+				}
+
+				return nil
+			},
+			Args:    cobra.ExactArgs(1),
+			Example: `policy get 60b7e1a5-c1d7-4422-b813-7a12d353d7c6 --owner-id 516425b2-e369-421b-838d-920e1f51b0f5`,
+		}
+		return cmd
+	}()
+
 	cmd.AddCommand(list)
+	cmd.AddCommand(create)
+	cmd.AddCommand(get)
 
 	return cmd
 }

--- a/cmd/policy/policy.go
+++ b/cmd/policy/policy.go
@@ -59,7 +59,7 @@ func NewCommand(config *settings.Config, preRunE validator) *cobra.Command {
 				return nil
 			},
 			Args:    cobra.ExactArgs(0),
-			Example: `policy list --owner-id 516425b2-e369-421b-838d-920e1f51b0f5 --active true`,
+			Example: `policy list --owner-id 516425b2-e369-421b-838d-920e1f51b0f5 --active=true`,
 		}
 
 		cmd.Flags().BoolVar(&active, "active", false, "(OPTIONAL) filter policies based on active status (true or false)")
@@ -152,6 +152,77 @@ func NewCommand(config *settings.Config, preRunE validator) *cobra.Command {
 			Args:    cobra.ExactArgs(1),
 			Example: `policy delete 60b7e1a5-c1d7-4422-b813-7a12d353d7c6 --owner-id 516425b2-e369-421b-838d-920e1f51b0f5`,
 		}
+
+		return cmd
+	}()
+
+	update := func() *cobra.Command {
+		var policyPath string
+		var active bool
+		var context string
+		var name string
+		var updateRequest policy.UpdateRequest
+
+		cmd := &cobra.Command{
+			Short: "Update a policy",
+			Use:   "update <policyID>",
+			RunE: func(cmd *cobra.Command, args []string) error {
+
+				if !(cmd.Flag("policy").Changed ||
+					cmd.Flag("active").Changed ||
+					cmd.Flag("context").Changed ||
+					cmd.Flag("name").Changed) {
+					return fmt.Errorf("one of policy, active, context, or name must be set")
+				}
+
+				if cmd.Flag("policy").Changed {
+					policyData, err := os.ReadFile(policyPath)
+					if err != nil {
+						return fmt.Errorf("failed to read policy file: %w", err)
+					}
+
+					content := string(policyData)
+
+					updateRequest.Content = &content
+				}
+
+				client := policy.NewClient(*policyBaseURL, config)
+
+				if cmd.Flag("active").Changed {
+					updateRequest.Active = &active
+				}
+
+				if cmd.Flag("context").Changed {
+					updateRequest.Context = &context
+				}
+
+				if cmd.Flag("name").Changed {
+					updateRequest.Name = &name
+				}
+
+				result, err := client.UpdatePolicy(*ownerID, args[0], updateRequest)
+				if err != nil {
+					return fmt.Errorf("failed to update policy: %w", err)
+				}
+
+				enc := json.NewEncoder(cmd.OutOrStdout())
+				enc.SetIndent("", "  ")
+
+				if err := enc.Encode(result); err != nil {
+					return fmt.Errorf("failed to encode result to stdout: %w", err)
+				}
+
+				return nil
+			},
+			Args:    cobra.ExactArgs(1),
+			Example: `policy update e9e300d1-5bab-4704-b610-addbd6e03b0b --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --name policy_name --active --policy ./policy.rego`,
+		}
+
+		cmd.Flags().StringVar(&name, "name", "", "set name of the given policy-id")
+		cmd.Flags().StringVar(&context, "context", "", "policy context (if set, must be config)")
+		cmd.Flags().BoolVar(&active, "active", false, "set policy active state (to deactivate, use --active=false)")
+		cmd.Flags().StringVar(&policyPath, "policy", "", "path to rego file containing the updated policy")
+
 		return cmd
 	}()
 
@@ -159,6 +230,7 @@ func NewCommand(config *settings.Config, preRunE validator) *cobra.Command {
 	cmd.AddCommand(create)
 	cmd.AddCommand(get)
 	cmd.AddCommand(delete)
+	cmd.AddCommand(update)
 
 	return cmd
 }

--- a/cmd/policy/policy.go
+++ b/cmd/policy/policy.go
@@ -95,6 +95,8 @@ func NewCommand(config *settings.Config, preRunE validator) *cobra.Command {
 
 				return nil
 			},
+			Args:    cobra.ExactArgs(0),
+			Example: `policy create --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --name policy_name --policy ./policy.rego`,
 		}
 
 		cmd.Flags().StringVar(&creationRequest.Name, "name", "", "name of policy to create")

--- a/cmd/policy/policy.go
+++ b/cmd/policy/policy.go
@@ -13,8 +13,10 @@ import (
 	"github.com/CircleCI-Public/circleci-cli/settings"
 )
 
+// validator is a cobra command and args validator to be run as persisten PreRun for every policy command.
 type validator func(cmd *cobra.Command, args []string) error
 
+// NewCommand creates the root policy command with all policy subcommands attached.
 func NewCommand(config *settings.Config, preRunE validator) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "policy",

--- a/cmd/policy/policy_test.go
+++ b/cmd/policy/policy_test.go
@@ -1,0 +1,178 @@
+package policy
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+
+	"github.com/CircleCI-Public/circleci-cli/settings"
+)
+
+func Test_ListPolicies(t *testing.T) {
+	t.Run("without owner-id", func(t *testing.T) {
+		config := &settings.Config{Token: "testtoken", HTTPClient: http.DefaultClient}
+		cmd := NewCommand(config, nil)
+
+		stdout := new(bytes.Buffer)
+		stderr := new(bytes.Buffer)
+		cmd.SetOut(stdout)
+		cmd.SetErr(stderr)
+
+		cmd.SetArgs([]string{"list"})
+
+		assert.Error(t, cmd.Execute(), "required flag(s) \"owner-id\" not set")
+		assert.Assert(t, cmp.Contains(stdout.String(), "required flag(s) \"owner-id\" not set"))
+	})
+
+	t.Run("invalid active filter value", func(t *testing.T) {
+		config := &settings.Config{Token: "testtoken", HTTPClient: &http.Client{}}
+		cmd := NewCommand(config, nil)
+		stdout := new(bytes.Buffer)
+		stderr := new(bytes.Buffer)
+		cmd.SetOut(stdout)
+		cmd.SetErr(stderr)
+
+		cmd.SetArgs([]string{
+			"list",
+			"--owner-id", "ownerID",
+			"--active=badValue",
+		})
+
+		err := cmd.Execute()
+		assert.Error(t, err, "invalid argument \"badValue\" for \"--active\" flag: strconv.ParseBool: parsing \"badValue\": invalid syntax")
+		assert.Assert(t, cmp.Contains(stdout.String(), "invalid argument \"badValue\" for \"--active\" flag: strconv.ParseBool: parsing \"badValue\": invalid syntax"))
+	})
+
+	t.Run("gets forbidden error", func(t *testing.T) {
+		expectedResponse := `{"error": "Forbidden"}`
+
+		svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, r.URL.String(), "/api/v1/owner/ownerID/policy")
+			w.WriteHeader(http.StatusForbidden)
+			w.Write([]byte(expectedResponse))
+		}))
+		defer svr.Close()
+
+		config := &settings.Config{Token: "testtoken", HTTPClient: http.DefaultClient}
+		cmd := NewCommand(config, nil)
+		stdout := new(bytes.Buffer)
+		stderr := new(bytes.Buffer)
+		cmd.SetOut(stdout)
+		cmd.SetErr(stderr)
+
+		cmd.SetArgs([]string{
+			"list",
+			"--owner-id", "ownerID",
+			"--policy-base-url", svr.URL,
+		})
+
+		err := cmd.Execute()
+		assert.Error(t, err, "failed to list policies: unexpected status-code: 403 - Forbidden")
+		assert.Assert(t, cmp.Contains(stdout.String(), "failed to list policies: unexpected status-code: 403 - Forbidden"))
+	})
+
+	t.Run("should set active to true", func(t *testing.T) {
+		svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, r.URL.String(), "/api/v1/owner/ownerID/policy?active=true")
+			w.Write([]byte("[]"))
+		}))
+		defer svr.Close()
+
+		config := &settings.Config{Token: "testtoken", HTTPClient: http.DefaultClient}
+		cmd := NewCommand(config, nil)
+		stdout := new(bytes.Buffer)
+		stderr := new(bytes.Buffer)
+		cmd.SetOut(stdout)
+		cmd.SetErr(stderr)
+
+		cmd.SetArgs([]string{
+			"list",
+			"--owner-id", "ownerID",
+			"--policy-base-url", svr.URL,
+			"--active",
+		})
+
+		assert.NilError(t, cmd.Execute())
+	})
+
+	t.Run("should set active to false", func(t *testing.T) {
+		svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, r.URL.String(), "/api/v1/owner/ownerID/policy?active=false")
+			w.Write([]byte("[]"))
+		}))
+		defer svr.Close()
+
+		config := &settings.Config{Token: "testtoken", HTTPClient: http.DefaultClient}
+		cmd := NewCommand(config, nil)
+		stdout := new(bytes.Buffer)
+		stderr := new(bytes.Buffer)
+		cmd.SetOut(stdout)
+		cmd.SetErr(stderr)
+
+		cmd.SetArgs([]string{
+			"list",
+			"--owner-id", "ownerID",
+			"--policy-base-url", svr.URL,
+			"--active=false",
+		})
+
+		assert.NilError(t, cmd.Execute())
+	})
+
+	t.Run("successfully gets list of policies", func(t *testing.T) {
+		expectedResponse := `[
+			{
+				"id": "60b7e1a5-c1d7-4422-b813-7a12d353d7c6",
+				"name": "policy_1",
+				"owner_id": "462d67f8-b232-4da4-a7de-0c86dd667d3f",
+				"context": "config",
+				"active": false,
+				"created_at": "2022-05-31T14:15:10.86097Z",
+				"modified_at": null
+			},
+			{
+				"id": "a917a0ab-ceb6-482d-9a4e-f2f6b8bdfdcd",
+				"name": "policy_2",
+				"owner_id": "462d67f8-b232-4da4-a7de-0c86dd667d3f",
+				"context": "config",
+				"active": true,
+				"created_at": "2022-05-31T14:15:23.582383Z",
+				"modified_at": "2022-05-31T14:15:46.72321Z"
+			}
+		]`
+
+		var expectedValue interface{}
+		assert.NilError(t, json.Unmarshal([]byte(expectedResponse), &expectedValue))
+
+		svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(expectedResponse))
+		}))
+		defer svr.Close()
+
+		config := &settings.Config{Token: "testtoken", HTTPClient: &http.Client{}}
+		cmd := NewCommand(config, nil)
+		stdout := new(bytes.Buffer)
+		stderr := new(bytes.Buffer)
+		cmd.SetOut(stdout)
+		cmd.SetErr(stderr)
+
+		cmd.SetArgs([]string{
+			"list",
+			"--owner-id", "ownerID",
+			"--policy-base-url", svr.URL,
+		})
+
+		err := cmd.Execute()
+		assert.NilError(t, err)
+
+		var actualValue interface{}
+		assert.NilError(t, json.Unmarshal(stdout.Bytes(), &actualValue))
+
+		assert.DeepEqual(t, expectedValue, actualValue)
+	})
+}

--- a/cmd/policy/policy_test.go
+++ b/cmd/policy/policy_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/CircleCI-Public/circleci-cli/settings"
 )
 
-func Test_ListPolicies(t *testing.T) {
+func TestListPolicies(t *testing.T) {
 	t.Run("without owner-id", func(t *testing.T) {
 		config := &settings.Config{Token: "testtoken", HTTPClient: http.DefaultClient}
 		cmd := NewCommand(config, nil)
@@ -164,6 +164,144 @@ func Test_ListPolicies(t *testing.T) {
 		cmd.SetArgs([]string{
 			"list",
 			"--owner-id", "ownerID",
+			"--policy-base-url", svr.URL,
+		})
+
+		err := cmd.Execute()
+		assert.NilError(t, err)
+
+		var actualValue interface{}
+		assert.NilError(t, json.Unmarshal(stdout.Bytes(), &actualValue))
+
+		assert.DeepEqual(t, expectedValue, actualValue)
+	})
+}
+
+func TestGetPolicy(t *testing.T) {
+	t.Run("without policy-id", func(t *testing.T) {
+		config := &settings.Config{Token: "testtoken", HTTPClient: http.DefaultClient}
+		cmd := NewCommand(config, nil)
+
+		stdout := new(bytes.Buffer)
+		stderr := new(bytes.Buffer)
+		cmd.SetOut(stdout)
+		cmd.SetErr(stderr)
+
+		cmd.SetArgs([]string{
+			"get",
+			"--owner-id", "ownerID"})
+
+		assert.Error(t, cmd.Execute(), "accepts 1 arg(s), received 0")
+		assert.Assert(t, cmp.Contains(stdout.String(), "accepts 1 arg(s), received 0"))
+	})
+
+	t.Run("without org-id", func(t *testing.T) {
+		config := &settings.Config{Token: "testtoken", HTTPClient: http.DefaultClient}
+		cmd := NewCommand(config, nil)
+
+		stdout := new(bytes.Buffer)
+		stderr := new(bytes.Buffer)
+		cmd.SetOut(stdout)
+		cmd.SetErr(stderr)
+
+		cmd.SetArgs([]string{
+			"get",
+			"policyID"})
+
+		assert.Error(t, cmd.Execute(), "required flag(s) \"owner-id\" not set")
+		assert.Assert(t, cmp.Contains(stdout.String(), "required flag(s) \"owner-id\" not set"))
+	})
+
+	t.Run("gets forbidden error", func(t *testing.T) {
+		expectedResponse := `{"error": "Forbidden"}`
+
+		svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, r.URL.String(), "/api/v1/owner/ownerID/policy/policyID")
+			w.WriteHeader(http.StatusForbidden)
+			w.Write([]byte(expectedResponse))
+		}))
+		defer svr.Close()
+
+		config := &settings.Config{Token: "testtoken", HTTPClient: http.DefaultClient}
+		cmd := NewCommand(config, nil)
+		stdout := new(bytes.Buffer)
+		stderr := new(bytes.Buffer)
+		cmd.SetOut(stdout)
+		cmd.SetErr(stderr)
+
+		cmd.SetArgs([]string{
+			"get",
+			"policyID",
+			"--owner-id", "ownerID",
+			"--policy-base-url", svr.URL,
+		})
+
+		err := cmd.Execute()
+		assert.Error(t, err, "failed to get policy: unexpected status-code: 403 - Forbidden")
+		assert.Assert(t, cmp.Contains(stdout.String(), "failed to get policy: unexpected status-code: 403 - Forbidden"))
+	})
+
+	t.Run("gets not found", func(t *testing.T) {
+		expectedResponse := `{"error": "policy not found"}`
+
+		svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, r.URL.String(), "/api/v1/owner/ownerID/policy/policyID")
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte(expectedResponse))
+		}))
+		defer svr.Close()
+
+		config := &settings.Config{Token: "testtoken", HTTPClient: http.DefaultClient}
+		cmd := NewCommand(config, nil)
+		stdout := new(bytes.Buffer)
+		stderr := new(bytes.Buffer)
+		cmd.SetOut(stdout)
+		cmd.SetErr(stderr)
+
+		cmd.SetArgs([]string{
+			"get",
+			"policyID",
+			"--owner-id", "ownerID",
+			"--policy-base-url", svr.URL,
+		})
+
+		err := cmd.Execute()
+		assert.Error(t, err, "failed to get policy: unexpected status-code: 404 - policy not found")
+		assert.Assert(t, cmp.Contains(stdout.String(), "failed to get policy: unexpected status-code: 404 - policy not found"))
+	})
+
+	t.Run("successfully gets a policy", func(t *testing.T) {
+		expectedResponse := `{
+   			 "document_version": 1,
+   			 "id": "60b7e1a5-c1d7-4422-b813-7a12d353d7c6",
+   			 "name": "policy_1",
+   			 "owner_id": "462d67f8-b232-4da4-a7de-0c86dd667d3f",
+   			 "context": "config",
+   			 "content": "package test",
+   			 "active": false,
+   			 "created_at": "2022-05-31T14:15:10.86097Z",
+   			 "modified_at": null
+		}`
+
+		var expectedValue interface{}
+		assert.NilError(t, json.Unmarshal([]byte(expectedResponse), &expectedValue))
+
+		svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(expectedResponse))
+		}))
+		defer svr.Close()
+
+		config := &settings.Config{Token: "testtoken", HTTPClient: &http.Client{}}
+		cmd := NewCommand(config, nil)
+		stdout := new(bytes.Buffer)
+		stderr := new(bytes.Buffer)
+		cmd.SetOut(stdout)
+		cmd.SetErr(stderr)
+
+		cmd.SetArgs([]string{
+			"get",
+			"60b7e1a5-c1d7-4422-b813-7a12d353d7c6",
+			"--owner-id", "462d67f8-b232-4da4-a7de-0c86dd667d3f",
 			"--policy-base-url", svr.URL,
 		})
 

--- a/cmd/policy/testdata/policy-expected-usage.txt
+++ b/cmd/policy/testdata/policy-expected-usage.txt
@@ -3,6 +3,7 @@ Usage:
 
 Available Commands:
   create      create policy
+  delete      Delete a policy
   get         Get a policy
   list        List all policies
 

--- a/cmd/policy/testdata/policy-expected-usage.txt
+++ b/cmd/policy/testdata/policy-expected-usage.txt
@@ -1,0 +1,10 @@
+Usage:
+  policy [command]
+
+Available Commands:
+  list        List all policies
+
+Flags:
+      --policy-base-url string   base url for policy api (default "https://internal.circleci.com")
+
+Use "policy [command] --help" for more information about a command.

--- a/cmd/policy/testdata/policy-expected-usage.txt
+++ b/cmd/policy/testdata/policy-expected-usage.txt
@@ -2,9 +2,12 @@ Usage:
   policy [command]
 
 Available Commands:
+  create      create policy
+  get         Get a policy
   list        List all policies
 
 Flags:
+      --owner-id string          the id of the owner of a policy
       --policy-base-url string   base url for policy api (default "https://internal.circleci.com")
 
 Use "policy [command] --help" for more information about a command.

--- a/cmd/policy/testdata/policy-expected-usage.txt
+++ b/cmd/policy/testdata/policy-expected-usage.txt
@@ -6,6 +6,7 @@ Available Commands:
   delete      Delete a policy
   get         Get a policy
   list        List all policies
+  update      Update a policy
 
 Flags:
       --owner-id string          the id of the owner of a policy

--- a/cmd/policy/testdata/policy/create-expected-usage.txt
+++ b/cmd/policy/testdata/policy/create-expected-usage.txt
@@ -1,11 +1,10 @@
 Usage:
-  policy list [flags]
-
-Examples:
-policy list --owner-id 516425b2-e369-421b-838d-920e1f51b0f5 --active true
+  policy create [flags]
 
 Flags:
-      --active   (OPTIONAL) filter policies based on active status (true or false)
+      --context string   policy context (default "config")
+      --name string      name of policy to create
+      --policy string    path to rego policy file
 
 Global Flags:
       --owner-id string          the id of the owner of a policy

--- a/cmd/policy/testdata/policy/create-expected-usage.txt
+++ b/cmd/policy/testdata/policy/create-expected-usage.txt
@@ -1,6 +1,9 @@
 Usage:
   policy create [flags]
 
+Examples:
+policy create --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --name policy_name --policy ./policy.rego
+
 Flags:
       --context string   policy context (default "config")
       --name string      name of policy to create

--- a/cmd/policy/testdata/policy/delete-expected-usage.txt
+++ b/cmd/policy/testdata/policy/delete-expected-usage.txt
@@ -1,0 +1,9 @@
+Usage:
+  policy delete <policyID> [flags]
+
+Examples:
+policy delete 60b7e1a5-c1d7-4422-b813-7a12d353d7c6 --owner-id 516425b2-e369-421b-838d-920e1f51b0f5
+
+Global Flags:
+      --owner-id string          the id of the owner of a policy
+      --policy-base-url string   base url for policy api (default "https://internal.circleci.com")

--- a/cmd/policy/testdata/policy/get-expected-usage.txt
+++ b/cmd/policy/testdata/policy/get-expected-usage.txt
@@ -1,11 +1,8 @@
 Usage:
-  policy list [flags]
+  policy get <policyID> [flags]
 
 Examples:
-policy list --owner-id 516425b2-e369-421b-838d-920e1f51b0f5 --active true
-
-Flags:
-      --active   (OPTIONAL) filter policies based on active status (true or false)
+policy get 60b7e1a5-c1d7-4422-b813-7a12d353d7c6 --owner-id 516425b2-e369-421b-838d-920e1f51b0f5
 
 Global Flags:
       --owner-id string          the id of the owner of a policy

--- a/cmd/policy/testdata/policy/list-expected-usage.txt
+++ b/cmd/policy/testdata/policy/list-expected-usage.txt
@@ -1,0 +1,12 @@
+Usage:
+  policy list [flags]
+
+Examples:
+policy list --owner-id 516425b2-e369-421b-838d-920e1f51b0f5 --active true
+
+Flags:
+      --active            (OPTIONAL) filter policies based on active status (true or false)
+      --owner-id string   the id of the owner of a policy
+
+Global Flags:
+      --policy-base-url string   base url for policy api (default "https://internal.circleci.com")

--- a/cmd/policy/testdata/policy/list-expected-usage.txt
+++ b/cmd/policy/testdata/policy/list-expected-usage.txt
@@ -2,7 +2,7 @@ Usage:
   policy list [flags]
 
 Examples:
-policy list --owner-id 516425b2-e369-421b-838d-920e1f51b0f5 --active true
+policy list --owner-id 516425b2-e369-421b-838d-920e1f51b0f5 --active=true
 
 Flags:
       --active   (OPTIONAL) filter policies based on active status (true or false)

--- a/cmd/policy/testdata/policy/update-expected-usage.txt
+++ b/cmd/policy/testdata/policy/update-expected-usage.txt
@@ -1,0 +1,15 @@
+Usage:
+  policy update <policyID> [flags]
+
+Examples:
+policy update e9e300d1-5bab-4704-b610-addbd6e03b0b --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --name policy_name --active --policy ./policy.rego
+
+Flags:
+      --active           set policy active state (to deactivate, use --active=false)
+      --context string   policy context (if set, must be config)
+      --name string      set name of the given policy-id
+      --policy string    path to rego file containing the updated policy
+
+Global Flags:
+      --owner-id string          the id of the owner of a policy
+      --policy-base-url string   base url for policy api (default "https://internal.circleci.com")

--- a/cmd/policy/testdata/test.rego
+++ b/cmd/policy/testdata/test.rego
@@ -1,0 +1,1 @@
+package test

--- a/cmd/policy/usage_test.go
+++ b/cmd/policy/usage_test.go
@@ -1,0 +1,28 @@
+package policy
+
+import (
+	"fmt"
+	"testing"
+
+	"gotest.tools/v3/golden"
+
+	"github.com/spf13/cobra"
+
+	"github.com/CircleCI-Public/circleci-cli/settings"
+)
+
+func TestUsage(t *testing.T) {
+	preRunE := func(cmd *cobra.Command, args []string) error { return nil }
+	cmd := NewCommand(&settings.Config{}, preRunE)
+	testSubCommandUsage(t, cmd.Name(), cmd)
+}
+
+func testSubCommandUsage(t *testing.T, prefix string, parent *cobra.Command) {
+	t.Helper()
+	t.Run(parent.Name(), func(t *testing.T) {
+		golden.Assert(t, parent.UsageString(), fmt.Sprintf("%s-expected-usage.txt", prefix))
+		for _, cmd := range parent.Commands() {
+			testSubCommandUsage(t, fmt.Sprintf("%s/%s", prefix, cmd.Name()), cmd)
+		}
+	})
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/CircleCI-Public/circleci-cli/api/header"
+	"github.com/CircleCI-Public/circleci-cli/cmd/policy"
 	"github.com/CircleCI-Public/circleci-cli/cmd/runner"
 	"github.com/CircleCI-Public/circleci-cli/data"
 	"github.com/CircleCI-Public/circleci-cli/md_docs"
@@ -138,6 +139,7 @@ func MakeCommands() *cobra.Command {
 	rootCmd.AddCommand(newSetupCommand(rootOptions))
 
 	rootCmd.AddCommand(followProjectCommand(rootOptions))
+	rootCmd.AddCommand(policy.NewCommand(rootOptions, validator))
 
 	if isUpdateIncluded(version.PackageManager()) {
 		rootCmd.AddCommand(newUpdateCommand(rootOptions))

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -3,19 +3,20 @@ package cmd_test
 import (
 	"os/exec"
 
-	"github.com/CircleCI-Public/circleci-cli/clitest"
-	"github.com/CircleCI-Public/circleci-cli/cmd"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
 	"github.com/onsi/gomega/gexec"
+
+	"github.com/CircleCI-Public/circleci-cli/clitest"
+	"github.com/CircleCI-Public/circleci-cli/cmd"
 )
 
 var _ = Describe("Root", func() {
 	Describe("subcommands", func() {
 		It("can create commands", func() {
 			commands := cmd.MakeCommands()
-			Expect(len(commands.Commands())).To(Equal(20))
+			Expect(len(commands.Commands())).To(Equal(21))
 		})
 	})
 


### PR DESCRIPTION
# Checklist

=========

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)
- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/master/CONTRIBUTING.md).

## Changes

=======

- added new policy command at `cmd/policy/policy.go`
- added policy subcommands  `get, list, create, delete`
- added policy api at `api/policy/policy.go`
- added tests
- added policy command to root circle command
- added godocs to functions
- added .idea to .gitignore

## Rationale

The Seceng team is releasing a new Policy-Service and the first way for customers to interact wit the policy apis is via the circleci-cli. 

The CLI must be able to create, update, delete, view and so on, policies as needed.

Relevant motivations:
Epic: https://circleci.atlassian.net/browse/SECENG-270
Confluence: https://circleci.atlassian.net/wiki/spaces/SD/pages/6437569182/Policy+Enforcement+on+Configs+Feature+Brief

## Considerations

- Attempted to isolate seceng relevant code in `policy` subfolders: `cmd/policy` & `api/policy`
- Used a policy flag `policy-base-url` in the policy root command to specify policy-api instead of using `settings.Config.Host`