### PR TITLE
PIPE-2315 - Changes behaviour such that process and validate commands respect server hosts

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -38,6 +38,14 @@ var configAnnotations = map[string]string{
 	"<path>": "The path to your config (use \"-\" for STDIN)",
 }
 
+func GetConfigAPIHost(cfg *settings.Config) string {
+	if cfg.Host != defaultHost {
+		return cfg.Host
+	} else {
+		return cfg.ConfigAPIHost
+	}
+}
+
 func newConfigCommand(config *settings.Config) *cobra.Command {
 	opts := configOptions{
 		cfg: config,
@@ -68,7 +76,7 @@ func newConfigCommand(config *settings.Config) *cobra.Command {
 		Short:   "Check that the config file is well formed.",
 		PreRun: func(cmd *cobra.Command, args []string) {
 			opts.args = args
-			opts.rest = rest.NewFromConfig(config.ConfigAPIHost, config)
+			opts.rest = rest.NewFromConfig(GetConfigAPIHost(opts.cfg), config)
 		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return validateConfig(opts, cmd.Flags())
@@ -90,7 +98,7 @@ func newConfigCommand(config *settings.Config) *cobra.Command {
 		Short: "Validate config and display expanded configuration.",
 		PreRun: func(cmd *cobra.Command, args []string) {
 			opts.args = args
-			opts.rest = rest.NewFromConfig(config.ConfigAPIHost, config)
+			opts.rest = rest.NewFromConfig(GetConfigAPIHost(opts.cfg), config)
 		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return processConfig(opts, cmd.Flags())

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -4,11 +4,15 @@ import (
 	"fmt"
 	"os/exec"
 	"path/filepath"
+	"testing"
 
 	"github.com/CircleCI-Public/circleci-cli/clitest"
+	"github.com/CircleCI-Public/circleci-cli/cmd"
+	"github.com/CircleCI-Public/circleci-cli/settings"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
+	"github.com/stretchr/testify/assert"
 	"gotest.tools/v3/golden"
 )
 
@@ -246,3 +250,17 @@ var _ = Describe("Config", func() {
 		})
 	})
 })
+
+func TestGetConfigAPIHost(t *testing.T) {
+	t.Run("tests that we correctly get the config api host when the host is not the default one", func(t *testing.T) {
+		// if the host isn't equal to `https://circleci.com` then this is likely a server instance and
+		// wont have the api.X.com subdomain so we should instead just respect the host for config commands
+		host := cmd.GetConfigAPIHost(&settings.Config{Host: "test"})
+		assert.Equal(t, host, "test")
+
+		// If the host passed in is the same as the defaultHost 'https://circleci.com' - then we know this is cloud
+		// and as such should use the `api.circleci.com` subdomain
+		host = cmd.GetConfigAPIHost(&settings.Config{Host: "https://circleci.com", ConfigAPIHost: "https://api.circleci.com"})
+		assert.Equal(t, host, "https://api.circleci.com")
+	})
+}


### PR DESCRIPTION
This PR Changes behaviour for the config process and validate commands to respect the --host flag when it's set to a non-default host.

This improves the UX of the changes introduced in the last PR such that customers don't have to also specify `--config-api-host`. 

# Checklist

=========

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)
- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/main/CONTRIBUTING.md).

### Internal Checklist
- [x] I am requesting a review from my own team as well as the owning team
- [x] I have a plan in place for the monitoring of the changes that I am making (this can include new monitors, logs to be aware of, etc...)

## Changes

=======

- When instantiating the command, use the host option if it's not equal to the default host. This effectively allows server setups to see no behavioural change for these commands.

## Validation

- [x] `./build/darwin/amd64/circleci config --host https://k9s.sphereci.com validate .circleci/config.yml --org-slug gh/circleci` - goes to correct `https://k9s.sphereci.com/api/v2/me/collaborations` and `https://k9s.sphereci.com/api/v2/compile-config-with-defaults` urls for config compilation
- [x]  `./build/darwin/amd64/circleci config validate .circleci/config.yml --org-slug gh/circleci` - goes to `circleci.com` and `api.circleci.com` respectively
- [x] config validation continues to work for private orbs
- [x] config processing continues to work for private orbs