### PR TITLE
Enrich github prompt to capture organization ID for GitHub App integr…

### DIFF
--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -17,6 +17,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/fatih/color"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"golang.org/x/exp/slices"
+	"gopkg.in/yaml.v3"
+
 	"github.com/CircleCI-Public/circleci-cli/api"
 	"github.com/CircleCI-Public/circleci-cli/api/collaborators"
 	"github.com/CircleCI-Public/circleci-cli/api/graphql"
@@ -28,11 +34,6 @@ import (
 	"github.com/CircleCI-Public/circleci-cli/settings"
 	"github.com/CircleCI-Public/circleci-cli/telemetry"
 	"github.com/CircleCI-Public/circleci-cli/version"
-	"github.com/fatih/color"
-	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
-	"golang.org/x/exp/slices"
-	"gopkg.in/yaml.v3"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/go-git/go-git/v5"
@@ -1300,6 +1301,12 @@ func initOrb(opts orbOptions) error {
 	iprompt := &survey.Input{
 		Message: fmt.Sprintf("Enter your %s username or organization", vcsProvider),
 		Default: opts.cfg.OrbPublishing.DefaultOwner,
+	}
+	if vcsProvider == "GitHub" {
+		iprompt = &survey.Input{
+			Message: fmt.Sprintf("If your organization is using CircleCI’s GitHub App integration (see %s to check), enter your organization ID found in Organization Settings. If not, enter your organization name as a string.",
+				"https://circleci.com/docs/github-apps-integration/"),
+		}
 	}
 	err = survey.AskOne(iprompt, &ownerName)
 	if err != nil {


### PR DESCRIPTION
…ation users

# Checklist

=========

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)
- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/main/CONTRIBUTING.md).

### Internal Checklist
- [x] I am requesting a review from my own team as well as the owning team
- [ ] I have a plan in place for the monitoring of the changes that I am making (this can include new monitors, logs to be aware of, etc...)

## Changes
- Add instructions for GH App integration users to use the organization ID in place of the organization name on orb creation

## Rationale
Organizations that are using GitHub App integration with CircleCI must use their organization ID rather than name when interacting with the orb commands in the CLI