### PR TITLE
[SECENG-679] added `eval` policy subcommand to get raw opa evalution

### DIFF
--- a/cmd/policy/policy.go
+++ b/cmd/policy/policy.go
@@ -31,18 +31,14 @@ func NewCommand(config *settings.Config, preRunE validator.Validator) *cobra.Com
 	}
 
 	policyBaseURL := cmd.PersistentFlags().String("policy-base-url", "https://internal.circleci.com", "base url for policy api")
-	ownerID := cmd.PersistentFlags().String("owner-id", "", "the id of the policy's owner")
-
-	if err := cmd.MarkPersistentFlagRequired("owner-id"); err != nil {
-		panic(err)
-	}
 
 	list := func() *cobra.Command {
+		var ownerID string
 		cmd := &cobra.Command{
 			Short: "List all policies",
 			Use:   "list",
 			RunE: func(cmd *cobra.Command, _ []string) error {
-				policies, err := policy.NewClient(*policyBaseURL, config).ListPolicies(*ownerID)
+				policies, err := policy.NewClient(*policyBaseURL, config).ListPolicies(ownerID)
 				if err != nil {
 					return fmt.Errorf("failed to list policies: %v", err)
 				}
@@ -56,11 +52,17 @@ func NewCommand(config *settings.Config, preRunE validator.Validator) *cobra.Com
 			Args:    cobra.ExactArgs(0),
 			Example: `policy list --owner-id 516425b2-e369-421b-838d-920e1f51b0f5`,
 		}
+
+		cmd.Flags().StringVar(&ownerID, "owner-id", "", "the id of the policy's owner")
+		if err := cmd.MarkFlagRequired("owner-id"); err != nil {
+			panic(err)
+		}
+
 		return cmd
 	}()
 
 	create := func() *cobra.Command {
-		var policyPath string
+		var policyPath, ownerID string
 		var creationRequest policy.CreationRequest
 
 		cmd := &cobra.Command{
@@ -73,7 +75,7 @@ func NewCommand(config *settings.Config, preRunE validator.Validator) *cobra.Com
 				}
 				creationRequest.Content = string(policyData)
 
-				result, err := policy.NewClient(*policyBaseURL, config).CreatePolicy(*ownerID, creationRequest)
+				result, err := policy.NewClient(*policyBaseURL, config).CreatePolicy(ownerID, creationRequest)
 				if err != nil {
 					return fmt.Errorf("failed to create policy: %w", err)
 				}
@@ -92,7 +94,10 @@ func NewCommand(config *settings.Config, preRunE validator.Validator) *cobra.Com
 
 		cmd.Flags().StringVar(&creationRequest.Context, "context", "config", "policy context")
 		cmd.Flags().StringVar(&policyPath, "policy", "", "path to rego policy file")
-
+		cmd.Flags().StringVar(&ownerID, "owner-id", "", "the id of the policy's owner")
+		if err := cmd.MarkFlagRequired("owner-id"); err != nil {
+			panic(err)
+		}
 		if err := cmd.MarkFlagRequired("policy"); err != nil {
 			panic(err)
 		}
@@ -101,11 +106,12 @@ func NewCommand(config *settings.Config, preRunE validator.Validator) *cobra.Com
 	}()
 
 	get := func() *cobra.Command {
+		var ownerID string
 		cmd := &cobra.Command{
 			Short: "Get a policy",
 			Use:   "get <policyID>",
 			RunE: func(cmd *cobra.Command, args []string) error {
-				p, err := policy.NewClient(*policyBaseURL, config).GetPolicy(*ownerID, args[0])
+				p, err := policy.NewClient(*policyBaseURL, config).GetPolicy(ownerID, args[0])
 				if err != nil {
 					return fmt.Errorf("failed to get policy: %v", err)
 				}
@@ -119,15 +125,21 @@ func NewCommand(config *settings.Config, preRunE validator.Validator) *cobra.Com
 			Args:    cobra.ExactArgs(1),
 			Example: `policy get 60b7e1a5-c1d7-4422-b813-7a12d353d7c6 --owner-id 516425b2-e369-421b-838d-920e1f51b0f5`,
 		}
+		cmd.Flags().StringVar(&ownerID, "owner-id", "", "the id of the policy's owner")
+		if err := cmd.MarkFlagRequired("owner-id"); err != nil {
+			panic(err)
+		}
+
 		return cmd
 	}()
 
 	delete := func() *cobra.Command {
+		var ownerID string
 		cmd := &cobra.Command{
 			Short: "Delete a policy",
 			Use:   "delete <policyID>",
 			RunE: func(cmd *cobra.Command, args []string) error {
-				err := policy.NewClient(*policyBaseURL, config).DeletePolicy(*ownerID, args[0])
+				err := policy.NewClient(*policyBaseURL, config).DeletePolicy(ownerID, args[0])
 				if err != nil {
 					return fmt.Errorf("failed to delete policy: %v", err)
 				}
@@ -137,13 +149,16 @@ func NewCommand(config *settings.Config, preRunE validator.Validator) *cobra.Com
 			Args:    cobra.ExactArgs(1),
 			Example: `policy delete 60b7e1a5-c1d7-4422-b813-7a12d353d7c6 --owner-id 516425b2-e369-421b-838d-920e1f51b0f5`,
 		}
+		cmd.Flags().StringVar(&ownerID, "owner-id", "", "the id of the policy's owner")
+		if err := cmd.MarkFlagRequired("owner-id"); err != nil {
+			panic(err)
+		}
 
 		return cmd
 	}()
 
 	update := func() *cobra.Command {
-		var policyPath string
-		var context string
+		var policyPath, context, ownerID string
 		var updateRequest policy.UpdateRequest
 
 		cmd := &cobra.Command{
@@ -167,7 +182,7 @@ func NewCommand(config *settings.Config, preRunE validator.Validator) *cobra.Com
 					updateRequest.Context = &context
 				}
 
-				result, err := policy.NewClient(*policyBaseURL, config).UpdatePolicy(*ownerID, args[0], updateRequest)
+				result, err := policy.NewClient(*policyBaseURL, config).UpdatePolicy(ownerID, args[0], updateRequest)
 				if err != nil {
 					return fmt.Errorf("failed to update policy: %w", err)
 				}
@@ -186,12 +201,16 @@ func NewCommand(config *settings.Config, preRunE validator.Validator) *cobra.Com
 
 		cmd.Flags().StringVar(&context, "context", "", "policy context (if set, must be config)")
 		cmd.Flags().StringVar(&policyPath, "policy", "", "path to rego file containing the updated policy")
+		cmd.Flags().StringVar(&ownerID, "owner-id", "", "the id of the policy's owner")
+		if err := cmd.MarkFlagRequired("owner-id"); err != nil {
+			panic(err)
+		}
 
 		return cmd
 	}()
 
 	logs := func() *cobra.Command {
-		var after, before, outputFile string
+		var after, before, outputFile, ownerID string
 		var request policy.DecisionQueryRequest
 
 		cmd := &cobra.Command{
@@ -243,7 +262,7 @@ func NewCommand(config *settings.Config, preRunE validator.Validator) *cobra.Com
 				client := policy.NewClient(*policyBaseURL, config)
 
 				for {
-					logsBatch, err := client.GetDecisionLogs(*ownerID, request)
+					logsBatch, err := client.GetDecisionLogs(ownerID, request)
 					if err != nil {
 						return fmt.Errorf("failed to get policy decision logs: %v", err)
 					}
@@ -272,6 +291,10 @@ func NewCommand(config *settings.Config, preRunE validator.Validator) *cobra.Com
 		cmd.Flags().StringVar(&request.Branch, "branch", "", "filter decision logs based on branch name")
 		cmd.Flags().StringVar(&request.ProjectID, "project-id", "", "filter decision logs based on project-id")
 		cmd.Flags().StringVar(&outputFile, "out", "", "specify output file name ")
+		cmd.Flags().StringVar(&ownerID, "owner-id", "", "the id of the policy's owner")
+		if err := cmd.MarkFlagRequired("owner-id"); err != nil {
+			panic(err)
+		}
 
 		return cmd
 	}()
@@ -281,6 +304,7 @@ func NewCommand(config *settings.Config, preRunE validator.Validator) *cobra.Com
 			inputPath  string
 			policyPath string
 			metaFile   string
+			ownerID    string
 			request    policy.DecisionRequest
 		)
 
@@ -288,7 +312,7 @@ func NewCommand(config *settings.Config, preRunE validator.Validator) *cobra.Com
 			Short: "make a decision",
 			Use:   "decide",
 			RunE: func(cmd *cobra.Command, _ []string) error {
-				if policyPath == "" && *ownerID == "" {
+				if policyPath == "" && ownerID == "" {
 					return fmt.Errorf("--owner-id or --policy is required")
 				}
 
@@ -314,7 +338,7 @@ func NewCommand(config *settings.Config, preRunE validator.Validator) *cobra.Com
 					}
 					request.Input = string(input)
 					request.Metadata = metadata
-					return policy.NewClient(*policyBaseURL, config).MakeDecision(*ownerID, request)
+					return policy.NewClient(*policyBaseURL, config).MakeDecision(ownerID, request)
 				}()
 				if err != nil {
 					return fmt.Errorf("failed to make decision: %w", err)
@@ -329,15 +353,65 @@ func NewCommand(config *settings.Config, preRunE validator.Validator) *cobra.Com
 			Args: cobra.ExactArgs(0),
 		}
 
-		// Redeclared flag to make optional
-		cmd.Flags().StringVar(ownerID, "owner-id", "", "the id of the policy's owner")
-
+		cmd.Flags().StringVar(&ownerID, "owner-id", "", "the id of the policy's owner")
 		cmd.Flags().StringVar(&request.Context, "context", "config", "policy context for decision")
 		cmd.Flags().StringVar(&inputPath, "input", "", "path to input file")
 		cmd.Flags().StringVar(&policyPath, "policy", "", "path to rego policy file or directory containing policy files")
 		cmd.Flags().StringVar(&metaFile, "metafile", "", "decision metadata file")
 
-		_ = cmd.MarkFlagRequired("input")
+		if err := cmd.MarkFlagRequired("input"); err != nil {
+			panic(err)
+		}
+
+		return cmd
+	}()
+
+	eval := func() *cobra.Command {
+		var inputPath, policyPath, metaFile string
+		cmd := &cobra.Command{
+			Short: "perform raw opa evaluation locally",
+			Use:   "eval",
+			RunE: func(cmd *cobra.Command, _ []string) error {
+				input, err := os.ReadFile(inputPath)
+				if err != nil {
+					return fmt.Errorf("failed to read input file: %w", err)
+				}
+
+				var metadata map[string]interface{}
+				if metaFile != "" {
+					raw, err := os.ReadFile(metaFile)
+					if err != nil {
+						return fmt.Errorf("failed to read meta file: %w", err)
+					}
+					if err := yaml.Unmarshal(raw, &metadata); err != nil {
+						return fmt.Errorf("failed to decode meta content: %w", err)
+					}
+				}
+
+				decision, err := getPolicyEvaluationLocally(policyPath, input, metadata)
+				if err != nil {
+					return fmt.Errorf("failed to make decision: %w", err)
+				}
+
+				if err := prettyJSONEncoder(cmd.OutOrStdout()).Encode(decision); err != nil {
+					return fmt.Errorf("failed to encode decision: %w", err)
+				}
+
+				return nil
+			},
+			Args: cobra.ExactArgs(0),
+		}
+
+		cmd.Flags().StringVar(&inputPath, "input", "", "path to input file")
+		cmd.Flags().StringVar(&policyPath, "policy", "", "path to rego policy file or directory containing policy files")
+		cmd.Flags().StringVar(&metaFile, "metafile", "", "decision metadata file")
+
+		if err := cmd.MarkFlagRequired("input"); err != nil {
+			panic(err)
+		}
+		if err := cmd.MarkFlagRequired("policy"); err != nil {
+			panic(err)
+		}
 
 		return cmd
 	}()
@@ -349,6 +423,7 @@ func NewCommand(config *settings.Config, preRunE validator.Validator) *cobra.Com
 	cmd.AddCommand(update)
 	cmd.AddCommand(logs)
 	cmd.AddCommand(decide)
+	cmd.AddCommand(eval)
 
 	return cmd
 }
@@ -379,12 +454,44 @@ func getPolicyDecisionLocally(policyPath string, rawInput []byte, meta map[strin
 		return cpa.LoadPolicyFile
 	}()
 
-	policy, err := loadPolicy(policyPath)
+	p, err := loadPolicy(policyPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load policy files: %w", err)
 	}
 
-	decision, err := policy.Decide(context.Background(), input, cpa.Meta(meta))
+	decision, err := p.Decide(context.Background(), input, cpa.Meta(meta))
+	if err != nil {
+		return nil, fmt.Errorf("failed to make decision: %w", err)
+	}
+
+	return decision, nil
+}
+
+// getPolicyEvaluationLocally takes path of policy path/directory and input (eg build config) as string, and performs policy evaluation locally and returns raw opa evaluation response
+func getPolicyEvaluationLocally(policyPath string, rawInput []byte, meta map[string]interface{}) (interface{}, error) {
+	var input interface{}
+	if err := yaml.Unmarshal(rawInput, &input); err != nil {
+		return nil, fmt.Errorf("invalid input: %w", err)
+	}
+
+	pathInfo, err := os.Stat(policyPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get path info: %w", err)
+	}
+
+	loadPolicy := func() func(string) (*cpa.Policy, error) {
+		if pathInfo.IsDir() {
+			return cpa.LoadPolicyDirectory
+		}
+		return cpa.LoadPolicyFile
+	}()
+
+	p, err := loadPolicy(policyPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load policy files: %w", err)
+	}
+
+	decision, err := p.Eval(context.Background(), "data", input, cpa.Meta(meta))
 	if err != nil {
 		return nil, fmt.Errorf("failed to make decision: %w", err)
 	}

--- a/cmd/policy/policy_test.go
+++ b/cmd/policy/policy_test.go
@@ -763,6 +763,88 @@ func TestMakeDecisionCommand(t *testing.T) {
 	}
 }
 
+func TestRawOPAEvaluationCommand(t *testing.T) {
+	testcases := []struct {
+		Name           string
+		Args           []string
+		ServerHandler  http.HandlerFunc
+		ExpectedOutput string
+		ExpectedErr    string
+	}{
+		{
+			Name:        "requires flags",
+			Args:        []string{"eval"},
+			ExpectedErr: `required flag(s) "input", "policy" not set`,
+		},
+		{
+			Name:        "fails if local-policy is not provided",
+			Args:        []string{"eval", "--input", "./testdata/test.yml"},
+			ExpectedErr: `required flag(s) "policy" not set`,
+		},
+		{
+			Name:        "fails if input is not provided",
+			Args:        []string{"eval", "--policy", "./testdata/policy.rego"},
+			ExpectedErr: `required flag(s) "input" not set`,
+		},
+		{
+			Name:        "fails for input file not found",
+			Args:        []string{"eval", "--policy", "./testdata/policy.rego", "--input", "./testdata/no_such_file.yml"},
+			ExpectedErr: "failed to read input file: open ./testdata/no_such_file.yml: ",
+		},
+		{
+			Name:        "fails for policy FILE/DIRECTORY not found",
+			Args:        []string{"eval", "--policy", "./testdata/no_such_file.rego", "--input", "./testdata/test.yml"},
+			ExpectedErr: "failed to make decision: failed to get path info: ",
+		},
+		{
+			Name: "successfully performs raw opa evaluation for policy FILE provided locally, input and metadata",
+			Args: []string{
+				"eval", "--metafile", "./testdata/meta.yml", "--policy", "./testdata/test0/meta-policy.rego", "--input",
+				"./testdata/test0/config.yml",
+			},
+			ExpectedOutput: `{
+  "meta": {
+    "branch": "main",
+    "project_id": "test-project-id"
+  },
+  "org": {
+    "enable_rule": [
+      "enabled"
+    ],
+    "policy_name": [
+      "meta_policy_test"
+    ]
+  }
+}
+`,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.Name, func(t *testing.T) {
+			if tc.ServerHandler == nil {
+				tc.ServerHandler = func(w http.ResponseWriter, r *http.Request) {}
+			}
+
+			svr := httptest.NewServer(tc.ServerHandler)
+			defer svr.Close()
+
+			cmd, stdout, _ := makeCMD()
+
+			cmd.SetArgs(append(tc.Args, "--policy-base-url", svr.URL))
+
+			err := cmd.Execute()
+			if tc.ExpectedErr == "" {
+				assert.NilError(t, err)
+			} else {
+				assert.ErrorContains(t, err, tc.ExpectedErr)
+				return
+			}
+			assert.Equal(t, stdout.String(), tc.ExpectedOutput)
+		})
+	}
+}
+
 func makeCMD() (*cobra.Command, *bytes.Buffer, *bytes.Buffer) {
 	config := &settings.Config{Token: "testtoken", HTTPClient: http.DefaultClient}
 	cmd := NewCommand(config, nil)

--- a/cmd/policy/policy_test.go
+++ b/cmd/policy/policy_test.go
@@ -706,7 +706,7 @@ func TestMakeDecisionCommand(t *testing.T) {
 		{
 			Name:        "fails for policy FILE/DIRECTORY not found",
 			Args:        []string{"decide", "--policy", "./testdata/no_such_file.rego", "--input", "./testdata/test.yml"},
-			ExpectedErr: "failed to make decision: failed to get path info: ",
+			ExpectedErr: "failed to make decision: failed to load policy files: failed to get path info: ",
 		},
 		{
 			Name: "successfully performs decision for policy FILE provided locally",
@@ -794,7 +794,7 @@ func TestRawOPAEvaluationCommand(t *testing.T) {
 		{
 			Name:        "fails for policy FILE/DIRECTORY not found",
 			Args:        []string{"eval", "--policy", "./testdata/no_such_file.rego", "--input", "./testdata/test.yml"},
-			ExpectedErr: "failed to make decision: failed to get path info: ",
+			ExpectedErr: "failed to make decision: failed to load policy files: failed to get path info: ",
 		},
 		{
 			Name: "successfully performs raw opa evaluation for policy FILE provided locally, input and metadata",
@@ -816,6 +816,17 @@ func TestRawOPAEvaluationCommand(t *testing.T) {
     ]
   }
 }
+`,
+		},
+		{
+			Name: "successfully performs raw opa evaluation for policy FILE provided locally, input, metadata and query",
+			Args: []string{
+				"eval", "--metafile", "./testdata/meta.yml", "--policy", "./testdata/test0/meta-policy.rego", "--input",
+				"./testdata/test0/config.yml", "--query", "data.org.enable_rule",
+			},
+			ExpectedOutput: `[
+  "enabled"
+]
 `,
 		},
 	}

--- a/cmd/policy/testdata/policy-expected-usage.txt
+++ b/cmd/policy/testdata/policy-expected-usage.txt
@@ -5,13 +5,13 @@ Available Commands:
   create      create policy
   decide      make a decision
   delete      Delete a policy
+  eval        perform raw opa evaluation locally
   get         Get a policy
   list        List all policies
   logs        Get policy (decision) logs
   update      Update a policy
 
 Flags:
-      --owner-id string          the id of the policy's owner
       --policy-base-url string   base url for policy api (default "https://internal.circleci.com")
 
 Use "policy [command] --help" for more information about a command.

--- a/cmd/policy/testdata/policy/create-expected-usage.txt
+++ b/cmd/policy/testdata/policy/create-expected-usage.txt
@@ -5,9 +5,9 @@ Examples:
 policy create --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --name policy_name --policy ./policy.rego
 
 Flags:
-      --context string   policy context (default "config")
-      --policy string    path to rego policy file
+      --context string    policy context (default "config")
+      --owner-id string   the id of the policy's owner
+      --policy string     path to rego policy file
 
 Global Flags:
-      --owner-id string          the id of the policy's owner
       --policy-base-url string   base url for policy api (default "https://internal.circleci.com")

--- a/cmd/policy/testdata/policy/delete-expected-usage.txt
+++ b/cmd/policy/testdata/policy/delete-expected-usage.txt
@@ -4,6 +4,8 @@ Usage:
 Examples:
 policy delete 60b7e1a5-c1d7-4422-b813-7a12d353d7c6 --owner-id 516425b2-e369-421b-838d-920e1f51b0f5
 
+Flags:
+      --owner-id string   the id of the policy's owner
+
 Global Flags:
-      --owner-id string          the id of the policy's owner
       --policy-base-url string   base url for policy api (default "https://internal.circleci.com")

--- a/cmd/policy/testdata/policy/eval-expected-usage.txt
+++ b/cmd/policy/testdata/policy/eval-expected-usage.txt
@@ -5,6 +5,7 @@ Flags:
       --input string      path to input file
       --metafile string   decision metadata file
       --policy string     path to rego policy file or directory containing policy files
+      --query string      policy decision query (default "data")
 
 Global Flags:
       --policy-base-url string   base url for policy api (default "https://internal.circleci.com")

--- a/cmd/policy/testdata/policy/eval-expected-usage.txt
+++ b/cmd/policy/testdata/policy/eval-expected-usage.txt
@@ -1,11 +1,9 @@
 Usage:
-  policy decide [flags]
+  policy eval [flags]
 
 Flags:
-      --context string    policy context for decision (default "config")
       --input string      path to input file
       --metafile string   decision metadata file
-      --owner-id string   the id of the policy's owner
       --policy string     path to rego policy file or directory containing policy files
 
 Global Flags:

--- a/cmd/policy/testdata/policy/get-expected-usage.txt
+++ b/cmd/policy/testdata/policy/get-expected-usage.txt
@@ -4,6 +4,8 @@ Usage:
 Examples:
 policy get 60b7e1a5-c1d7-4422-b813-7a12d353d7c6 --owner-id 516425b2-e369-421b-838d-920e1f51b0f5
 
+Flags:
+      --owner-id string   the id of the policy's owner
+
 Global Flags:
-      --owner-id string          the id of the policy's owner
       --policy-base-url string   base url for policy api (default "https://internal.circleci.com")

--- a/cmd/policy/testdata/policy/list-expected-usage.txt
+++ b/cmd/policy/testdata/policy/list-expected-usage.txt
@@ -4,6 +4,8 @@ Usage:
 Examples:
 policy list --owner-id 516425b2-e369-421b-838d-920e1f51b0f5
 
+Flags:
+      --owner-id string   the id of the policy's owner
+
 Global Flags:
-      --owner-id string          the id of the policy's owner
       --policy-base-url string   base url for policy api (default "https://internal.circleci.com")

--- a/cmd/policy/testdata/policy/logs-expected-usage.txt
+++ b/cmd/policy/testdata/policy/logs-expected-usage.txt
@@ -9,9 +9,9 @@ Flags:
       --before string       filter decision logs triggered BEFORE this datetime
       --branch string       filter decision logs based on branch name
       --out string          specify output file name 
+      --owner-id string     the id of the policy's owner
       --project-id string   filter decision logs based on project-id
       --status string       filter decision logs based on their status
 
 Global Flags:
-      --owner-id string          the id of the policy's owner
       --policy-base-url string   base url for policy api (default "https://internal.circleci.com")

--- a/cmd/policy/testdata/policy/update-expected-usage.txt
+++ b/cmd/policy/testdata/policy/update-expected-usage.txt
@@ -5,9 +5,9 @@ Examples:
 policy update e9e300d1-5bab-4704-b610-addbd6e03b0b --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --name policy_name --policy ./policy.rego
 
 Flags:
-      --context string   policy context (if set, must be config)
-      --policy string    path to rego file containing the updated policy
+      --context string    policy context (if set, must be config)
+      --owner-id string   the id of the policy's owner
+      --policy string     path to rego file containing the updated policy
 
 Global Flags:
-      --owner-id string          the id of the policy's owner
       --policy-base-url string   base url for policy api (default "https://internal.circleci.com")


### PR DESCRIPTION
# Checklist

=========

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)
- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/master/CONTRIBUTING.md).

## Changes

=======

- Added `eval` subcommand under `policy` command
- added unit-tests for `eval` subcommand
- moved `owner-id` flag declaration from `policy` root to individual subcommands

## Rationale

=========

The rationale behind adding subcommand is allowing the advanced users of our circleci-policy-agent to obtain raw opa evaluation response and evaluate whether our helper functions are working as intended.

## Considerations

==============

The `owner-id` flag isn't declared at root `policy` command level, because for `eval` subcommand it is not needed. and decide` subcommand it is optional.