### PR TITLE
feat: enabled the configuration of the build-agent through argument of config file

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -16,6 +16,8 @@ func newLocalExecuteCommand(config *settings.Config) *cobra.Command {
 	}
 
 	local.AddFlagsForDocumentation(buildCommand.Flags())
+	buildAgentVersionUsage := `The version of the build agent image you want to use. This can be configured by writing in $HOME/.circleci/build_agent_settings.json: '{"LatestSha256":"<version-of-build-agent>"}'`
+	buildCommand.Flags().String("build-agent-version", "", buildAgentVersionUsage)
 	buildCommand.Flags().StringP("org-slug", "o", "", "organization slug (for example: github/example-org), used when a config depends on private orbs belonging to that org")
 	buildCommand.Flags().String("org-id", "", "organization id, used when a config depends on private orbs belonging to that org")
 


### PR DESCRIPTION
# Checklist

## Changes

For the commands `circleci build` and `circleci local execute`, added the arguments `--picard-version` that enable to use a version of the picard image to use for the build. This option can be configured by creating a file in `$HOME/.circleci/build_agent_settings.json` which would contains ```{"LatestSha256":"<your-image>"}```

## Rationale

Because the latest picard image has actually some errors on the latest mac versions, a solution was use an old version of the picard executor. There was no way to do it with the actual version of the CLI, this pr allows this configuration
More information about this issue can be found the following issues:
 - https://github.com/CircleCI-Public/circleci-cli/issues/676
 - https://github.com/CircleCI-Public/circleci-cli/issues/589


## Screenshots

![Capture d’écran 2023-01-16 à 11 32 50](https://user-images.githubusercontent.com/26357621/212657631-fa78a09a-d630-48e0-abe8-4da591144636.png)

