### PR TITLE
Rename install function in the install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -16,7 +16,7 @@ function error {
 }
 
 # Use a function to ensure connection errors don't partially execute when being piped
-function install {
+function install_cli {
 
 	echo "Starting installation."
 
@@ -78,4 +78,4 @@ function install {
 	rm -r "$SCRATCH"
 }
 
-install
+install_cli


### PR DESCRIPTION
# Checklist

=========

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)
- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/main/CONTRIBUTING.md).

## Changes

- Fix the ambiguity of the `install` shell command and the `install` script function.

## Rationale

As noticed in #941, the install command now gets into infinite recursion.
