### PR TITLE
feat: default http client timeout override

### DIFF
--- a/api/header/global.go
+++ b/api/header/global.go
@@ -1,5 +1,7 @@
 package header
 
+import "time"
+
 // When the CLI is initialized, we set this to a string of the current CLI subcommand
 // (e.g. `circleci orb list`) with no args or flags, so we include it as a header in API requests.
 var cliCommandStr string = ""
@@ -10,4 +12,10 @@ func SetCommandStr(commandStr string) {
 
 func GetCommandStr() string {
 	return cliCommandStr
+}
+
+const defaultTimeout = 60 * time.Second
+
+func GetDefaultTimeout() time.Duration {
+	return defaultTimeout
 }

--- a/api/rest/client.go
+++ b/api/rest/client.go
@@ -44,7 +44,7 @@ func NewFromConfig(host string, config *settings.Config) *Client {
 		if parsedTimeout, err := time.ParseDuration(timeoutEnv); err == nil {
 			timeout = parsedTimeout
 		} else {
-			fmt.Printf("failed to parse HTTP_TIMEOUT_SECONDS: %s\n", err.Error())
+			fmt.Printf("failed to parse CIRCLECI_CLI_TIMEOUT: %s\n", err.Error())
 		}
 	}
 

--- a/api/rest/client.go
+++ b/api/rest/client.go
@@ -17,8 +17,6 @@ import (
 	"github.com/CircleCI-Public/circleci-cli/version"
 )
 
-const defaultTimeout = 10 * time.Second
-
 type Client struct {
 	BaseURL     *url.URL
 	circleToken string
@@ -41,7 +39,7 @@ func NewFromConfig(host string, config *settings.Config) *Client {
 	}
 
 	baseURL, _ := url.Parse(host)
-	timeout := defaultTimeout
+	timeout := header.GetDefaultTimeout()
 	if timeoutEnv, ok := os.LookupEnv("CIRCLECI_CLI_TIMEOUT"); ok {
 		if parsedTimeout, err := time.ParseDuration(timeoutEnv); err == nil {
 			timeout = parsedTimeout

--- a/api/rest/client.go
+++ b/api/rest/client.go
@@ -42,7 +42,7 @@ func NewFromConfig(host string, config *settings.Config) *Client {
 
 	baseURL, _ := url.Parse(host)
 	timeout := defaultTimeout
-	if timeoutEnv, ok := os.LookupEnv("HTTP_TIMEOUT"); ok {
+	if timeoutEnv, ok := os.LookupEnv("CIRCLECI_CLI_TIMEOUT"); ok {
 		if parsedTimeout, err := time.ParseDuration(timeoutEnv); err == nil {
 			timeout = parsedTimeout
 		} else {

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -16,6 +16,7 @@ import (
 
 	yaml "gopkg.in/yaml.v3"
 
+	"github.com/CircleCI-Public/circleci-cli/api/header"
 	"github.com/CircleCI-Public/circleci-cli/data"
 	"github.com/spf13/afero"
 )
@@ -287,7 +288,7 @@ func (cfg *Config) WithHTTPClient() error {
 	customTransport.TLSClientConfig = tlsConfig
 
 	cfg.HTTPClient = &http.Client{
-		Timeout:   60 * time.Second,
+		Timeout:   header.GetDefaultTimeout(),
 		Transport: customTransport,
 	}
 


### PR DESCRIPTION
# Checklist

=========

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ x I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)
- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/main/CONTRIBUTING.md).


## Changes
- Fixed #1012 
- Allows using `HTTP_TIMEOUT` env variable:
```bash
export HTTP_TIMEOUT=30s
circleci config validate config.yml
```

## Considerations

- 10 seconds should definitely be enough for the API server to respond
- This override feature is only for cases where there is some **temporal** misbehavior.
