### PR TITLE
fix pandoc installation on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,7 +162,11 @@ jobs:
     executor: go
     steps:
       - checkout
-      - run: sudo apt-get install pandoc
+      - run:
+          name: Install pandoc
+          command: |
+            sudo apt-get update
+            sudo apt-get install pandoc
       - gomod
       - run: go run main.go usage
       - store_artifacts:


### PR DESCRIPTION
`pandoc` installation in the `docs` CI job have been failing because of:
```bash
#!/bin/bash -eo pipefail
sudo apt-get install pandoc
Reading package lists... Done
Building dependency tree       
Reading state information... Done
E: Unable to locate package pandoc

Exited with code exit status 100
```

I tested this locally on a `cimg/go:1.18` container. Running `sudo apt-get update` prior to installing the `pandoc `package did indeed fix the installation.

## Changes

=======

- fix failing `pandoc` installation on CI build which was causing the "Docs" job to continuously fail for quite some time