### PR TITLE
Increase http client timeout to 60s

### DIFF
--- a/settings/settings.go
+++ b/settings/settings.go
@@ -223,7 +223,7 @@ func (cfg *Config) WithHTTPClient() error {
 	}
 
 	cfg.HTTPClient = &http.Client{
-		Timeout: 30 * time.Second,
+		Timeout: 60 * time.Second,
 		Transport: &http.Transport{
 			ExpectContinueTimeout: 1 * time.Second,
 			IdleConnTimeout:       90 * time.Second,


### PR DESCRIPTION
# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have checked for similar issues and haven't found anything relevant.
- [ ] This is not a security issue (which should be reported here: https://circleci.com/security/)
- [ ] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/master/CONTRIBUTING.md).

## Changes

- Increase http client timeout to 60s

## Rationale

Should help with timeouts that have been seen in /api/v2/context/* 95th/max requests causing job flakiness for some users

## **Here are some helpful tips you can follow when submitting a pull request:**

1. Fork [the repository](https://github.com/CircleCI-Public/circleci-cli) and create your branch from `master`.
2. Run `make build` in the repository root.
3. If you've fixed a bug or added code that should be tested, add tests!
4. Ensure the test suite passes (`make test`).
5. The `--debug` flag is often helpful for debugging HTTP client requests and responses.
6. Format your code with [gofmt](https://golang.org/cmd/gofmt/).
7. Make sure your code lints (`make lint`). Note: This requires Docker to run inside a local job.
