### PR TITLE
[EXT-307] Use SkipInsecureVerify to HTTP call used by runner command

### DIFF
--- a/api/rest/client.go
+++ b/api/rest/client.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/CircleCI-Public/circleci-cli/api/header"
+	"github.com/CircleCI-Public/circleci-cli/settings"
 	"github.com/CircleCI-Public/circleci-cli/version"
 )
 
@@ -21,19 +22,22 @@ type Client struct {
 	client      *http.Client
 }
 
-func New(host, endpoint, circleToken string) *Client {
+func New(host string, config *settings.Config) *Client {
 	// Ensure endpoint ends with a slash
+	endpoint := config.RestEndpoint
 	if !strings.HasSuffix(endpoint, "/") {
 		endpoint += "/"
 	}
 
 	u, _ := url.Parse(host)
+
+	client := config.HTTPClient
+	client.Timeout = 10 * time.Second
+
 	return &Client{
 		baseURL:     u.ResolveReference(&url.URL{Path: endpoint}),
-		circleToken: circleToken,
-		client: &http.Client{
-			Timeout: 10 * time.Second,
-		},
+		circleToken: config.Token,
+		client:      client,
 	}
 }
 

--- a/api/rest/client_test.go
+++ b/api/rest/client_test.go
@@ -12,6 +12,7 @@ import (
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/assert/cmp"
 
+	"github.com/CircleCI-Public/circleci-cli/settings"
 	"github.com/CircleCI-Public/circleci-cli/version"
 )
 
@@ -167,5 +168,13 @@ func (f *fixture) Run(statusCode int, respBody string) (c *Client, cleanup func(
 	})
 	server := httptest.NewServer(mux)
 
-	return New(server.URL, "api/v2", "fake-token"), server.Close
+	cfg := &settings.Config{
+		Debug:        false,
+		Token:        "fake-token",
+		RestEndpoint: "api/v2",
+		Endpoint:     "api/v2",
+		HTTPClient:   http.DefaultClient,
+	}
+
+	return New(server.URL, cfg), server.Close
 }

--- a/api/runner/runner_test.go
+++ b/api/runner/runner_test.go
@@ -14,6 +14,7 @@ import (
 	"gotest.tools/v3/assert/cmp"
 
 	"github.com/CircleCI-Public/circleci-cli/api/rest"
+	"github.com/CircleCI-Public/circleci-cli/settings"
 	"github.com/CircleCI-Public/circleci-cli/version"
 )
 
@@ -489,5 +490,13 @@ func (f *fixture) Run(statusCode int, respBody string) (r *Runner, cleanup func(
 	})
 	server := httptest.NewServer(mux)
 
-	return New(rest.New(server.URL, "api/v2", "fake-token")), server.Close
+	cfg := &settings.Config{
+		Debug:        false,
+		Token:        "fake-token",
+		RestEndpoint: "api/v2",
+		Endpoint:     "api/v2",
+		HTTPClient:   http.DefaultClient,
+	}
+
+	return New(rest.New(server.URL, cfg)), server.Close
 }

--- a/cmd/runner/runner.go
+++ b/cmd/runner/runner.go
@@ -27,7 +27,7 @@ func NewCommand(config *settings.Config, preRunE validator.Validator) *cobra.Com
 			} else {
 				host = config.Host
 			}
-			opts.r = runner.New(rest.New(host, config.RestEndpoint, config.Token))
+			opts.r = runner.New(rest.New(host, config))
 		},
 	}
 


### PR DESCRIPTION
[EXT-307](https://circleci.atlassian.net/browse/EXT-307)

# Checklist

=========

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)
- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/master/CONTRIBUTING.md).

## Changes


- Use SkipInsecureVerify to HTTP call used by runner command to fix bug when CLI is run with insecure / custom certifications

## Rationale


We would like users to be able to run the CLI behind proxies and other environments that may be using custom certs

## Considerations



I am passing config as a whole since the helper function is now using more than just 2 strings. Unit tests were updated to match new function signature.


## **Here are some helpful tips you can follow when submitting a pull request:**

1. Fork [the repository](https://github.com/CircleCI-Public/circleci-cli) and create your branch from `master`.
2. Run `make build` in the repository root.
3. If you've fixed a bug or added code that should be tested, add tests!
4. Ensure the test suite passes (`make test`).
5. The `--debug` flag is often helpful for debugging HTTP client requests and responses.
6. Format your code with [gofmt](https://golang.org/cmd/gofmt/).
7. Make sure your code lints (`make lint`). Note: This requires Docker to run inside a local job.
