### PR TITLE
[SECENG-821] Get policy decision log by decision id

### DIFF
--- a/api/policy/policy.go
+++ b/api/policy/policy.go
@@ -174,15 +174,11 @@ func (c Client) GetDecisionLogs(ownerID string, context string, request Decision
 }
 
 // GetDecisionLog calls the GET decision query API of policy-service for a DecisionID.
-// It also accepts a getPolicyBundle bool param; If set to true will return only the policy bundle corresponding to that decision log.
-func (c Client) GetDecisionLog(ownerID string, context string, decisionID string, getPolicyBundle bool) (interface{}, error) {
+// It also accepts a policyBundle bool param; If set to true will return only the policy bundle corresponding to that decision log.
+func (c Client) GetDecisionLog(ownerID string, context string, decisionID string, policyBundle bool) (interface{}, error) {
 	path := fmt.Sprintf("%s/api/v1/owner/%s/context/%s/decision/%s", c.serverUrl, ownerID, context, decisionID)
-	var err error
-	if getPolicyBundle {
-		path, err = url.JoinPath(path, "policy-bundle")
-		if err != nil {
-			return nil, err
-		}
+	if policyBundle {
+		path = fmt.Sprintf("%s/%s", path, "policy-bundle")
 	}
 	req, err := http.NewRequest("GET", path, nil)
 	if err != nil {

--- a/api/policy/policy.go
+++ b/api/policy/policy.go
@@ -178,7 +178,7 @@ func (c Client) GetDecisionLogs(ownerID string, context string, request Decision
 func (c Client) GetDecisionLog(ownerID string, context string, decisionID string, policyBundle bool) (interface{}, error) {
 	path := fmt.Sprintf("%s/api/v1/owner/%s/context/%s/decision/%s", c.serverUrl, ownerID, context, decisionID)
 	if policyBundle {
-		path = fmt.Sprintf("%s/%s", path, "policy-bundle")
+		path += "/policy-bundle"
 	}
 	req, err := http.NewRequest("GET", path, nil)
 	if err != nil {

--- a/api/policy/policy_test.go
+++ b/api/policy/policy_test.go
@@ -413,7 +413,7 @@ func TestClientGetDecisionLogs(t *testing.T) {
 }
 
 func TestClientGetDecisionLog(t *testing.T) {
-	t.Run("expected request with getPolicyBundle=false", func(t *testing.T) {
+	t.Run("expected request with policyBundle=false", func(t *testing.T) {
 		svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, r.Header.Get("circle-token"), "testtoken")
 			assert.Equal(t, r.Header.Get("accept"), "application/json")
@@ -438,7 +438,7 @@ func TestClientGetDecisionLog(t *testing.T) {
 		assert.NilError(t, err)
 	})
 
-	t.Run("expected request without getPolicyBundle=true", func(t *testing.T) {
+	t.Run("expected request without policyBundle=true", func(t *testing.T) {
 		svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, r.Header.Get("circle-token"), "testtoken")
 			assert.Equal(t, r.Header.Get("accept"), "application/json")

--- a/cmd/policy/policy.go
+++ b/cmd/policy/policy.go
@@ -164,7 +164,7 @@ func NewCommand(config *settings.Config, preRunE validator.Validator) *cobra.Com
 
 	logs := func() *cobra.Command {
 		var after, before, outputFile, ownerID, context, decisionID string
-		var getPolicyBundle bool
+		var policyBundle bool
 		var request policy.DecisionQueryRequest
 
 		cmd := &cobra.Command{
@@ -177,7 +177,7 @@ func NewCommand(config *settings.Config, preRunE validator.Validator) *cobra.Com
 				if decisionID != "" && (after != "" || before != "" || request.Status != "" || request.Offset != 0 || request.Branch != "" || request.ProjectID != "") {
 					return fmt.Errorf("filters are not accepted when decision_id is provided")
 				}
-				if getPolicyBundle && decisionID == "" {
+				if policyBundle && decisionID == "" {
 					return fmt.Errorf("decision_id is required when --policy-bundle flag is used")
 				}
 				if cmd.Flag("after").Changed {
@@ -213,7 +213,7 @@ func NewCommand(config *settings.Config, preRunE validator.Validator) *cobra.Com
 				client := policy.NewClient(*policyBaseURL, config)
 
 				if decisionID != "" { //fetch single decision log
-					log, err := client.GetDecisionLog(ownerID, context, decisionID, getPolicyBundle)
+					log, err := client.GetDecisionLog(ownerID, context, decisionID, policyBundle)
 					if err != nil {
 						return fmt.Errorf("failed to get policy decision log: %v", err)
 					}
@@ -265,7 +265,7 @@ func NewCommand(config *settings.Config, preRunE validator.Validator) *cobra.Com
 		cmd.Flags().StringVar(&request.Branch, "branch", "", "filter decision logs based on branch name")
 		cmd.Flags().StringVar(&request.ProjectID, "project-id", "", "filter decision logs based on project-id")
 		cmd.Flags().StringVar(&outputFile, "out", "", "specify output file name ")
-		cmd.Flags().BoolVar(&getPolicyBundle, "policy-bundle", false, "get only the policy bundle for given decisionID")
+		cmd.Flags().BoolVar(&policyBundle, "policy-bundle", false, "get only the policy bundle for given decisionID")
 		cmd.Flags().StringVar(&context, "context", "config", "policy context")
 		cmd.Flags().StringVar(&ownerID, "owner-id", "", "the id of the policy's owner")
 		if err := cmd.MarkFlagRequired("owner-id"); err != nil {

--- a/cmd/policy/policy_test.go
+++ b/cmd/policy/policy_test.go
@@ -416,6 +416,16 @@ func TestGetDecisionLogs(t *testing.T) {
 			ExpectedErr: `error in parsing --before value: This date has ambiguous mm/dd vs dd/mm type format`,
 		},
 		{
+			Name:        "gives error when a filter is provided when decisionID is also provided",
+			Args:        []string{"logs", "decisionID", "--owner-id", "ownerID", "--branch", "main"},
+			ExpectedErr: `filters are not accepted when decision_id is provided`,
+		},
+		{
+			Name:        "gives error when --policy-bundle flag is used but decisionID is not provided",
+			Args:        []string{"logs", "--owner-id", "ownerID", "--policy-bundle"},
+			ExpectedErr: `decision_id is required when --policy-bundle flag is used`,
+		},
+		{
 			Name: "no filter is set",
 			Args: []string{"logs", "--owner-id", "ownerID"},
 			ServerHandler: func(w http.ResponseWriter, r *http.Request) {
@@ -511,6 +521,32 @@ func TestGetDecisionLogs(t *testing.T) {
   }
 ]
 `,
+		},
+		{
+			Name: "successfully gets a decision log for given decision ID",
+			Args: []string{"logs", "--owner-id", "ownerID", "decisionID"},
+			ServerHandler: func() http.HandlerFunc {
+				return func(w http.ResponseWriter, r *http.Request) {
+					assert.Equal(t, r.Method, "GET")
+					assert.Equal(t, r.URL.String(), "/api/v1/owner/ownerID/context/config/decision/decisionID")
+					_, err := w.Write([]byte("{}"))
+					assert.NilError(t, err)
+				}
+			}(),
+			ExpectedOutput: "{}\n",
+		},
+		{
+			Name: "successfully gets policy-bundle for given decision ID",
+			Args: []string{"logs", "--owner-id", "ownerID", "decisionID", "--policy-bundle"},
+			ServerHandler: func() http.HandlerFunc {
+				return func(w http.ResponseWriter, r *http.Request) {
+					assert.Equal(t, r.Method, "GET")
+					assert.Equal(t, r.URL.String(), "/api/v1/owner/ownerID/context/config/decision/decisionID/policy-bundle")
+					_, err := w.Write([]byte("{}"))
+					assert.NilError(t, err)
+				}
+			}(),
+			ExpectedOutput: "{}\n",
 		},
 	}
 

--- a/cmd/policy/testdata/policy-expected-usage.txt
+++ b/cmd/policy/testdata/policy-expected-usage.txt
@@ -6,7 +6,7 @@ Available Commands:
   diff        Get diff between local and remote policy bundles
   eval        perform raw opa evaluation locally
   fetch       Fetch policy bundle (or a single policy)
-  logs        Get policy decision logs
+  logs        Get policy decision logs / Get decision log (or policy bundle) by decision ID
   push        push policy bundle
 
 Flags:

--- a/cmd/policy/testdata/policy/logs-expected-usage.txt
+++ b/cmd/policy/testdata/policy/logs-expected-usage.txt
@@ -1,5 +1,5 @@
 Usage:
-  policy logs [flags]
+  policy logs [decision_id] [flags]
 
 Examples:
 policy logs --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --after 2022/03/14 --out output.json
@@ -11,6 +11,7 @@ Flags:
       --context string      policy context (default "config")
       --out string          specify output file name 
       --owner-id string     the id of the policy's owner
+      --policy-bundle       get only the policy bundle for given decisionID
       --project-id string   filter decision logs based on project-id
       --status string       filter decision logs based on their status
 


### PR DESCRIPTION
# Checklist

=========

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)
- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/master/CONTRIBUTING.md).

## Changes

=======

- Added support for `decisionID` argument in existing `policy logs` command
- Added support for `--policy-bundle` flag in existing `policy logs` command
- Updated help text
- Updated unit-tests

## Rationale

=========

The new command will allow the users to fetch policy bundle associated with policy decision log