### PR TITLE
[Life 1571] Trigger Create | Only prompt users to supply `checkout_ref` & `config_ref` if differnt from the pipeline repo

### DIFF
--- a/api/trigger/trigger.go
+++ b/api/trigger/trigger.go
@@ -5,7 +5,13 @@ type CreateTriggerInfo struct {
 	Name string
 }
 
+type GetPipelineDefinitionOptions struct {
+	ProjectID            string
+	PipelineDefinitionID string
+}
+
 // TriggerClient is the interface to interact with trigger
 type TriggerClient interface {
 	CreateTrigger(options CreateTriggerOptions) (*CreateTriggerInfo, error)
+	GetPipelineDefinition(options GetPipelineDefinitionOptions) (*PipelineDefinition, error)
 }

--- a/api/trigger/trigger_rest.go
+++ b/api/trigger/trigger_rest.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/url"
 
+	"github.com/CircleCI-Public/circleci-cli/api/pipeline"
 	"github.com/CircleCI-Public/circleci-cli/api/rest"
 	"github.com/CircleCI-Public/circleci-cli/settings"
 )
@@ -97,5 +98,38 @@ func (c *triggerRestClient) CreateTrigger(options CreateTriggerOptions) (*Create
 	return &CreateTriggerInfo{
 		Id:   resp.ID,
 		Name: resp.Name,
+	}, nil
+}
+
+type PipelineDefinition struct {
+	ConfigSourceId   string
+	CheckoutSourceId string
+}
+
+type GetPipelineDefinitionResponse struct {
+	ID             string                          `json:"id"`
+	Name           string                          `json:"name"`
+	Description    string                          `json:"description"`
+	CreatedAt      string                          `json:"created_at"`
+	ConfigSource   pipeline.ConfigSourceResponse   `json:"config_source"`
+	CheckoutSource pipeline.CheckoutSourceResponse `json:"checkout_source"`
+}
+
+func (c *triggerRestClient) GetPipelineDefinition(options GetPipelineDefinitionOptions) (*PipelineDefinition, error) {
+	path := fmt.Sprintf("projects/%s/pipeline-definitions/%s", options.ProjectID, options.PipelineDefinitionID)
+	req, err := c.client.NewRequest("GET", &url.URL{Path: path}, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp GetPipelineDefinitionResponse
+	_, err = c.client.DoRequest(req, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &PipelineDefinition{
+		ConfigSourceId:   resp.ConfigSource.Repo.ExternalID,
+		CheckoutSourceId: resp.CheckoutSource.Repo.ExternalID,
 	}, nil
 }

--- a/cmd/trigger/create.go
+++ b/cmd/trigger/create.go
@@ -65,21 +65,20 @@ Note: --config_ref and --checkout_ref flags are only required if your config sou
 				PipelineDefinitionID: pipelineDefinitionID,
 			}
 			pipelineResp, pipelineErr := ops.triggerClient.GetPipelineDefinition(pipelineOptions)
-			cmd.Println("\nconfigSourceId what is this: ", pipelineResp.ConfigSourceId)
-			cmd.Println("\nrepoID what is this: ", repoID)
+
 			if pipelineErr != nil {
 				cmd.Println("\nThere was an error fetching your pipeline definition")
 				return pipelineErr
 			}
 
 			if configRef == "" && pipelineResp.ConfigSourceId != repoID {
-				configRefPrompt := "Your pipeline repo and config source repo are different. Enter the branch or tag to use when fetching config for pipeline runs created from this trigger"
+				configRefPrompt := "Your pipeline repo and config source repo are different. Enter the branch or tag to use when fetching config for pipeline runs"
 				configRef = ops.reader.ReadStringFromUser(configRefPrompt)
 
 			}
 
 			if checkoutRef == "" && pipelineResp.CheckoutSourceId != repoID {
-				checkoutRefPrompt := "Your pipeline repo and checkout source repo are different. Enter the branch or tag to use when checking out code for pipeline runs created from this trigger"
+				checkoutRefPrompt := "Your pipeline repo and checkout source repo are different. Enter the branch or tag to use when checking out code for pipeline runs"
 				checkoutRef = ops.reader.ReadStringFromUser(checkoutRefPrompt)
 			}
 

--- a/cmd/trigger/create.go
+++ b/cmd/trigger/create.go
@@ -60,22 +60,27 @@ Note: --config_ref and --checkout_ref flags are only required if your config sou
 				repoID = ops.reader.ReadStringFromUser(repoPrompt)
 			}
 
-			if configRef == "" {
-				refPrompt := "Is your config source source repository different to the repository for this trigger (y/n)?"
-				refPromptResponse := ops.reader.ReadStringFromUser(refPrompt)
-				if refPromptResponse == "y" {
-					configRefPrompt := "Enter the branch or tag to use when fetching config for pipeline runs created from this trigger"
-					configRef = ops.reader.ReadStringFromUser(configRefPrompt)
-				}
+			pipelineOptions := trigger.GetPipelineDefinitionOptions{
+				ProjectID:            projectID,
+				PipelineDefinitionID: pipelineDefinitionID,
+			}
+			pipelineResp, pipelineErr := ops.triggerClient.GetPipelineDefinition(pipelineOptions)
+			cmd.Println("\nconfigSourceId what is this: ", pipelineResp.ConfigSourceId)
+			cmd.Println("\nrepoID what is this: ", repoID)
+			if pipelineErr != nil {
+				cmd.Println("\nThere was an error fetching your pipeline definition")
+				return pipelineErr
 			}
 
-			if checkoutRef == "" {
-				refPrompt := "Is your checkout source repository different to the repository for this trigger (y/n)?"
-				refPromptResponse := ops.reader.ReadStringFromUser(refPrompt)
-				if refPromptResponse == "y" {
-					checkoutRefPrompt := "Enter the branch or tag to use when checking out code for pipeline runs created from this trigger"
-					checkoutRef = ops.reader.ReadStringFromUser(checkoutRefPrompt)
-				}
+			if configRef == "" && pipelineResp.ConfigSourceId != repoID {
+				configRefPrompt := "Your pipeline repo and config source repo are different. Enter the branch or tag to use when fetching config for pipeline runs created from this trigger"
+				configRef = ops.reader.ReadStringFromUser(configRefPrompt)
+
+			}
+
+			if checkoutRef == "" && pipelineResp.CheckoutSourceId != repoID {
+				checkoutRefPrompt := "Your pipeline repo and checkout source repo are different. Enter the branch or tag to use when checking out code for pipeline runs created from this trigger"
+				checkoutRef = ops.reader.ReadStringFromUser(checkoutRefPrompt)
 			}
 
 			triggerOptions := trigger.CreateTriggerOptions{

--- a/cmd/trigger/create.go
+++ b/cmd/trigger/create.go
@@ -20,26 +20,47 @@ func newCreateCommand(ops *triggerOpts, preRunE validator.Validator) *cobra.Comm
 		Use:   "create <project-id> [--name <trigger-name>] [--description <description>] [--repo-id <github-repo-id>] [--event-preset <preset-to-filter-triggers>] [--config-ref <ref-to-fetch-config>] [--checkout-ref <ref-to-checkout-code>]",
 		Short: "Create a new trigger for a CircleCI project.",
 		Long: `Create a new trigger for a CircleCI project.
-All flags are optional - if not provided, you will be prompted interactively for the required values:
-	--pipeline-definition-id  Pipeline definition ID you wish to create a trigger for (required)
-	--name                    Name of the trigger (required)
-	--description             Description of the trigger (will not prompt if omitted)
-	--repo-id                 GitHub repository ID you wish to create a trigger for (required)
-	--event-preset            The name of the event preset to use when filtering events for this trigger (will not prompt if omitted)
-	--checkout-ref            Git ref (branch, or tag for example) to check out code for pipeline runs (only required if different repository, will not prompt if omitted)
-	--config-ref              Git ref (branch, or tag for example) to fetch config for pipeline runs (only required if different repository, will not prompt if omitted)
-To api/v2 documentation for creating a trigger, see: https://circleci.com/docs/api/v2/index.html#tag/Trigger/operation/createTrigger
+
+All flags are optional - if not provided, you will be prompted interactively for
+  the required values:
+
+  --pipeline-definition-id  Pipeline definition ID you wish to create a trigger for
+                           (required)
+  --name                    Name of the trigger (required)
+  --description             Description of the trigger (will not prompt if omitted)
+  --repo-id                 GitHub repository ID you wish to create a trigger for
+                           (required)
+  --event-preset            The name of the event preset to use when filtering events
+                           for this trigger (will not prompt if omitted)
+  --checkout-ref            Git ref (branch, or tag for example) to check out code
+                           for pipeline runs (only required if different repository,
+                           will not prompt if omitted)
+  --config-ref              Git ref (branch, or tag for example) to fetch config for
+                           pipeline runs (only required if different repository,
+                           will not prompt if omitted)
+
+To api/v2 documentation for creating a trigger, see:
+  https://circleci.com/docs/api/v2/index.html#tag/Trigger/operation/createTrigger
 
 Examples:
   # Minimal usage (will prompt for required values):
   circleci trigger create 1662d941-6e28-43ab-bea2-aa678c098d4c
-  
+
   # Full usage with all flags:
-  circleci trigger create 1662d941-6e28-43ab-bea2-aa678c098d4c --name my-trigger --description "Trigger description" --repo-id 123456 --event-preset all-pushes --config-ref my-config --checkout-ref my-checkout
-Note: This is only supporting pipeline definitions created with GitHub App provider. You will need our GitHub App installed in your repository.
-Note: To get the repository id you can use https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#get-a-repository
-Note: To get the pipeline definition id you can visit the Pipelines tab in project settings: https://app.circleci.com/settings/project/circleci/<org>/<project>/configurations
-Note: --config_ref and --checkout_ref flags are only required if your config source or checkout source exist in a different repo to your trigger repo
+  circleci trigger create 1662d941-6e28-43ab-bea2-aa678c098d4c --name my-trigger \
+    --description "Trigger description" --repo-id 123456 --event-preset all-pushes \
+    --config-ref my-config --checkout-ref my-checkout
+
+Notes:
+  - This is only supporting pipeline definitions created with GitHub App provider.
+    You will need our GitHub App installed in your repository.
+  - To get the repository id you can use:
+    https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#get-a-repository
+  - To get the pipeline definition id you can visit the Pipelines tab in project
+    settings:
+    https://app.circleci.com/settings/project/circleci/<org>/<project>/configurations
+  - --config_ref and --checkout_ref flags are only required if your config source or
+    checkout source exist in a different repo to your trigger repo
 `,
 		PreRunE: preRunE,
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
# Checklist

=========

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)
- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/main/CONTRIBUTING.md).

### Internal Checklist
- [x] I am requesting a review from my own team as well as the owning team
- [x] I have a plan in place for the monitoring of the changes that I am making (this can include new monitors, logs to be aware of, etc...)

## Changes

=======

- adds a new function: GetPipelineDefinition to trigger package
- update trigger_rest tests
-  updates tests for the trigger create command

## Rationale

=========

In this PR: https://github.com/CircleCI-Public/circleci-cli/pull/1138, we are always prompting the user. However, in this iteration, we only prompt if required, by fetching the pipeline definition, [using api/v2 endpoint](https://circleci.com/docs/api/v2/index.html#tag/Pipeline-Definition/operation/getPipelineDefinition). 

This improvement improves ux, so that (1) users don't get confused about the `--config_ref` and `--chechout_ref`, and (2) users don't introduce the flags, and lead to failing request, unless they have to.

## Considerations

==============

I opted to re-use some of the structs in the pipeline package to avoid redundancy. 

## Screenshots

============

<h4>Before</h4>

<img width="1728" alt="Screenshot 2025-05-23 at 2 28 50 PM" src="https://github.com/user-attachments/assets/0bea6870-46ea-4897-9aba-0af9d7db55ff" />

<img width="1727" alt="Screenshot 2025-05-23 at 2 27 47 PM" src="https://github.com/user-attachments/assets/289ecaf3-dd11-4b62-96c5-ded14a684fa4" />

<h4>After</h4>

**checkout source and config source are the same**

<img width="1694" alt="Screenshot 2025-05-23 at 6 29 06 PM" src="https://github.com/user-attachments/assets/c2484e36-8ba6-4275-91c5-a860dce609cc" />

**checkout source differs** 

<img width="1878" alt="Screenshot 2025-05-23 at 6 44 38 PM" src="https://github.com/user-attachments/assets/5e0c4018-1aac-4895-a630-9cbd7257287e" />

**Successfully created a trigger, with checkoutSource after prompted**

<img width="1127" alt="Screenshot 2025-05-23 at 6 45 01 PM" src="https://github.com/user-attachments/assets/e2632f34-f6ce-4f68-aa73-aa362d4c439d" />

**Successfully created a trigger, with `--config_ref` flag passed in** 

<img width="1883" alt="Screenshot 2025-05-23 at 7 05 49 PM" src="https://github.com/user-attachments/assets/b8bd2d5e-6aed-4def-8e96-cf593ca241a1" />


<img width="1170" alt="Screenshot 2025-05-23 at 7 06 11 PM" src="https://github.com/user-attachments/assets/303b5f9d-e37a-4937-9bdb-c4abd2869465" />



## **Here are some helpful tips you can follow when submitting a pull request:**

1. Fork [the repository](https://github.com/CircleCI-Public/circleci-cli) and create your branch from `main`.
2. Run `make build` in the repository root.
3. If you've fixed a bug or added code that should be tested, add tests!
4. Ensure the test suite passes (`make test`).
5. The `--debug` flag is often helpful for debugging HTTP client requests and responses.
6. Format your code with [gofmt](https://golang.org/cmd/gofmt/).
7. Make sure your code lints (`make lint`). Note: This requires Docker to run inside a local job.
