### PR TITLE
Docs/orb init warning

### DIFF
--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -1055,7 +1055,6 @@ func inlineIncludes(node *yaml.Node, orbRoot string) error {
 func initOrb(opts orbOptions) error {
 	orbPath := opts.args[0]
 	var err error
-	fmt.Println("Note: This command is in preview. Please report any bugs! https://github.com/CircleCI-Public/circleci-cli/issues/new/choose")
 
 	fullyAutomated := 0
 	prompt := &survey.Select{

--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -1056,22 +1056,21 @@ func initOrb(opts orbOptions) error {
 	orbPath := opts.args[0]
 	var err error
 
-if !opts.private {
-	prompt := &survey.Select{
-		Message: "Would you like to create a public or private orb?",
-		Options: []string{"Public", "Private"},
-	}
-	var selectedOption string
-	err := survey.AskOne(prompt, &selectedOption)
-	if err != nil {
-		return errors.Wrap(err, "Unexpected error")
-	}
+	if !opts.private {
+		prompt := &survey.Select{
+			Message: "Would you like to create a public or private orb?",
+			Options: []string{"Public", "Private"},
+		}
+		var selectedOption string
+		err := survey.AskOne(prompt, &selectedOption)
+		if err != nil {
+			return errors.Wrap(err, "Unexpected error")
+		}
 
-	if selectedOption == "Private" {
-		opts.private = true
+		if selectedOption == "Private" {
+			opts.private = true
+		}
 	}
-}
-
 
 	fullyAutomated := 0
 	prompt := &survey.Select{

--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -1056,6 +1056,23 @@ func initOrb(opts orbOptions) error {
 	orbPath := opts.args[0]
 	var err error
 
+if !opts.private {
+	prompt := &survey.Select{
+		Message: "Would you like to create a public or private orb?",
+		Options: []string{"Public", "Private"},
+	}
+	var selectedOption string
+	err := survey.AskOne(prompt, &selectedOption)
+	if err != nil {
+		return errors.Wrap(err, "Unexpected error")
+	}
+
+	if selectedOption == "Private" {
+		opts.private = true
+	}
+}
+
+
 	fullyAutomated := 0
 	prompt := &survey.Select{
 		Message: "Would you like to perform an automated setup of this orb?",


### PR DESCRIPTION
# Checklist

=========

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)
- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/main/CONTRIBUTING.md).

### Internal Checklist
- [x] I am requesting a review from my own team as well as the owning team
- [x] I have a plan in place for the monitoring of the changes that I am making (this can include new monitors, logs to be aware of, etc...)

## Changes

=======

- Removed the `preview` messaging in the orb init command
- When the `private` flag is not passed to the command, we now prompt the user to select `public` or `private`.

## Rationale

=========

What was the overarching product goal of this PR as well as any pertinent
history of changes

## Considerations

==============

Why you made some of the technical decisions that you made, especially if the
reasoning is not immediately obvious

## Screenshots

============

<h4>Before</h4>
<img width="1081" alt="image" src="https://github.com/CircleCI-Public/circleci-cli/assets/33272306/f3fa90f7-fea3-477c-97a6-b7f442be6f84">

<h4>After</h4>
<img width="822" alt="image" src="https://github.com/CircleCI-Public/circleci-cli/assets/33272306/c00967d8-1e3c-4a1a-8d28-fd58ce2e6f74">
