### PR TITLE
Use the runner v3 API [ONPREM-237]

### DIFF
--- a/cmd/runner/runner.go
+++ b/cmd/runner/runner.go
@@ -15,7 +15,12 @@ type runnerOpts struct {
 	r running
 }
 
-func NewCommand(config *settings.Config, preRunE validator.Validator) *cobra.Command {
+func NewCommand(rootConfig *settings.Config, preRunE validator.Validator) *cobra.Command {
+	// The runner API versioning is decoupled from the other Circle APIs. Here we make a copy of the root configuration,
+	// and update the rest endpoint accordingly
+	config := *rootConfig
+	config.RestEndpoint = "/api/v3"
+
 	var opts runnerOpts
 	cmd := &cobra.Command{
 		Use:   "runner",
@@ -27,7 +32,7 @@ func NewCommand(config *settings.Config, preRunE validator.Validator) *cobra.Com
 			} else {
 				host = config.Host
 			}
-			opts.r = runner.New(rest.NewFromConfig(host, config))
+			opts.r = runner.New(rest.NewFromConfig(host, &config))
 		},
 	}
 

--- a/cmd/runner/runner_test.go
+++ b/cmd/runner/runner_test.go
@@ -1,0 +1,31 @@
+package runner
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+
+	"github.com/CircleCI-Public/circleci-cli/settings"
+)
+
+func Test_NewCommand(t *testing.T) {
+	t.Run("Runner uses /api/v3", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Check(t, cmp.Equal(r.URL.EscapedPath(), "/api/v3/runner"))
+
+			w.Header().Set("Content-Type", "application/json")
+			_, err := w.Write([]byte(`{"items":[]}`))
+			assert.NilError(t, err)
+			w.WriteHeader(http.StatusOK)
+		}))
+		t.Cleanup(server.Close)
+
+		cmd := NewCommand(&settings.Config{Host: server.URL, HTTPClient: &http.Client{}}, nil)
+		cmd.SetArgs([]string{"instance", "ls", "my-namespace"})
+		err := cmd.Execute()
+		assert.NilError(t, err)
+	})
+}


### PR DESCRIPTION
# Checklist

=========

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)
- [ ] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/main/CONTRIBUTING.md).

### Internal Checklist
- [x] I am requesting a review from my own team as well as the owning team
- [x] I have a plan in place for the monitoring of the changes that I am making (this can include new monitors, logs to be aware of, etc...)

## Changes

=======

- Update the runner CRUD operations to use the _runner_ v3 API instead of v2

## Rationale

=========

What was the overarching product goal of this PR as well as any pertinent
history of changes

The _runner_ v2 API is being [actively deprecated](https://status.circleci.com/incidents/7jy5kpsbh8q4) and will be EoL soon, so the CLI needs to be updated to provide a migration path for CircleCI runner users.

## Considerations

==============

Why you made some of the technical decisions that you made, especially if the
reasoning is not immediately obvious

Server 4.6 just recently shipped, marking 4.2 as unsupported. This was the last version that didn't support the runner v3 API.

## Screenshots

============

<h4>Before</h4>
Image or [gif](https://giphy.com/apps/giphycapture)

<h4>After</h4>
Image or gif where change can be clearly seen

## **Here are some helpful tips you can follow when submitting a pull request:**

1. Fork [the repository](https://github.com/CircleCI-Public/circleci-cli) and create your branch from `main`.
2. Run `make build` in the repository root.
3. If you've fixed a bug or added code that should be tested, add tests!
4. Ensure the test suite passes (`make test`).
5. The `--debug` flag is often helpful for debugging HTTP client requests and responses.
6. Format your code with [gofmt](https://golang.org/cmd/gofmt/).
7. Make sure your code lints (`make lint`). Note: This requires Docker to run inside a local job.
