### PR TITLE
PIPE-4877 Remove config validate test with invalid org ID

### DIFF
--- a/integration_tests/features/circleci_config.feature
+++ b/integration_tests/features/circleci_config.feature
@@ -84,30 +84,6 @@ Feature: Config checking
     Then the exit status should be 0
     And the output should contain "Config file at config.yml is valid"
 
-  Scenario: Checking a valid config file with a private org
-    Given a file named "config.yml" with:
-    """
-    version: 2.1
-
-    orbs:
-      node: circleci/node@5.0.3
-  
-    jobs:
-      datadog-hello-world:
-        docker:
-          - image: cimg/base:stable
-        steps:
-          - run: |
-              echo "doing something really cool"
-    workflows:
-      datadog-hello-world:
-        jobs:
-          - datadog-hello-world
-    """
-    When I run `circleci config validate --skip-update-check --org-id bb604b45-b6b0-4b81-ad80-796f15eddf87 -c config.yml`
-    Then the output should contain "Config file at config.yml is valid"
-    And the exit status should be 0
-
   Scenario: Checking a valid config file with a non-existant orb
     Given a file named "config.yml" with:
     """


### PR DESCRIPTION
# Checklist

=========

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)
- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/main/CONTRIBUTING.md).

### Internal Checklist
- [x] I am requesting a review from my own team as well as the owning team
- [x] I have a plan in place for the monitoring of the changes that I am making (this can include new monitors, logs to be aware of, etc...)

## Changes

=======

- Remove config validate test with invalid org ID

## Rationale

=========

There has been a change to how configs are compiled that makes this test invalid.

Previously we would allow any random owner ID to be passed in when compiling certified orbs as these were enabled by default and didn't require any checks with the provided owner ID.

To support an upcoming feature, now when compiling the config, all provided owner IDs are checked and must exist to validate that the organization allows that type of orb.

The CLI can continue to use no owner ID with public certified orbs as tested in the above case.

https://github.com/CircleCI-Public/circleci-cli/blob/2766f0e710c8727e346e247f6c779079a79b010c/integration_tests/features/circleci_config.feature#L63-L85

## Considerations

==============

An alternative we can consider is to provide a valid private test organization ID to satisfy the test case, I opted against this since the config being compiled only uses a public certified orb which has the same behaviour with or without the owner ID.

## Screenshots

============

<h4>Before</h4>
Image or [gif](https://giphy.com/apps/giphycapture)

<h4>After</h4>
Image or gif where change can be clearly seen

## **Here are some helpful tips you can follow when submitting a pull request:**

1. Fork [the repository](https://github.com/CircleCI-Public/circleci-cli) and create your branch from `main`.
2. Run `make build` in the repository root.
3. If you've fixed a bug or added code that should be tested, add tests!
4. Ensure the test suite passes (`make test`).
5. The `--debug` flag is often helpful for debugging HTTP client requests and responses.
6. Format your code with [gofmt](https://golang.org/cmd/gofmt/).
7. Make sure your code lints (`make lint`). Note: This requires Docker to run inside a local job.
