### PR TITLE
Remove trigger name and description

### DIFF
--- a/api/trigger/trigger.go
+++ b/api/trigger/trigger.go
@@ -1,8 +1,7 @@
 package trigger
 
 type CreateTriggerInfo struct {
-	Id   string
-	Name string
+	Id string
 }
 
 type GetPipelineDefinitionOptions struct {

--- a/api/trigger/trigger_rest.go
+++ b/api/trigger/trigger_rest.go
@@ -28,8 +28,6 @@ type EventSource struct {
 }
 
 type createTriggerRequest struct {
-	Name        string      `json:"name"`
-	Description string      `json:"description"`
 	EventSource EventSource `json:"event_source"`
 	EventPreset string      `json:"event_preset"`
 	ConfigRef   string      `json:"config_ref,omitempty"`
@@ -38,8 +36,6 @@ type createTriggerRequest struct {
 
 type createTriggerResponse struct {
 	ID          string      `json:"id"`
-	Name        string      `json:"name"`
-	Description string      `json:"description"`
 	CreatedAt   string      `json:"created_at"`
 	EventSource EventSource `json:"event_source"`
 	EventPreset string      `json:"event_preset"`
@@ -50,8 +46,6 @@ type createTriggerResponse struct {
 type CreateTriggerOptions struct {
 	ProjectID            string
 	PipelineDefinitionID string
-	Name                 string
-	Description          string
 	RepoID               string
 	EventPreset          string
 	ConfigRef            string
@@ -69,8 +63,6 @@ func NewTriggerRestClient(config settings.Config) (*triggerRestClient, error) {
 
 func (c *triggerRestClient) CreateTrigger(options CreateTriggerOptions) (*CreateTriggerInfo, error) {
 	reqBody := createTriggerRequest{
-		Name:        options.Name,
-		Description: options.Description,
 		EventSource: EventSource{
 			Provider: "github_app",
 			Repo: Repo{
@@ -95,7 +87,6 @@ func (c *triggerRestClient) CreateTrigger(options CreateTriggerOptions) (*Create
 	}
 
 	return &CreateTriggerInfo{
-		Id:   resp.ID,
-		Name: resp.Name,
+		Id: resp.ID,
 	}, nil
 }

--- a/api/trigger/trigger_rest_test.go
+++ b/api/trigger/trigger_rest_test.go
@@ -39,8 +39,6 @@ func Test_triggerRestClient_CreateTrigger(t *testing.T) {
 			options: trigger.CreateTriggerOptions{
 				ProjectID:            "testProjectID",
 				PipelineDefinitionID: "pipelineDefinitionID",
-				Name:                 "testName",
-				Description:          "description",
 				RepoID:               "repoID",
 				EventPreset:          "eventPreset",
 			},
@@ -56,16 +54,14 @@ func Test_triggerRestClient_CreateTrigger(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 
 				resp, err := json.Marshal(map[string]any{
-					"id":   "123",
-					"name": "testName",
+					"id": "123",
 				})
 				assert.NilError(t, err)
 				_, err = w.Write(resp)
 				assert.NilError(t, err)
 			},
 			want: &trigger.CreateTriggerInfo{
-				Id:   "123",
-				Name: "testName",
+				Id: "123",
 			},
 		},
 		{
@@ -73,8 +69,6 @@ func Test_triggerRestClient_CreateTrigger(t *testing.T) {
 			options: trigger.CreateTriggerOptions{
 				ProjectID:            "projectID",
 				PipelineDefinitionID: "pipelineDefinitionID",
-				Name:                 "testName",
-				Description:          "description",
 				RepoID:               "repoID",
 				EventPreset:          "eventPreset",
 				ConfigRef:            "configRef",
@@ -89,8 +83,6 @@ func Test_triggerRestClient_CreateTrigger(t *testing.T) {
 				assert.Equal(t, r.URL.Path, fmt.Sprintf("/api/v2/projects/%s/pipeline-definitions/%s/triggers", "projectID", "pipelineDefinitionID"))
 
 				expectedRequestBody := map[string]any{
-					"name":         "testName",
-					"description":  "description",
 					"event_preset": "eventPreset",
 					"event_source": map[string]any{
 						"provider": "github_app",
@@ -115,16 +107,14 @@ func Test_triggerRestClient_CreateTrigger(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 
 				resp, err := json.Marshal(map[string]any{
-					"id":   "123",
-					"name": "testName",
+					"id": "123",
 				})
 				assert.NilError(t, err)
 				_, err = w.Write(resp)
 				assert.NilError(t, err)
 			},
 			want: &trigger.CreateTriggerInfo{
-				Id:   "123",
-				Name: "testName",
+				Id: "123",
 			},
 		},
 		{

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -36,11 +36,9 @@ type initOptions struct {
 	configRepoID        string
 	filePath            string
 	// Trigger creation options
-	triggerName        string
-	triggerDescription string
-	eventPreset        string
-	configRef          string
-	checkoutRef        string
+	eventPreset string
+	configRef   string
+	checkoutRef string
 }
 
 type UserInputReader interface {
@@ -176,8 +174,6 @@ Examples:
 	initCmd.Flags().StringVar(&opts.filePath, "file-path", "", "Path to the CircleCI config file (default: .circleci/config.yml)")
 
 	// Trigger creation flags
-	initCmd.Flags().StringVar(&opts.triggerName, "trigger-name", "", "Name of the trigger to create")
-	initCmd.Flags().StringVar(&opts.triggerDescription, "trigger-description", "", "Description of the trigger")
 	initCmd.Flags().StringVar(&opts.eventPreset, "event-preset", "", "Event preset to filter triggers. Valid values: all-pushes, only-tags, default-branch-pushes, only-build-prs, only-open-prs, only-merged-prs, only-ready-for-review-prs, only-labeled-prs, only-build-pushes-to-non-draft-prs")
 	initCmd.Flags().StringVar(&opts.configRef, "config-ref", "", "Git ref to use when fetching config (only needed if different from trigger repo)")
 	initCmd.Flags().StringVar(&opts.checkoutRef, "checkout-ref", "", "Git ref to use when checking out code (only needed if different from trigger repo)")
@@ -601,10 +597,6 @@ func initCmd(opts initOptions, reader UserInputReader, _ *cobra.Command) error {
 	fmt.Println("⚡ Creating trigger for the pipeline...")
 	fmt.Println("   Triggers determine when your pipeline runs - on code pushes, pull requests, or custom webhooks.")
 
-	if opts.triggerName == "" {
-		opts.triggerName = reader.ReadStringFromUser("Enter a name for the trigger", fmt.Sprintf("%s-trigger", opts.pipelineName), nil)
-	}
-
 	if opts.eventPreset == "" {
 		fmt.Println("📋 Event Preset Selection")
 		selectedPreset, err := selectEventPreset()
@@ -635,13 +627,11 @@ func initCmd(opts initOptions, reader UserInputReader, _ *cobra.Command) error {
 		opts.checkoutRef = reader.ReadStringFromUser("Your pipeline repo and checkout source repo are different. Enter the branch or tag to use when checking out code for pipeline runs", "", nil)
 	}
 
-	fmt.Printf("⚡ Creating trigger '%s' for pipeline '%s'...\n", opts.triggerName, pipelineRes.Name)
+	fmt.Printf("⚡ Creating trigger for pipeline '%s'...\n", pipelineRes.Name)
 
 	triggerOptions := triggerapi.CreateTriggerOptions{
 		ProjectID:            projectRes.Id,
 		PipelineDefinitionID: pipelineRes.Id,
-		Name:                 opts.triggerName,
-		Description:          opts.triggerDescription,
 		RepoID:               opts.repoID,
 		EventPreset:          opts.eventPreset,
 		ConfigRef:            opts.configRef,
@@ -656,13 +646,13 @@ func initCmd(opts initOptions, reader UserInputReader, _ *cobra.Command) error {
 		return fmt.Errorf("failed to create trigger: %w", err)
 	}
 
-	fmt.Printf("✅ Trigger '%s' successfully created!\n", triggerRes.Name)
+	fmt.Printf("✅ Trigger successfully created!\n")
 	fmt.Println()
 
 	fmt.Println("🎉 Project initialization completed successfully! Summary:")
 	fmt.Printf("   ✅ Project: %s (ID: %s)\n", projectRes.Name, projectRes.Id)
 	fmt.Printf("   ✅ Pipeline: %s (ID: %s)\n", pipelineRes.Name, pipelineRes.Id)
-	fmt.Printf("   ✅ Trigger: %s (ID: %s)\n", triggerRes.Name, triggerRes.Id)
+	fmt.Printf("   ✅ Trigger: (ID: %s)\n", triggerRes.Id)
 	fmt.Println()
 	fmt.Println("🔗 Useful links:")
 	fmt.Printf("   Project: https://app.circleci.com/projects/%s\n", projectRes.Slug)

--- a/cmd/trigger/create.go
+++ b/cmd/trigger/create.go
@@ -9,8 +9,6 @@ import (
 )
 
 func newCreateCommand(ops *triggerOpts, preRunE validator.Validator) *cobra.Command {
-	var name string
-	var description string
 	var pipelineDefinitionID string
 	var repoID string
 	var eventPreset string
@@ -18,7 +16,7 @@ func newCreateCommand(ops *triggerOpts, preRunE validator.Validator) *cobra.Comm
 	var checkoutRef string
 
 	cmd := &cobra.Command{
-		Use:   "create <project-id> [--name <trigger-name>] [--description <description>] [--repo-id <github-repo-id>] [--event-preset <preset-to-filter-triggers>] [--config-ref <ref-to-fetch-config>] [--checkout-ref <ref-to-checkout-code>]",
+		Use:   "create <project-id> [--repo-id <github-repo-id>] [--event-preset <preset-to-filter-triggers>] [--config-ref <ref-to-fetch-config>] [--checkout-ref <ref-to-checkout-code>]",
 		Short: "Create a new trigger for a CircleCI project.",
 		Long: `Create a new trigger for a CircleCI project.
 
@@ -67,11 +65,6 @@ Notes:
 		RunE: func(cmd *cobra.Command, args []string) error {
 			projectID := args[0]
 
-			if name == "" {
-				namePrompt := "Enter a name for the trigger"
-				name = ops.reader.ReadStringFromUser(namePrompt)
-			}
-
 			if pipelineDefinitionID == "" {
 				pipelineDefinitionIDPrompt := "Enter the pipeline definition ID you wish to create a trigger for"
 				pipelineDefinitionID = ops.reader.ReadStringFromUser(pipelineDefinitionIDPrompt)
@@ -107,30 +100,26 @@ Notes:
 			triggerOptions := trigger.CreateTriggerOptions{
 				ProjectID:            projectID,
 				PipelineDefinitionID: pipelineDefinitionID,
-				Name:                 name,
-				Description:          description,
 				RepoID:               repoID,
 				EventPreset:          eventPreset,
 				ConfigRef:            configRef,
 				CheckoutRef:          checkoutRef,
 			}
 
-			res, err := ops.triggerClient.CreateTrigger(triggerOptions)
+			_, err := ops.triggerClient.CreateTrigger(triggerOptions)
 			if err != nil {
 				cmd.Println("\nThere was an error creating your trigger. Do you have Github App installed in your repository?")
 				return err
 			}
 
-			cmd.Printf("Trigger '%s' created successfully\n", res.Name)
+			cmd.Printf("Trigger created successfully\n")
 			cmd.Println("You may view your new trigger in your project settings: https://app.circleci.com/settings/project/circleci/<org>/<project>/triggers")
 			return nil
 		},
 		Args: cobra.ExactArgs(1),
 	}
 
-	cmd.Flags().StringVar(&name, "name", "", "Name of the trigger to create")
 	cmd.Flags().StringVar(&pipelineDefinitionID, "pipeline-definition-id", "", "Pipeline definition ID you wish to create a trigger for")
-	cmd.Flags().StringVar(&description, "description", "", "Description of the trigger to create")
 	cmd.Flags().StringVar(&repoID, "repo-id", "", "Repository ID of the codebase you wish to create a trigger for")
 	cmd.Flags().StringVar(&eventPreset, "event-preset", "", "The name of the event preset to use when filtering events for this trigger")
 	cmd.Flags().StringVar(&configRef, "config-ref", "", "Git ref (branch, or tag for example) to use when fetching config for pipeline runs created from this trigger")

--- a/cmd/trigger/trigger_test.go
+++ b/cmd/trigger/trigger_test.go
@@ -20,8 +20,6 @@ type testCreateTriggerArgs struct {
 	projectID            string
 	pipelineDefinitionID string
 	statusCode           int
-	triggerName          string
-	description          string
 	repoID               string
 	eventPreset          string
 	configRef            string
@@ -68,8 +66,6 @@ func TestCreateTrigger(t *testing.T) {
 	const (
 		pipelineDefinitionID = "test-pipeline-definition-id"
 		projectID            = "test-project-id"
-		triggerName          = "Test Trigger"
-		description          = "Test trigger description"
 		repoID               = "123456"
 		eventPreset          = "all-pushes"
 		configRef            = "main"
@@ -88,14 +84,12 @@ func TestCreateTrigger(t *testing.T) {
 				projectID:            projectID,
 				pipelineDefinitionID: pipelineDefinitionID,
 				statusCode:           http.StatusOK,
-				triggerName:          triggerName,
-				description:          description,
 				repoID:               repoID,
 				eventPreset:          eventPreset,
 				configRef:            configRef,
 				checkoutRef:          checkoutRef,
 			},
-			want: fmt.Sprintf("Trigger '%s' created successfully\nYou may view your new trigger in your project settings: https://app.circleci.com/settings/project/circleci/<org>/<project>/triggers\n", triggerName),
+			want: "Trigger created successfully\nYou may view your new trigger in your project settings: https://app.circleci.com/settings/project/circleci/<org>/<project>/triggers\n",
 		},
 		{
 			name: "Handle API error when creating trigger",
@@ -103,8 +97,6 @@ func TestCreateTrigger(t *testing.T) {
 				projectID:            projectID,
 				pipelineDefinitionID: pipelineDefinitionID,
 				statusCode:           http.StatusInternalServerError,
-				triggerName:          triggerName,
-				description:          description,
 				repoID:               repoID,
 				eventPreset:          eventPreset,
 				configRef:            configRef,
@@ -156,8 +148,6 @@ func TestCreateTrigger(t *testing.T) {
 				err = json.Unmarshal(body, &requestBody)
 				assert.NilError(t, err)
 
-				assert.Equal(t, requestBody["name"].(string), tt.args.triggerName)
-
 				eventSource, ok := requestBody["event_source"].(map[string]interface{})
 				assert.Assert(t, ok, "event_source should be a map")
 
@@ -171,8 +161,7 @@ func TestCreateTrigger(t *testing.T) {
 
 				if tt.args.statusCode == http.StatusOK {
 					responseBody := map[string]interface{}{
-						"id":   "trigger-id",
-						"name": tt.args.triggerName,
+						"id": "trigger-id",
 						"repo": map[string]interface{}{
 							"external_id": tt.args.repoID,
 						},
@@ -196,7 +185,6 @@ func TestCreateTrigger(t *testing.T) {
 			defer server.Close()
 
 			inputs := map[string]string{
-				"Enter a name for the trigger":                                      tt.args.triggerName,
 				"Enter the pipeline definition ID you wish to create a trigger for": tt.args.pipelineDefinitionID,
 				"Enter the ID of your github repository":                            tt.args.repoID,
 			}
@@ -212,9 +200,6 @@ func TestCreateTrigger(t *testing.T) {
 			cmd, stdout, _ := scaffoldCMD(server.URL, noValidator, opts...)
 
 			cmdArgs := []string{"create", tt.args.projectID}
-			if tt.args.triggerName != "" {
-				cmdArgs = append(cmdArgs, "--name", tt.args.triggerName)
-			}
 			if tt.args.pipelineDefinitionID != "" {
 				cmdArgs = append(cmdArgs, "--pipeline-definition-id", tt.args.pipelineDefinitionID)
 			}


### PR DESCRIPTION
# Checklist

=========

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)
- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/main/CONTRIBUTING.md).

### Internal Checklist
- [x] I am requesting a review from my own team as well as the owning team
- [x] I have a plan in place for the monitoring of the changes that I am making (this can include new monitors, logs to be aware of, etc...)

## Changes

=======

- Remove `--name` and `--description` options from trigger command
- Remove trigger name/description from project setup command
- Remove `name` and `description` fields from trigger API request and response payloads

## Rationale

=========

The `name` and `description` fields of the trigger APIs are being deprecated:

https://discuss.circleci.com/t/upcoming-changes-1-breaking-to-crud-trigger-v2-apis-may-27-2025/53314

So we need to stop using them here. This means removing the `--name` and `--description` flags and prompts from the trigger command as well as the project setup command.

## Considerations

==============

N/A - this is mostly 🟥, so there weren't many technical decisions made.
