### PR TITLE
ci: restore brew autoupdate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,6 @@ executors:
     resource_class: macos.m1.medium.gen1
     environment:
       CGO_ENABLED: 0
-      HOMEBREW_NO_AUTO_UPDATE: 1
       TERM: xterm-256color
 
 commands:


### PR DESCRIPTION
## Changes

=======

- Do not set `NO_HOMEBREW_AUTO_UPDATE` in the CI, as it is no longer recommended, and interferes with releasing to brew.

