### PR TITLE
PIPE-2315 - Remove unstable GraphQL service from config compilation path

### DIFF
--- a/api/rest/client_test.go
+++ b/api/rest/client_test.go
@@ -9,8 +9,7 @@ import (
 	"sync"
 	"testing"
 
-	"gotest.tools/v3/assert"
-	"gotest.tools/v3/assert/cmp"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/CircleCI-Public/circleci-cli/settings"
 	"github.com/CircleCI-Public/circleci-cli/version"
@@ -30,29 +29,29 @@ func TestClient_DoRequest(t *testing.T) {
 				A: "aaa",
 				B: 123,
 			})
-			assert.NilError(t, err)
+			assert.Nil(t, err)
 
 			resp := make(map[string]interface{})
 			statusCode, err := c.DoRequest(r, &resp)
-			assert.NilError(t, err)
+			assert.Nil(t, err)
 			assert.Equal(t, statusCode, http.StatusCreated)
-			assert.Check(t, cmp.DeepEqual(resp, map[string]interface{}{
+			assert.Equal(t, resp, map[string]interface{}{
 				"key": "value",
-			}))
+			})
 		})
 
 		t.Run("Check request", func(t *testing.T) {
-			assert.Check(t, cmp.Equal(fix.URL(), url.URL{Path: "/api/v2/my/endpoint"}))
-			assert.Check(t, cmp.Equal(fix.Method(), "PUT"))
-			assert.Check(t, cmp.DeepEqual(fix.Header(), http.Header{
+			assert.Equal(t, fix.URL(), url.URL{Path: "/api/v2/my/endpoint"})
+			assert.Equal(t, fix.Method(), "PUT")
+			assert.Equal(t, fix.Header(), http.Header{
 				"Accept-Encoding": {"gzip"},
 				"Accept":          {"application/json"},
 				"Circle-Token":    {"fake-token"},
 				"Content-Length":  {"20"},
 				"Content-Type":    {"application/json"},
 				"User-Agent":      {version.UserAgent()},
-			}))
-			assert.Check(t, cmp.Equal(fix.Body(), `{"A":"aaa","B":123}`+"\n"))
+			})
+			assert.Equal(t, fix.Body(), `{"A":"aaa","B":123}`+"\n")
 		})
 	})
 
@@ -63,25 +62,25 @@ func TestClient_DoRequest(t *testing.T) {
 
 		t.Run("Check result", func(t *testing.T) {
 			r, err := c.NewRequest(http.MethodGet, &url.URL{Path: "my/error/endpoint"}, nil)
-			assert.NilError(t, err)
+			assert.Nil(t, err)
 
 			resp := make(map[string]interface{})
 			statusCode, err := c.DoRequest(r, &resp)
 			assert.Error(t, err, "the error message")
 			assert.Equal(t, statusCode, http.StatusBadRequest)
-			assert.Check(t, cmp.DeepEqual(resp, map[string]interface{}{}))
+			assert.Equal(t, resp, map[string]interface{}{})
 		})
 
 		t.Run("Check request", func(t *testing.T) {
-			assert.Check(t, cmp.Equal(fix.URL(), url.URL{Path: "/api/v2/my/error/endpoint"}))
-			assert.Check(t, cmp.Equal(fix.Method(), http.MethodGet))
-			assert.Check(t, cmp.DeepEqual(fix.Header(), http.Header{
+			assert.Equal(t, fix.URL(), url.URL{Path: "/api/v2/my/error/endpoint"})
+			assert.Equal(t, fix.Method(), http.MethodGet)
+			assert.Equal(t, fix.Header(), http.Header{
 				"Accept-Encoding": {"gzip"},
 				"Accept":          {"application/json"},
 				"Circle-Token":    {"fake-token"},
 				"User-Agent":      {version.UserAgent()},
-			}))
-			assert.Check(t, cmp.Equal(fix.Body(), ""))
+			})
+			assert.Equal(t, fix.Body(), "")
 		})
 	})
 
@@ -92,28 +91,28 @@ func TestClient_DoRequest(t *testing.T) {
 
 		t.Run("Check result", func(t *testing.T) {
 			r, err := c.NewRequest(http.MethodGet, &url.URL{Path: "path"}, nil)
-			assert.NilError(t, err)
+			assert.Nil(t, err)
 
 			resp := make(map[string]interface{})
 			statusCode, err := c.DoRequest(r, &resp)
-			assert.NilError(t, err)
+			assert.Nil(t, err)
 			assert.Equal(t, statusCode, http.StatusCreated)
-			assert.Check(t, cmp.DeepEqual(resp, map[string]interface{}{
+			assert.Equal(t, resp, map[string]interface{}{
 				"a": "abc",
 				"b": true,
-			}))
+			})
 		})
 
 		t.Run("Check request", func(t *testing.T) {
-			assert.Check(t, cmp.Equal(fix.URL(), url.URL{Path: "/api/v2/path"}))
-			assert.Check(t, cmp.Equal(fix.Method(), http.MethodGet))
-			assert.Check(t, cmp.DeepEqual(fix.Header(), http.Header{
+			assert.Equal(t, fix.URL(), url.URL{Path: "/api/v2/path"})
+			assert.Equal(t, fix.Method(), http.MethodGet)
+			assert.Equal(t, fix.Header(), http.Header{
 				"Accept-Encoding": {"gzip"},
 				"Accept":          {"application/json"},
 				"Circle-Token":    {"fake-token"},
 				"User-Agent":      {version.UserAgent()},
-			}))
-			assert.Check(t, cmp.Equal(fix.Body(), ""))
+			})
+			assert.Equal(t, fix.Body(), "")
 		})
 	})
 }
@@ -125,8 +124,7 @@ func TestAPIRequest(t *testing.T) {
 
 	t.Run("test new api request sets the default headers", func(t *testing.T) {
 		req, err := c.NewAPIRequest("GET", &url.URL{}, struct{}{})
-		assert.NilError(t, err)
-
+		assert.Nil(t, err)
 		assert.Equal(t, req.Header.Get("User-Agent"), "circleci-cli/0.0.0-dev+dirty-local-tree (source)")
 		assert.Equal(t, req.Header.Get("Circle-Token"), c.circleToken)
 		assert.Equal(t, req.Header.Get("Accept"), "application/json")
@@ -138,20 +136,46 @@ func TestAPIRequest(t *testing.T) {
 
 	t.Run("test new api request sets the default headers", func(t *testing.T) {
 		req, err := c.NewAPIRequest("GET", &url.URL{}, testPayload{Message: "hello"})
-		assert.NilError(t, err)
-
+		assert.Nil(t, err)
 		assert.Equal(t, req.Header.Get("Circleci-Cli-Command"), "")
 		assert.Equal(t, req.Header.Get("Content-Type"), "application/json")
 	})
 
 	t.Run("test new api request doesn't set content-type with empty payload", func(t *testing.T) {
 		req, err := c.NewAPIRequest("GET", &url.URL{}, nil)
-		assert.NilError(t, err)
-
+		assert.Nil(t, err)
 		assert.Equal(t, req.Header.Get("Circleci-Cli-Command"), "")
-		if req.Header.Get("Content-Type") != "" {
-			t.Fail()
-		}
+		assert.Equal(t, req.Header.Get("Content-Type"), "")
+	})
+
+	type Options struct {
+		OwnerID            string                 `json:"owner_id,omitempty"`
+		PipelineParameters map[string]interface{} `json:"pipeline_parameters,omitempty"`
+		PipelineValues     map[string]string      `json:"pipeline_values,omitempty"`
+	}
+
+	type CompileConfigRequest struct {
+		ConfigYaml string  `json:"config_yaml"`
+		Options    Options `json:"options"`
+	}
+
+	t.Run("config compile and validate payloads have expected shape", func(t *testing.T) {
+		req, err := c.NewAPIRequest("GET", &url.URL{}, CompileConfigRequest{
+			ConfigYaml: "test-config",
+			Options: Options{
+				OwnerID: "1234",
+				PipelineValues: map[string]string{
+					"key": "val",
+				},
+			},
+		})
+		assert.Nil(t, err)
+		assert.Equal(t, req.Header.Get("Circleci-Cli-Command"), "")
+		assert.Equal(t, req.Header.Get("Content-Type"), "application/json")
+
+		reqBody, _ := io.ReadAll(req.Body)
+		assert.Contains(t, string(reqBody), `"config_yaml":"test-config"`)
+		assert.Contains(t, string(reqBody), `"owner_id":"1234"`)
 	})
 }
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -179,9 +179,9 @@ func validateConfig(opts configOptions, flags *pflag.FlagSet) error {
 	}
 
 	if path == "-" {
-		fmt.Printf("Config input is valid.\n")
+		fmt.Printf("\nConfig input is valid.\n")
 	} else {
-		fmt.Printf("Config file at %s is valid.\n", path)
+		fmt.Printf("\nConfig file at %s is valid.\n", path)
 	}
 
 	return nil

--- a/config/config.go
+++ b/config/config.go
@@ -28,7 +28,7 @@ type CompileConfigRequest struct {
 }
 
 type Options struct {
-	OwnerID            string                 `json:"owner-id,omitempty"`
+	OwnerID            string                 `json:"owner_id,omitempty"`
 	PipelineParameters map[string]interface{} `json:"pipeline_parameters,omitempty"`
 	PipelineValues     map[string]string      `json:"pipeline_values,omitempty"`
 }

--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 	github.com/charmbracelet/bubbles v0.11.0 // indirect
 	github.com/charmbracelet/bubbletea v0.21.0 // indirect
 	github.com/containerd/console v1.0.3 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emirpasic/gods v1.12.0 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
@@ -71,10 +72,12 @@ require (
 	github.com/muesli/termenv v0.12.0 // indirect
 	github.com/nxadm/tail v1.4.8 // indirect
 	github.com/open-policy-agent/opa v0.49.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/rogpeppe/go-internal v1.9.0 // indirect
 	github.com/sergi/go-diff v1.1.0 // indirect
+	github.com/stretchr/testify v1.8.2 // indirect
 	github.com/tchap/go-patricia/v2 v2.3.1 // indirect
 	github.com/xanzy/ssh-agent v0.2.1 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect

--- a/go.sum
+++ b/go.sum
@@ -315,11 +315,17 @@ github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnIn
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.2.1/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
+github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
+github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/tchap/go-patricia/v2 v2.3.1 h1:6rQp39lgIYZ+MHmdEq4xzuk1t7OdC35z/xm0BGhTkes=
 github.com/tchap/go-patricia/v2 v2.3.1/go.mod h1:VZRHKAb53DLaG+nA9EaYYiaEx6YztwDlLElMsnSHD4k=
 github.com/tcnksm/go-gitconfig v0.1.2 h1:iiDhRitByXAEyjgBqsKi9QU4o2TNtv9kPP3RgPgXBPw=


### PR DESCRIPTION
- First pass at removing the api-service dependency for config compilation and validation
- Fixed the json key for owner-id which now allows for private orb resolution

# Checklist

=========

- [x ] I have performed a self-review of my own code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [x ] I have checked for similar issues and haven't found anything relevant.
- [x ] This is not a security issue (which should be reported here: https://circleci.com/security/)
- [x ] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/main/CONTRIBUTING.md).

### Internal Checklist
- [x ] I am requesting a review from my own team as well as the owning team
- [x ] I have a plan in place for the monitoring of the changes that I am making (this can include new monitors, logs to be aware of, etc...)

## Changes

=======

- Removes the unstable graphQL service from the config compilation path.

## Rationale

=========

Simplifying our architecture.

