### PR TITLE
Migrates the old calls to the deprecated ioutil package to io and os respectively

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -3,7 +3,7 @@ package api
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -484,9 +484,9 @@ func loadYaml(path string) (string, error) {
 	var err error
 	var config []byte
 	if path == "-" {
-		config, err = ioutil.ReadAll(os.Stdin)
+		config, err = io.ReadAll(os.Stdin)
 	} else {
-		config, err = ioutil.ReadFile(path)
+		config, err = os.ReadFile(path)
 	}
 
 	if err != nil {

--- a/api/context_rest.go
+++ b/api/context_rest.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 
@@ -71,7 +70,7 @@ func (c *ContextRestClient) DeleteEnvironmentVariable(contextID, variable string
 		return err
 	}
 
-	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	bodyBytes, err := io.ReadAll(resp.Body)
 	defer resp.Body.Close()
 	if err != nil {
 		return err
@@ -99,7 +98,7 @@ func (c *ContextRestClient) CreateContextWithOrgID(orgID *string, name string) e
 		return err
 	}
 
-	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	bodyBytes, err := io.ReadAll(resp.Body)
 	defer resp.Body.Close()
 	if err != nil {
 		return err
@@ -131,7 +130,7 @@ func (c *ContextRestClient) CreateContext(vcs, org, name string) error {
 		return err
 	}
 
-	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	bodyBytes, err := io.ReadAll(resp.Body)
 	defer resp.Body.Close()
 	if err != nil {
 		return err
@@ -162,7 +161,7 @@ func (c *ContextRestClient) CreateEnvironmentVariable(contextID, variable, value
 		return err
 	}
 
-	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	bodyBytes, err := io.ReadAll(resp.Body)
 	defer resp.Body.Close()
 	if err != nil {
 		return err
@@ -190,7 +189,7 @@ func (c *ContextRestClient) DeleteContext(contextID string) error {
 		return err
 	}
 
-	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	bodyBytes, err := io.ReadAll(resp.Body)
 	defer resp.Body.Close()
 	if err != nil {
 		return err
@@ -300,7 +299,7 @@ func (c *ContextRestClient) listEnvironmentVariables(params *listEnvironmentVari
 		return nil, err
 	}
 
-	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	bodyBytes, err := io.ReadAll(resp.Body)
 	defer resp.Body.Close()
 	if err != nil {
 		return nil, err
@@ -334,7 +333,7 @@ func (c *ContextRestClient) listContexts(params *listContextsParams) (*listConte
 		return nil, err
 	}
 
-	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	bodyBytes, err := io.ReadAll(resp.Body)
 	defer resp.Body.Close()
 	if err != nil {
 		return nil, err
@@ -580,7 +579,7 @@ func (c *ContextRestClient) EnsureExists() error {
 		return errors.New("API v2 test request failed.")
 	}
 
-	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	bodyBytes, err := io.ReadAll(resp.Body)
 	defer resp.Body.Close()
 	if err != nil {
 		return err

--- a/api/context_rest_test.go
+++ b/api/context_rest_test.go
@@ -2,7 +2,7 @@ package api
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/CircleCI-Public/circleci-cli/settings"
@@ -32,7 +32,7 @@ func appendRESTPostHandler(server *ghttp.Server, combineHandlers ...MockRequestR
 				ghttp.VerifyRequest("POST", "/api/v2/context"),
 				ghttp.VerifyContentType("application/json"),
 				func(w http.ResponseWriter, req *http.Request) {
-					body, err := ioutil.ReadAll(req.Body)
+					body, err := io.ReadAll(req.Body)
 					Expect(err).ShouldNot(HaveOccurred())
 					err = req.Body.Close()
 					Expect(err).ShouldNot(HaveOccurred())

--- a/api/graphql/client.go
+++ b/api/graphql/client.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/url"
@@ -254,7 +254,7 @@ func (cl *Client) Run(request *Request, resp interface{}) error {
 	if cl.Debug {
 		var bodyBytes []byte
 		if res.Body != nil {
-			bodyBytes, err = ioutil.ReadAll(res.Body)
+			bodyBytes, err = io.ReadAll(res.Body)
 			if err != nil {
 				return errors.Wrap(err, "reading response")
 			}
@@ -262,7 +262,7 @@ func (cl *Client) Run(request *Request, resp interface{}) error {
 			l.Printf("<< %s", string(bodyBytes))
 
 			// Restore the io.ReadCloser to its original state
-			res.Body = ioutil.NopCloser(bytes.NewBuffer(bodyBytes))
+			res.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 		}
 	}
 

--- a/api/graphql/client_test.go
+++ b/api/graphql/client_test.go
@@ -2,7 +2,6 @@ package graphql
 
 import (
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
@@ -53,7 +52,7 @@ func TestDoJSON(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		calls++
 
-		b, err := ioutil.ReadAll(r.Body)
+		b, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Errorf(err.Error())
 		}
@@ -96,7 +95,7 @@ func TestQueryJSON(t *testing.T) {
 	var calls int
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		calls++
-		b, err := ioutil.ReadAll(r.Body)
+		b, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Errorf(err.Error())
 		}
@@ -146,7 +145,7 @@ func TestDoJSONErr(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, req *http.Request) {
 		calls++
 
-		body, err := ioutil.ReadAll(req.Body)
+		body, err := io.ReadAll(req.Body)
 		if err != nil {
 			t.Errorf(err.Error())
 		}

--- a/api/info/info.go
+++ b/api/info/info.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 
@@ -58,7 +57,7 @@ func (c *InfoRESTClient) GetInfo() (*[]Organization, error) {
 		return nil, err
 	}
 
-	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	bodyBytes, err := io.ReadAll(resp.Body)
 	defer resp.Body.Close()
 	if err != nil {
 		return nil, err

--- a/api/schedule_rest.go
+++ b/api/schedule_rest.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 
@@ -49,7 +48,7 @@ func (c *ScheduleRestClient) CreateSchedule(vcs, org, project, name, description
 		return nil, err
 	}
 
-	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	bodyBytes, err := io.ReadAll(resp.Body)
 	defer resp.Body.Close()
 	if err != nil {
 		return nil, err
@@ -86,7 +85,7 @@ func (c *ScheduleRestClient) UpdateSchedule(scheduleID, name, description string
 		return nil, err
 	}
 
-	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	bodyBytes, err := io.ReadAll(resp.Body)
 	defer resp.Body.Close()
 	if err != nil {
 		return nil, err
@@ -121,7 +120,7 @@ func (c *ScheduleRestClient) DeleteSchedule(scheduleID string) error {
 		return err
 	}
 
-	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	bodyBytes, err := io.ReadAll(resp.Body)
 	defer resp.Body.Close()
 	if err != nil {
 		return err
@@ -157,7 +156,7 @@ func (c *ScheduleRestClient) ScheduleByID(scheduleID string) (*Schedule, error) 
 		return nil, err
 	}
 
-	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	bodyBytes, err := io.ReadAll(resp.Body)
 	defer resp.Body.Close()
 	if err != nil {
 		return nil, err
@@ -231,7 +230,7 @@ func (c *ScheduleRestClient) listSchedules(vcs, org, project string, params *lis
 		return nil, err
 	}
 
-	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	bodyBytes, err := io.ReadAll(resp.Body)
 	defer resp.Body.Close()
 	if err != nil {
 		return nil, err
@@ -438,7 +437,7 @@ func (c *ScheduleRestClient) EnsureExists() error {
 		return errors.New("API v2 test request failed.")
 	}
 
-	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	bodyBytes, err := io.ReadAll(resp.Body)
 	defer resp.Body.Close()
 	if err != nil {
 		return err

--- a/clitest/clitest.go
+++ b/clitest/clitest.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -50,7 +49,7 @@ func (tempSettings TempSettings) AssertConfigRereadMatches(contents string) {
 	file, err := os.Open(tempSettings.Config.Path)
 	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 
-	reread, err := ioutil.ReadAll(file)
+	reread, err := io.ReadAll(file)
 	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 	gomega.Expect(string(reread)).To(gomega.ContainSubstring(contents))
 }
@@ -61,7 +60,7 @@ func WithTempSettings() *TempSettings {
 
 	tempSettings := &TempSettings{}
 
-	tempSettings.Home, err = ioutil.TempDir("", "circleci-cli-test-")
+	tempSettings.Home, err = os.MkdirTemp("", "circleci-cli-test-")
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 	settingsPath := filepath.Join(tempSettings.Home, ".circleci")
@@ -101,7 +100,7 @@ func (tempSettings *TempSettings) AppendRESTPostHandler(combineHandlers ...MockR
 				ghttp.VerifyRequest("POST", "/api/v2/context"),
 				ghttp.VerifyContentType("application/json"),
 				func(w http.ResponseWriter, req *http.Request) {
-					body, err := ioutil.ReadAll(req.Body)
+					body, err := io.ReadAll(req.Body)
 					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 					err = req.Body.Close()
 					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
@@ -131,7 +130,7 @@ func (tempSettings *TempSettings) AppendPostHandler(authToken string, combineHan
 					// VerifyContentType("application/json") check
 					// that fails with "application/json; charset=utf-8"
 					func(w http.ResponseWriter, req *http.Request) {
-						body, err := ioutil.ReadAll(req.Body)
+						body, err := io.ReadAll(req.Body)
 						gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 						err = req.Body.Close()
 						gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
@@ -152,7 +151,7 @@ func (tempSettings *TempSettings) AppendPostHandler(authToken string, combineHan
 					// VerifyContentType("application/json") check
 					// that fails with "application/json; charset=utf-8"
 					func(w http.ResponseWriter, req *http.Request) {
-						body, err := ioutil.ReadAll(req.Body)
+						body, err := io.ReadAll(req.Body)
 						gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 						err = req.Body.Close()
 						gomega.Expect(err).ShouldNot(gomega.HaveOccurred())

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -2,8 +2,8 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/url"
+	"os"
 	"strings"
 
 	"github.com/CircleCI-Public/circleci-cli/api/rest"
@@ -204,7 +204,7 @@ func processConfig(opts configOptions, flags *pflag.FlagSet) error {
 	if len(paramsYaml) > 0 {
 		// The 'src' value can be a filepath, or a yaml string. If the file cannot be read successfully,
 		// proceed with the assumption that the value is already valid yaml.
-		raw, err := ioutil.ReadFile(paramsYaml)
+		raw, err := os.ReadFile(paramsYaml)
 		if err != nil {
 			raw = []byte(paramsYaml)
 		}

--- a/cmd/context.go
+++ b/cmd/context.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 	"time"
@@ -189,7 +189,7 @@ func showContext(client api.ContextInterface, vcsType, orgName, contextName stri
 func readSecretValue() (string, error) {
 	stat, _ := os.Stdin.Stat()
 	if (stat.Mode() & os.ModeCharDevice) == 0 {
-		bytes, err := ioutil.ReadAll(os.Stdin)
+		bytes, err := io.ReadAll(os.Stdin)
 		return string(bytes), err
 	} else {
 		fmt.Print("Enter secret value and press enter: ")

--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -1122,7 +1121,7 @@ func initOrb(opts orbOptions) error {
 		return errors.Wrap(err, "Unexpected error")
 	}
 
-	body, err := ioutil.ReadAll(req.Body)
+	body, err := io.ReadAll(req.Body)
 	if err != nil {
 		return errors.Wrap(err, "Unexpected error")
 	}
@@ -1385,46 +1384,46 @@ func initOrb(opts orbOptions) error {
 		return y[0]
 	}()
 
-	circleConfigSetup, err := ioutil.ReadFile(path.Join(orbPath, ".circleci", "config.yml"))
+	circleConfigSetup, err := os.ReadFile(path.Join(orbPath, ".circleci", "config.yml"))
 	if err != nil {
 		return err
 	}
 
 	configSetupString := string(circleConfigSetup)
-	err = ioutil.WriteFile(path.Join(orbPath, ".circleci", "config.yml"), []byte(orbTemplate(configSetupString, projectName, ownerName, orbName, namespace)), 0644)
+	err = os.WriteFile(path.Join(orbPath, ".circleci", "config.yml"), []byte(orbTemplate(configSetupString, projectName, ownerName, orbName, namespace)), 0644)
 	if err != nil {
 		return err
 	}
 
-	circleConfigDeploy, err := ioutil.ReadFile(path.Join(orbPath, ".circleci", "test-deploy.yml"))
+	circleConfigDeploy, err := os.ReadFile(path.Join(orbPath, ".circleci", "test-deploy.yml"))
 	if err != nil {
 		return err
 	}
 
 	configDeployString := string(circleConfigDeploy)
-	err = ioutil.WriteFile(path.Join(orbPath, ".circleci", "test-deploy.yml"), []byte(orbTemplate(configDeployString, projectName, ownerName, orbName, namespace)), 0644)
+	err = os.WriteFile(path.Join(orbPath, ".circleci", "test-deploy.yml"), []byte(orbTemplate(configDeployString, projectName, ownerName, orbName, namespace)), 0644)
 	if err != nil {
 		return err
 	}
 
-	readme, err := ioutil.ReadFile(path.Join(orbPath, "README.md"))
+	readme, err := os.ReadFile(path.Join(orbPath, "README.md"))
 	if err != nil {
 		return err
 	}
 
 	readmeString := string(readme)
-	err = ioutil.WriteFile(path.Join(orbPath, "README.md"), []byte(orbTemplate(readmeString, projectName, ownerName, orbName, namespace)), 0644)
+	err = os.WriteFile(path.Join(orbPath, "README.md"), []byte(orbTemplate(readmeString, projectName, ownerName, orbName, namespace)), 0644)
 	if err != nil {
 		return err
 	}
 
-	orbRoot, err := ioutil.ReadFile(path.Join(orbPath, "src", "@orb.yml"))
+	orbRoot, err := os.ReadFile(path.Join(orbPath, "src", "@orb.yml"))
 	if err != nil {
 		return err
 	}
 
 	orbRootString := string(orbRoot)
-	err = ioutil.WriteFile(path.Join(orbPath, "src", "@orb.yml"), []byte(orbTemplate(orbRootString, projectName, ownerName, orbName, namespace)), 0644)
+	err = os.WriteFile(path.Join(orbPath, "src", "@orb.yml"), []byte(orbTemplate(orbRootString, projectName, ownerName, orbName, namespace)), 0644)
 	if err != nil {
 		return err
 	}
@@ -1504,7 +1503,7 @@ func initOrb(opts orbOptions) error {
 	}
 
 	tempOrbFile := filepath.Join(tempOrbDir, "orb.yml")
-	err = ioutil.WriteFile(tempOrbFile, []byte(packedOrb), 0644)
+	err = os.WriteFile(tempOrbFile, []byte(packedOrb), 0644)
 	if err != nil {
 		return errors.Wrap(err, "Unable to write packed orb")
 	}

--- a/cmd/orb_import_test.go
+++ b/cmd/orb_import_test.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/CircleCI-Public/circleci-cli/api"
@@ -678,7 +678,7 @@ The following orb versions already exist:
   ('namespace1/orb@0.0.3')
 
 `
-			actual, err := ioutil.ReadAll(&b)
+			actual, err := io.ReadAll(&b)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(string(actual)).To(Equal(expOutput))
 		})

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 
 	"github.com/CircleCI-Public/circleci-cli/api/graphql"
@@ -51,9 +51,9 @@ func query(opts queryOptions) error {
 	var resp map[string]interface{}
 
 	if opts.args[0] == "-" {
-		q, err = ioutil.ReadAll(os.Stdin)
+		q, err = io.ReadAll(os.Stdin)
 	} else {
-		q, err = ioutil.ReadFile(opts.args[0])
+		q, err = os.ReadFile(opts.args[0])
 	}
 
 	if err != nil {

--- a/cmd/setup_test.go
+++ b/cmd/setup_test.go
@@ -2,7 +2,7 @@ package cmd_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/exec"
 	"regexp"
@@ -248,7 +248,7 @@ Your configuration has been saved to %s.
 					file, err := os.Open(tempSettings.Config.Path)
 					Expect(err).ShouldNot(HaveOccurred())
 
-					reread, err := ioutil.ReadAll(file)
+					reread, err := io.ReadAll(file)
 					Expect(err).ShouldNot(HaveOccurred())
 					Expect(string(reread)).To(Equal(`host: https://zomg.com
 endpoint: graphql-unstable

--- a/config/config.go
+++ b/config/config.go
@@ -2,7 +2,7 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/url"
 	"os"
 
@@ -38,9 +38,9 @@ func loadYaml(path string) (string, error) {
 	var err error
 	var config []byte
 	if path == "-" {
-		config, err = ioutil.ReadAll(os.Stdin)
+		config, err = io.ReadAll(os.Stdin)
 	} else {
-		config, err = ioutil.ReadFile(path)
+		config, err = os.ReadFile(path)
 	}
 
 	if err != nil {

--- a/filetree/filetree.go
+++ b/filetree/filetree.go
@@ -2,7 +2,6 @@ package filetree
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -117,7 +116,7 @@ func (n Node) marshalLeaf() (interface{}, error) {
 		return content, nil
 	}
 
-	buf, err := ioutil.ReadFile(n.FullPath)
+	buf, err := os.ReadFile(n.FullPath)
 
 	if err != nil {
 		return content, err

--- a/filetree/filetree_test.go
+++ b/filetree/filetree_test.go
@@ -1,7 +1,6 @@
 package filetree_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -22,7 +21,7 @@ var _ = Describe("filetree", func() {
 
 	BeforeEach(func() {
 		var err error
-		tempRoot, err = ioutil.TempDir("", "circleci-cli-test-")
+		tempRoot, err = os.MkdirTemp("", "circleci-cli-test-")
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -39,7 +38,7 @@ var _ = Describe("filetree", func() {
 			emptyDir = filepath.Join(tempRoot, "empty_dir")
 
 			Expect(os.Mkdir(subDir, 0700)).To(Succeed())
-			Expect(ioutil.WriteFile(subDirFile, []byte("foo:\n  bar:\n    baz"), 0600)).To(Succeed())
+			Expect(os.WriteFile(subDirFile, []byte("foo:\n  bar:\n    baz"), 0600)).To(Succeed())
 			Expect(os.Mkdir(emptyDir, 0700)).To(Succeed())
 
 		})
@@ -48,7 +47,7 @@ var _ = Describe("filetree", func() {
 			anotherDir := filepath.Join(tempRoot, "another_dir")
 			anotherDirFile := filepath.Join(tempRoot, "another_dir", "another_dir_file.yml")
 			Expect(os.Mkdir(anotherDir, 0700)).To(Succeed())
-			Expect(ioutil.WriteFile(anotherDirFile, []byte("1some: in: valid: yaml"), 0600)).To(Succeed())
+			Expect(os.WriteFile(anotherDirFile, []byte("1some: in: valid: yaml"), 0600)).To(Succeed())
 			tree, err := filetree.NewTree(tempRoot)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -118,7 +117,7 @@ sub_dir:
 			emptyDir = filepath.Join(tempRoot, "empty_dir")
 
 			Expect(os.Mkdir(subDir, 0700)).To(Succeed())
-			Expect(ioutil.WriteFile(subDirFile, []byte("foo:\n  bar:\n    baz"), 0600)).To(Succeed())
+			Expect(os.WriteFile(subDirFile, []byte("foo:\n  bar:\n    baz"), 0600)).To(Succeed())
 			Expect(os.Mkdir(emptyDir, 0700)).To(Succeed())
 
 		})

--- a/local/local.go
+++ b/local/local.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -262,7 +261,7 @@ func writeStringToTempFile(data string) (string, error) {
 	// > The path /var/folders/q0/2g2lcf6j79df6vxqm0cg_0zm0000gn/T/287575618-config.yml
 	// > is not shared from OS X and is not known to Docker.
 	// Docker has `/tmp` shared by default.
-	f, err := ioutil.TempFile("/tmp", "*_circleci_config.yml")
+	f, err := os.CreateTemp("/tmp", "*_circleci_config.yml")
 
 	if err != nil {
 		return "", errors.Wrap(err, "Error creating temporary config file")

--- a/local/local_test.go
+++ b/local/local_test.go
@@ -1,7 +1,7 @@
 package local
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 
 	. "github.com/onsi/ginkgo"
@@ -39,7 +39,7 @@ var _ = Describe("build", func() {
 			path, err := writeStringToTempFile("cynosure")
 			Expect(err).NotTo(HaveOccurred())
 			defer os.Remove(path)
-			Expect(ioutil.ReadFile(path)).To(BeEquivalentTo("cynosure"))
+			Expect(os.ReadFile(path)).To(BeEquivalentTo("cynosure"))
 		})
 	})
 
@@ -51,7 +51,7 @@ var _ = Describe("build", func() {
 			// add a 'debug' flag - the build command will inherit this from the
 			// root command when not testing in isolation.
 			flags.Bool("debug", false, "Enable debug logging.")
-			flags.SetOutput(ioutil.Discard)
+			flags.SetOutput(io.Discard)
 			err := flags.Parse(args)
 			return flags, err
 		}

--- a/mock/http.go
+++ b/mock/http.go
@@ -1,7 +1,7 @@
 package mock
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 )
@@ -23,6 +23,6 @@ func NewHTTPClient(f func(*http.Request) (*http.Response, error)) *http.Client {
 func NewHTTPResponse(code int, body string) *http.Response {
 	return &http.Response{
 		StatusCode: code,
-		Body:       ioutil.NopCloser(strings.NewReader(body)),
+		Body:       io.NopCloser(strings.NewReader(body)),
 	}
 }

--- a/process/process.go
+++ b/process/process.go
@@ -2,7 +2,7 @@ package process
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -31,7 +31,7 @@ func MaybeIncludeFile(s string, orbDirectory string) (string, error) {
 		}
 
 		filepath := filepath.Join(orbDirectory, subMatch)
-		file, err := ioutil.ReadFile(filepath)
+		file, err := os.ReadFile(filepath)
 		if err != nil {
 			return "", fmt.Errorf("could not open %s for inclusion", filepath)
 		}

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -5,7 +5,6 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -65,7 +64,7 @@ func (upd *UpdateCheck) Load() error {
 
 	upd.FileUsed = path
 
-	content, err := ioutil.ReadFile(path) // #nosec
+	content, err := os.ReadFile(path) // #nosec
 	if err != nil {
 		return err
 	}
@@ -81,7 +80,7 @@ func (upd *UpdateCheck) WriteToDisk() error {
 		return err
 	}
 
-	err = ioutil.WriteFile(upd.FileUsed, enc, 0600)
+	err = os.WriteFile(upd.FileUsed, enc, 0600)
 	return err
 }
 
@@ -106,7 +105,7 @@ func (cfg *Config) LoadFromDisk() error {
 
 	cfg.FileUsed = path
 
-	content, err := ioutil.ReadFile(path) // #nosec
+	content, err := os.ReadFile(path) // #nosec
 	if err != nil {
 		return err
 	}
@@ -126,7 +125,7 @@ func (cfg *Config) WriteToDisk() error {
 		return err
 	}
 
-	err = ioutil.WriteFile(cfg.FileUsed, enc, 0600)
+	err = os.WriteFile(cfg.FileUsed, enc, 0600)
 	return err
 }
 
@@ -220,7 +219,7 @@ func (cfg *Config) WithHTTPClient() error {
 			return fmt.Errorf("invalid tls cert provided: %s", err.Error())
 		}
 
-		pemData, err := ioutil.ReadFile(cfg.TLSCert)
+		pemData, err := os.ReadFile(cfg.TLSCert)
 		if err != nil {
 			return fmt.Errorf("unable to read tls cert: %s", err.Error())
 		}


### PR DESCRIPTION
# Checklist

=========

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)
- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/main/CONTRIBUTING.md).

### Internal Checklist
- [x] I am requesting a review from my own team as well as the owning team
- [x] I have a plan in place for the monitoring of the changes that I am making (this can include new monitors, logs to be aware of, etc...)

## Changes

=======

- Migrates deprecated function calls to their new respective packages. ioutil -> io + os

## Rationale

=========

Linting now throws errors when crafting new PRs and these will eventually have to be fixed.


