### PR TITLE
Reapply reverted changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ executors:
   go:
     docker:
       - image: cimg/go:1.20
+    resource_class: large
     environment:
       CGO_ENABLED: 0
   mac:
@@ -26,7 +27,7 @@ commands:
           # https://app.circleci.com/jobs/github/CircleCI-Public/circleci-cli/6480
           #     curl: (92) HTTP/2 stream 0 was not closed cleanly: PROTOCOL_ERROR (err 1)
           # The issue seems to be on the server-side, so force HTTP 1.1
-          name: 'cURL: Force HTTP 1.1'
+          name: "cURL: Force HTTP 1.1"
           command: echo '--http1.1' >> ~/.curlrc
   build-docker-image:
     steps:
@@ -42,36 +43,31 @@ commands:
           command: |
             docker build -t circleci/circleci-cli:0.1.$CIRCLE_BUILD_NUM-alpine --file Dockerfile.alpine .
             docker run --rm circleci/circleci-cli:0.1.$CIRCLE_BUILD_NUM-alpine update check
-  deploy-save-cache-workspace-and-artifacts:
+  deploy-save-workspace-and-artifacts:
     steps:
-      - save_cache:
-          key: v4-goreleaser-{{ checksum "~/goreleaser_amd64.deb" }}
-          paths: [~/goreleaser_amd64.deb]
       - persist_to_workspace:
           root: .
           paths:
-            - 'dist'
+            - "dist"
       - store_artifacts:
           path: ./dist
           destination: dist
   install-goreleaser:
     parameters:
-      GORELEASER_URL:
+      version:
         type: string
-        default: https://github.com/goreleaser/goreleaser/releases/download/v0.184.0/goreleaser_amd64.deb
+        default: "1.19.1"
     steps:
-      - restore_cache:
-          keys: [v5-goreleaser-]
       - run:
           name: Install GoReleaser
           command: |
-            [ -f ~/goreleaser_amd64.deb ] || curl --silent --location --fail --retry 3 << parameters.GORELEASER_URL >> > ~/goreleaser_amd64.deb
-            sudo apt-get update -y
-            sudo apt install ~/goreleaser_amd64.deb
+            echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | sudo tee /etc/apt/sources.list.d/goreleaser.list
+            sudo apt -q update -y
+            sudo apt -q install -y --no-install-recommends goreleaser=<< parameters.version >>
   gomod:
     steps:
       - restore_cache:
-          keys: ['v3-gomod-{{ arch }}-']
+          keys: ["v3-gomod-{{ arch }}-"]
       - run:
           name: Download go module dependencies
           command: go mod download
@@ -122,7 +118,7 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-            - 'build'
+            - "build"
   cucumber:
     docker:
       - image: cimg/ruby:2.7
@@ -131,7 +127,7 @@ jobs:
       - attach_workspace:
           at: .
       - run:
-          name: 'Install CLI tool from workspace'
+          name: "Install CLI tool from workspace"
           command: sudo cp ~/project/build/linux/amd64/circleci /usr/local/bin/
       - run:
           command: bundle install
@@ -210,7 +206,7 @@ jobs:
           docker_layer_caching: true
       - build-docker-image
       - build-alpine-image
-      - deploy-save-cache-workspace-and-artifacts
+      - deploy-save-workspace-and-artifacts
 
   deploy:
     executor: go
@@ -247,7 +243,7 @@ jobs:
             docker push     circleci/circleci-cli:0.1.$CIRCLE_BUILD_NUM-alpine
             docker tag      circleci/circleci-cli:0.1.$CIRCLE_BUILD_NUM-alpine circleci/circleci-cli:alpine
             docker push     circleci/circleci-cli:alpine
-      - deploy-save-cache-workspace-and-artifacts
+      - deploy-save-workspace-and-artifacts
 
   snap:
     docker:

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,4 @@ LABEL maintainer="Developer Experience Team <developer_experience@circleci.com>"
 
 ENV CIRCLECI_CLI_SKIP_UPDATE_CHECK true
 
-COPY ./dist/circleci-cli_linux_amd64/circleci /usr/local/bin
+COPY ./dist/circleci-cli_linux_amd64_v1/circleci /usr/local/bin

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -2,7 +2,7 @@ FROM alpine:3.8
 
 ENV CIRCLECI_CLI_SKIP_UPDATE_CHECK true
 
-COPY ./dist/circleci-cli_linux_amd64/circleci /usr/local/bin
+COPY ./dist/circleci-cli_linux_amd64_v1/circleci /usr/local/bin
 
 RUN apk add --no-cache --upgrade git openssh ca-certificates
 

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -257,7 +257,7 @@ var _ = Describe("Config", func() {
 			session.Wait()
 
 			Eventually(session.Err.Contents()).Should(BeEmpty())
-			Eventually(session.Out.Contents()).Should(MatchRegexp("npm run test"))
+			Eventually(session.Out.Contents()).Should(MatchRegexp("npm test"))
 			Eventually(session).Should(gexec.Exit(0))
 		})
 
@@ -273,7 +273,7 @@ var _ = Describe("Config", func() {
 			session.Wait()
 
 			Eventually(session.Err.Contents()).Should(BeEmpty())
-			Eventually(session.Out.Contents()).Should(MatchRegexp("npm run test"))
+			Eventually(session.Out.Contents()).Should(MatchRegexp("npm test"))
 			Eventually(session).Should(gexec.Exit(0))
 		})
 	})

--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -1218,7 +1218,8 @@ func initOrb(opts orbOptions) error {
 	defer resp.Body.Close()
 
 	// Create the file
-	out, err := os.Create(filepath.Join(os.TempDir(), "orb-template.zip"))
+	zipPath := filepath.Join(os.TempDir(), "orb-template.zip")
+	out, err := os.Create(zipPath)
 	if err != nil {
 		return err
 	}
@@ -1230,9 +1231,17 @@ func initOrb(opts orbOptions) error {
 		return err
 	}
 
-	err = unzipToOrbPath(filepath.Join(os.TempDir(), "orb-template.zip"), orbPath)
+	err = unzipToOrbPath(zipPath, orbPath)
 	if err != nil {
 		return err
+	}
+
+	// Remove MIT License file if orb is private
+	if opts.private {
+		err = os.Remove(filepath.Join(orbPath, "LICENSE"))
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
 	}
 
 	if fullyAutomated == 1 {

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,6 @@ require (
 	github.com/ProtonMail/go-crypto v0.0.0-20230518184743-7afd39499903 // indirect
 	github.com/acomagu/bufpipe v1.0.4 // indirect
 	github.com/agnivade/levenshtein v1.1.1 // indirect
-	github.com/alessio/shellescape v1.4.1 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
@@ -117,8 +116,5 @@ require (
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
-
-// fix vulnerability: CVE-2020-15114 in etcd v3.3.10+incompatible
-replace github.com/coreos/etcd => github.com/coreos/etcd v3.3.24+incompatible
 
 go 1.20

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 )
 
 require (
-	github.com/CircleCI-Public/circleci-config v0.0.0-20230609135034-182164ce950a
+	github.com/CircleCI-Public/circleci-config v0.0.0-20230629192034-c469d9e9936b
 	github.com/a8m/envsubst v1.4.2
 	github.com/charmbracelet/lipgloss v0.5.0
 	github.com/erikgeiser/promptkit v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/CircleCI-Public/circle-policy-agent v0.0.683 h1:EzZaLy9mUGl4dwDNWceBH
 github.com/CircleCI-Public/circle-policy-agent v0.0.683/go.mod h1:72U4Q4OtvAGRGGo/GqlCCO0tARg1cSG9xwxWyz3ktQI=
 github.com/CircleCI-Public/circleci-config v0.0.0-20230609135034-182164ce950a h1:RqA4H9p77FsqV++HNNDBq8dJftYuJ+r+KdD9HAX28t4=
 github.com/CircleCI-Public/circleci-config v0.0.0-20230609135034-182164ce950a/go.mod h1:XZaQPj2ylXZaz5vW31dRdkUY/Ey8MdpbgrUHbHyzICY=
+github.com/CircleCI-Public/circleci-config v0.0.0-20230629192034-c469d9e9936b h1:emg7uU3bRjVMlwSpOATBiybaBPXNWUIiFE/qbQQXZtE=
+github.com/CircleCI-Public/circleci-config v0.0.0-20230629192034-c469d9e9936b/go.mod h1:0iW5+XMF4XtikTlfCElaBQjT/OTMjQRHM1DgSWxcWuE=
 github.com/Masterminds/semver v1.4.2 h1:WBLTQ37jOCzSLtXNdoo8bNM8876KhNqOKvrlGITgsTc=
 github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Microsoft/go-winio v0.5.2 h1:a9IhgEQBCUEk6QCdml9CiJGhAws+YwffDHEMp1VMrpA=

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,6 @@ github.com/AlecAivazis/survey/v2 v2.1.1 h1:LEMbHE0pLj75faaVEKClEX1TM4AJmmnOh9eim
 github.com/AlecAivazis/survey/v2 v2.1.1/go.mod h1:9FJRdMdDm8rnT+zHVbvQT2RTSTLq0Ttd6q3Vl2fahjk=
 github.com/CircleCI-Public/circle-policy-agent v0.0.683 h1:EzZaLy9mUGl4dwDNWceBHeDb3X0KAAjV4eFOk3C7lts=
 github.com/CircleCI-Public/circle-policy-agent v0.0.683/go.mod h1:72U4Q4OtvAGRGGo/GqlCCO0tARg1cSG9xwxWyz3ktQI=
-github.com/CircleCI-Public/circleci-config v0.0.0-20230609135034-182164ce950a h1:RqA4H9p77FsqV++HNNDBq8dJftYuJ+r+KdD9HAX28t4=
-github.com/CircleCI-Public/circleci-config v0.0.0-20230609135034-182164ce950a/go.mod h1:XZaQPj2ylXZaz5vW31dRdkUY/Ey8MdpbgrUHbHyzICY=
 github.com/CircleCI-Public/circleci-config v0.0.0-20230629192034-c469d9e9936b h1:emg7uU3bRjVMlwSpOATBiybaBPXNWUIiFE/qbQQXZtE=
 github.com/CircleCI-Public/circleci-config v0.0.0-20230629192034-c469d9e9936b/go.mod h1:0iW5+XMF4XtikTlfCElaBQjT/OTMjQRHM1DgSWxcWuE=
 github.com/Masterminds/semver v1.4.2 h1:WBLTQ37jOCzSLtXNdoo8bNM8876KhNqOKvrlGITgsTc=
@@ -22,8 +20,6 @@ github.com/acomagu/bufpipe v1.0.4 h1:e3H4WUzM3npvo5uv95QuJM3cQspFNtFBzvJ2oNjKIDQ
 github.com/acomagu/bufpipe v1.0.4/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
 github.com/agnivade/levenshtein v1.1.1 h1:QY8M92nrzkmr798gCo3kmMyqXFzdQVpxLlGPRBij0P8=
 github.com/agnivade/levenshtein v1.1.1/go.mod h1:veldBMzWxcCG2ZvUTKD2kJNRdCk5hVbJomOvKkmgYbo=
-github.com/alessio/shellescape v1.4.1 h1:V7yhSDDn8LP4lc4jS8pFkt0zCnzVJlG5JXy9BVKJUX0=
-github.com/alessio/shellescape v1.4.1/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
 github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de h1:FxWPpzIjnTlhPwqqXc4/vE0f7GvRjuAsbW+HOIe8KnA=
 github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de/go.mod h1:DCaWoUhZrYW9p1lxo/cm8EmUOOzAPSEZNGF2DK1dJgw=


### PR DESCRIPTION
This PR only aims at reapplying some of the changes that were reverted in [this PR](https://github.com/CircleCI-Public/circleci-cli/pull/982)

It reintroduces:
 - the bump of the `circleci-config` version
 - the fix to not create a license file on initializing a private orb
 - the build & release of the `darwin/arm64` binary
 - the removal of replace directive

It **does not** reintroduce:
 - the telemetry: being the source of the bug, there is still a decision to be taken on how to address it