### PR TITLE
[Ready for Review] Add json flag to remaining table.Render-ing cmds

### DIFF
--- a/cmd/create_telemetry_test.go
+++ b/cmd/create_telemetry_test.go
@@ -60,12 +60,14 @@ func TestLoadTelemetrySettings(t *testing.T) {
 					UniqueID:          uniqueId,
 				},
 				telemetryEvents: []telemetry.Event{
-					{Object: "cli-telemetry", Action: "enabled",
+					{
+						Object: "cli-telemetry", Action: "enabled",
 						Properties: map[string]interface{}{
 							"UUID":           uniqueId,
 							"user_id":        userId,
 							"is_self_hosted": false,
-						}},
+						},
+					},
 				},
 			},
 		},

--- a/cmd/info/info_test.go
+++ b/cmd/info/info_test.go
@@ -152,7 +152,7 @@ func TestTelemetry(t *testing.T) {
 	assert.DeepEqual(t, telemetryClient.events, []telemetry.Event{
 		telemetry.CreateInfoEvent(telemetry.CommandInfo{
 			Name:      "org",
-			LocalArgs: map[string]string{"help": "false"},
+			LocalArgs: map[string]string{"help": "false", "json": "false"},
 		}, nil),
 	})
 }

--- a/cmd/runner/testdata/runner/instance-expected-usage.txt
+++ b/cmd/runner/testdata/runner/instance-expected-usage.txt
@@ -4,4 +4,7 @@ Usage:
 Available Commands:
   list        List runner instances
 
+Flags:
+      --json   Return output back in JSON format
+
 Use "runner instance [command] --help" for more information about a command.

--- a/cmd/runner/testdata/runner/instance/list-expected-usage.txt
+++ b/cmd/runner/testdata/runner/instance/list-expected-usage.txt
@@ -1,5 +1,5 @@
 Usage:
-  runner instance list <namespace or resource-class>
+  runner instance list <namespace or resource-class> [flags]
 
 Aliases:
   list, ls
@@ -7,3 +7,6 @@ Aliases:
 Examples:
   circleci runner instance ls my-namespace
   circleci runner instance ls my-namespace/my-resource-class
+
+Global Flags:
+      --json   Return output back in JSON format

--- a/cmd/runner/testdata/runner/token-expected-usage.txt
+++ b/cmd/runner/testdata/runner/token-expected-usage.txt
@@ -6,4 +6,7 @@ Available Commands:
   delete      Delete a token
   list        List tokens for a resource-class
 
+Flags:
+      --json   Return output back in JSON format
+
 Use "runner token [command] --help" for more information about a command.

--- a/cmd/runner/testdata/runner/token/create-expected-usage.txt
+++ b/cmd/runner/testdata/runner/token/create-expected-usage.txt
@@ -1,2 +1,5 @@
 Usage:
-  runner token create <resource-class> <nickname>
+  runner token create <resource-class> <nickname> [flags]
+
+Global Flags:
+      --json   Return output back in JSON format

--- a/cmd/runner/testdata/runner/token/delete-expected-usage.txt
+++ b/cmd/runner/testdata/runner/token/delete-expected-usage.txt
@@ -1,5 +1,8 @@
 Usage:
-  runner token delete <token-id>
+  runner token delete <token-id> [flags]
 
 Aliases:
   delete, rm
+
+Global Flags:
+      --json   Return output back in JSON format

--- a/cmd/runner/testdata/runner/token/list-expected-usage.txt
+++ b/cmd/runner/testdata/runner/token/list-expected-usage.txt
@@ -1,5 +1,8 @@
 Usage:
-  runner token list <resource-class>
+  runner token list <resource-class> [flags]
 
 Aliases:
   list, ls
+
+Global Flags:
+      --json   Return output back in JSON format


### PR DESCRIPTION
Note (April 13th, 2025):  Please do not review yet, i'm working on adding testing details/filling out the PR description

This PR builds on top of the work completed in https://github.com/CircleCI-Public/circleci-cli/pull/1088

# Checklist

=========

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)
- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/main/CONTRIBUTING.md).

### Internal Checklist

Not applicable to me, a non-CircleCI employee

## Changes

=======

Building on top of https://github.com/CircleCI-Public/circleci-cli/pull/1088, this PR adds `--json` flag support to other CircleCI CLI commands that up until now only offer one return format, an ASCII table formatted stdout powered by the github.com/olekukonko/tablewriter GoLang package. The commands that now have `--json` flag support (which have been verified/executed successfully) can be seen below*:

*Note:  The following commands below assume a CircleCI organization called "jdelnano"

```
➜  circleci-cli git:(add-json-flag-to-cli-cmds) ./build/darwin/arm64/circleci context list github jdelnano --json

➜  circleci-cli git:(add-json-flag-to-cli-cmds) ./build/darwin/arm64/circleci info org --json

➜  circleci-cli git:(add-json-flag-to-cli-cmds) ./build/darwin/arm64/circleci project secret create github jdelnano test-repo jdelnano_secret --env-value testvalue --json

➜  circleci-cli git:(add-json-flag-to-cli-cmds) ./build/darwin/arm64/circleci project secret list github jdelnano test-repo --json

➜  circleci-cli git:(add-json-flag-to-cli-cmds) ./build/darwin/arm64/circleci runner instance list jdelnano/test-runner-instance --json

➜  circleci-cli git:(add-json-flag-to-cli-cmds) ./build/darwin/arm64/circleci runner token list jdelnano/test-runner-token --json
```

## Rationale

=========

In my organization at Okta, a CircleCI customer, we have a few automation use cases that leverage commands affected by this PR.  As a result, adding JSON output support to these commands would make parsing the output of these commands and doing subsequent actions easier in automated tooling.