### PR TITLE
Fix infinite loop in install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -16,7 +16,7 @@ function error {
 }
 
 # Use a function to ensure connection errors don't partially execute when being piped
-function install {
+function install_circleci {
 
 	echo "Starting installation."
 
@@ -78,4 +78,4 @@ function install {
 	rm -r "$SCRATCH"
 }
 
-install
+install_circleci


### PR DESCRIPTION
# Checklist

=========

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)
- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/main/CONTRIBUTING.md).

## Changes

=======

- Fix the infinite loop in the install script by renaming the `install` function in the script to `install_circleci`, so that it no longer has a name collision with the system's `install` command 

## Rationale

=========

Per [this issue](https://github.com/CircleCI-Public/circleci-cli/issues/941) and [comment](https://github.com/CircleCI-Public/circleci-cli/pull/352#issuecomment-1547796209), a recently merged [PR](https://github.com/CircleCI-Public/circleci-cli/pull/352) appears to have introduced an infinite loop in the install script because of a name collision with the `install` function and the system's `install` command. When piping the script into `bash`, it loops indefinitely as the `install` function recursively calls itself:
```
Starting installation.
Installing CircleCI CLI v0.1.26646
Installing to /usr/local/bin
Starting installation.
Installing CircleCI CLI v0.1.26646
Installing to /usr/local/bin
Starting installation.
Installing CircleCI CLI v0.1.26646
^C⏎
```  

## Considerations

==============

N/A

## Screenshots

============

N/A