### PR TITLE
fix: Remove typo in introspection query

### DIFF
--- a/api/orb/client.go
+++ b/api/orb/client.go
@@ -31,7 +31,7 @@ func NewClient(config *settings.Config) (Client, error) {
 
 	clientVersion, err := detectClientVersion(gql)
 	if err != nil {
-		return &v1Client{gql}, nil
+		return nil, err
 	}
 
 	switch clientVersion {
@@ -74,7 +74,7 @@ type OrbIntrospectionResponse struct {
 
 func orbQueryHandleOwnerId(gql *graphql.Client) (bool, error) {
 	query := `query IntrospectionQuery {
-	_schema {
+	__schema {
 		queryType {
 			fields(includeDeprecated: true) {
 				name

--- a/cmd/orb_test.go
+++ b/cmd/orb_test.go
@@ -3713,7 +3713,7 @@ func mockOrbIntrospection(isValid bool, token string, tempSettings *clitest.Temp
 
 	requestStruct := map[string]interface{}{
 		"query": `query IntrospectionQuery {
-	_schema {
+	__schema {
 		queryType {
 			fields(includeDeprecated: true) {
 				name


### PR DESCRIPTION
# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)
- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/main/CONTRIBUTING.md).

## Changes

Introspection query was requesting `_schema` and not `__schema`

## Rationale

Fixes https://github.com/CircleCI-Public/circleci-cli/issues/992
