### PR TITLE
Fix: replace the HTTP request header Accept-Type with Accept

### DIFF
--- a/api/rest/client.go
+++ b/api/rest/client.go
@@ -58,7 +58,7 @@ func (c *Client) NewRequest(method string, u *url.URL, payload interface{}) (req
 	}
 
 	req.Header.Set("Circle-Token", c.circleToken)
-	req.Header.Set("Accept-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
 	req.Header.Set("User-Agent", version.UserAgent())
 	commandStr := header.GetCommandStr()
 	if commandStr != "" {

--- a/api/rest/client_test.go
+++ b/api/rest/client_test.go
@@ -46,7 +46,7 @@ func TestClient_DoRequest(t *testing.T) {
 			assert.Check(t, cmp.Equal(fix.Method(), "PUT"))
 			assert.Check(t, cmp.DeepEqual(fix.Header(), http.Header{
 				"Accept-Encoding": {"gzip"},
-				"Accept-Type":     {"application/json"},
+				"Accept":          {"application/json"},
 				"Circle-Token":    {"fake-token"},
 				"Content-Length":  {"20"},
 				"Content-Type":    {"application/json"},
@@ -77,7 +77,7 @@ func TestClient_DoRequest(t *testing.T) {
 			assert.Check(t, cmp.Equal(fix.Method(), http.MethodGet))
 			assert.Check(t, cmp.DeepEqual(fix.Header(), http.Header{
 				"Accept-Encoding": {"gzip"},
-				"Accept-Type":     {"application/json"},
+				"Accept":          {"application/json"},
 				"Circle-Token":    {"fake-token"},
 				"User-Agent":      {version.UserAgent()},
 			}))
@@ -109,7 +109,7 @@ func TestClient_DoRequest(t *testing.T) {
 			assert.Check(t, cmp.Equal(fix.Method(), http.MethodGet))
 			assert.Check(t, cmp.DeepEqual(fix.Header(), http.Header{
 				"Accept-Encoding": {"gzip"},
-				"Accept-Type":     {"application/json"},
+				"Accept":          {"application/json"},
 				"Circle-Token":    {"fake-token"},
 				"User-Agent":      {version.UserAgent()},
 			}))

--- a/api/runner/runner_test.go
+++ b/api/runner/runner_test.go
@@ -46,7 +46,7 @@ func TestRunner_CreateResourceClass(t *testing.T) {
 		assert.Check(t, cmp.Equal(fix.method, "POST"))
 		assert.Check(t, cmp.DeepEqual(fix.Header(), http.Header{
 			"Accept-Encoding": {"gzip"},
-			"Accept-Type":     {"application/json"},
+			"Accept":          {"application/json"},
 			"Circle-Token":    {"fake-token"},
 			"Content-Length":  {"86"},
 			"Content-Type":    {"application/json"},
@@ -86,7 +86,7 @@ func TestRunner_GetResourceClassByName(t *testing.T) {
 		assert.Check(t, cmp.Equal(fix.method, http.MethodGet))
 		assert.Check(t, cmp.DeepEqual(fix.Header(), http.Header{
 			"Accept-Encoding": {"gzip"},
-			"Accept-Type":     {"application/json"},
+			"Accept":          {"application/json"},
 			"Circle-Token":    {"fake-token"},
 			"User-Agent":      {version.UserAgent()},
 		}))
@@ -137,7 +137,7 @@ func TestRunner_GetResourceClassesByNamespace(t *testing.T) {
 		assert.Check(t, cmp.Equal(fix.method, http.MethodGet))
 		assert.Check(t, cmp.DeepEqual(fix.Header(), http.Header{
 			"Accept-Encoding": {"gzip"},
-			"Accept-Type":     {"application/json"},
+			"Accept":          {"application/json"},
 			"Circle-Token":    {"fake-token"},
 			"User-Agent":      {version.UserAgent()},
 		}))
@@ -160,7 +160,7 @@ func TestRunner_DeleteResourceClass(t *testing.T) {
 		assert.Check(t, cmp.Equal(fix.method, "DELETE"))
 		assert.Check(t, cmp.DeepEqual(fix.Header(), http.Header{
 			"Accept-Encoding": {"gzip"},
-			"Accept-Type":     {"application/json"},
+			"Accept":          {"application/json"},
 			"Circle-Token":    {"fake-token"},
 			"User-Agent":      {version.UserAgent()},
 		}))
@@ -180,7 +180,7 @@ func TestRunner_DeleteResourceClass_Force(t *testing.T) {
 	assert.Check(t, cmp.Equal(fix.method, "DELETE"))
 	assert.Check(t, cmp.DeepEqual(fix.Header(), http.Header{
 		"Accept-Encoding": {"gzip"},
-		"Accept-Type":     {"application/json"},
+		"Accept":          {"application/json"},
 		"Circle-Token":    {"fake-token"},
 		"User-Agent":      {version.UserAgent()},
 	}))
@@ -232,7 +232,7 @@ func TestRunner_CreateToken(t *testing.T) {
 		assert.Check(t, cmp.Equal(fix.method, "POST"))
 		assert.Check(t, cmp.DeepEqual(fix.Header(), http.Header{
 			"Accept-Encoding": {"gzip"},
-			"Accept-Type":     {"application/json"},
+			"Accept":          {"application/json"},
 			"Circle-Token":    {"fake-token"},
 			"Content-Length":  {"80"},
 			"Content-Type":    {"application/json"},
@@ -302,7 +302,7 @@ func TestRunner_GetRunnerTokensByResourceClass(t *testing.T) {
 		assert.Check(t, cmp.Equal(fix.method, http.MethodGet))
 		assert.Check(t, cmp.DeepEqual(fix.Header(), http.Header{
 			"Accept-Encoding": {"gzip"},
-			"Accept-Type":     {"application/json"},
+			"Accept":          {"application/json"},
 			"Circle-Token":    {"fake-token"},
 			"User-Agent":      {version.UserAgent()},
 		}))
@@ -325,7 +325,7 @@ func TestRunner_DeleteToken(t *testing.T) {
 		assert.Check(t, cmp.Equal(fix.method, "DELETE"))
 		assert.Check(t, cmp.DeepEqual(fix.Header(), http.Header{
 			"Accept-Encoding": {"gzip"},
-			"Accept-Type":     {"application/json"},
+			"Accept":          {"application/json"},
 			"Circle-Token":    {"fake-token"},
 			"User-Agent":      {version.UserAgent()},
 		}))
@@ -413,7 +413,7 @@ func TestRunner_GetRunnerInstances_ByNamespace(t *testing.T) {
 		assert.Check(t, cmp.Equal(fix.method, http.MethodGet))
 		assert.Check(t, cmp.DeepEqual(fix.Header(), http.Header{
 			"Accept-Encoding": {"gzip"},
-			"Accept-Type":     {"application/json"},
+			"Accept":          {"application/json"},
 			"Circle-Token":    {"fake-token"},
 			"User-Agent":      {version.UserAgent()},
 		}))


### PR DESCRIPTION
# Checklist

=========

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)
- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/master/CONTRIBUTING.md).

## Changes

=======

- Replace a request header `Accept-Type` with `Accept` in api/rest/client.go

## Rationale

=========

These changes are related to https://github.com/CircleCI-Public/circleci-cli/pull/770.
- `Accept` header, rather than `Accept-Type`, is generally used to controll `content-type` response header
- The API `projects/envvar`, which is used by https://github.com/CircleCI-Public/circleci-cli/pull/770, requires `Accept` header to return responses of `content-type:application/json`
    - If not the case, the response header is `content-type:text/plain`
    - This can't be accepted by the Client of `api/rest/client.go`

## Considerations

==============

- With my checking, the `runner` API doesn't care `Accept-Type` header
    - I checked that `runner resource-class` and `runner token` commands succeeded without `Accept-Type` or `Accept`
    - ref. https://github.com/CircleCI-Public/circleci-cli/pull/474 is the PR that the `Accept-Type` is added

## Screenshots

============

The `runner` API works even if these changes are applied.

```
$ go run main.go runner resource-class list threepipes
+------------------+------------------+
|  RESOURCE CLASS  |   DESCRIPTION    |
+------------------+------------------+
| threepipes/test2 | test2            |
| threepipes/test3 | test description |
+------------------+------------------+
```

```
$ go run main.go runner resource-class create threepipes/test4 "test description 4"
If you have not already agreed to Runner Terms in a signed Order, then by continuing to install Runner, you are agreeing to CircleCI's Runner Terms which are found at: https://circleci.com/legal/runner-terms/.
If you already agreed to Runner Terms in a signed Order, the Runner Terms in the signed Order supersede the Runner Terms in the web address above.
If you did not already agree to Runner Terms through a signed Order and do not agree to the Runner Terms in the web address above, please do not install or use Runner.

+------------------+--------------------+
|  RESOURCE CLASS  |    DESCRIPTION     |
+------------------+--------------------+
| threepipes/test4 | test description 4 |
+------------------+--------------------+
```

```
$ go run main.go runner token create threepipes/test4 testtoken
api:
    auth_token: xxxxx
```

```
$ go run main.go runner token list threepipes/test4
+--------------------------------------+-----------+----------------------+
|                  ID                  | NICKNAME  |      CREATED AT      |
+--------------------------------------+-----------+----------------------+
| xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx | testtoken | 2022-09-22T13:50:01Z |
+--------------------------------------+-----------+----------------------+
```

```
$ go run main.go runner instance list threepipes/test4
+------+----------------+----------+-----------------+----------------+-----------+----+---------+
| NAME | RESOURCE CLASS | HOSTNAME | FIRST CONNECTED | LAST CONNECTED | LAST USED | IP | VERSION |
+------+----------------+----------+-----------------+----------------+-----------+----+---------+
+------+----------------+----------+-----------------+----------------+-----------+----+---------+
```


## **Here are some helpful tips you can follow when submitting a pull request:**

1. Fork [the repository](https://github.com/CircleCI-Public/circleci-cli) and create your branch from `master`.
2. Run `make build` in the repository root.
3. If you've fixed a bug or added code that should be tested, add tests!
4. Ensure the test suite passes (`make test`).
5. The `--debug` flag is often helpful for debugging HTTP client requests and responses.
6. Format your code with [gofmt](https://golang.org/cmd/gofmt/).
7. Make sure your code lints (`make lint`). Note: This requires Docker to run inside a local job.
