### PR TITLE
PIPE-3873 fixing type-casting issue

### DIFF
--- a/config/commands.go
+++ b/config/commands.go
@@ -29,7 +29,6 @@ func (c *ConfigCompiler) getOrgID(
 	optsOrgSlug string,
 ) (string, error) {
 	if optsOrgID == "" && optsOrgSlug == "" {
-		fmt.Println("No org id or slug has been provided")
 		return "", nil
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -64,7 +64,7 @@ type CompileConfigRequest struct {
 type Options struct {
 	OwnerID            string                 `json:"owner_id,omitempty"`
 	PipelineParameters map[string]interface{} `json:"pipeline_parameters,omitempty"`
-	PipelineValues     map[string]string      `json:"pipeline_values,omitempty"`
+	PipelineValues     map[string]interface{} `json:"pipeline_values,omitempty"`
 }
 
 // ConfigQuery - attempts to compile or validate a given config file with the

--- a/config/pipeline.go
+++ b/config/pipeline.go
@@ -7,7 +7,7 @@ import (
 )
 
 // CircleCI provides various `<< pipeline.x >>` values to be used in your config, but sometimes we need to fabricate those values when validating config.
-type Values map[string]string
+type Values map[string]interface{}
 
 // Static typing is bypassed using an empty interface here due to pipeline parameters supporting multiple types.
 type Parameters map[string]interface{}
@@ -31,9 +31,9 @@ func LocalPipelineValues() Values {
 		}
 	}
 
-	vals := map[string]string{
+	vals := map[string]interface{}{
 		"id":                "00000000-0000-0000-0000-000000000001",
-		"number":            "1",
+		"number":            1,
 		"project.git_url":   gitUrl,
 		"project.type":      projectType,
 		"git.tag":           git.Tag(),

--- a/integration_tests/features/circleci_config.feature
+++ b/integration_tests/features/circleci_config.feature
@@ -159,6 +159,36 @@ Feature: Config checking
     Then the output should contain "fighters"
     And the exit status should be 0
 
+  Scenario: Testing new type casting works as expected
+    Given a file named "config.yml" with:
+    """
+    version: 2.1
+
+    jobs:
+      datadog-hello-world:
+        docker:
+          - image: cimg/base:stable
+        parameters:
+          an-integer:
+            description: a test case to ensure parameters are passed correctly
+            type: integer
+            default: -1
+        steps:
+          - unless:
+              condition:
+                equal: [<< parameters.an-integer >>, -1]
+              steps:
+                - run: echo "<< parameters.an-integer >> - test" 
+    workflows:
+      main-workflow:
+        jobs:
+        - datadog-hello-world:
+            an-integer: << pipeline.number >>
+    """ 
+    When I run `circleci config process config.yml`
+    Then the output should contain "1 - test"
+    And the exit status should be 0
+
   Scenario: Checking a valid config file with default pipeline params
     Given a file named "config.yml" with:
     """


### PR DESCRIPTION
The CLI previously handled pipeline values as a map of strings to strings which was presumably to appease the formats expected by the unstable GraphQL server. 

With the migration from this unstable GraphQL service to a direct HTTP call, this exposed this bug https://github.com/CircleCI-Public/circleci-cli/issues/895

I've added 2 commits to this PR - the first is a failing test case that replicates the issue the user was having and then the code change from `map[string]string` -> `map[string]interface{}` for the values which the enables the test case to pass and non-string values to be handled correctly.

# Checklist

=========

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)
- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/main/CONTRIBUTING.md).

### Internal Checklist
- [x] I am requesting a review from my own team as well as the owning team
- [x] I have a plan in place for the monitoring of the changes that I am making (this can include new monitors, logs to be aware of, etc...)

## Changes

=======

- Converts the Pipeline values from map[string]string to map[string]interface{} in order to allow for integer and boolean types.
- Fixes https://github.com/CircleCI-Public/circleci-cli/issues/895

## Rationale

=========

What was the overarching product goal of this PR as well as any pertinent
history of changes

## Considerations

==============

Why you made some of the technical decisions that you made, especially if the
reasoning is not immediately obvious

## Screenshots

============

<h4>Before</h4>
Image or [gif](https://giphy.com/apps/giphycapture)

<h4>After</h4>
Image or gif where change can be clearly seen

## **Here are some helpful tips you can follow when submitting a pull request:**

1. Fork [the repository](https://github.com/CircleCI-Public/circleci-cli) and create your branch from `main`.
2. Run `make build` in the repository root.
3. If you've fixed a bug or added code that should be tested, add tests!
4. Ensure the test suite passes (`make test`).
5. The `--debug` flag is often helpful for debugging HTTP client requests and responses.
6. Format your code with [gofmt](https://golang.org/cmd/gofmt/).
7. Make sure your code lints (`make lint`). Note: This requires Docker to run inside a local job.
