### PR TITLE
docs: Improved the compatibility matrix in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Please see the [documentation](https://circleci-public.github.io/circleci-cli) o
 
 ## Server compatibility
 
-There are some difference of behavior depending on the version you use:
- - config validation will use the GraphQL API until **Server v4.0.5, v4.1.3, v4.2.0**. The above versions will use the new route `compile-config-with-defaults`
- - `circleci orb validate` will only allow you to validate orbs using other private orbs with the option `--org-slug` from version **Server v4.2.0**
+| Functionality | Impacted commands | Change description | Compatibility with Server |
+| --- | --- | --- | --- |
+| Config compilation and validation | <ul><li>`circleci config validate`</li><li>`circleci config process`</li><li>`circleci local execute`</li> | The config validation has been moved from the GraphQL API to a specific API endpoint | <ul><li>**Server v4.0.5, v4.1.3, v4.2.0 and above**: Commands use the new specific endpoint</li><li>**Previous version**: Commands use the GraphQL API</li></ul> |
+| Orb compilation and validation of orb using private orbs | <ul><li>`circleci orb process`</li><li>`circleci orb validate`</li></ul> | To support the validation of orbs requesting private orbs (see [issue](https://github.com/CircleCI-Public/circleci-cli/issues/751)). A field `ownerId` has been added to the GraphQL orb validation endpoint. Thus allowing the `Impacted commands` to use the `--org-id` parameter to enable the orb compilation / validation  | <ul><li>**Server v4.2.0 and above**: The field is accessible so you can use the parameter</li><li>**Previous versions**: The field does not exist making the functionality unavailable</li></ul> |


### PR DESCRIPTION
# Checklist

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have checked for similar issues and haven't found anything relevant.
- [X] This is not a security issue (which should be reported here: https://circleci.com/security/)
- [X] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/main/CONTRIBUTING.md).

## Changes

Improved the compatibility matrix of the README. Now it shows the command impacted and give a better description of what is happening as well as from which server versions the support starts from.

## Rationale

After the implementation of backward compatibility, it felt necessary to improve the visibility of what was happening

## Considerations

[Asked a review from Server team](https://circleci.slack.com/archives/CAT9Q7TGW/p1689761906718419) to make sure the information here is correct

## Screenshots

[README URL](https://github.com/CircleCI-Public/circleci-cli/blob/task/DEVEX-1087/create-internal-doc-to-document-cli-compatibility-ap-is-usage-matrix/README.md#server-compatibility)

README screenshot:
![Capture d’écran 2023-07-19 à 12 01 28](https://github.com/CircleCI-Public/circleci-cli/assets/26357621/d203432c-0a81-4f3b-a57a-4e9174ee2ad2)

