### PR TITLE
[SECENG-685] Add human-friendly outputs for policy commands

### DIFF
--- a/cmd/policy/policy.go
+++ b/cmd/policy/policy.go
@@ -78,6 +78,8 @@ func NewCommand(config *settings.Config, preRunE validator.Validator) *cobra.Com
 					return fmt.Errorf("failed to create policy: %w", err)
 				}
 
+				_, _ = io.WriteString(cmd.ErrOrStderr(), "Policy Created Successfully\n")
+
 				if err := prettyJSONEncoder(cmd.OutOrStdout()).Encode(result); err != nil {
 					return fmt.Errorf("failed to encode result to stdout: %w", err)
 				}
@@ -129,7 +131,7 @@ func NewCommand(config *settings.Config, preRunE validator.Validator) *cobra.Com
 				if err != nil {
 					return fmt.Errorf("failed to delete policy: %v", err)
 				}
-				_, _ = io.WriteString(cmd.OutOrStdout(), "Deleted Successfully\n")
+				_, _ = io.WriteString(cmd.ErrOrStderr(), "Policy Deleted Successfully\n")
 				return nil
 			},
 			Args:    cobra.ExactArgs(1),
@@ -169,6 +171,8 @@ func NewCommand(config *settings.Config, preRunE validator.Validator) *cobra.Com
 				if err != nil {
 					return fmt.Errorf("failed to update policy: %w", err)
 				}
+
+				_, _ = io.WriteString(cmd.ErrOrStderr(), "Policy Updated Successfully\n")
 
 				if err := prettyJSONEncoder(cmd.OutOrStdout()).Encode(result); err != nil {
 					return fmt.Errorf("failed to encode result to stdout: %w", err)

--- a/cmd/policy/policy_test.go
+++ b/cmd/policy/policy_test.go
@@ -299,7 +299,6 @@ func TestDeletePolicy(t *testing.T) {
 				assert.Equal(t, r.URL.String(), "/api/v1/owner/462d67f8-b232-4da4-a7de-0c86dd667d3f/policy/60b7e1a5-c1d7-4422-b813-7a12d353d7c6")
 				w.WriteHeader(http.StatusNoContent)
 			},
-			ExpectedOutput: "Deleted Successfully\n",
 		},
 	}
 


### PR DESCRIPTION
# Checklist

=========

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)
- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/master/CONTRIBUTING.md).

## Changes

=======

- Additionally print user-friendly command outputs for `create`, `update` and `delete` policy subcommands to stderr.
- Update test(s)

## Rationale

=========
The current output format was focused towards scripting, but we also need human-friendly output for policy commands.

## Considerations

==============

The human friendly output is logged to stderr, and machine parsable output (JSON) is output to the stdout right after.
This way we get both the info we need, without the need to having to choose between one, and also eliminating the need for special flags.