### PR TITLE
update go.mod to declare go1.18 and updated CI to use Go 1.18 for tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ orbs:
 executors:
   go:
     docker:
-      - image: circleci/golang:1.17
+      - image: circleci/golang:1.18
     environment:
       CGO_ENABLED: 0
   mac:
@@ -27,7 +27,7 @@ commands:
           # https://app.circleci.com/jobs/github/CircleCI-Public/circleci-cli/6480
           #     curl: (92) HTTP/2 stream 0 was not closed cleanly: PROTOCOL_ERROR (err 1)
           # The issue seems to be on the server-side, so force HTTP 1.1
-          name: "cURL: Force HTTP 1.1"
+          name: 'cURL: Force HTTP 1.1'
           command: echo '--http1.1' >> ~/.curlrc
   build-docker-image:
     steps:
@@ -51,7 +51,7 @@ commands:
       - persist_to_workspace:
           root: .
           paths:
-            - "dist"
+            - 'dist'
       - store_artifacts:
           path: ./dist
           destination: dist
@@ -72,7 +72,7 @@ commands:
   gomod:
     steps:
       - restore_cache:
-          keys: ["v2-gomod-{{ arch }}-"]
+          keys: ['v2-gomod-{{ arch }}-']
       - run:
           name: Download go module dependencies
           command: go mod download
@@ -104,8 +104,8 @@ jobs:
     steps:
       - checkout
       - run: |
-          brew install go@1.13
-          echo 'export PATH="/usr/local/opt/go@1.13/bin:$PATH"' >> ~/.bash_profile
+          brew install go@1.18
+          echo 'export PATH="/usr/local/opt/go@1.18/bin:$PATH"' >> ~/.bash_profile
       - gomod
       - run: make test
   build:
@@ -117,7 +117,7 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-            - "build"
+            - 'build'
   cucumber:
     docker:
       - image: cimg/ruby:2.7
@@ -126,7 +126,7 @@ jobs:
       - attach_workspace:
           at: .
       - run:
-          name: "Install CLI tool from workspace"
+          name: 'Install CLI tool from workspace'
           command: sudo cp ~/project/build/linux/amd64/circleci /usr/local/bin/
       - run:
           command: bundle install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ orbs:
 executors:
   go:
     docker:
-      - image: circleci/golang:1.17
+      - image: cimg/go:1.18
     environment:
       CGO_ENABLED: 0
   mac:
@@ -105,8 +105,8 @@ jobs:
       - checkout
       - run: |
           brew update
-          brew install go@1.17
-          echo 'export PATH="/usr/local/opt/go@1.17/bin:$PATH"' >> ~/.bash_profile
+          brew install go@1.18
+          echo 'export PATH="/usr/local/opt/go@1.18/bin:$PATH"' >> ~/.bash_profile
       - gomod
       - run: make test
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,6 +104,7 @@ jobs:
     steps:
       - checkout
       - run: |
+          brew update
           brew install go@1.17
           echo 'export PATH="/usr/local/opt/go@1.17/bin:$PATH"' >> ~/.bash_profile
       - gomod

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ orbs:
 executors:
   go:
     docker:
-      - image: circleci/golang:1.18
+      - image: circleci/golang:1.17
     environment:
       CGO_ENABLED: 0
   mac:
@@ -104,8 +104,8 @@ jobs:
     steps:
       - checkout
       - run: |
-          brew install go@1.18
-          echo 'export PATH="/usr/local/opt/go@1.18/bin:$PATH"' >> ~/.bash_profile
+          brew install go@1.17
+          echo 'export PATH="/usr/local/opt/go@1.17/bin:$PATH"' >> ~/.bash_profile
       - gomod
       - run: make test
   build:

--- a/.circleci/install-lint.sh
+++ b/.circleci/install-lint.sh
@@ -10,6 +10,6 @@ function error() {
 
 trap error SIGINT
 
-curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.35.2
+curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.46.2
 
 command -v ./bin/golangci-lint

--- a/cmd/orb_import_test.go
+++ b/cmd/orb_import_test.go
@@ -680,7 +680,7 @@ The following orb versions already exist:
 `
 			actual, err := ioutil.ReadAll(&b)
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(fmt.Sprintf("%s", actual)).To(Equal(expOutput))
+			Expect(string(actual)).To(Equal(expOutput))
 		})
 	})
 

--- a/go.mod
+++ b/go.mod
@@ -64,4 +64,4 @@ require (
 // fix vulnerability: CVE-2020-15114 in etcd v3.3.10+incompatible
 replace github.com/coreos/etcd => github.com/coreos/etcd v3.3.24+incompatible
 
-go 1.17
+go 1.18


### PR DESCRIPTION
# Checklist

=========

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)
- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/master/CONTRIBUTING.md).

## Changes

- declare go 1.18 in go.mod
- update CI to use go.18 executor and update test_mac to test using go1.18

## Rationale

Some dependencies require go 1.17 and greater. Because we were running CI with versions using go1.13 we were unable to use dependencies that required features from versions newer than 1.13. 

Since go1.18 is latest version and go is backwards compatible we choose this new version for our update.