### PR TITLE
[SNC-590] Update usage text for "policy-base-url" on Server

### DIFF
--- a/cmd/policy/policy.go
+++ b/cmd/policy/policy.go
@@ -51,7 +51,7 @@ func NewCommand(globalConfig *settings.Config, preRunE validator.Validator) *cob
 This group of commands allows the management of polices to be verified against build configs.`,
 	}
 
-	policyBaseURL := cmd.PersistentFlags().String("policy-base-url", "https://internal.circleci.com", "base url for policy api")
+	policyBaseURL := cmd.PersistentFlags().String("policy-base-url", "https://internal.circleci.com", "base url for policy api. For Server, set this to the URL of your instance i.e. https://customer.domain.com")
 
 	push := func() *cobra.Command {
 		var ownerID, context string

--- a/cmd/policy/testdata/policy-expected-usage.txt
+++ b/cmd/policy/testdata/policy-expected-usage.txt
@@ -12,6 +12,6 @@ Available Commands:
   test        runs policy tests
 
 Flags:
-      --policy-base-url string   base url for policy api (default "https://internal.circleci.com")
+      --policy-base-url string   base url for policy api. For Server, set this to the URL of your instance i.e. https://customer.domain.com (default "https://internal.circleci.com")
 
 Use "policy [command] --help" for more information about a command.

--- a/cmd/policy/testdata/policy/decide-expected-usage.txt
+++ b/cmd/policy/testdata/policy/decide-expected-usage.txt
@@ -15,4 +15,4 @@ Flags:
       --strict                       return non-zero status code for decision resulting in HARD_FAIL
 
 Global Flags:
-      --policy-base-url string   base url for policy api (default "https://internal.circleci.com")
+      --policy-base-url string   base url for policy api. For Server, set this to the URL of your instance i.e. https://customer.domain.com (default "https://internal.circleci.com")

--- a/cmd/policy/testdata/policy/diff-expected-usage.txt
+++ b/cmd/policy/testdata/policy/diff-expected-usage.txt
@@ -9,4 +9,4 @@ Flags:
       --owner-id string   the id of the policy's owner
 
 Global Flags:
-      --policy-base-url string   base url for policy api (default "https://internal.circleci.com")
+      --policy-base-url string   base url for policy api. For Server, set this to the URL of your instance i.e. https://customer.domain.com (default "https://internal.circleci.com")

--- a/cmd/policy/testdata/policy/eval-expected-usage.txt
+++ b/cmd/policy/testdata/policy/eval-expected-usage.txt
@@ -15,4 +15,4 @@ Flags:
       --query string                 policy decision query (default "data")
 
 Global Flags:
-      --policy-base-url string   base url for policy api (default "https://internal.circleci.com")
+      --policy-base-url string   base url for policy api. For Server, set this to the URL of your instance i.e. https://customer.domain.com (default "https://internal.circleci.com")

--- a/cmd/policy/testdata/policy/fetch-expected-usage.txt
+++ b/cmd/policy/testdata/policy/fetch-expected-usage.txt
@@ -9,4 +9,4 @@ Flags:
       --owner-id string   the id of the policy's owner
 
 Global Flags:
-      --policy-base-url string   base url for policy api (default "https://internal.circleci.com")
+      --policy-base-url string   base url for policy api. For Server, set this to the URL of your instance i.e. https://customer.domain.com (default "https://internal.circleci.com")

--- a/cmd/policy/testdata/policy/logs-expected-usage.txt
+++ b/cmd/policy/testdata/policy/logs-expected-usage.txt
@@ -16,4 +16,4 @@ Flags:
       --status string       filter decision logs based on their status
 
 Global Flags:
-      --policy-base-url string   base url for policy api (default "https://internal.circleci.com")
+      --policy-base-url string   base url for policy api. For Server, set this to the URL of your instance i.e. https://customer.domain.com (default "https://internal.circleci.com")

--- a/cmd/policy/testdata/policy/push-expected-usage.txt
+++ b/cmd/policy/testdata/policy/push-expected-usage.txt
@@ -10,4 +10,4 @@ Flags:
       --owner-id string   the id of the policy's owner
 
 Global Flags:
-      --policy-base-url string   base url for policy api (default "https://internal.circleci.com")
+      --policy-base-url string   base url for policy api. For Server, set this to the URL of your instance i.e. https://customer.domain.com (default "https://internal.circleci.com")

--- a/cmd/policy/testdata/policy/settings-expected-usage.txt
+++ b/cmd/policy/testdata/policy/settings-expected-usage.txt
@@ -10,4 +10,4 @@ Flags:
       --owner-id string   the id of the policy's owner
 
 Global Flags:
-      --policy-base-url string   base url for policy api (default "https://internal.circleci.com")
+      --policy-base-url string   base url for policy api. For Server, set this to the URL of your instance i.e. https://customer.domain.com (default "https://internal.circleci.com")

--- a/cmd/policy/testdata/policy/test-expected-usage.txt
+++ b/cmd/policy/testdata/policy/test-expected-usage.txt
@@ -12,4 +12,4 @@ Flags:
   -v, --verbose           print all tests instead of only failed tests
 
 Global Flags:
-      --policy-base-url string   base url for policy api (default "https://internal.circleci.com")
+      --policy-base-url string   base url for policy api. For Server, set this to the URL of your instance i.e. https://customer.domain.com (default "https://internal.circleci.com")


### PR DESCRIPTION
# Checklist

=========

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)
- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/main/CONTRIBUTING.md).

### Internal Checklist
- [x] I am requesting a review from my own team as well as the owning team
- [ ] I have a plan in place for the monitoring of the changes that I am making (this can include new monitors, logs to be aware of, etc...)

## Changes

=======

- Adjusted the parameter usage text to specifically call out the requirement for Server customers. 

## Rationale

=========

Policy management is available to Server customer however, they may not be aware that in order to use the cli setting the `policy-base-url` flag is required.

## Considerations

==============

Leave helper text as is and only relay on the update to the public docs around cli usage in Server. See PR https://github.com/circleci/circleci-docs/pull/8588. 
