### PR TITLE
[SECENG-669] Remove 'active' attribute for policies

### DIFF
--- a/api/policy/policy.go
+++ b/api/policy/policy.go
@@ -30,20 +30,12 @@ type httpError struct {
 	Context map[string]interface{} `json:"context,omitempty"`
 }
 
-// ListPolicies calls the view policy-service list policy API. If the active filter is nil, all policies are returned. If
-// activeFilter is not nil it will only return active or inactive policies based on the value of *activeFilter.
-func (c Client) ListPolicies(ownerID string, activeFilter *bool) (interface{}, error) {
+// ListPolicies calls the view policy-service list policy API
+func (c Client) ListPolicies(ownerID string) (interface{}, error) {
 	req, err := http.NewRequest("GET", fmt.Sprintf("%s/api/v1/owner/%s/policy", c.serverUrl, ownerID), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to construct request: %v", err)
 	}
-
-	query := make(url.Values)
-	if activeFilter != nil {
-		query.Set("active", fmt.Sprint(*activeFilter))
-	}
-
-	req.URL.RawQuery = query.Encode()
 
 	resp, err := c.client.Do(req)
 	if err != nil {
@@ -117,7 +109,6 @@ type UpdateRequest struct {
 	Name    *string `json:"name,omitempty"`
 	Context *string `json:"context,omitempty"`
 	Content *string `json:"content,omitempty"`
-	Active  *bool   `json:"active,omitempty"`
 }
 
 // UpdatePolicy calls the UPDATE policy API in the policy-service. It updates a policy in the policy-service matching the given owner-id and policy-id.

--- a/api/policy/policy.go
+++ b/api/policy/policy.go
@@ -46,7 +46,7 @@ func (c Client) ListPolicies(ownerID string) (interface{}, error) {
 	if resp.StatusCode != http.StatusOK {
 		var payload httpError
 		if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
-			return nil, fmt.Errorf("unexected status-code: %d", resp.StatusCode)
+			return nil, fmt.Errorf("unexpected status-code: %d", resp.StatusCode)
 		}
 		return nil, fmt.Errorf("unexpected status-code: %d - %s", resp.StatusCode, payload.Error)
 	}
@@ -168,7 +168,7 @@ func (c Client) GetPolicy(ownerID string, policyID string) (interface{}, error) 
 	if resp.StatusCode != http.StatusOK {
 		var payload httpError
 		if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
-			return nil, fmt.Errorf("unexected status-code: %d", resp.StatusCode)
+			return nil, fmt.Errorf("unexpected status-code: %d", resp.StatusCode)
 		}
 		return nil, fmt.Errorf("unexpected status-code: %d - %s", resp.StatusCode, payload.Error)
 	}
@@ -199,7 +199,7 @@ func (c Client) DeletePolicy(ownerID string, policyID string) error {
 	if resp.StatusCode != http.StatusNoContent {
 		var payload httpError
 		if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
-			return fmt.Errorf("unexected status-code: %d", resp.StatusCode)
+			return fmt.Errorf("unexpected status-code: %d", resp.StatusCode)
 		}
 		return fmt.Errorf("unexpected status-code: %d - %s", resp.StatusCode, payload.Error)
 	}
@@ -251,7 +251,7 @@ func (c Client) GetDecisionLogs(ownerID string, request DecisionQueryRequest) ([
 	if resp.StatusCode != http.StatusOK {
 		var payload httpError
 		if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
-			return nil, fmt.Errorf("unexected status-code: %d", resp.StatusCode)
+			return nil, fmt.Errorf("unexpected status-code: %d", resp.StatusCode)
 		}
 		return nil, fmt.Errorf("unexpected status-code: %d - %s", resp.StatusCode, payload.Error)
 	}

--- a/api/policy/policy_test.go
+++ b/api/policy/policy_test.go
@@ -57,6 +57,23 @@ func TestClientListPolicies(t *testing.T) {
 		assert.Error(t, err, "unexpected status-code: 403 - Forbidden")
 	})
 
+	t.Run("List Policies - Bad error json", func(t *testing.T) {
+		expectedResponse := `{"this is bad json": }`
+		svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+			_, err := w.Write([]byte(expectedResponse))
+			assert.NilError(t, err)
+		}))
+		defer svr.Close()
+
+		config := &settings.Config{Token: "testtoken", HTTPClient: &http.Client{}}
+		client := NewClient(svr.URL, config)
+
+		policies, err := client.ListPolicies("ownerId")
+		assert.Equal(t, policies, nil)
+		assert.Error(t, err, "unexpected status-code: 403")
+	})
+
 	t.Run("List Policies - no policies", func(t *testing.T) {
 		expectedResponse := "[]"
 

--- a/api/policy/policy_test.go
+++ b/api/policy/policy_test.go
@@ -36,26 +36,8 @@ func TestClientListPolicies(t *testing.T) {
 		config := &settings.Config{Token: "testtoken", HTTPClient: &http.Client{}}
 		client := NewClient(svr.URL, config)
 
-		_, err := client.ListPolicies("ownerId", nil)
+		_, err := client.ListPolicies("ownerId")
 		assert.NilError(t, err)
-	})
-
-	t.Run("List Policies - Bad Request", func(t *testing.T) {
-		expectedResponse := `{"error": "active: query string not a boolean."}`
-
-		svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusBadRequest)
-			_, err := w.Write([]byte(expectedResponse))
-			assert.NilError(t, err)
-		}))
-		defer svr.Close()
-
-		config := &settings.Config{Token: "testtoken", HTTPClient: &http.Client{}}
-		client := NewClient(svr.URL, config)
-
-		policies, err := client.ListPolicies("ownerId", nil)
-		assert.Equal(t, policies, nil)
-		assert.Error(t, err, "unexpected status-code: 400 - active: query string not a boolean.")
 	})
 
 	t.Run("List Policies - Forbidden", func(t *testing.T) {
@@ -70,7 +52,7 @@ func TestClientListPolicies(t *testing.T) {
 		config := &settings.Config{Token: "testtoken", HTTPClient: &http.Client{}}
 		client := NewClient(svr.URL, config)
 
-		policies, err := client.ListPolicies("ownerId", nil)
+		policies, err := client.ListPolicies("ownerId")
 		assert.Equal(t, policies, nil)
 		assert.Error(t, err, "unexpected status-code: 403 - Forbidden")
 	})
@@ -90,7 +72,7 @@ func TestClientListPolicies(t *testing.T) {
 		config := &settings.Config{Token: "testtoken", HTTPClient: &http.Client{}}
 		client := NewClient(svr.URL, config)
 
-		policies, err := client.ListPolicies("ownerId", nil)
+		policies, err := client.ListPolicies("ownerId")
 		assert.DeepEqual(t, policies, expectedResponseValue)
 		assert.NilError(t, err)
 	})
@@ -102,7 +84,6 @@ func TestClientListPolicies(t *testing.T) {
 				"name": "policy_1",
 				"owner_id": "462d67f8-b232-4da4-a7de-0c86dd667d3f",
 				"context": "config",
-				"active": false,
 				"created_at": "2022-05-31T14:15:10.86097Z",
 				"modified_at": null
 			},
@@ -111,7 +92,6 @@ func TestClientListPolicies(t *testing.T) {
 				"name": "policy_2",
 				"owner_id": "462d67f8-b232-4da4-a7de-0c86dd667d3f",
 				"context": "config",
-				"active": true,
 				"created_at": "2022-05-31T14:15:23.582383Z",
 				"modified_at": "2022-05-31T14:15:46.72321Z"
 			}
@@ -129,7 +109,7 @@ func TestClientListPolicies(t *testing.T) {
 		config := &settings.Config{Token: "testtoken", HTTPClient: &http.Client{}}
 		client := NewClient(svr.URL, config)
 
-		policies, err := client.ListPolicies("ownerId", nil)
+		policies, err := client.ListPolicies("ownerId")
 		assert.DeepEqual(t, policies, expectedResponseValue)
 		assert.NilError(t, err)
 	})
@@ -220,7 +200,6 @@ func TestClientGetPolicy(t *testing.T) {
    			 "owner_id": "462d67f8-b232-4da4-a7de-0c86dd667d3f",
    			 "context": "config",
    			 "content": "package test",
-   			 "active": false,
    			 "created_at": "2022-05-31T14:15:10.86097Z",
    			 "modified_at": null
 		}`
@@ -383,7 +362,6 @@ func TestClientDeletePolicy(t *testing.T) {
 
 func TestClientUpdatePolicy(t *testing.T) {
 	t.Run("expected request", func(t *testing.T) {
-		isActive := true
 		name := "test-name"
 		context := "config"
 		content := "test-content"
@@ -391,45 +369,6 @@ func TestClientUpdatePolicy(t *testing.T) {
 			Name:    &name,
 			Context: &context,
 			Content: &content,
-			Active:  &isActive,
-		}
-
-		svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			assert.Equal(t, r.Header.Get("circle-token"), "testtoken")
-			assert.Equal(t, r.Header.Get("accept"), "application/json")
-			assert.Equal(t, r.Header.Get("content-type"), "application/json")
-			assert.Equal(t, r.Header.Get("user-agent"), version.UserAgent())
-			assert.Equal(t, r.Header.Get("circle-token"), "testtoken")
-
-			assert.Equal(t, r.Method, "PATCH")
-			assert.Equal(t, r.URL.Path, "/api/v1/owner/ownerID/policy/policyID")
-
-			var actual UpdateRequest
-			assert.NilError(t, json.NewDecoder(r.Body).Decode(&actual))
-			assert.DeepEqual(t, actual, req)
-
-			w.WriteHeader(http.StatusOK)
-			_, err := w.Write([]byte("{}"))
-			assert.NilError(t, err)
-		}))
-		defer svr.Close()
-
-		config := &settings.Config{Token: "testtoken", HTTPClient: http.DefaultClient}
-		client := NewClient(svr.URL, config)
-
-		_, err := client.UpdatePolicy("ownerID", "policyID", req)
-		assert.NilError(t, err)
-	})
-
-	t.Run("nil active", func(t *testing.T) {
-		name := "test-name"
-		context := "config"
-		content := "test-content"
-		req := UpdateRequest{
-			Name:    &name,
-			Context: &context,
-			Content: &content,
-			Active:  nil,
 		}
 
 		svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -492,7 +431,7 @@ func TestClientUpdatePolicy(t *testing.T) {
 			assert.NilError(t, json.NewDecoder(r.Body).Decode(&actual))
 			assert.DeepEqual(t, actual, req)
 
-			expectedResponse := `{"error": "at least one of name, context, content, or active cannot be blank"}`
+			expectedResponse := `{"error": "at least one of name, context, or content, cannot be blank"}`
 			w.WriteHeader(http.StatusBadRequest)
 			_, err := w.Write([]byte(expectedResponse))
 			assert.NilError(t, err)
@@ -503,7 +442,7 @@ func TestClientUpdatePolicy(t *testing.T) {
 		client := NewClient(svr.URL, config)
 
 		_, err := client.UpdatePolicy("ownerID", "policyID", req)
-		assert.Error(t, err, "unexpected status-code: 400 - at least one of name, context, content, or active cannot be blank")
+		assert.Error(t, err, "unexpected status-code: 400 - at least one of name, context, or content, cannot be blank")
 	})
 
 	t.Run("one change", func(t *testing.T) {

--- a/cmd/policy/policy_test.go
+++ b/cmd/policy/policy_test.go
@@ -122,6 +122,11 @@ func TestCreatePolicy(t *testing.T) {
 			ExpectedErr: "required flag(s) \"name\", \"owner-id\", \"policy\" not set",
 		},
 		{
+			Name:        "fails for policy file not found",
+			Args:        []string{"create", "--owner-id", "test-org", "--name", "test-policy", "--policy", "./testdata/file_not_present.rego"},
+			ExpectedErr: "failed to read policy file: open ./testdata/file_not_present.rego: ",
+		},
+		{
 			Name: "sends appropriate desired request",
 			Args: []string{"create", "--owner-id", "test-org", "--name", "test-policy", "--policy", "./testdata/test.rego"},
 			ServerHandler: func(w http.ResponseWriter, r *http.Request) {
@@ -160,7 +165,7 @@ func TestCreatePolicy(t *testing.T) {
 			if tc.ExpectedErr == "" {
 				assert.NilError(t, err)
 			} else {
-				assert.Error(t, err, tc.ExpectedErr)
+				assert.ErrorContains(t, err, tc.ExpectedErr)
 				return
 			}
 
@@ -358,7 +363,7 @@ func TestUpdatePolicy(t *testing.T) {
 		{
 			Name:        "fails if policy file not found",
 			Args:        []string{"update", "test-policy-id", "--owner-id", "test-org", "--policy", "./testdata/file_not_present.rego"},
-			ExpectedErr: "failed to read policy file: open ./testdata/file_not_present.rego: no such file or directory",
+			ExpectedErr: "failed to read policy file: open ./testdata/file_not_present.rego: ",
 		},
 		{
 			Name: "gets error response",
@@ -491,7 +496,7 @@ func TestUpdatePolicy(t *testing.T) {
 			if tc.ExpectedErr == "" {
 				assert.NilError(t, err)
 			} else {
-				assert.Error(t, err, tc.ExpectedErr)
+				assert.ErrorContains(t, err, tc.ExpectedErr)
 				return
 			}
 
@@ -517,6 +522,11 @@ func TestGetDecisionLogs(t *testing.T) {
 			Name:        "invalid --after filter value",
 			Args:        []string{"logs", "--owner-id", "ownerID", "--after", "1/2/2022"},
 			ExpectedErr: `error in parsing --after value: This date has ambiguous mm/dd vs dd/mm type format`,
+		},
+		{
+			Name:        "invalid --before filter value",
+			Args:        []string{"logs", "--owner-id", "ownerID", "--before", "1/2/2022"},
+			ExpectedErr: `error in parsing --before value: This date has ambiguous mm/dd vs dd/mm type format`,
 		},
 		{
 			Name: "no filter is set",

--- a/cmd/policy/testdata/policy/list-expected-usage.txt
+++ b/cmd/policy/testdata/policy/list-expected-usage.txt
@@ -2,10 +2,7 @@ Usage:
   policy list [flags]
 
 Examples:
-policy list --owner-id 516425b2-e369-421b-838d-920e1f51b0f5 --active=true
-
-Flags:
-      --active   (OPTIONAL) filter policies based on active status (true or false)
+policy list --owner-id 516425b2-e369-421b-838d-920e1f51b0f5
 
 Global Flags:
       --owner-id string          the id of the policy's owner

--- a/cmd/policy/testdata/policy/update-expected-usage.txt
+++ b/cmd/policy/testdata/policy/update-expected-usage.txt
@@ -2,10 +2,9 @@ Usage:
   policy update <policyID> [flags]
 
 Examples:
-policy update e9e300d1-5bab-4704-b610-addbd6e03b0b --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --name policy_name --active --policy ./policy.rego
+policy update e9e300d1-5bab-4704-b610-addbd6e03b0b --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --name policy_name --policy ./policy.rego
 
 Flags:
-      --active           set policy active state (to deactivate, use --active=false)
       --context string   policy context (if set, must be config)
       --name string      set name of the given policy-id
       --policy string    path to rego file containing the updated policy


### PR DESCRIPTION
# Checklist

=========

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)
- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/master/CONTRIBUTING.md).

## Changes

=======

- Remove 'active' attribute for policies in source (both cmd/api)
- Updated unit-tests
- Updated expected-data.txt (golden tests data)

## Rationale

=========
This is in continuation to https://github.com/circleci/policy-service/pull/146

