### PR TITLE
chore: Dynamically print flag options in error message

### DIFF
--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -594,8 +594,15 @@ func validateSortFlag(sort string) error {
 	if _, valid := validSortFlag[sort]; valid {
 		return nil
 	}
-	// TODO(zzak): we could probably reuse the map above to print the valid values
-	return fmt.Errorf("expected `%s` to be one of \"builds\", \"projects\", or \"orgs\"", sort)
+
+	keys := make([]string, 0, len(validSortFlag))
+	for key := range validSortFlag {
+		keys = append(keys, key)
+	}
+
+	validFlags := fmt.Sprint(strings.Join(keys, ", "))
+
+	return fmt.Errorf("expected `%s` to be one of: %s", sort, validFlags)
 }
 
 func listOrbs(opts orbOptions) error {

--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -590,8 +590,8 @@ var validSortFlag = map[string]bool{
 	"projects": true,
 	"orgs":     true}
 
-func validateSortFlag(sort string) error {
-	if _, valid := validSortFlag[sort]; valid {
+func validateSortFlag(sortFlag string) error {
+	if _, valid := validSortFlag[sortFlag]; valid {
 		return nil
 	}
 
@@ -599,10 +599,11 @@ func validateSortFlag(sort string) error {
 	for key := range validSortFlag {
 		keys = append(keys, key)
 	}
+	sort.Strings(keys)
 
 	validFlags := fmt.Sprint(strings.Join(keys, ", "))
 
-	return fmt.Errorf("expected `%s` to be one of: %s", sort, validFlags)
+	return fmt.Errorf("expected `%s` to be one of: %s", sortFlag, validFlags)
 }
 
 func listOrbs(opts orbOptions) error {

--- a/cmd/orb_test.go
+++ b/cmd/orb_test.go
@@ -1979,7 +1979,7 @@ Search, filter, and view sources for all Orbs online at https://circleci.com/dev
 				Eventually(session).Should(clitest.ShouldFail())
 
 				stderr := session.Wait().Err.Contents()
-				Expect(string(stderr)).To(Equal("Error: expected `idontknow` to be one of: builds, projects, orgs\n"))
+				Expect(string(stderr)).To(Equal("Error: expected `idontknow` to be one of: builds, orgs, projects\n"))
 			})
 		})
 

--- a/cmd/orb_test.go
+++ b/cmd/orb_test.go
@@ -1979,7 +1979,7 @@ Search, filter, and view sources for all Orbs online at https://circleci.com/dev
 				Eventually(session).Should(clitest.ShouldFail())
 
 				stderr := session.Wait().Err.Contents()
-				Expect(string(stderr)).To(Equal("Error: expected `idontknow` to be one of \"builds\", \"projects\", or \"orgs\"\n"))
+				Expect(string(stderr)).To(Equal("Error: expected `idontknow` to be one of: builds, projects, orgs\n"))
 			})
 		})
 


### PR DESCRIPTION
Signed-off-by: Adam Harvey <adaharve@cisco.com>

# Checklist

=========

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)
- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/master/CONTRIBUTING.md).

## Changes

=======

- Refactors error message to dynamically print out flag array

## Rationale

=========

This PR checks off a `// TODO` from the code by dynamically printing the values of an array.

Using this as an experimental PR as I get more comfortable with Golang. 😁  Local tests now go clean for me.


## Considerations

==============

* There's a bit of an existing hard tie-in to the test, in that the test also hardcodes the array elements.
* This slightly reduces the readability (quotes, and the human readable "or") in preference of simplifying the mechanics for how it is printed out. Could definitely do a more manual loop through them but thought this might be a bit more elegant.

## Screenshots

============

<h4>Before & After visible in code diff on test</h4>

<img width="867" alt="image" src="https://user-images.githubusercontent.com/33203301/191826839-1486217a-43db-47ca-8639-525b9e3073f3.png">

## **Here are some helpful tips you can follow when submitting a pull request:**

1. Fork [the repository](https://github.com/CircleCI-Public/circleci-cli) and create your branch from `master`.
2. Run `make build` in the repository root.
3. If you've fixed a bug or added code that should be tested, add tests!
4. Ensure the test suite passes (`make test`).
5. The `--debug` flag is often helpful for debugging HTTP client requests and responses.
6. Format your code with [gofmt](https://golang.org/cmd/gofmt/).
7. Make sure your code lints (`make lint`). Note: This requires Docker to run inside a local job.
