### PR TITLE
upgrade circle-policy-agent

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/CircleCI-Public/circleci-cli
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
-	github.com/CircleCI-Public/circle-policy-agent v0.0.702
+	github.com/CircleCI-Public/circle-policy-agent v0.0.727
 	github.com/Masterminds/semver v1.5.0
 	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de
 	github.com/blang/semver v3.5.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/AlecAivazis/survey/v2 v2.3.7 h1:6I/u8FvytdGsgonrYsVn2t8t4QiRnh6QSTqkk
 github.com/AlecAivazis/survey/v2 v2.3.7/go.mod h1:xUTIdE4KCOIjsBAE1JYsUPoCqYdZ1reCfTwbto0Fduo=
 github.com/CircleCI-Public/circle-policy-agent v0.0.702 h1:dEPPZs9j2pgVV1bZEnvthHprJTn8HB2KyMxCdeD6Z3g=
 github.com/CircleCI-Public/circle-policy-agent v0.0.702/go.mod h1:72U4Q4OtvAGRGGo/GqlCCO0tARg1cSG9xwxWyz3ktQI=
+github.com/CircleCI-Public/circle-policy-agent v0.0.727 h1:DS5QkuffkAO/EwNIN2mgQC4an73wfo/VR7ZurAA2qkc=
+github.com/CircleCI-Public/circle-policy-agent v0.0.727/go.mod h1:72U4Q4OtvAGRGGo/GqlCCO0tARg1cSG9xwxWyz3ktQI=
 github.com/CircleCI-Public/circleci-config v0.0.0-20231003143420-842d4b0025ef h1:Bhr3xH8/XV0CF8wHFxWgBkmDRTQIW5O1MiuL3n1AEug=
 github.com/CircleCI-Public/circleci-config v0.0.0-20231003143420-842d4b0025ef/go.mod h1:2AyBtY8aKfifpEw4OBC+8jrVeoPEkpYTzBojhZ5pEtE=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=


### PR DESCRIPTION
## Changes

- Upgrade `circle-policy-agent` to address https://github.com/CircleCI-Public/circleci-cli/issues/1048 after [this PR](https://github.com/CircleCI-Public/circle-policy-agent/pull/122).

## Rationale

N/A.

## Considerations

N/A.

## Screenshots

N/A.