### PR TITLE
Store test results in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,7 +143,11 @@ jobs:
     steps:
       - checkout
       - gomod
-      - run: make test
+      - run: gotestsum --junitfile test_results/linux.xml
+      - store_test_results:
+          path: test_results
+      - store_artifacts:
+          path: test_results
 
   coverage:
     executor: go


### PR DESCRIPTION
This makes it much easier to see what tests have failed, and also will allow CircleCI to identify flaky tests.