### PR TITLE
[LIFE-307] Don't link to orb docs on server

### DIFF
--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -621,7 +621,7 @@ func formatListOrbsResult(list api.OrbsForListing, opts orbOptions) (string, err
 		}
 	}
 
-	if !opts.private {
+	if !opts.private && opts.cfg.Host == defaultHost {
 		b.WriteString("\nIn order to see more details about each orb, type: `circleci orb info orb-namespace/orb-name`\n")
 		b.WriteString("\nSearch, filter, and view sources for all Orbs online at https://circleci.com/developer/orbs/")
 	}

--- a/cmd/orb_test.go
+++ b/cmd/orb_test.go
@@ -2229,9 +2229,6 @@ second (0.8.0)
 third (0.9.0)
 first (0.7.0)
 
-In order to see more details about each orb, type: ` + "`circleci orb info orb-namespace/orb-name`" + `
-
-Search, filter, and view sources for all Orbs online at https://circleci.com/developer/orbs/
 `))
 			})
 
@@ -2256,9 +2253,6 @@ third (0.9.0)
 first (0.7.0)
 second (0.8.0)
 
-In order to see more details about each orb, type: ` + "`circleci orb info orb-namespace/orb-name`" + `
-
-Search, filter, and view sources for all Orbs online at https://circleci.com/developer/orbs/
 `))
 			})
 
@@ -2283,9 +2277,6 @@ second (0.8.0)
 first (0.7.0)
 third (0.9.0)
 
-In order to see more details about each orb, type: ` + "`circleci orb info orb-namespace/orb-name`" + `
-
-Search, filter, and view sources for all Orbs online at https://circleci.com/developer/orbs/
 `))
 			})
 		})
@@ -2475,9 +2466,6 @@ query ListOrbs ($after: String!, $certifiedOnly: Boolean!) {
 				Eventually(session.Out).Should(gbytes.Say("circleci/codecov-clojure \\(0.0.4\\)"))
 				// Include an orb with contents from the second mocked response
 				Eventually(session.Out).Should(gbytes.Say("zzak/test4 \\(0.1.0\\)"))
-
-				Eventually(session.Out).Should(gbytes.Say("In order to see more details about each orb, type: `circleci orb info orb-namespace/orb-name`"))
-				Eventually(session.Out).Should(gbytes.Say("Search, filter, and view sources for all Orbs online at https://circleci.com/developer/orbs/"))
 				Expect(tempSettings.TestServer.ReceivedRequests()).Should(HaveLen(2))
 			})
 

--- a/cmd/orb_test.go
+++ b/cmd/orb_test.go
@@ -2513,7 +2513,7 @@ query ListOrbs ($after: String!, $certifiedOnly: Boolean!) {
 				command = exec.Command(pathCLI,
 					"orb", "list",
 					"--skip-update-check",
-					"--host", tempSettings.TestServer.URL(),
+					"--host", "https://circleci.com",
 					"--details",
 				)
 				By("setting up a mock server")

--- a/cmd/orb_test.go
+++ b/cmd/orb_test.go
@@ -2513,7 +2513,7 @@ query ListOrbs ($after: String!, $certifiedOnly: Boolean!) {
 				command = exec.Command(pathCLI,
 					"orb", "list",
 					"--skip-update-check",
-					"--host", "https://circleci.com",
+					"--host", tempSettings.TestServer.URL(),
 					"--details",
 				)
 				By("setting up a mock server")
@@ -2584,9 +2584,6 @@ foo/test (0.7.0)
     - last30DaysOrganizationCount: 0
     - last30DaysProjectCount: 0
 
-In order to see more details about each orb, type: ` + "`circleci orb info orb-namespace/orb-name`" + `
-
-Search, filter, and view sources for all Orbs online at https://circleci.com/developer/orbs/
 `))
 				Eventually(session).Should(gexec.Exit(0))
 				Expect(tempSettings.TestServer.ReceivedRequests()).Should(HaveLen(1))


### PR DESCRIPTION
# Checklist

=========

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)
- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/main/CONTRIBUTING.md).

### Internal Checklist
- [x] I am requesting a review from my own team as well as the owning team
- [x] I have a plan in place for the monitoring of the changes that I am making (this can include new monitors, logs to be aware of, etc...)

## Changes

=======

- Don't link to orb docs when CLI hostname does not point to cloud.

## Rationale

=========

Enterprise users don't have access to the regular orb registry.

## Considerations

==============

I wasn't sure about changing the default hostname in the tests (it's being set to `tempSettings.TestServer.URL()`), so instead I removed the string from the relevant tests and added a new test case with the default host to ensure it does get printed.


