### PR TITLE
feat: allow installer to download releases for ARM64

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -34,7 +34,7 @@ function error {
 
 trap error ERR
 
-# Determine release filename. This can be expanded with CPU arch in the future.
+# Determine release filename.
 case "$(uname)" in
 	Linux)
 		OS='linux'
@@ -48,7 +48,20 @@ case "$(uname)" in
 	;;
 esac
 
-RELEASE_URL="${GITHUB_BASE_URL}/releases/download/v${VERSION}/circleci-cli_${VERSION}_${OS}_amd64.tar.gz"
+case "$(uname -m)" in
+	aarch64 | arm64)
+		ARCH='arm64'
+	;;
+	x86_64)
+		ARCH="amd64"
+	;;
+	*)
+		echo "This architecture is not supported."
+		exit 1
+	;;
+esac
+
+RELEASE_URL="${GITHUB_BASE_URL}/releases/download/v${VERSION}/circleci-cli_${VERSION}_${OS}_${ARCH}.tar.gz"
 
 # Download & unpack the release tarball.
 curl -sL --retry 3 "${RELEASE_URL}" | tar zx --strip 1


### PR DESCRIPTION
# Checklist

=========

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)
- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/master/CONTRIBUTING.md).

### Internal Checklist
- [ ] I am requesting a review from my own team as well as the owning team
- [ ] I have a plan in place for the monitoring of the changes that I am making (this can include new monitors, logs to be aware of, etc...)

## Changes

=======

- Update _install.sh_ to account for CPU architecture when downloading the CLI binary releases

## Rationale

A customer noted that running the script [according to our docs here](https://circleci.com/docs/local-cli/#alternative-installation-method), would install the CircleCI CLI for linux/amd64 even if the machine is linux/arm64.

I have also tested these changes on a public sample repo with this modified _install.sh_ here:
https://github.com/kelvintaywl-cci/circleci-cli-install ([commit](https://github.com/kelvintaywl-cci/circleci-cli-install/commit/abe0dd7c8396c9f90e05ca1016977321219261c8))

We can see the builds for MacOS and Linux (arm64 + amd64):
https://app.circleci.com/pipelines/github/kelvintaywl-cci/circleci-cli-install/3