### PR TITLE
[SNC-392] compile support for policy test command

### DIFF
--- a/api/policy/policy.go
+++ b/api/policy/policy.go
@@ -331,6 +331,8 @@ func NewClient(baseURL string, config *settings.Config) *Client {
 		client = http.DefaultClient
 	}
 
+	// Make sure to create a copy of the client so that any modifications we make to the transport
+	// doesn't affect the http.DefaultClient
 	client = func(c http.Client) *http.Client { return &c }(*client)
 
 	transport := client.Transport
@@ -349,13 +351,13 @@ func NewClient(baseURL string, config *settings.Config) *Client {
 		time.AfterFunc(time.Second, func() { <-sem })
 
 		if config.Token != "" {
-			r.Header.Add("circle-token", config.Token)
+			r.Header.Set("circle-token", config.Token)
 		}
-		r.Header.Add("Accept", "application/json")
-		r.Header.Add("Content-Type", "application/json")
-		r.Header.Add("User-Agent", version.UserAgent())
+		r.Header.Set("Accept", "application/json")
+		r.Header.Set("Content-Type", "application/json")
+		r.Header.Set("User-Agent", version.UserAgent())
 		if commandStr := header.GetCommandStr(); commandStr != "" {
-			r.Header.Add("Circleci-Cli-Command", commandStr)
+			r.Header.Set("Circleci-Cli-Command", commandStr)
 		}
 		return transport.RoundTrip(r)
 	})

--- a/cmd/policy/policy.go
+++ b/cmd/policy/policy.go
@@ -479,8 +479,9 @@ This group of commands allows the management of polices to be verified against b
 		)
 
 		cmd := &cobra.Command{
-			Use:   "test [path]",
-			Short: "runs policy tests",
+			Use:          "test [path]",
+			Short:        "runs policy tests",
+			SilenceUsage: true,
 			RunE: func(cmd *cobra.Command, args []string) (err error) {
 				var include *regexp.Regexp
 				if run != "" {
@@ -490,14 +491,15 @@ This group of commands allows the management of polices to be verified against b
 					}
 				}
 
-				client := rest.NewFromConfig(config.GetCompileHost(globalConfig.Host), globalConfig)
-
 				runnerOpts := tester.RunnerOptions{
 					Path:    args[0],
 					Include: include,
 					Compile: func(data []byte, pipelineValues map[string]any) ([]byte, error) {
 						parameters, _ := pipelineValues["parameters"].(map[string]any)
 						delete(pipelineValues, "parameters")
+
+						host := config.GetCompileHost(globalConfig.Host)
+						client := rest.NewFromConfig(host, globalConfig)
 
 						req, err := client.NewRequest(
 							"POST",

--- a/cmd/policy/policy.go
+++ b/cmd/policy/policy.go
@@ -490,12 +490,7 @@ This group of commands allows the management of polices to be verified against b
 					}
 				}
 
-				host := globalConfig.Host
-				if host == "https://circleci.com" {
-					host = "https://api.circleci.com"
-				}
-
-				client := rest.NewFromConfig(host, globalConfig)
+				client := rest.NewFromConfig(config.GetCompileHost(globalConfig.Host), globalConfig)
 
 				runnerOpts := tester.RunnerOptions{
 					Path:    args[0],

--- a/cmd/policy/testdata/compile_policies/compile.rego
+++ b/cmd/policy/testdata/compile_policies/compile.rego
@@ -1,0 +1,13 @@
+package org
+
+import future.keywords
+
+policy_name["example_compiled"]
+
+enable_hard["enforce_small_jobs"]
+
+enforce_small_jobs[reason] {
+	some job_name, job in input._compiled_.jobs
+	job.resource_class != "small"
+	reason = sprintf("job %s: resource_class must be small", [job_name])
+}

--- a/cmd/policy/testdata/compile_policies/compile_test.yaml
+++ b/cmd/policy/testdata/compile_policies/compile_test.yaml
@@ -1,0 +1,25 @@
+test_compile_policy:
+  compile: true
+  pipeline_parameters:
+    parameters:
+      size: small
+  input:
+    version: 2.1
+    parameters:
+      size:
+        type: string
+        default: medium
+    jobs:
+      test:
+        docker:
+          - image: go
+        resource_class: << pipeline.parameters.size >>
+        steps:
+          - run: it
+    workflows:
+      main:
+        jobs:
+          - test
+  decision:
+    status: PASS
+    enabled_rules: [enforce_small_jobs]

--- a/cmd/policy/testdata/policy/test-expected-usage.txt
+++ b/cmd/policy/testdata/policy/test-expected-usage.txt
@@ -5,10 +5,11 @@ Examples:
 circleci policy test ./policies/...
 
 Flags:
-      --debug           print test debug context. Sets verbose to true
-      --format string   select desired format between json or junit
-      --run string      select which tests to run based on regular expression
-  -v, --verbose         print all tests instead of only failed tests
+      --debug             print test debug context. Sets verbose to true
+      --format string     select desired format between json or junit
+      --owner-id string   the id of the policy's owner
+      --run string        select which tests to run based on regular expression
+  -v, --verbose           print all tests instead of only failed tests
 
 Global Flags:
       --policy-base-url string   base url for policy api (default "https://internal.circleci.com")

--- a/config/config.go
+++ b/config/config.go
@@ -31,9 +31,8 @@ type ConfigCompiler struct {
 }
 
 func New(cfg *settings.Config) *ConfigCompiler {
-	hostValue := getCompileHost(cfg.Host)
+	hostValue := GetCompileHost(cfg.Host)
 	collaboratorsClient, err := collaborators.NewCollaboratorsRestClient(*cfg)
-
 	if err != nil {
 		panic(err)
 	}
@@ -49,7 +48,7 @@ func New(cfg *settings.Config) *ConfigCompiler {
 	return configCompiler
 }
 
-func getCompileHost(cfgHost string) string {
+func GetCompileHost(cfgHost string) string {
 	if cfgHost != defaultHost {
 		return cfgHost
 	} else {

--- a/config/config.go
+++ b/config/config.go
@@ -49,7 +49,7 @@ func New(cfg *settings.Config) *ConfigCompiler {
 }
 
 func GetCompileHost(cfgHost string) string {
-	if cfgHost != defaultHost {
+	if cfgHost != defaultHost && cfgHost != "" {
 		return cfgHost
 	} else {
 		return defaultAPIHost

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -33,12 +33,12 @@ func TestCompiler(t *testing.T) {
 		t.Run("tests that we correctly get the config api host when the host is not the default one", func(t *testing.T) {
 			// if the host isn't equal to `https://circleci.com` then this is likely a server instance and
 			// wont have the api.X.com subdomain so we should instead just respect the host for config commands
-			host := getCompileHost("test")
+			host := GetCompileHost("test")
 			assert.Equal(t, host, "test")
 
 			// If the host passed in is the same as the defaultHost 'https://circleci.com' - then we know this is cloud
 			// and as such should use the `api.circleci.com` subdomain
-			host = getCompileHost("https://circleci.com")
+			host = GetCompileHost("https://circleci.com")
 			assert.Equal(t, host, "https://api.circleci.com")
 		})
 	})
@@ -119,9 +119,7 @@ func TestCompiler(t *testing.T) {
 			assert.Equal(t, "output", resp.OutputYaml)
 			assert.Equal(t, "source", resp.SourceYaml)
 		})
-
 	})
-
 }
 
 func TestLoadYaml(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -119,6 +119,9 @@ require (
 )
 
 // fix vulnerability: CVE-2020-15114 in etcd v3.3.10+incompatible
-replace github.com/coreos/etcd => github.com/coreos/etcd v3.3.24+incompatible
+replace (
+	github.com/CircleCI-Public/circle-policy-agent => ../circle-policy-agent
+	github.com/coreos/etcd => github.com/coreos/etcd v3.3.24+incompatible
+)
 
 go 1.20

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/CircleCI-Public/circleci-cli
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.1.1
-	github.com/CircleCI-Public/circle-policy-agent v0.0.663
+	github.com/CircleCI-Public/circle-policy-agent v0.0.683
 	github.com/Masterminds/semver v1.4.2
 	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de
 	github.com/blang/semver v3.5.1+incompatible
@@ -119,9 +119,6 @@ require (
 )
 
 // fix vulnerability: CVE-2020-15114 in etcd v3.3.10+incompatible
-replace (
-	github.com/CircleCI-Public/circle-policy-agent => ../circle-policy-agent
-	github.com/coreos/etcd => github.com/coreos/etcd v3.3.24+incompatible
-)
+replace github.com/coreos/etcd => github.com/coreos/etcd v3.3.24+incompatible
 
 go 1.20

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/AlecAivazis/survey/v2 v2.1.1 h1:LEMbHE0pLj75faaVEKClEX1TM4AJmmnOh9eimREzLWI=
 github.com/AlecAivazis/survey/v2 v2.1.1/go.mod h1:9FJRdMdDm8rnT+zHVbvQT2RTSTLq0Ttd6q3Vl2fahjk=
-github.com/CircleCI-Public/circle-policy-agent v0.0.663 h1:v2DbMYrzcoO6x5KN8y7hxByXMdUjntm8eM5DGnXhKeg=
-github.com/CircleCI-Public/circle-policy-agent v0.0.663/go.mod h1:72U4Q4OtvAGRGGo/GqlCCO0tARg1cSG9xwxWyz3ktQI=
 github.com/CircleCI-Public/circleci-config v0.0.0-20230609135034-182164ce950a h1:RqA4H9p77FsqV++HNNDBq8dJftYuJ+r+KdD9HAX28t4=
 github.com/CircleCI-Public/circleci-config v0.0.0-20230609135034-182164ce950a/go.mod h1:XZaQPj2ylXZaz5vW31dRdkUY/Ey8MdpbgrUHbHyzICY=
 github.com/Masterminds/semver v1.4.2 h1:WBLTQ37jOCzSLtXNdoo8bNM8876KhNqOKvrlGITgsTc=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/AlecAivazis/survey/v2 v2.1.1 h1:LEMbHE0pLj75faaVEKClEX1TM4AJmmnOh9eimREzLWI=
 github.com/AlecAivazis/survey/v2 v2.1.1/go.mod h1:9FJRdMdDm8rnT+zHVbvQT2RTSTLq0Ttd6q3Vl2fahjk=
+github.com/CircleCI-Public/circle-policy-agent v0.0.683 h1:EzZaLy9mUGl4dwDNWceBHeDb3X0KAAjV4eFOk3C7lts=
+github.com/CircleCI-Public/circle-policy-agent v0.0.683/go.mod h1:72U4Q4OtvAGRGGo/GqlCCO0tARg1cSG9xwxWyz3ktQI=
 github.com/CircleCI-Public/circleci-config v0.0.0-20230609135034-182164ce950a h1:RqA4H9p77FsqV++HNNDBq8dJftYuJ+r+KdD9HAX28t4=
 github.com/CircleCI-Public/circleci-config v0.0.0-20230609135034-182164ce950a/go.mod h1:XZaQPj2ylXZaz5vW31dRdkUY/Ey8MdpbgrUHbHyzICY=
 github.com/Masterminds/semver v1.4.2 h1:WBLTQ37jOCzSLtXNdoo8bNM8876KhNqOKvrlGITgsTc=


### PR DESCRIPTION
# Checklist

=========

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)
- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/main/CONTRIBUTING.md).

### Internal Checklist
- [x] I am requesting a review from my own team as well as the owning team
- [x] I have a plan in place for the monitoring of the changes that I am making (this can include new monitors, logs to be aware of, etc...)

## Changes

=======

- Updated the CircleCI-Public/circle-policy-agent
- Modified the `circleci policy test` command by adding the policy-agent compile function
  - calls the orbs-service API via graphql to compile test input
- Fixes a bug in the policy API client that was causing failures across tests
- adds the compily policy and test to validate the compilation is working in e2e fashion

## Rationale

=========

To provide a better testing experience of CircleCI Config Policies, we needed to update the policy-agent that understood the compile and pipeline_parameters directive, and provide a compilation function for it to use.

