### PR TITLE
fix: Resolve orb validation error

### DIFF
--- a/api/orb/client.go
+++ b/api/orb/client.go
@@ -31,7 +31,7 @@ func NewClient(config *settings.Config) (Client, error) {
 
 	clientVersion, err := detectClientVersion(gql)
 	if err != nil {
-		return nil, err
+		return &v1Client{gql}, nil
 	}
 
 	switch clientVersion {


### PR DESCRIPTION
# Checklist

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have checked for similar issues and haven't found anything relevant.
- [X] This is not a security issue (which should be reported here: https://circleci.com/security/)
- [X] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/main/CONTRIBUTING.md).

## Changes

Orb validation uses the v1 validation if the GraphQL detection request errors

## Rationale

As stated in [this issue](https://github.com/CircleCI-Public/circleci-cli/issues/992) on older versions of the GraphQL endpoint, the `_schema` is not requestable, this indicates an old version of the GraphQL endpoint, and should fallback to v1 validation

