### PR TITLE
Update go1.20

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 executors:
   go:
     docker:
-      - image: cimg/go:1.18
+      - image: cimg/go:1.20
     environment:
       CGO_ENABLED: 0
   mac:
@@ -108,8 +108,8 @@ jobs:
       - checkout
       - run: |
           brew update
-          brew install go@1.18
-          echo 'export PATH="/usr/local/opt/go@1.18/bin:$PATH"' >> ~/.bash_profile
+          brew install go@1.20
+          echo 'export PATH="/usr/local/opt/go@1.20/bin:$PATH"' >> ~/.bash_profile
       - gomod
       - run: make test
   build:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cimg/go:1.18.3
+FROM cimg/go:1.20
 
 ENV CIRCLECI_CLI_SKIP_UPDATE_CHECK true
 

--- a/go.mod
+++ b/go.mod
@@ -98,4 +98,4 @@ require (
 // fix vulnerability: CVE-2020-15114 in etcd v3.3.10+incompatible
 replace github.com/coreos/etcd => github.com/coreos/etcd v3.3.24+incompatible
 
-go 1.18
+go 1.20


### PR DESCRIPTION
# Checklist

=========

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have checked for similar issues and haven't found anything relevant.
- [X] This is not a security issue (which should be reported here: https://circleci.com/security/)
- [X] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/main/CONTRIBUTING.md).

### Internal Checklist
- [ ] I am requesting a review from my own team as well as the owning team
- [X] I have a plan in place for the monitoring of the changes that I am making (this can include new monitors, logs to be aware of, etc...)

## Changes

=======

- update go.mod to use 1.20
- updated build system and ci to use go1.20

## Rationale

- Keep go up to date
- Features and libraries the cli depends on will want to use go1.20 (circle-policy-agent for example)
