### PR TITLE
[SNC-387] In policy decide, compile config only when context is config

### DIFF
--- a/cmd/policy/policy.go
+++ b/cmd/policy/policy.go
@@ -283,9 +283,6 @@ This group of commands allows the management of polices to be verified against b
 				if policyPath == "" && ownerID == "" {
 					return fmt.Errorf("either [policy_file_or_dir_path] or --owner-id is required")
 				}
-				if !noCompile && ownerID == "" {
-					return fmt.Errorf("--owner-id is required for compiling config (use --no-compile to evaluate policy against source config only)")
-				}
 
 				metadata, err := readMetadata(meta, metaFile)
 				if err != nil {
@@ -297,7 +294,7 @@ This group of commands allows the management of polices to be verified against b
 					return fmt.Errorf("failed to read input file: %w", err)
 				}
 
-				if !noCompile {
+				if !noCompile && context == "config" {
 					compiler := config.New(globalConfig)
 					input, err = mergeCompiledConfig(compiler, config.ProcessConfigOpts{
 						ConfigPath:             inputPath,
@@ -356,6 +353,7 @@ This group of commands allows the management of polices to be verified against b
 			inputPath              string
 			meta                   string
 			metaFile               string
+			context                string
 			ownerID                string
 			query                  string
 			noCompile              bool
@@ -367,10 +365,6 @@ This group of commands allows the management of polices to be verified against b
 			RunE: func(cmd *cobra.Command, args []string) error {
 				policyPath := args[0]
 
-				if !noCompile && ownerID == "" {
-					return fmt.Errorf("--owner-id is required for compiling config (use --no-compile to evaluate policy against source config only)")
-				}
-
 				metadata, err := readMetadata(meta, metaFile)
 				if err != nil {
 					return fmt.Errorf("failed to read metadata: %w", err)
@@ -381,7 +375,7 @@ This group of commands allows the management of polices to be verified against b
 					return fmt.Errorf("failed to read input file: %w", err)
 				}
 
-				if !noCompile {
+				if !noCompile && context == "config" {
 					compiler := config.New(globalConfig)
 					input, err = mergeCompiledConfig(compiler, config.ProcessConfigOpts{
 						ConfigPath:             inputPath,
@@ -410,6 +404,7 @@ This group of commands allows the management of polices to be verified against b
 
 		cmd.Flags().StringVar(&ownerID, "owner-id", "", "the id of the policy's owner")
 		cmd.Flags().StringVar(&inputPath, "input", "", "path to input file")
+		cmd.Flags().StringVar(&context, "context", "config", "policy context for decision")
 		cmd.Flags().StringVar(&meta, "meta", "", "decision metadata (json string)")
 		cmd.Flags().StringVar(&metaFile, "metafile", "", "decision metadata file")
 		cmd.Flags().StringVar(&query, "query", "data", "policy decision query")

--- a/cmd/policy/policy_test.go
+++ b/cmd/policy/policy_test.go
@@ -827,11 +827,6 @@ test: config
 			ExpectedErr: "failed to read metadata: use either --meta or --metafile flag, but not both",
 		},
 		{
-			Name:        "fails if config compilation is enabled, but owner-id isn't provided",
-			Args:        []string{"decide", "./testdata/test0/policy.rego", "--input", "./testdata/test1/test.yml"},
-			ExpectedErr: "--owner-id is required for compiling config (use --no-compile to evaluate policy against source config only)",
-		},
-		{
 			Name:           "successfully performs decision for policy FILE provided locally",
 			Args:           []string{"decide", "./testdata/test0/policy.rego", "--input", "./testdata/test0/config.yml", "--no-compile"},
 			ExpectedOutput: `{"status": "PASS", "enabled_rules": ["branch_is_main"]}`,

--- a/cmd/policy/testdata/policy/eval-expected-usage.txt
+++ b/cmd/policy/testdata/policy/eval-expected-usage.txt
@@ -5,6 +5,7 @@ Examples:
 circleci policy eval ./policies --input ./.circleci/config.yml
 
 Flags:
+      --context string               policy context for decision (default "config")
       --input string                 path to input file
       --meta string                  decision metadata (json string)
       --metafile string              decision metadata file


### PR DESCRIPTION
Jira: [SNC-387](https://circleci.atlassian.net/browse/SNC-337)

# Checklist

=========

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)
- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/main/CONTRIBUTING.md).

### Internal Checklist
- [x] I am requesting a review from my own team as well as the owning team
- [x] I have a plan in place for the monitoring of the changes that I am making (this can include new monitors, logs to be aware of, etc...)

## Changes

=======

- In policy decide, compile config only when context is config
- Also, remove the requirement of owner-id for compilation

## Rationale

=========

The policy feature could be used non CircleCI-config related areas as well in the future.
But, the compilation is relevant to circleci configs only.

## Considerations

==============

It was understood that ownerid is not needed policy compilation, so that check is also removed.

## Screenshots

============

<h4>Before</h4>
Image or [gif](https://giphy.com/apps/giphycapture)

<h4>After</h4>
Image or gif where change can be clearly seen

## **Here are some helpful tips you can follow when submitting a pull request:**

1. Fork [the repository](https://github.com/CircleCI-Public/circleci-cli) and create your branch from `main`.
2. Run `make build` in the repository root.
3. If you've fixed a bug or added code that should be tested, add tests!
4. Ensure the test suite passes (`make test`).
5. The `--debug` flag is often helpful for debugging HTTP client requests and responses.
6. Format your code with [gofmt](https://golang.org/cmd/gofmt/).
7. Make sure your code lints (`make lint`). Note: This requires Docker to run inside a local job.


[SNC-387]: https://circleci.atlassian.net/browse/SNC-387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ