### PR TITLE
deprecate follow command

### DIFF
--- a/cmd/follow.go
+++ b/cmd/follow.go
@@ -53,7 +53,7 @@ func followProjectCommand(config *settings.Config) *cobra.Command {
 	}
 	followCommand := &cobra.Command{
 		Use:   "follow",
-		Short: "Attempt to follow the project for the current git repository.",
+		Short: "Attempt to follow the project for the current git repository.\nThis command is intended to be run from a git repository with a remote named 'origin' that is hosted on Github or Bitbucket only. NOTE: this command is deprecated and is not reliable on Github projects created after September 2023",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			err := followProject(opts)
 
@@ -64,6 +64,7 @@ func followProjectCommand(config *settings.Config) *cobra.Command {
 
 			return err
 		},
+		Deprecated: "This command is deprecated and is not reliable on Github projects created after September 2023",
 	}
 	return followCommand
 }


### PR DESCRIPTION
# Checklist

=========

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)
- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/main/CONTRIBUTING.md).

### Internal Checklist
- [x] I am requesting a review from my own team as well as the owning team
- [x] I have a plan in place for the monitoring of the changes that I am making (this can include new monitors, logs to be aware of, etc...)

## Changes

=======

- deprecate follow command

## Rationale

=========

this command is deprecated and is not reliable on Github projects created after September 2023

## Screenshots

============
<img width="981" alt="Screenshot 2024-01-03 at 15 28 25" src="https://github.com/CircleCI-Public/circleci-cli/assets/111757332/c6ddc4ed-a13d-4b15-8492-b22ac7c0f810">

