### PR TITLE
TEST-72 Update run command to autodetect envars

### DIFF
--- a/api/project/project_rest.go
+++ b/api/project/project_rest.go
@@ -8,11 +8,11 @@ import (
 	"github.com/CircleCI-Public/circleci-cli/settings"
 )
 
-type projectRestClient struct {
+type ProjectRestClient struct {
 	client *rest.Client
 }
 
-var _ ProjectClient = &projectRestClient{}
+var _ ProjectClient = &ProjectRestClient{}
 
 type listProjectEnvVarsParams struct {
 	vcs       string
@@ -60,10 +60,10 @@ type projectInfo struct {
 	Id string `json:"id"`
 }
 
-// NewProjectRestClient returns a new projectRestClient satisfying the api.ProjectInterface
+// NewProjectRestClient returns a new ProjectRestClient satisfying the api.ProjectInterface
 // interface via the REST API.
-func NewProjectRestClient(config settings.Config) (*projectRestClient, error) {
-	client := &projectRestClient{
+func NewProjectRestClient(config settings.Config) (*ProjectRestClient, error) {
+	client := &ProjectRestClient{
 		client: rest.NewFromConfig(config.Host, &config),
 	}
 	return client, nil
@@ -72,7 +72,7 @@ func NewProjectRestClient(config settings.Config) (*projectRestClient, error) {
 // ListAllEnvironmentVariables returns all of the environment variables owned by the
 // given project. Note that pagination is not supported - we get all
 // pages of env vars and return them all.
-func (p *projectRestClient) ListAllEnvironmentVariables(vcs, org, project string) ([]*ProjectEnvironmentVariable, error) {
+func (p *ProjectRestClient) ListAllEnvironmentVariables(vcs, org, project string) ([]*ProjectEnvironmentVariable, error) {
 	res := make([]*ProjectEnvironmentVariable, 0)
 	var nextPageToken string
 	for {
@@ -102,7 +102,7 @@ func (p *projectRestClient) ListAllEnvironmentVariables(vcs, org, project string
 	return res, nil
 }
 
-func (c *projectRestClient) listEnvironmentVariables(params *listProjectEnvVarsParams) (*listAllProjectEnvVarsResponse, error) {
+func (c *ProjectRestClient) listEnvironmentVariables(params *listProjectEnvVarsParams) (*listAllProjectEnvVarsResponse, error) {
 	path := fmt.Sprintf("project/%s/%s/%s/envvar", params.vcs, params.org, params.project)
 	urlParams := url.Values{}
 	if params.pageToken != "" {
@@ -124,7 +124,7 @@ func (c *projectRestClient) listEnvironmentVariables(params *listProjectEnvVarsP
 
 // GetEnvironmentVariable retrieves and returns a variable with the given name.
 // If the response status code is 404, nil is returned.
-func (c *projectRestClient) GetEnvironmentVariable(vcs string, org string, project string, envName string) (*ProjectEnvironmentVariable, error) {
+func (c *ProjectRestClient) GetEnvironmentVariable(vcs string, org string, project string, envName string) (*ProjectEnvironmentVariable, error) {
 	path := fmt.Sprintf("project/%s/%s/%s/envvar/%s", vcs, org, project, envName)
 	req, err := c.client.NewRequest("GET", &url.URL{Path: path}, nil)
 	if err != nil {
@@ -147,7 +147,7 @@ func (c *projectRestClient) GetEnvironmentVariable(vcs string, org string, proje
 	}, nil
 }
 
-func (c *projectRestClient) CreateProject(vcs string, org string, name string) (*CreateProjectInfo, error) {
+func (c *ProjectRestClient) CreateProject(vcs string, org string, name string) (*CreateProjectInfo, error) {
 	orgSlug := fmt.Sprintf("%s/%s", vcs, org)
 
 	path := fmt.Sprintf("organization/%s/project", orgSlug)
@@ -178,7 +178,7 @@ func (c *projectRestClient) CreateProject(vcs string, org string, name string) (
 
 // CreateEnvironmentVariable creates a variable on the given project.
 // This returns the variable if successfully created.
-func (c *projectRestClient) CreateEnvironmentVariable(vcs string, org string, project string, v ProjectEnvironmentVariable) (*ProjectEnvironmentVariable, error) {
+func (c *ProjectRestClient) CreateEnvironmentVariable(vcs string, org string, project string, v ProjectEnvironmentVariable) (*ProjectEnvironmentVariable, error) {
 	path := fmt.Sprintf("project/%s/%s/%s/envvar", vcs, org, project)
 	req, err := c.client.NewRequest("POST", &url.URL{Path: path}, &createProjectEnvVarRequest{
 		Name:  v.Name,
@@ -200,7 +200,7 @@ func (c *projectRestClient) CreateEnvironmentVariable(vcs string, org string, pr
 }
 
 // ProjectInfo retrieves and returns the project info.
-func (c *projectRestClient) ProjectInfo(vcs string, org string, project string) (*ProjectInfo, error) {
+func (c *ProjectRestClient) ProjectInfo(vcs string, org string, project string) (*ProjectInfo, error) {
 	path := fmt.Sprintf("project/%s/%s/%s", vcs, org, project)
 	req, err := c.client.NewRequest("GET", &url.URL{Path: path}, nil)
 	if err != nil {

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -14,11 +15,12 @@ import (
 	"strings"
 	"time"
 
-	yaml "gopkg.in/yaml.v3"
+	"gopkg.in/yaml.v3"
+
+	"github.com/spf13/afero"
 
 	"github.com/CircleCI-Public/circleci-cli/api/header"
 	"github.com/CircleCI-Public/circleci-cli/data"
-	"github.com/spf13/afero"
 )
 
 var (
@@ -50,6 +52,8 @@ type Config struct {
 	MockTelemetry string            `yaml:"-"`
 	OrbPublishing OrbPublishingInfo `yaml:"orb_publishing"`
 	TempDir       string            `yaml:"temp_dir,omitempty"`
+	Stdout        io.Writer         `yaml:"-"`
+	Stderr        io.Writer         `yaml:"-"`
 }
 
 type OrbPublishingInfo struct {
@@ -161,6 +165,9 @@ func (cfg *Config) LoadFromDisk() error {
 	if err != nil {
 		return nil
 	}
+
+	cfg.Stdout = os.Stdout
+	cfg.Stderr = os.Stderr
 
 	return cfg.WithHTTPClient()
 }


### PR DESCRIPTION
## Changes

=======

- Update run command to pass in envars.
- Update config to support stdout/stderr.

## Rationale

=========

The testsuite plugin requires some envars to be able to run test
selection:

- `CIRCLE_URL` - to call the public API.
- `CIRCLE_TOKEN` - API auth.
- `CIRCLE_PROJECT_ID` - fetch impact data for a given project.
- `os.Environ` - allows running commands that depend on `os`.

These have been added to the `run` command, with the expectation that
other plugins will also require these envars.

The `projectRestClient` has been changed to exported so that its type
can be defined in a function arg.

The `settings.Config` now supports a stdout/stderr, providing a way
to test output of commands. The output is set to `os` when loading the
CLI config.

## Considerations

==============

This enables users to run the testsuite plugin without requiring envars.

## Screenshots

============

Building and running locally now passes/autodetects required envars:

```
./circleci run testsuite "ci tests"
Running test-suite-subcommand version "1.0.14935-630104a" built "2025-11-25T16:15:39Z"
Testsuite timeout: 4h40m0s
Running test suite 'ci tests'
```

