### PR TITLE
fix: use bold rather than backticks around command output

### DIFF
--- a/cmd/disabled.go
+++ b/cmd/disabled.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/CircleCI-Public/circleci-cli/settings"
 	"github.com/CircleCI-Public/circleci-cli/version"
+	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
 
@@ -39,7 +40,8 @@ func newDisabledCommand(config *settings.Config, command string) *cobra.Command 
 }
 
 func disableCommand(opts disableOptions) {
-	fmt.Printf("`%s` is not available because this tool was installed using `%s`.\n", opts.command, version.PackageManager())
+	bold := color.New(color.Bold).SprintFunc()
+	fmt.Printf("%s is not available because this tool was installed using %s.\n", bold(opts.command), bold(version.PackageManager()))
 
 	if opts.command == "update" {
 		fmt.Println("Please consult the package manager's documentation on how to update the CLI.")

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -64,7 +64,7 @@ var _ = Describe("Root", func() {
 
 			Eventually(session.Err.Contents()).Should(BeEmpty())
 
-			Eventually(session.Out).Should(gbytes.Say("`update` is not available because this tool was installed using `homebrew`."))
+			Eventually(session.Out).Should(gbytes.Say("update is not available because this tool was installed using homebrew."))
 			Eventually(session.Out).Should(gbytes.Say("Please consult the package manager's documentation on how to update the CLI."))
 			Eventually(session).Should(gexec.Exit(0))
 		})


### PR DESCRIPTION
# Checklist

=========

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)
- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/main/CONTRIBUTING.md).

### Internal Checklist
- [ ] I am requesting a review from my own team as well as the owning team
- [ ] I have a plan in place for the monitoring of the changes that I am making (this can include new monitors, logs to be aware of, etc...)

## Changes

- Use `color` module to bold output of update command error

## Rationale

Having backticks in the output of the error when update is disabled doesn't make as much since, since the backticks are rendered literally. Bolding the text probably is better visually.

## Considerations

==============

I haven't figured out how to test this easily, or to force `fatih/color` to send control codes in test mode so that this can be tested.

## Screenshots

============

<h4>Before</h4>
<img width="710" alt="image" src="https://user-images.githubusercontent.com/10714426/236286191-b52c2aa1-69f6-4dd6-893e-0569bc34695c.png">

<h4>After</h4>
<img width="710" alt="image" src="https://user-images.githubusercontent.com/10714426/236286276-172228f1-f93d-4b05-aef8-d32e3ee8e1d4.png">
[haven't functionally tested with the exact code, but should look roughly like this]

## **Here are some helpful tips you can follow when submitting a pull request:**

1. Fork [the repository](https://github.com/CircleCI-Public/circleci-cli) and create your branch from `main`.
2. Run `make build` in the repository root.
3. If you've fixed a bug or added code that should be tested, add tests!
4. Ensure the test suite passes (`make test`).
5. The `--debug` flag is often helpful for debugging HTTP client requests and responses.
6. Format your code with [gofmt](https://golang.org/cmd/gofmt/).
7. Make sure your code lints (`make lint`). Note: This requires Docker to run inside a local job.
