### PR TITLE
return non-zero status codes for some cases

### DIFF
--- a/api/policy/policy.go
+++ b/api/policy/policy.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/CircleCI-Public/circle-policy-agent/cpa"
+
 	"github.com/CircleCI-Public/circleci-cli/api/header"
 	"github.com/CircleCI-Public/circleci-cli/settings"
 	"github.com/CircleCI-Public/circleci-cli/version"
@@ -215,7 +217,7 @@ type DecisionRequest struct {
 }
 
 // MakeDecision sends a requests to Policy-Service public decision endpoint and returns the decision response
-func (c Client) MakeDecision(ownerID string, context string, req DecisionRequest) (interface{}, error) {
+func (c Client) MakeDecision(ownerID string, context string, req DecisionRequest) (*cpa.Decision, error) {
 	payload, err := json.Marshal(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
@@ -244,12 +246,12 @@ func (c Client) MakeDecision(ownerID string, context string, req DecisionRequest
 		return nil, fmt.Errorf("unexpected status-code: %d - %s", resp.StatusCode, payload.Error)
 	}
 
-	var body interface{}
+	var body cpa.Decision
 	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
 		return nil, fmt.Errorf("failed to decode response body: %w", err)
 	}
 
-	return body, nil
+	return &body, nil
 }
 
 // NewClient returns a new policy client that will use the provided settings.Config to automatically inject appropriate

--- a/api/policy/policy_test.go
+++ b/api/policy/policy_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/CircleCI-Public/circle-policy-agent/cpa"
 	"gotest.tools/v3/assert"
 
 	"github.com/CircleCI-Public/circleci-cli/settings"
@@ -579,7 +580,7 @@ func TestMakeDecision(t *testing.T) {
 
 				_ = json.NewEncoder(w).Encode(map[string]string{"status": "PASS"})
 			},
-			ExpectedDecision: map[string]interface{}{"status": "PASS"},
+			ExpectedDecision: &cpa.Decision{Status: cpa.StatusPass},
 		},
 		{
 			Name:    "unexpected status code",

--- a/cmd/policy/policy_test.go
+++ b/cmd/policy/policy_test.go
@@ -607,6 +607,42 @@ func TestMakeDecisionCommand(t *testing.T) {
 			ExpectedOutput: "{\n  \"status\": \"PASS\"\n}\n",
 		},
 		{
+			Name: "passes when decision status = HARD_FAIL AND --strict is OFF",
+			Args: []string{"decide", "--owner-id", "test-owner", "--input", "./testdata/test1/test.yml"},
+			ServerHandler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, r.Method, "POST")
+				assert.Equal(t, r.URL.Path, "/api/v1/owner/test-owner/context/config/decision")
+
+				var payload map[string]interface{}
+				assert.NilError(t, json.NewDecoder(r.Body).Decode(&payload))
+
+				assert.DeepEqual(t, payload, map[string]interface{}{
+					"input": "test: config\n",
+				})
+
+				_, _ = io.WriteString(w, `{"status":"HARD_FAIL"}`)
+			},
+			ExpectedOutput: "{\n  \"status\": \"HARD_FAIL\"\n}\n",
+		},
+		{
+			Name: "fails when decision status = HARD_FAIL AND --strict is ON",
+			Args: []string{"decide", "--owner-id", "test-owner", "--input", "./testdata/test1/test.yml", "--strict"},
+			ServerHandler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, r.Method, "POST")
+				assert.Equal(t, r.URL.Path, "/api/v1/owner/test-owner/context/config/decision")
+
+				var payload map[string]interface{}
+				assert.NilError(t, json.NewDecoder(r.Body).Decode(&payload))
+
+				assert.DeepEqual(t, payload, map[string]interface{}{
+					"input": "test: config\n",
+				})
+
+				_, _ = io.WriteString(w, `{"status":"HARD_FAIL"}`)
+			},
+			ExpectedErr: "policy decision status: HARD_FAIL",
+		},
+		{
 			Name: "sends expected request with context",
 			Args: []string{"decide", "--owner-id", "test-owner", "--input", "./testdata/test1/test.yml", "--context", "custom"},
 			ServerHandler: func(w http.ResponseWriter, r *http.Request) {
@@ -686,6 +722,28 @@ func TestMakeDecisionCommand(t *testing.T) {
   ]
 }
 `,
+		},
+		{
+			Name: "successfully performs decision for policy FILE provided locally, passes when decision = HARD_FAIL and strict = OFF",
+			Args: []string{"decide", "./testdata/test2/hard_fail_policy.rego", "--input", "./testdata/test0/config.yml"},
+			ExpectedOutput: `{
+  "status": "HARD_FAIL",
+  "enabled_rules": [
+    "always_hard_fails"
+  ],
+  "hard_failures": [
+    {
+      "rule": "always_hard_fails",
+      "reason": "0 is not equals 1"
+    }
+  ]
+}
+`,
+		},
+		{
+			Name:        "successfully performs decision for policy FILE provided locally, fails when decision = HARD_FAIL and strict = ON",
+			Args:        []string{"decide", "./testdata/test2/hard_fail_policy.rego", "--input", "./testdata/test0/config.yml", "--strict"},
+			ExpectedErr: "policy decision status: HARD_FAIL",
 		},
 		{
 			Name: "successfully performs decision with metadata for policy FILE provided locally",

--- a/cmd/policy/testdata/policy/decide-expected-usage.txt
+++ b/cmd/policy/testdata/policy/decide-expected-usage.txt
@@ -9,6 +9,7 @@ Flags:
       --input string      path to input file
       --metafile string   decision metadata file
       --owner-id string   the id of the policy's owner
+      --strict            return non-zero status code for decision resulting in HARD_FAIL
 
 Global Flags:
       --policy-base-url string   base url for policy api (default "https://internal.circleci.com")

--- a/cmd/policy/testdata/test2/hard_fail_policy.rego
+++ b/cmd/policy/testdata/test2/hard_fail_policy.rego
@@ -1,0 +1,6 @@
+package org
+
+policy_name["hard_fail_test"]
+enable_rule["always_hard_fails"]
+hard_fail["always_hard_fails"]
+always_hard_fails = "0 is not equals 1" { 0 != 1 }


### PR DESCRIPTION
# Checklist

=========

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)
- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/master/CONTRIBUTING.md).

## Changes

=======

- Return non-zero status code for failed user interaction on `policy push` command [[SECENG-816](https://circleci.atlassian.net/browse/SECENG-816)]
- Return non-zero status code for decision resulting in non-PASSED [[SECENG-822](https://circleci.atlassian.net/browse/SECENG-822)]