### PR TITLE
fix: Change path where snap takes the CLI

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,7 +10,7 @@ parts:
     plugin: nil
     override-build: |
       snapcraftctl build
-      cp dist/circleci-cli_linux_amd64/circleci $SNAPCRAFT_PART_INSTALL
+      cp dist/circleci-cli_linux_amd64_v1/circleci $SNAPCRAFT_PART_INSTALL
       chmod +x $SNAPCRAFT_PART_INSTALL/circleci
     stage-packages: [docker.io]
 apps:


### PR DESCRIPTION
# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)
- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/main/CONTRIBUTING.md).

## Changes

Same problem as [here](https://github.com/CircleCI-Public/circleci-cli/pull/988), look into the PR for more details