### PR TITLE
PIPE-4359 Update config compilation pipeline values to add parameters

### DIFF
--- a/cmd/policy/policy.go
+++ b/cmd/policy/policy.go
@@ -521,7 +521,7 @@ This group of commands allows the management of polices to be verified against b
 								ConfigYaml: string(data),
 								Options: config.Options{
 									OwnerID:            ownerID,
-									PipelineValues:     pipelineValues,
+									PipelineValues:     config.LocalPipelineValues(parameters),
 									PipelineParameters: parameters,
 								},
 							},

--- a/config/commands.go
+++ b/config/commands.go
@@ -82,7 +82,7 @@ func (c *ConfigCompiler) ProcessConfig(opts ProcessConfigOpts) (response *Config
 	}
 
 	//if no orgId provided use org slug
-	values := LocalPipelineValues()
+	values := LocalPipelineValues(params)
 	if opts.VerboseOutput {
 		fmt.Fprintln(os.Stderr, "Processing config with following values:")
 		printValues(values)
@@ -126,7 +126,7 @@ func (c *ConfigCompiler) ValidateConfig(opts ValidateConfigOpts) error {
 	var response *ConfigResponse
 
 	//if no orgId provided use org slug
-	values := LocalPipelineValues()
+	values := LocalPipelineValues(nil)
 	if opts.VerboseOutput {
 		fmt.Fprintln(os.Stderr, "Validating config with following values:")
 		printValues(values)
@@ -141,7 +141,7 @@ func (c *ConfigCompiler) ValidateConfig(opts ValidateConfigOpts) error {
 		opts.ConfigPath,
 		orgID,
 		nil,
-		LocalPipelineValues(),
+		values,
 	)
 	if err != nil {
 		return err

--- a/config/config.go
+++ b/config/config.go
@@ -5,9 +5,10 @@ import (
 	"io"
 	"os"
 
+	"github.com/pkg/errors"
+
 	"github.com/CircleCI-Public/circleci-cli/api/collaborators"
 	"github.com/CircleCI-Public/circleci-cli/settings"
-	"github.com/pkg/errors"
 )
 
 var (
@@ -71,7 +72,9 @@ type CompileConfigRequest struct {
 }
 
 type Options struct {
-	OwnerID            string                 `json:"owner_id,omitempty"`
+	OwnerID string `json:"owner_id,omitempty"`
+	// PipelineParameters are deprecated and will be removed in the future.
+	// Use PipelineValues instead.
 	PipelineParameters map[string]interface{} `json:"pipeline_parameters,omitempty"`
 	PipelineValues     map[string]interface{} `json:"pipeline_values,omitempty"`
 }

--- a/config/pipeline.go
+++ b/config/pipeline.go
@@ -12,9 +12,9 @@ type Values map[string]interface{}
 // Static typing is bypassed using an empty interface here due to pipeline parameters supporting multiple types.
 type Parameters map[string]interface{}
 
-// vars should contain any pipeline parameters that should be accessible via
-// << pipeline.parameters.foo >>
-func LocalPipelineValues() Values {
+// LocalPipelineValues returns a map of pipeline values that can be used for local validation.
+// The given parameters will be prefixed with "pipeline.parameters." and accessible via << pipeline.parameters.foo >>.
+func LocalPipelineValues(parameters Parameters) Values {
 	revision := git.Revision()
 	gitUrl := "https://github.com/CircleCI-Public/circleci-cli"
 	projectType := "github"
@@ -32,14 +32,18 @@ func LocalPipelineValues() Values {
 	}
 
 	vals := map[string]interface{}{
-		"id":                "00000000-0000-0000-0000-000000000001",
-		"number":            1,
-		"project.git_url":   gitUrl,
-		"project.type":      projectType,
-		"git.tag":           git.Tag(),
-		"git.branch":        git.Branch(),
-		"git.revision":      revision,
-		"git.base_revision": revision,
+		"pipeline.id":                "00000000-0000-0000-0000-000000000001",
+		"pipeline.number":            1,
+		"pipeline.project.git_url":   gitUrl,
+		"pipeline.project.type":      projectType,
+		"pipeline.git.tag":           git.Tag(),
+		"pipeline.git.branch":        git.Branch(),
+		"pipeline.git.revision":      revision,
+		"pipeline.git.base_revision": revision,
+	}
+
+	for k, v := range parameters {
+		vals[fmt.Sprintf("pipeline.parameters.%s", k)] = v
 	}
 
 	return vals

--- a/config/pipeline_test.go
+++ b/config/pipeline_test.go
@@ -1,0 +1,52 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/exp/maps"
+)
+
+func TestLocalPipelineValues(t *testing.T) {
+	tests := []struct {
+		name       string
+		parameters Parameters
+		wantKeys   []string
+	}{
+		{
+			name:       "standard values given nil parameters",
+			parameters: nil,
+			wantKeys: []string{
+				"pipeline.id",
+				"pipeline.number",
+				"pipeline.project.git_url",
+				"pipeline.project.type",
+				"pipeline.git.tag",
+				"pipeline.git.branch",
+				"pipeline.git.revision",
+				"pipeline.git.base_revision",
+			},
+		},
+		{
+			name:       "standard and prefixed parameters given map of parameters",
+			parameters: Parameters{"foo": "bar", "baz": "buzz"},
+			wantKeys: []string{
+				"pipeline.id",
+				"pipeline.number",
+				"pipeline.project.git_url",
+				"pipeline.project.type",
+				"pipeline.git.tag",
+				"pipeline.git.branch",
+				"pipeline.git.revision",
+				"pipeline.git.base_revision",
+				"pipeline.parameters.foo",
+				"pipeline.parameters.baz",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.ElementsMatchf(t, tt.wantKeys, maps.Keys(LocalPipelineValues(tt.parameters)), "LocalPipelineValues(%v)", tt.parameters)
+		})
+	}
+}

--- a/local/local.go
+++ b/local/local.go
@@ -10,10 +10,11 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/CircleCI-Public/circleci-cli/config"
-	"github.com/CircleCI-Public/circleci-cli/settings"
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
+
+	"github.com/CircleCI-Public/circleci-cli/config"
+	"github.com/CircleCI-Public/circleci-cli/settings"
 )
 
 var picardRepo = "circleci/picard"
@@ -46,13 +47,13 @@ func Execute(flags *pflag.FlagSet, cfg *settings.Config, args []string) error {
 	//if no orgId provided use org slug
 	orgID, _ := flags.GetString("org-id")
 	if strings.TrimSpace(orgID) != "" {
-		configResponse, err = compiler.ConfigQuery(configPath, orgID, nil, config.LocalPipelineValues())
+		configResponse, err = compiler.ConfigQuery(configPath, orgID, nil, config.LocalPipelineValues(nil))
 		if err != nil {
 			return err
 		}
 	} else {
 		orgSlug, _ := flags.GetString("org-slug")
-		configResponse, err = compiler.ConfigQuery(configPath, orgSlug, nil, config.LocalPipelineValues())
+		configResponse, err = compiler.ConfigQuery(configPath, orgSlug, nil, config.LocalPipelineValues(nil))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
# Checklist

=========

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)
- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/main/CONTRIBUTING.md).

### Internal Checklist
- [x] I am requesting a review from my own team as well as the owning team
- [x] I have a plan in place for the monitoring of the changes that I am making (this can include new monitors, logs to be aware of, etc...)

## Changes

=======

- Update config compilation to include pipeline values and parameters together.

## Rationale

=========

Config compilation now accepts pipeline values and parameters in a single map with the expected prefixes.

All standard values are now prefixed with `pipeline.`, and all parameters are prefixed with `pipeline.parameters.` as described in the Pipeline Values documentation.

https://circleci.com/docs/pipeline-variables/

## Considerations

==============

The parameters inside pipeline values are not currently used, there are metrics in place to reach a 100% match before we start relying on the data in a single map.

Although the service is prepared to accept the new prefixed format, should things go wrong, this could impact any command that requires config compilation where the config references a pipeline value or parameter.

