### PR TITLE
bug: fix scheduler parameters to support bools and numbers

### DIFF
--- a/api/schedule.go
+++ b/api/schedule.go
@@ -17,15 +17,15 @@ type Actor struct {
 }
 
 type Schedule struct {
-	ID          string            `json:"id"`
-	ProjectSlug string            `json:"project-slug"`
-	Name        string            `json:"name"`
-	Description string            `json:"description,omitempty"`
-	Timetable   Timetable         `json:"timetable"`
-	Actor       Actor             `json:"actor"`
-	Parameters  map[string]string `json:"parameters"`
-	CreatedAt   time.Time         `json:"created-at"`
-	UpdatedAt   time.Time         `json:"updated-at"`
+	ID          string                 `json:"id"`
+	ProjectSlug string                 `json:"project-slug"`
+	Name        string                 `json:"name"`
+	Description string                 `json:"description,omitempty"`
+	Timetable   Timetable              `json:"timetable"`
+	Actor       Actor                  `json:"actor"`
+	Parameters  map[string]interface{} `json:"parameters"`
+	CreatedAt   time.Time              `json:"created-at"`
+	UpdatedAt   time.Time              `json:"updated-at"`
 }
 
 type ScheduleInterface interface {

--- a/api/schedule_rest.go
+++ b/api/schedule_rest.go
@@ -36,7 +36,7 @@ type listSchedulesParams struct {
 
 // Creates a new schedule in the supplied project.
 func (c *ScheduleRestClient) CreateSchedule(vcs, org, project, name, description string,
-	useSchedulingSystem bool, timetable Timetable, parameters map[string]string) (*Schedule, error) {
+	useSchedulingSystem bool, timetable Timetable, parameters map[string]interface{}) (*Schedule, error) {
 
 	req, err := c.newCreateScheduleRequest(vcs, org, project, name, description, useSchedulingSystem, timetable, parameters)
 	if err != nil {
@@ -73,7 +73,7 @@ func (c *ScheduleRestClient) CreateSchedule(vcs, org, project, name, description
 
 // Updates an existing schedule.
 func (c *ScheduleRestClient) UpdateSchedule(scheduleID, name, description string,
-	useSchedulingSystem bool, timetable Timetable, parameters map[string]string) (*Schedule, error) {
+	useSchedulingSystem bool, timetable Timetable, parameters map[string]interface{}) (*Schedule, error) {
 
 	req, err := c.newUpdateScheduleRequest(scheduleID, name, description, useSchedulingSystem, timetable, parameters)
 	if err != nil {
@@ -273,7 +273,7 @@ func (c *ScheduleRestClient) newGetScheduleRequest(scheduleID string) (*http.Req
 
 // Builds a request to create a new schedule.
 func (c *ScheduleRestClient) newCreateScheduleRequest(vcs, org, project, name, description string,
-	useSchedulingSystem bool, timetable Timetable, parameters map[string]string) (*http.Request, error) {
+	useSchedulingSystem bool, timetable Timetable, parameters map[string]interface{}) (*http.Request, error) {
 
 	var err error
 	queryURL, err := url.Parse(c.server)
@@ -293,11 +293,11 @@ func (c *ScheduleRestClient) newCreateScheduleRequest(vcs, org, project, name, d
 	var bodyReader io.Reader
 
 	var body = struct {
-		Name             string            `json:"name"`
-		Description      string            `json:"description,omitempty"`
-		AttributionActor string            `json:"attribution-actor"`
-		Parameters       map[string]string `json:"parameters"`
-		Timetable        Timetable         `json:"timetable"`
+		Name             string                 `json:"name"`
+		Description      string                 `json:"description,omitempty"`
+		AttributionActor string                 `json:"attribution-actor"`
+		Parameters       map[string]interface{} `json:"parameters"`
+		Timetable        Timetable              `json:"timetable"`
 	}{
 		Name:             name,
 		Description:      description,
@@ -318,7 +318,7 @@ func (c *ScheduleRestClient) newCreateScheduleRequest(vcs, org, project, name, d
 
 // Builds a request to update an existing schedule.
 func (c *ScheduleRestClient) newUpdateScheduleRequest(scheduleID, name, description string,
-	useSchedulingSystem bool, timetable Timetable, parameters map[string]string) (*http.Request, error) {
+	useSchedulingSystem bool, timetable Timetable, parameters map[string]interface{}) (*http.Request, error) {
 
 	var err error
 	queryURL, err := url.Parse(c.server)
@@ -338,11 +338,11 @@ func (c *ScheduleRestClient) newUpdateScheduleRequest(scheduleID, name, descript
 	var bodyReader io.Reader
 
 	var body = struct {
-		Name             string            `json:"name,omitempty"`
-		Description      string            `json:"description,omitempty"`
-		AttributionActor string            `json:"attribution-actor,omitempty"`
-		Parameters       map[string]string `json:"parameters,omitempty"`
-		Timetable        Timetable         `json:"timetable,omitempty"`
+		Name             string                 `json:"name,omitempty"`
+		Description      string                 `json:"description,omitempty"`
+		AttributionActor string                 `json:"attribution-actor,omitempty"`
+		Parameters       map[string]interface{} `json:"parameters,omitempty"`
+		Timetable        Timetable              `json:"timetable,omitempty"`
 	}{
 		Name:             name,
 		Description:      description,

--- a/api/schedule_test.go
+++ b/api/schedule_test.go
@@ -28,8 +28,9 @@ func mockSchedule() Schedule {
 			Login: "test-actor",
 			Name:  "T. Actor",
 		},
-		Parameters: map[string]string{
+		Parameters: map[string]interface{}{
 			"test": "parameter",
+			"bool": true,
 		},
 	}
 }


### PR DESCRIPTION
# Checklist

=========

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)
- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/master/CONTRIBUTING.md).

## Changes

=======

- Changed type of schedule parameters from `map[string]string` to `map[string]interface{}` to enable support for bools and numbers as well as string parameters

## Rationale

=========

Without this, only strings are supported via the api-client.

## Considerations

==============

`map[string]interface{}` will transparently marshal into json without any further changes. Changing the type of the `Parameters` field in the `Schedule` struct is, unfortunately a breaking change.
