### PR TITLE
Update wording of error to be slightly less confusing

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -255,7 +255,7 @@ func validateToken(rootOptions *settings.Config) error {
 	}
 
 	if rootOptions.Token == "token" || rootOptions.Token == "" {
-		err = fmt.Errorf(`please set a token with 'circleci setup'
+		err = fmt.Errorf(`please set a token by running 'circleci setup'
 You can create a new personal API token here:
 %s`, url)
 	}


### PR DESCRIPTION
I found this error message to be slightly confusing -- like, I didn't know `circleci setup` was a command, although it's obvious in retrospect.

<img width="684" alt="CleanShot 2023-09-25 at 16 44 58@2x" src="https://github.com/CircleCI-Public/circleci-cli/assets/1479215/695bc63e-848a-4192-af6f-2a3bea9bf588">

By changing the wording here, I think it's a bit more clear.
