### PR TITLE
Change install command to include -t option

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -70,7 +70,7 @@ function install_cli {
 	curl --ssl-reqd -sL --retry 3 "${RELEASE_URL}" | tar zx --strip 1
 
 	echo "Installing to $DESTDIR"
-	install circleci "$DESTDIR"
+	install circleci -t "$DESTDIR"
 
 	command -v circleci
 


### PR DESCRIPTION
This pull request fixes an issue where the installer writes the circleci binary to a file name /usr/local/bin, if /usr/local/bin is not a directory

This should fix this error:
```
# rm /usr/local/bin 

# ls -la /usr/local/bin
ls: cannot access '/usr/local/bin': No such file or directory

# curl -fLSs https://raw.githubusercontent.com/CircleCI-Public/circleci-cli/main/install.sh | bash
Starting installation.
Installing CircleCI CLI v0.1.33494
Installing to /usr/local/bin
An error occured installing the tool.
The contents of the directory /tmp/tmp.fBvjlvSUXG have been left in place to help to debug the issue.

# ls -la /usr/local/bin 
-rwxr-xr-x 1 root root 30974136 Nov 13 10:20 /usr/local/bin
```

After applying this patch, an install to a non-existent directory fails, instead of writing the file to the wrong place:
```
# curl -fLSs https://raw.githubusercontent.com/mdierolf/circleci-cli/refs/heads/install-command-directory/install.sh | bash
Starting installation.
Installing CircleCI CLI v0.1.33494
Installing to /usr/local/bin
install: failed to access '/usr/local/bin': No such file or directory
An error occured installing the tool.
The contents of the directory /tmp/tmp.HHJQp7j9K0 have been left in place to help to debug the issue.

# ls -la /usr/local/bin
ls: cannot access '/usr/local/bin': No such file or directory

```
