### PR TITLE
fix snapcraft deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -253,7 +253,7 @@ jobs:
       - attach_workspace:
           at: .
       - run: |
-          TAG=$(./dist/circleci-cli_linux_amd64/circleci version | cut -d' ' -f 1) && export TAG
+          TAG=$(./dist/circleci-cli_linux_amd64_v1/circleci version | cut -d' ' -f 1) && export TAG
           sed -i -- "s/%CLI_VERSION_PLACEHOLDER%/$TAG/g" snap/snapcraft.yaml
       - run: snapcraft
       - run:


### PR DESCRIPTION
# Checklist

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have checked for similar issues and haven't found anything relevant.
- [X] This is not a security issue (which should be reported here: https://circleci.com/security/)
- [X] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/main/CONTRIBUTING.md).

## Changes

Changes the folder that the snapcraft part of the CI uses to get the CLI version

## Rationale

With the update of goreleaser, the binaries destination folder has changed and so must be changed in the snapcraft release
To have more detail you can look into the [failed workflow](https://app.circleci.com/pipelines/github/CircleCI-Public/circleci-cli/4100/workflows/031889b0-5fbe-4438-8d95-9c1677cb1e55)

## Considerations

Other release flows have been looked into:
 - Chocolatey: gets the version and the binary from the GitHub release API -> is not affected
 - Homebrew: gets the version and the binary from the [global download script](https://circle.ci/cli)
