### PR TITLE
[SECENG-855] add --y flag for non-interactive policy push

### DIFF
--- a/cmd/policy/policy.go
+++ b/cmd/policy/policy.go
@@ -94,6 +94,8 @@ This group of commands allows the management of polices to be verified against b
 		cmd.Flags().StringVar(&context, "context", "config", "policy context")
 		cmd.Flags().StringVar(&ownerID, "owner-id", "", "the id of the policy's owner")
 		cmd.Flags().BoolVar(&noPrompt, "no-prompt", false, "removes the prompt")
+		cmd.Flags().MarkDeprecated("no-prompt", "please use --y instead.")
+		cmd.Flags().BoolVar(&noPrompt, "y", false, "runs non-interactively, assumes 'yes' to policy push prompt")
 		if err := cmd.MarkFlagRequired("owner-id"); err != nil {
 			panic(err)
 		}

--- a/cmd/policy/policy.go
+++ b/cmd/policy/policy.go
@@ -93,9 +93,11 @@ This group of commands allows the management of polices to be verified against b
 
 		cmd.Flags().StringVar(&context, "context", "config", "policy context")
 		cmd.Flags().StringVar(&ownerID, "owner-id", "", "the id of the policy's owner")
-		cmd.Flags().BoolVar(&noPrompt, "no-prompt", false, "removes the prompt")
-		cmd.Flags().MarkDeprecated("no-prompt", "please use --y instead.")
 		cmd.Flags().BoolVar(&noPrompt, "y", false, "runs non-interactively, assumes 'yes' to policy push prompt")
+		cmd.Flags().BoolVar(&noPrompt, "no-prompt", false, "removes the prompt")
+		if err := cmd.Flags().MarkDeprecated("no-prompt", "please use --y instead."); err != nil {
+			panic(err)
+		}
 		if err := cmd.MarkFlagRequired("owner-id"); err != nil {
 			panic(err)
 		}

--- a/cmd/policy/policy_test.go
+++ b/cmd/policy/policy_test.go
@@ -171,7 +171,7 @@ func TestPushPolicyBundleNoPrompt(t *testing.T) {
 
 			cmd, stdout, stderr := makeCMD()
 
-			cmd.SetArgs(append(tc.Args, "--policy-base-url", svr.URL, "--no-prompt"))
+			cmd.SetArgs(append(tc.Args, "--policy-base-url", svr.URL, "--y"))
 
 			err := cmd.Execute()
 			if tc.ExpectedErr != "" {

--- a/cmd/policy/testdata/policy/push-expected-usage.txt
+++ b/cmd/policy/testdata/policy/push-expected-usage.txt
@@ -6,8 +6,8 @@ policy push ./policies --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f
 
 Flags:
       --context string    policy context (default "config")
-      --no-prompt         removes the prompt
       --owner-id string   the id of the policy's owner
+      --y                 runs non-interactively, assumes 'yes' to policy push prompt
 
 Global Flags:
       --policy-base-url string   base url for policy api (default "https://internal.circleci.com")


### PR DESCRIPTION
# Checklist

=========

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)
- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/master/CONTRIBUTING.md).

### Internal Checklist
- [x] I am requesting a review from my own team as well as the owning team
- [x] I have a plan in place for the monitoring of the changes that I am making (this can include new monitors, logs to be aware of, etc...)

## Changes

=======

- added --y flag for non-interactive policy push
- set no-prompt flag as deprecated

## Rationale

=========

--y flag is more unix-like for non-interactive command run, so it would be more familiar to the users

## **Here are some helpful tips you can follow when submitting a pull request:**

1. Fork [the repository](https://github.com/CircleCI-Public/circleci-cli) and create your branch from `master`.
2. Run `make build` in the repository root.
3. If you've fixed a bug or added code that should be tested, add tests!
4. Ensure the test suite passes (`make test`).
5. The `--debug` flag is often helpful for debugging HTTP client requests and responses.
6. Format your code with [gofmt](https://golang.org/cmd/gofmt/).
7. Make sure your code lints (`make lint`). Note: This requires Docker to run inside a local job.
