### PR TITLE
Additional formatting updates for config validation

### DIFF
--- a/config/commands.go
+++ b/config/commands.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -10,9 +11,19 @@ import (
 )
 
 func printValues(values Values) {
-	for key, value := range values {
-		fmt.Fprintf(os.Stderr, "%-18s %s\n", key+":", value)
+	// Provide a stable sort order for printed values
+	keys := make([]string, 0, len(values))
+	for k := range values {
+		keys = append(keys, k)
 	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		fmt.Fprintf(os.Stderr, "%-18s %v\n", key+":", values[key])
+	}
+
+	// Add empty newline at end
+	fmt.Fprintf(os.Stderr, "\n")
 }
 
 type ProcessConfigOpts struct {
@@ -73,7 +84,7 @@ func (c *ConfigCompiler) ProcessConfig(opts ProcessConfigOpts) error {
 	//if no orgId provided use org slug
 	values := LocalPipelineValues()
 	if opts.VerboseOutput {
-		fmt.Println("Processing config with following values")
+		fmt.Fprintln(os.Stderr, "Processing config with following values:")
 		printValues(values)
 	}
 
@@ -118,7 +129,7 @@ func (c *ConfigCompiler) ValidateConfig(opts ValidateConfigOpts) error {
 	//if no orgId provided use org slug
 	values := LocalPipelineValues()
 	if opts.VerboseOutput {
-		fmt.Println("Validating config with following values")
+		fmt.Fprintln(os.Stderr, "Validating config with following values:")
 		printValues(values)
 	}
 
@@ -152,6 +163,6 @@ func (c *ConfigCompiler) ValidateConfig(opts ValidateConfigOpts) error {
 		}
 	}
 
-	fmt.Printf("\nConfig file at %s is valid.\n", opts.ConfigPath)
+	fmt.Printf("Config file at %s is valid.\n", opts.ConfigPath)
 	return nil
 }


### PR DESCRIPTION
# Checklist

=========

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)
- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/main/CONTRIBUTING.md).

### Internal Checklist
- [ ] I am requesting a review from my own team as well as the owning team
- [ ] I have a plan in place for the monitoring of the changes that I am making (this can include new monitors, logs to be aware of, etc...)

## Changes
- Suppress some whitespace when verbose output is not enabled
- Write to stderr again
- Use `%v` instead of `%s` so that "number" in pipeline values gets printed correctly
- Sort values to provide stable output order for pipeline values

## Rationale
@elliotforbes sorry - I think one or both of us missed that `number` doesn't get printed out right when `%s` is used vs `%v`. This also moves most of the verbose output to stderr (esp. could be an issue for subcommands that output yaml otherwise). It also gets rid of the extra newline before validate output in the case where verbose output is not used

See #860 for original context. Resolve some issues from #861 and #896

## Considerations

## Screenshots

============

<h4>Before</h4>
<img width="750" alt="image" src="https://user-images.githubusercontent.com/10714426/229970561-c8d4aefb-fd2e-4949-8e35-c736364a0cc3.png">

<h4>After</h4>
<img width="750" alt="image" src="https://user-images.githubusercontent.com/10714426/229970725-e86986f4-8e06-481c-98d0-a61d92d08906.png">

## **Here are some helpful tips you can follow when submitting a pull request:**

1. Fork [the repository](https://github.com/CircleCI-Public/circleci-cli) and create your branch from `main`.
2. Run `make build` in the repository root.
3. If you've fixed a bug or added code that should be tested, add tests!
4. Ensure the test suite passes (`make test`).
5. The `--debug` flag is often helpful for debugging HTTP client requests and responses.
6. Format your code with [gofmt](https://golang.org/cmd/gofmt/).
7. Make sure your code lints (`make lint`). Note: This requires Docker to run inside a local job.
