### PR TITLE
refactor: Abstracted the different config validation routes

### DIFF
--- a/api/rest/client.go
+++ b/api/rest/client.go
@@ -98,7 +98,7 @@ func (c *Client) DoRequest(req *http.Request, resp interface{}) (int, error) {
 		}{}
 		body, err := io.ReadAll(httpResp.Body)
 		if err != nil {
-			return httpResp.StatusCode, err
+			return 0, err
 		}
 		err = json.Unmarshal(body, &httpError)
 		if err != nil {

--- a/api/rest/client.go
+++ b/api/rest/client.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
@@ -97,7 +96,7 @@ func (c *Client) DoRequest(req *http.Request, resp interface{}) (int, error) {
 		httpError := struct {
 			Message string `json:"message"`
 		}{}
-		body, err := ioutil.ReadAll(httpResp.Body)
+		body, err := io.ReadAll(httpResp.Body)
 		if err != nil {
 			return httpResp.StatusCode, err
 		}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -50,7 +50,11 @@ func newConfigCommand(globalConfig *settings.Config) *cobra.Command {
 		Aliases: []string{"check"},
 		Short:   "Check that the config file is well formed.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			compiler := config.New(globalConfig)
+			compiler, err := config.NewWithConfig(globalConfig)
+			if err != nil {
+				return err
+			}
+
 			orgID, _ := cmd.Flags().GetString("org-id")
 			orgSlug, _ := cmd.Flags().GetString("org-slug")
 			path := config.DefaultConfigPath
@@ -86,7 +90,11 @@ func newConfigCommand(globalConfig *settings.Config) *cobra.Command {
 		Use:   "process <path>",
 		Short: "Validate config and display expanded configuration.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			compiler := config.New(globalConfig)
+			compiler, err := config.NewWithConfig(globalConfig)
+			if err != nil {
+				return err
+			}
+
 			pipelineParamsFilePath, _ := cmd.Flags().GetString("pipeline-parameters")
 			orgID, _ := cmd.Flags().GetString("org-id")
 			orgSlug, _ := cmd.Flags().GetString("org-slug")

--- a/cmd/policy/policy.go
+++ b/cmd/policy/policy.go
@@ -295,7 +295,10 @@ This group of commands allows the management of polices to be verified against b
 				}
 
 				if !noCompile && context == "config" {
-					compiler := config.New(globalConfig)
+					compiler, err := config.NewWithConfig(globalConfig)
+					if err != nil {
+						return err
+					}
 					input, err = mergeCompiledConfig(compiler, config.ProcessConfigOpts{
 						ConfigPath:             inputPath,
 						OrgID:                  ownerID,
@@ -376,7 +379,10 @@ This group of commands allows the management of polices to be verified against b
 				}
 
 				if !noCompile && context == "config" {
-					compiler := config.New(globalConfig)
+					compiler, err := config.NewWithConfig(globalConfig)
+					if err != nil {
+						return err
+					}
 					input, err = mergeCompiledConfig(compiler, config.ProcessConfigOpts{
 						ConfigPath:             inputPath,
 						OrgID:                  ownerID,

--- a/cmd/policy/policy_test.go
+++ b/cmd/policy/policy_test.go
@@ -635,7 +635,10 @@ test: config
 			CompilerServerHandler: func(w http.ResponseWriter, r *http.Request) {
 				var req config.CompileConfigRequest
 				err := json.NewDecoder(r.Body).Decode(&req)
-				require.NoError(t, err)
+				if err != nil {
+					w.WriteHeader(http.StatusBadRequest)
+					return
+				}
 
 				// dummy compilation here (remove the _compiled_ key in compiled config, as compiled config can't have that at top-level key).
 				var yamlResp map[string]any
@@ -678,7 +681,10 @@ test: config
 			CompilerServerHandler: func(w http.ResponseWriter, r *http.Request) {
 				var req config.CompileConfigRequest
 				err := json.NewDecoder(r.Body).Decode(&req)
-				require.NoError(t, err)
+				if err != nil {
+					w.WriteHeader(http.StatusBadRequest)
+					return
+				}
 
 				response := config.ConfigResponse{Valid: true, SourceYaml: req.ConfigYaml, OutputYaml: req.ConfigYaml}
 
@@ -837,7 +843,10 @@ test: config
 			CompilerServerHandler: func(w http.ResponseWriter, r *http.Request) {
 				var req config.CompileConfigRequest
 				err := json.NewDecoder(r.Body).Decode(&req)
-				require.NoError(t, err)
+				if err != nil {
+					w.WriteHeader(http.StatusBadRequest)
+					return
+				}
 
 				response := config.ConfigResponse{Valid: true, SourceYaml: req.ConfigYaml, OutputYaml: req.ConfigYaml}
 
@@ -1082,7 +1091,10 @@ test: config
 			CompilerServerHandler: func(w http.ResponseWriter, r *http.Request) {
 				var req config.CompileConfigRequest
 				err := json.NewDecoder(r.Body).Decode(&req)
-				require.NoError(t, err)
+				if err != nil {
+					w.WriteHeader(http.StatusBadRequest)
+					return
+				}
 
 				response := config.ConfigResponse{Valid: true, SourceYaml: req.ConfigYaml, OutputYaml: req.ConfigYaml}
 

--- a/config/api_client.go
+++ b/config/api_client.go
@@ -34,7 +34,7 @@ func GetAPIClient(config *settings.Config) (APIClient, error) {
 }
 
 func newAPIClient(config *settings.Config) (APIClient, error) {
-	hostValue := getCompileHost(config.Host)
+	hostValue := GetCompileHost(config.Host)
 	restClient := rest.NewFromConfig(hostValue, config)
 
 	version, err := detectAPIClientVersion(restClient)

--- a/config/api_client.go
+++ b/config/api_client.go
@@ -59,10 +59,8 @@ func detectAPIClientVersion(restClient *rest.Client) (apiClientVersion, error) {
 	}
 
 	statusCode, err := restClient.DoRequest(req, nil)
-	if err != nil {
-		if _, ok := err.(*rest.HTTPError); ok {
-			return "", err
-		}
+	if _, ok := err.(*rest.HTTPError); !ok {
+		return "", err
 	}
 	if statusCode == 404 {
 		return v1_string, nil

--- a/config/api_client.go
+++ b/config/api_client.go
@@ -3,7 +3,6 @@ package config
 import (
 	"fmt"
 	"net/url"
-	"sync"
 
 	"github.com/CircleCI-Public/circleci-cli/api/graphql"
 	"github.com/CircleCI-Public/circleci-cli/api/rest"
@@ -11,10 +10,6 @@ import (
 )
 
 var (
-	compiler      APIClient
-	compilerError error
-	once          sync.Once
-
 	compilePath = "compile-config-with-defaults"
 )
 
@@ -22,15 +17,6 @@ type apiClientVersion string
 
 type APIClient interface {
 	CompileConfig(configContent string, orgID string, params Parameters, values Values) (*ConfigResponse, error)
-}
-
-func GetAPIClient(config *settings.Config) (APIClient, error) {
-	if compiler == nil {
-		once.Do(func() {
-			compiler, compilerError = newAPIClient(config)
-		})
-	}
-	return compiler, compilerError
 }
 
 func newAPIClient(config *settings.Config) (APIClient, error) {

--- a/config/api_client.go
+++ b/config/api_client.go
@@ -1,0 +1,71 @@
+package config
+
+import (
+	"fmt"
+	"net/url"
+	"sync"
+
+	"github.com/CircleCI-Public/circleci-cli/api/graphql"
+	"github.com/CircleCI-Public/circleci-cli/api/rest"
+	"github.com/CircleCI-Public/circleci-cli/settings"
+)
+
+var (
+	compiler      APIClient
+	compilerError error
+	once          sync.Once
+
+	compilePath = "compile-config-with-defaults"
+)
+
+type apiClientVersion string
+
+type APIClient interface {
+	CompileConfig(configContent string, orgID string, params Parameters, values Values) (*ConfigResponse, error)
+}
+
+func GetAPIClient(config *settings.Config) (APIClient, error) {
+	if compiler == nil {
+		once.Do(func() {
+			compiler, compilerError = newAPIClient(config)
+		})
+	}
+	return compiler, compilerError
+}
+
+func newAPIClient(config *settings.Config) (APIClient, error) {
+	hostValue := getCompileHost(config.Host)
+	restClient := rest.NewFromConfig(hostValue, config)
+
+	version, err := detectAPIClientVersion(restClient)
+	if err != nil {
+		return nil, err
+	}
+
+	switch version {
+	case v1_string:
+		return &v1APIClient{graphql.NewClient(config.HTTPClient, config.Host, config.Endpoint, config.Token, config.Debug)}, nil
+	case v2_string:
+		return &v2APIClient{restClient}, nil
+	default:
+		return nil, fmt.Errorf("Unable to recognise your Server's config file API")
+	}
+}
+
+func detectAPIClientVersion(restClient *rest.Client) (apiClientVersion, error) {
+	req, err := restClient.NewRequest("POST", &url.URL{Path: compilePath}, nil)
+	if err != nil {
+		return "", err
+	}
+
+	statusCode, err := restClient.DoRequest(req, nil)
+	if err != nil {
+		if _, ok := err.(*rest.HTTPError); ok {
+			return "", err
+		}
+	}
+	if statusCode == 404 {
+		return v1_string, nil
+	}
+	return v2_string, nil
+}

--- a/config/api_client_test.go
+++ b/config/api_client_test.go
@@ -1,0 +1,61 @@
+package config
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/CircleCI-Public/circleci-cli/api/rest"
+	"gotest.tools/v3/assert"
+)
+
+func TestAPIClient(t *testing.T) {
+	t.Run("detectCompilerVersion", func(t *testing.T) {
+		t.Run("when the route returns a 400 tells that the version is v2", func(t *testing.T) {
+			svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(400)
+				w.Header().Set("Content-Type", "application/octet-stream")
+				fmt.Fprintf(w, "Invalid input")
+			}))
+			url, err := url.Parse(svr.URL)
+			assert.NilError(t, err)
+
+			restClient := rest.New(url, "token", http.DefaultClient)
+			version, err := detectAPIClientVersion(restClient)
+			assert.NilError(t, err)
+			assert.Equal(t, version, v2_string)
+		})
+
+		t.Run("when the route returns a 404 tells that the version is v1", func(t *testing.T) {
+			svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(404)
+				w.Header().Set("Content-Type", "application/octet-stream")
+				fmt.Fprintf(w, "Invalid input")
+			}))
+			url, err := url.Parse(svr.URL)
+			assert.NilError(t, err)
+
+			restClient := rest.New(url, "token", http.DefaultClient)
+			version, err := detectAPIClientVersion(restClient)
+			assert.NilError(t, err)
+			assert.Equal(t, version, v1_string)
+		})
+
+		t.Run("in any other case, return an error", func(t *testing.T) {
+			svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(500)
+				w.Header().Set("Content-Type", "application/octet-stream")
+				fmt.Fprintf(w, "Invalid input")
+			}))
+			url, err := url.Parse(svr.URL)
+			assert.NilError(t, err)
+
+			restClient := rest.New(url, "token", http.DefaultClient)
+			version, err := detectAPIClientVersion(restClient)
+			assert.Equal(t, version, apiClientVersion(""))
+			assert.Error(t, err, "Invalid input")
+		})
+	})
+}

--- a/config/api_client_test.go
+++ b/config/api_client_test.go
@@ -13,25 +13,9 @@ import (
 
 func TestAPIClient(t *testing.T) {
 	t.Run("detectCompilerVersion", func(t *testing.T) {
-		t.Run("when the route returns a 400 tells that the version is v2", func(t *testing.T) {
-			svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(400)
-				w.Header().Set("Content-Type", "application/octet-stream")
-				fmt.Fprintf(w, "Invalid input")
-			}))
-			url, err := url.Parse(svr.URL)
-			assert.NilError(t, err)
-
-			restClient := rest.New(url, "token", http.DefaultClient)
-			version, err := detectAPIClientVersion(restClient)
-			assert.NilError(t, err)
-			assert.Equal(t, version, v2_string)
-		})
-
 		t.Run("when the route returns a 404 tells that the version is v1", func(t *testing.T) {
 			svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(404)
-				w.Header().Set("Content-Type", "application/octet-stream")
 				fmt.Fprintf(w, "Invalid input")
 			}))
 			url, err := url.Parse(svr.URL)
@@ -43,10 +27,9 @@ func TestAPIClient(t *testing.T) {
 			assert.Equal(t, version, v1_string)
 		})
 
-		t.Run("in any other case, return an error", func(t *testing.T) {
+		t.Run("on other cases return v2", func(t *testing.T) {
 			svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(500)
-				w.Header().Set("Content-Type", "application/octet-stream")
 				fmt.Fprintf(w, "Invalid input")
 			}))
 			url, err := url.Parse(svr.URL)
@@ -54,8 +37,8 @@ func TestAPIClient(t *testing.T) {
 
 			restClient := rest.New(url, "token", http.DefaultClient)
 			version, err := detectAPIClientVersion(restClient)
-			assert.Equal(t, version, apiClientVersion(""))
-			assert.Error(t, err, "Invalid input")
+			assert.NilError(t, err)
+			assert.Equal(t, version, v2_string)
 		})
 	})
 }

--- a/config/commands_test.go
+++ b/config/commands_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/CircleCI-Public/circleci-cli/api/collaborators"
+	"github.com/CircleCI-Public/circleci-cli/api/rest"
 	"github.com/CircleCI-Public/circleci-cli/settings"
 	"github.com/stretchr/testify/assert"
 )
@@ -18,7 +20,11 @@ func TestGetOrgID(t *testing.T) {
 		fmt.Fprintf(w, `[{"vcs_type":"circleci","slug":"gh/test","id":"2345"}]`)
 	}))
 	defer svr.Close()
-	compiler := New(&settings.Config{Host: svr.URL, HTTPClient: http.DefaultClient})
+	cfg := &settings.Config{Host: svr.URL, HTTPClient: http.DefaultClient}
+	apiClient := &v2APIClient{rest.NewFromConfig(cfg.Host, cfg)}
+	collaboratorsClient, err := collaborators.NewCollaboratorsRestClient(*cfg)
+	assert.NoError(t, err)
+	compiler := New(apiClient, collaboratorsClient)
 
 	t.Run("returns the original org-id passed if it is set", func(t *testing.T) {
 		expected := "1234"
@@ -66,9 +72,13 @@ func TestValidateConfig(t *testing.T) {
 				fmt.Fprintf(w, `{"valid":true,"source-yaml":"%s","output-yaml":"%s","errors":[]}`, testYaml, testYaml)
 			}))
 			defer svr.Close()
-			compiler := New(&settings.Config{Host: svr.URL, HTTPClient: http.DefaultClient})
+			cfg := &settings.Config{Host: svr.URL, HTTPClient: http.DefaultClient}
+			apiClient := &v2APIClient{rest.NewFromConfig(cfg.Host, cfg)}
+			collaboratorsClient, err := collaborators.NewCollaboratorsRestClient(*cfg)
+			assert.NoError(t, err)
+			compiler := New(apiClient, collaboratorsClient)
 
-			err := compiler.ValidateConfig(ValidateConfigOpts{
+			err = compiler.ValidateConfig(ValidateConfigOpts{
 				ConfigPath: "testdata/config.yml",
 			})
 			assert.NoError(t, err)
@@ -87,9 +97,13 @@ func TestValidateConfig(t *testing.T) {
 				fmt.Fprintf(w, `{"valid":true,"source-yaml":"%s","output-yaml":"%s","errors":[]}`, testYaml, testYaml)
 			}))
 			defer svr.Close()
-			compiler := New(&settings.Config{Host: svr.URL, HTTPClient: http.DefaultClient})
+			cfg := &settings.Config{Host: svr.URL, HTTPClient: http.DefaultClient}
+			apiClient := &v2APIClient{rest.NewFromConfig(cfg.Host, cfg)}
+			collaboratorsClient, err := collaborators.NewCollaboratorsRestClient(*cfg)
+			assert.NoError(t, err)
+			compiler := New(apiClient, collaboratorsClient)
 
-			err := compiler.ValidateConfig(ValidateConfigOpts{
+			err = compiler.ValidateConfig(ValidateConfigOpts{
 				ConfigPath: "testdata/config.yml",
 				OrgID:      "1234",
 			})
@@ -119,9 +133,13 @@ func TestValidateConfig(t *testing.T) {
 			svr := httptest.NewServer(mux)
 			defer svr.Close()
 
-			compiler := New(&settings.Config{Host: svr.URL, HTTPClient: http.DefaultClient})
+			cfg := &settings.Config{Host: svr.URL, HTTPClient: http.DefaultClient}
+			apiClient := &v2APIClient{rest.NewFromConfig(cfg.Host, cfg)}
+			collaboratorsClient, err := collaborators.NewCollaboratorsRestClient(*cfg)
+			assert.NoError(t, err)
+			compiler := New(apiClient, collaboratorsClient)
 
-			err := compiler.ValidateConfig(ValidateConfigOpts{
+			err = compiler.ValidateConfig(ValidateConfigOpts{
 				ConfigPath: "testdata/config.yml",
 				OrgSlug:    "gh/test",
 			})
@@ -151,9 +169,13 @@ func TestValidateConfig(t *testing.T) {
 			svr := httptest.NewServer(mux)
 			defer svr.Close()
 
-			compiler := New(&settings.Config{Host: svr.URL, HTTPClient: http.DefaultClient})
+			cfg := &settings.Config{Host: svr.URL, HTTPClient: http.DefaultClient}
+			apiClient := &v2APIClient{rest.NewFromConfig(cfg.Host, cfg)}
+			collaboratorsClient, err := collaborators.NewCollaboratorsRestClient(*cfg)
+			assert.NoError(t, err)
+			compiler := New(apiClient, collaboratorsClient)
 
-			err := compiler.ValidateConfig(ValidateConfigOpts{
+			err = compiler.ValidateConfig(ValidateConfigOpts{
 				ConfigPath: "testdata/config.yml",
 				OrgSlug:    "gh/nonexistent",
 			})

--- a/config/config.go
+++ b/config/config.go
@@ -24,7 +24,7 @@ type ConfigCompiler struct {
 }
 
 func NewWithConfig(cfg *settings.Config) (*ConfigCompiler, error) {
-	apiClient, err := GetAPIClient(cfg)
+	apiClient, err := newAPIClient(cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/config/v1_api_client_test.go
+++ b/config/v1_api_client_test.go
@@ -2,7 +2,7 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -91,7 +91,7 @@ func TestAPIV1Flow(t *testing.T) {
 		gqlHitCounter := 0
 
 		mux.HandleFunc("/compile-config-with-defaults", func(w http.ResponseWriter, r *http.Request) {
-			body, err := ioutil.ReadAll(r.Body)
+			body, err := io.ReadAll(r.Body)
 			assert.NoError(t, err)
 			if len(body) == 0 {
 				w.WriteHeader(http.StatusBadRequest)

--- a/config/v2_api_client.go
+++ b/config/v2_api_client.go
@@ -1,0 +1,62 @@
+package config
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/CircleCI-Public/circleci-cli/api/rest"
+	"github.com/pkg/errors"
+)
+
+const v2_string apiClientVersion = "v2"
+
+type v2APIClient struct {
+	restClient *rest.Client
+}
+
+func configErrorsAsError(configErrors []ConfigError) error {
+	message := "config compilation contains errors:"
+	for _, err := range configErrors {
+		message += fmt.Sprintf("\n\t- %s", err.Message)
+	}
+	return errors.New(message)
+}
+
+func (client *v2APIClient) CompileConfig(configContent string, orgID string, params Parameters, values Values) (*ConfigResponse, error) {
+	compileRequest := CompileConfigRequest{
+		ConfigYaml: configContent,
+		Options: Options{
+			OwnerID:            orgID,
+			PipelineValues:     values,
+			PipelineParameters: params,
+		},
+	}
+
+	req, err := client.restClient.NewRequest(
+		"POST",
+		&url.URL{
+			Path: "compile-config-with-defaults",
+		},
+		compileRequest,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("an error occurred creating the request: %w", err)
+	}
+
+	configCompilationResp := &ConfigResponse{}
+	statusCode, originalErr := client.restClient.DoRequest(req, configCompilationResp)
+
+	if originalErr != nil {
+		return nil, fmt.Errorf("config compilation request returned an error: %w", originalErr)
+	}
+
+	if statusCode != 200 {
+		return nil, errors.New("unable to validate or compile config")
+	}
+
+	if len(configCompilationResp.Errors) > 0 {
+		return nil, fmt.Errorf("config compilation contains errors: %s", configErrorsAsError(configCompilationResp.Errors))
+	}
+
+	return configCompilationResp, nil
+}

--- a/config/v2_api_client.go
+++ b/config/v2_api_client.go
@@ -34,9 +34,7 @@ func (client *v2APIClient) CompileConfig(configContent string, orgID string, par
 
 	req, err := client.restClient.NewRequest(
 		"POST",
-		&url.URL{
-			Path: "compile-config-with-defaults",
-		},
+		&url.URL{Path: compilePath},
 		compileRequest,
 	)
 	if err != nil {

--- a/config/v2_api_client_test.go
+++ b/config/v2_api_client_test.go
@@ -1,0 +1,17 @@
+package config
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestConfigErrorsAsError(t *testing.T) {
+	err := configErrorsAsError([]ConfigError{
+		{Message: "error on line 1"},
+		{Message: "error on line 42"},
+	})
+	assert.Error(t, err, `config compilation contains errors:
+	- error on line 1
+	- error on line 42`)
+}

--- a/local/local.go
+++ b/local/local.go
@@ -26,7 +26,10 @@ func Execute(flags *pflag.FlagSet, cfg *settings.Config, args []string) error {
 	var configResponse *config.ConfigResponse
 	processedArgs, configPath := buildAgentArguments(flags)
 
-	compiler := config.New(cfg)
+	compiler, err := config.NewWithConfig(cfg)
+	if err != nil {
+		return err
+	}
 
 	//if no orgId provided use org slug
 	orgID, _ := flags.GetString("org-id")


### PR DESCRIPTION
# Checklist

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have checked for similar issues and haven't found anything relevant.
- [X] This is not a security issue (which should be reported here: https://circleci.com/security/)
- [X] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/main/CONTRIBUTING.md).

## Changes

Abstracted the API that compiles config so that it's transparent whether you use the new API route or the GraphQL endpoint

## Rationale

The config compilation has recently been moved from the GraphQL to a new API route. At first it was implemented such as if the compilation request failed with a 404, we tried falling back to the legacy GraphQL endpoint because it mostly meant that we were on old Server version that did not have the new API route
Now you have to pass an `APIClient` to the config compiler upon creation. This client should be obtained with `config.NewWithConfig(*settings.Config)`. This API client is an interface which implementation either request the new API route or the GraphQL
To detect which implementation must be given, a call is made to the new route, on 404 the GraphQL implementation is returned, else the new API route implementation is returned

## Screenshots

Nothing to show as it only changes how the code operates internally but do not add any product change