### PR TITLE
fix: don't create license file when initializing private orb

### DIFF
--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -1218,7 +1218,8 @@ func initOrb(opts orbOptions) error {
 	defer resp.Body.Close()
 
 	// Create the file
-	out, err := os.Create(filepath.Join(os.TempDir(), "orb-template.zip"))
+	zipPath := filepath.Join(os.TempDir(), "orb-template.zip")
+	out, err := os.Create(zipPath)
 	if err != nil {
 		return err
 	}
@@ -1230,9 +1231,17 @@ func initOrb(opts orbOptions) error {
 		return err
 	}
 
-	err = unzipToOrbPath(filepath.Join(os.TempDir(), "orb-template.zip"), orbPath)
+	err = unzipToOrbPath(zipPath, orbPath)
 	if err != nil {
 		return err
+	}
+
+	// Remove MIT License file if orb is private
+	if opts.private {
+		err = os.Remove(filepath.Join(orbPath, "LICENSE"))
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
 	}
 
 	if fullyAutomated == 1 {


### PR DESCRIPTION
# Checklist

=========

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)
- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/main/CONTRIBUTING.md).

### Internal Checklist
- [ ] I am requesting a review from my own team as well as the owning team
- [ ] I have a plan in place for the monitoring of the changes that I am making (this can include new monitors, logs to be aware of, etc...)

## Changes

- Don't create MIT `LICENSE` file when using `circleci orb init --private`

## Rationale

Private Orbs shouldn't be loaded with a permissive license by default.

