### PR TITLE
Add --json flag for resource-class cmds

### DIFF
--- a/cmd/runner/resource_class.go
+++ b/cmd/runner/resource_class.go
@@ -84,7 +84,7 @@ func newResourceClassCommand(o *runnerOpts, preRunE validator.Validator) *cobra.
 		},
 	}
 	createCmd.PersistentFlags().BoolVar(&jsonFormat, "json", false,
-		"Return stdout output in JSON format.")
+		"Return output back in JSON format")
 	createCmd.PersistentFlags().BoolVar(&genToken, "generate-token", false,
 		"Generate a default token")
 	cmd.AddCommand(createCmd)
@@ -141,7 +141,7 @@ func newResourceClassCommand(o *runnerOpts, preRunE validator.Validator) *cobra.
 		},
 	}
 	listCmd.PersistentFlags().BoolVar(&jsonFormat, "json", false,
-		"Return stdout output in JSON format.")
+		"Return output back in JSON format")
 	cmd.AddCommand(listCmd)
 
 	return cmd

--- a/cmd/runner/resource_class.go
+++ b/cmd/runner/resource_class.go
@@ -59,7 +59,9 @@ func newResourceClassCommand(o *runnerOpts, preRunE validator.Validator) *cobra.
 					return err
 				}
 				jsonWriter := cmd.OutOrStdout()
-				jsonWriter.Write(jsonRc)
+				if _, err := jsonWriter.Write(jsonRc); err != nil {
+					return err
+				}
 			} else if jsonFormat && genToken {
 				// return JSON formatted output for token since it contains enough related resource-class info
 				jsonToken, err := json.Marshal(token)
@@ -67,7 +69,9 @@ func newResourceClassCommand(o *runnerOpts, preRunE validator.Validator) *cobra.
 					return err
 				}
 				jsonWriter := cmd.OutOrStdout()
-				jsonWriter.Write(jsonToken)
+				if _, err := jsonWriter.Write(jsonToken); err != nil {
+					return err
+				}
 			} else {
 				// return default ASCII table format for output
 				table := newResourceClassTable(cmd.OutOrStdout())
@@ -127,7 +131,9 @@ func newResourceClassCommand(o *runnerOpts, preRunE validator.Validator) *cobra.
 					return err
 				}
 				jsonWriter := cmd.OutOrStdout()
-				jsonWriter.Write(jsonRcs)
+				if _, err := jsonWriter.Write(jsonRcs); err != nil {
+					return err
+				}
 			} else {
 				// return default ASCII table format for output
 				table := newResourceClassTable(cmd.OutOrStdout())

--- a/cmd/runner/resource_class_test.go
+++ b/cmd/runner/resource_class_test.go
@@ -47,6 +47,31 @@ func Test_ResourceClass(t *testing.T) {
 			assert.Check(t, cmp.Contains(stderr.String(), terms))
 		})
 
+		t.Run("without default token and json", func(t *testing.T) {
+			defer runner.reset()
+			defer stdout.Reset()
+			defer stderr.Reset()
+
+			cmd.SetArgs([]string{
+				"create",
+				"my-namespace/my-resource-class",
+				"my-description",
+				"--json",
+			})
+
+			err := cmd.Execute()
+			assert.NilError(t, err)
+
+			assert.Check(t, cmp.Equal(len(runner.resourceClasses), 1))
+			assert.Check(t, cmp.Equal(runner.resourceClasses[0].ResourceClass, "my-namespace/my-resource-class"))
+			assert.Check(t, cmp.Equal(runner.resourceClasses[0].Description, "my-description"))
+			assert.Check(t, cmp.Contains(stdout.String(), "my-namespace/my-resource-class"))
+
+			assert.Check(t, cmp.Equal(len(runner.tokens), 0))
+
+			assert.Check(t, cmp.Contains(stderr.String(), terms))
+		})
+
 		t.Run("with default token", func(t *testing.T) {
 			defer runner.reset()
 			defer stdout.Reset()
@@ -57,6 +82,36 @@ func Test_ResourceClass(t *testing.T) {
 				"my-namespace/my-other-resource-class",
 				"my-description",
 				"--generate-token",
+			})
+
+			err := cmd.Execute()
+			assert.NilError(t, err)
+			out := stdout.String()
+
+			assert.Check(t, cmp.Equal(len(runner.resourceClasses), 1))
+			assert.Check(t, cmp.Equal(runner.resourceClasses[0].ResourceClass, "my-namespace/my-other-resource-class"))
+			assert.Check(t, cmp.Equal(runner.resourceClasses[0].Description, "my-description"))
+			assert.Check(t, cmp.Contains(out, "my-namespace/my-other-resource-class"))
+
+			assert.Check(t, cmp.Equal(len(runner.tokens), 1))
+			assert.Check(t, cmp.Equal(runner.tokens[0].ResourceClass, "my-namespace/my-other-resource-class"))
+			assert.Check(t, cmp.Equal(runner.tokens[0].Nickname, "default"))
+			assert.Check(t, cmp.Contains(out, "fake-token"))
+
+			assert.Check(t, cmp.Contains(stderr.String(), terms))
+		})
+
+		t.Run("with default token and json", func(t *testing.T) {
+			defer runner.reset()
+			defer stdout.Reset()
+			defer stderr.Reset()
+
+			cmd.SetArgs([]string{
+				"create",
+				"my-namespace/my-other-resource-class",
+				"my-description",
+				"--generate-token",
+				"--json",
 			})
 
 			err := cmd.Execute()

--- a/cmd/runner/telemetry_test.go
+++ b/cmd/runner/telemetry_test.go
@@ -55,6 +55,7 @@ func Test_RunnerTelemetry(t *testing.T) {
 				LocalArgs: map[string]string{
 					"generate-token": "true",
 					"help":           "false",
+					"json":           "false",
 				},
 			}),
 		})

--- a/cmd/runner/testdata/runner/resource-class/create-expected-usage.txt
+++ b/cmd/runner/testdata/runner/resource-class/create-expected-usage.txt
@@ -3,3 +3,4 @@ Usage:
 
 Flags:
       --generate-token   Generate a default token
+      --json             Return output back in JSON format

--- a/cmd/runner/testdata/runner/resource-class/list-expected-usage.txt
+++ b/cmd/runner/testdata/runner/resource-class/list-expected-usage.txt
@@ -3,3 +3,6 @@ Usage:
 
 Aliases:
   list, ls
+
+Flags:
+      --json             Return output back in JSON format

--- a/cmd/runner/testdata/runner/resource-class/list-expected-usage.txt
+++ b/cmd/runner/testdata/runner/resource-class/list-expected-usage.txt
@@ -1,8 +1,8 @@
 Usage:
-  runner resource-class list <namespace>
+  runner resource-class list <namespace> [flags]
 
 Aliases:
   list, ls
 
 Flags:
-      --json             Return output back in JSON format
+      --json   Return output back in JSON format

--- a/cmd/runner/testdata/runner/token/list-expected-usage.txt
+++ b/cmd/runner/testdata/runner/token/list-expected-usage.txt
@@ -1,5 +1,5 @@
 Usage:
-  runner token list <resource-class>
+  runner token list <resource-class> [flags]
 
 Aliases:
   list, ls

--- a/cmd/runner/testdata/runner/token/list-expected-usage.txt
+++ b/cmd/runner/testdata/runner/token/list-expected-usage.txt
@@ -1,5 +1,5 @@
 Usage:
-  runner token list <resource-class> [flags]
+  runner token list <resource-class>
 
 Aliases:
   list, ls


### PR DESCRIPTION
Relates to https://github.com/CircleCI-Public/circleci-cli/issues/380

# Checklist

=========

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)
- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/main/CONTRIBUTING.md).

### Internal Checklist

Not applicable to me, a non-CircleCI employee

## Changes

=======

### Implementation

I implemented my changes in the following way:

- I added a local `--json` flag to the `resource_class.go` file where it was appropriate to, for the `create` and `list` command actions.
- In each command, I check whether or not the `--json` flag was set on the command line, and if so, we Marshal the appropriate object and set it in the Writer interface offered by the cobra `cmd` object.
- I introduced the JSON formatting logic such that **the original CLI behavior is unchanged**. If you submit commands like:
  - `circleci runner resource-class list <>`
  - `circleci runner resource-class create <>`

they will behave exactly as they did. Only if you include a `--json` flag will you see new behavior, returned to stdout.

### Automated Tests

I made sure to add tests in `resource_class_test.go` where appropriate as well as update the expected usage files.

### Manual Tests

I executed the following commands manually (alongside the automated testing), to ensure:

- They work as expected, adding in the new JSON formatting.
- The old CLI behavior is maintained as before these changes.

```bash
➜ make build  # the CLI builds successfully


➜ ./build/darwin/arm64/circleci runner resource-class list jdelnano --json

[{"id":"<redacted>","resource_class":"jdelnano/test","description":"test"}]

========================================================================================================================================================

➜ ./build/darwin/arm64/circleci runner resource-class list jdelnano
+-------------------------------------------------------------+--------------------------------------------------+
|                       RESOURCE CLASS                        |                   DESCRIPTION                    |
+-------------------------------------------------------------+--------------------------------------------------+
| jdelnano/test                                               | test                                             |
+-------------------------------------------------------------+--------------------------------------------------+

➜ ./build/darwin/arm64/circleci runner resource-class create jdelnano/test "test"
If you have not already agreed to Runner Terms in a signed Order, then by continuing to install Runner, you are agreeing to CircleCI's Runner Terms which are found at: https://circleci.com/legal/runner-terms/.
If you already agreed to Runner Terms in a signed Order, the Runner Terms in the signed Order supersede the Runner Terms in the web address above.
If you did not already agree to Runner Terms through a signed Order and do not agree to the Runner Terms in the web address above, please do not install or use Runner.

+-------------------------------------------+-------------+
|              RESOURCE CLASS               | DESCRIPTION |
+-------------------------------------------+-------------+
| jdelnano/test                             | test        |
+-------------------------------------------+-------------+

========================================================================================================================================================

➜ ./build/darwin/arm64/circleci runner resource-class create jdelnano/test "test" --generate-token
If you have not already agreed to Runner Terms in a signed Order, then by continuing to install Runner, you are agreeing to CircleCI's Runner Terms which are found at: https://circleci.com/legal/runner-terms/.
If you already agreed to Runner Terms in a signed Order, the Runner Terms in the signed Order supersede the Runner Terms in the web address above.
If you did not already agree to Runner Terms through a signed Order and do not agree to the Runner Terms in the web address above, please do not install or use Runner.

api:
    auth_token: <redacted>
+-------------------------------------------+-------------+
|              RESOURCE CLASS               | DESCRIPTION |
+-------------------------------------------+-------------+
| jdelnano/test                             | test        |
+-------------------------------------------+-------------+

========================================================================================================================================================

➜ ./build/darwin/arm64/circleci runner resource-class create jdelnano/test "test" --json
If you have not already agreed to Runner Terms in a signed Order, then by continuing to install Runner, you are agreeing to CircleCI's Runner Terms which are found at: https://circleci.com/legal/runner-terms/.
If you already agreed to Runner Terms in a signed Order, the Runner Terms in the signed Order supersede the Runner Terms in the web address above.
If you did not already agree to Runner Terms through a signed Order and do not agree to the Runner Terms in the web address above, please do not install or use Runner.

{"id":"<redacted>","resource_class":"jdelnano/test","description":"test"}

========================================================================================================================================================

➜ ./build/darwin/arm64/circleci runner resource-class create jdelnano/test "test" --generate-token --json
If you have not already agreed to Runner Terms in a signed Order, then by continuing to install Runner, you are agreeing to CircleCI's Runner Terms which are found at: https://circleci.com/legal/runner-terms/.
If you already agreed to Runner Terms in a signed Order, the Runner Terms in the signed Order supersede the Runner Terms in the web address above.
If you did not already agree to Runner Terms through a signed Order and do not agree to the Runner Terms in the web address above, please do not install or use Runner.

{"id":"<redacted>","token":"<redacted>","resource_class":"jdelnano/test","nickname":"default","created_at":"2024-12-27T18:43:48.345011Z"}
```

## Rationale

=========

### Background
In my position at Okta, a CircleCI customer, I have a few automation tasks that require the use of the  `circleci runner resource-class list` and `circleci runner resource-class create` commands, where I specifically need to grab the output of these commands and do subsequent actions. As a result, my motivation for adding the `--json` flag support for the `circleci runner resource-class` command is to return more easily parsable output, instead of the default ASCII table format.

### Potential Future Work

If this PR is accepted, and it is deemed advantageous, I can move this new `--json` flag to be global/applicable so that other CLI commands can return JSON formatted responses to stdout.