### PR TITLE
[SECENG-676] added 'status' filter to decision logs fetch command

### DIFF
--- a/api/policy/policy.go
+++ b/api/policy/policy.go
@@ -208,6 +208,7 @@ func (c Client) DeletePolicy(ownerID string, policyID string) error {
 }
 
 type DecisionQueryRequest struct {
+	Status    string
 	After     *time.Time
 	Before    *time.Time
 	Branch    string
@@ -224,6 +225,9 @@ func (c Client) GetDecisionLogs(ownerID string, request DecisionQueryRequest) ([
 	}
 
 	query := make(url.Values)
+	if request.Status != "" {
+		query.Set("status", fmt.Sprint(request.Status))
+	}
 	if request.After != nil {
 		query.Set("after", request.After.Format(time.RFC3339))
 	}

--- a/api/policy/policy_test.go
+++ b/api/policy/policy_test.go
@@ -562,7 +562,7 @@ func TestClientGetDecisionLogs(t *testing.T) {
 			assert.Equal(
 				t,
 				r.URL.RawQuery,
-				"after=2000-01-01T00%3A00%3A00Z&before=2000-01-01T00%3A00%3A00Z&branch=branchValue&offset=42&project_id=projectIDValue",
+				"after=2000-01-01T00%3A00%3A00Z&before=2000-01-01T00%3A00%3A00Z&branch=branchValue&offset=42&project_id=projectIDValue&status=PASS",
 			)
 
 			assert.Equal(t, r.URL.Query().Get("before"), testTime.Format(time.RFC3339))
@@ -578,6 +578,7 @@ func TestClientGetDecisionLogs(t *testing.T) {
 		client := NewClient(svr.URL, config)
 
 		_, err := client.GetDecisionLogs("ownerId", DecisionQueryRequest{
+			Status:    "PASS",
 			After:     &testTime,
 			Before:    &testTime,
 			Branch:    "branchValue",

--- a/cmd/policy/policy.go
+++ b/cmd/policy/policy.go
@@ -284,6 +284,7 @@ func NewCommand(config *settings.Config, preRunE validator) *cobra.Command {
 			Example: `policy logs  --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --after 2022/03/14 --out output.json`,
 		}
 
+		cmd.Flags().StringVar(&request.Status, "status", "", "filter decision logs based on their status")
 		cmd.Flags().StringVar(&after, "after", "", "filter decision logs triggered AFTER this datetime")
 		cmd.Flags().StringVar(&before, "before", "", "filter decision logs triggered BEFORE this datetime")
 		cmd.Flags().StringVar(&request.Branch, "branch", "", "filter decision logs based on branch name")

--- a/cmd/policy/policy_test.go
+++ b/cmd/policy/policy_test.go
@@ -542,12 +542,12 @@ func TestGetDecisionLogs(t *testing.T) {
 		{
 			Name: "all filters are set",
 			Args: []string{
-				"logs", "--owner-id", "ownerID", "--after", "2022/03/14", "--before", "2022/03/15",
+				"logs", "--owner-id", "ownerID", "--status", "PASS", "--after", "2022/03/14", "--before", "2022/03/15",
 				"--branch", "branchValue", "--project-id", "projectIDValue",
 			},
 			ServerHandler: func(w http.ResponseWriter, r *http.Request) {
 				assert.Equal(t, r.Method, "GET")
-				assert.Equal(t, r.URL.String(), "/api/v1/owner/ownerID/decision?after=2022-03-14T00%3A00%3A00Z&before=2022-03-15T00%3A00%3A00Z&branch=branchValue&project_id=projectIDValue")
+				assert.Equal(t, r.URL.String(), "/api/v1/owner/ownerID/decision?after=2022-03-14T00%3A00%3A00Z&before=2022-03-15T00%3A00%3A00Z&branch=branchValue&project_id=projectIDValue&status=PASS")
 				_, err := w.Write([]byte("[]"))
 				assert.NilError(t, err)
 			},

--- a/cmd/policy/testdata/policy/logs-expected-usage.txt
+++ b/cmd/policy/testdata/policy/logs-expected-usage.txt
@@ -10,6 +10,7 @@ Flags:
       --branch string       filter decision logs based on branch name
       --out string          specify output file name 
       --project-id string   filter decision logs based on project-id
+      --status string       filter decision logs based on their status
 
 Global Flags:
       --owner-id string          the id of the policy's owner


### PR DESCRIPTION
# Checklist

=========

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)
- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/master/CONTRIBUTING.md).

## Changes

=======

- added 'status' filter to decision logs fetch command
- updated unit-tests
- updated usage tests golden data

## Rationale

=========

This is in continuation to: https://github.com/circleci/policy-service/pull/147