### PR TITLE
EXT-282-follow-project

### DIFF
--- a/cmd/follow.go
+++ b/cmd/follow.go
@@ -25,7 +25,7 @@ func followProject(opts options) error {
 	//check that project url contains github or bitbucket; our legacy vcs
 	if remote.VcsType == git.GitHub || remote.VcsType == git.Bitbucket {
 		vcsShort := "gh"
-		if remote.VcsType == "BITBUCKET" {
+		if remote.VcsType == git.Bitbucket {
 			vcsShort = "bb"
 		}
 		res, err := api.FollowProject(*opts.cfg, vcsShort, remote.Organization, remote.Project)
@@ -38,8 +38,10 @@ func followProject(opts options) error {
 			fmt.Println("Unable to determine project slug for CircleCI (slug is case sensitive).")
 		}
 
+	} else {
+		//if not warn user their vcs is not supported
+		return errors.New(errorMessage)
 	}
-	//if not warn user their vcs is not supported
 	return errors.New(errorMessage)
 }
 

--- a/cmd/follow.go
+++ b/cmd/follow.go
@@ -42,7 +42,7 @@ func followProject(opts options) error {
 		//if not warn user their vcs is not supported
 		return errors.New(errorMessage)
 	}
-	return errors.New(errorMessage)
+	return nil
 }
 
 //followProjectCommand follow cobra command creation

--- a/cmd/follow.go
+++ b/cmd/follow.go
@@ -14,31 +14,36 @@ type options struct {
 	cfg *settings.Config
 }
 
+//followProject gets the remote data and attempts to follow its git project
 func followProject(opts options) error {
 
 	remote, err := git.InferProjectFromGitRemotes()
-
 	if err != nil {
 		return errors.Wrap(err, errorMessage)
 	}
 
-	vcsShort := "gh"
-	if remote.VcsType == "BITBUCKET" {
-		vcsShort = "bb"
-	}
-	res, err := api.FollowProject(*opts.cfg, vcsShort, remote.Organization, remote.Project)
-	if err != nil {
-		return err
-	}
-	if res.Followed {
-		fmt.Println("Project successfully followed!")
-	} else if res.Message == "Project not found" {
-		fmt.Println("Unable to determine project slug for CircleCI (slug is case sensitive).")
-	}
+	//check that project url contains github or bitbucket; our legacy vcs
+	if remote.VcsType == git.GitHub || remote.VcsType == git.Bitbucket {
+		vcsShort := "gh"
+		if remote.VcsType == "BITBUCKET" {
+			vcsShort = "bb"
+		}
+		res, err := api.FollowProject(*opts.cfg, vcsShort, remote.Organization, remote.Project)
+		if err != nil {
+			return err
+		}
+		if res.Followed {
+			fmt.Println("Project successfully followed!")
+		} else if res.Message == "Project not found" {
+			fmt.Println("Unable to determine project slug for CircleCI (slug is case sensitive).")
+		}
 
-	return nil
+	}
+	//if not warn user their vcs is not supported
+	return errors.New(errorMessage)
 }
 
+//followProjectCommand follow cobra command creation
 func followProjectCommand(config *settings.Config) *cobra.Command {
 	opts := options{
 		cfg: config,


### PR DESCRIPTION
# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)
- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/master/CONTRIBUTING.md).

## Changes
Added a warning in the error for Follow command that only Github and Bitbucket are supported at this time
Further commenting and formatting on the follow.go file

## Rationale
We are no longer supporting the 'follow' command going forward, but we do not wish to remove the legacy functionality

## Screenshots
<img width="905" alt="image" src="https://user-images.githubusercontent.com/25936094/177166194-d3e50860-9792-4f4f-9620-46fa6fa94088.png">
