### PR TITLE
SC-2677 - Added new PR comment pipeline values

### DIFF
--- a/config/pipeline.go
+++ b/config/pipeline.go
@@ -110,6 +110,8 @@ func LocalPipelineValues(parameters Parameters) Values {
 		"pipeline.deploy.current_version":                            "",
 		"pipeline.deploy.namespace":                                  "",
 		"pipeline.deploy.reason":                                     "",
+		"pipeline.event.github.comment.body":                         "",
+		"pipeline.event.github.sender.type":                          "",
 	}
 
 	for k, v := range parameters {

--- a/config/pipeline_test.go
+++ b/config/pipeline_test.go
@@ -95,6 +95,8 @@ func TestLocalPipelineValues(t *testing.T) {
 				"pipeline.deploy.current_version",
 				"pipeline.deploy.namespace",
 				"pipeline.deploy.reason",
+				"pipeline.event.github.comment.body",
+				"pipeline.event.github.sender.type",
 			},
 		},
 		{
@@ -181,6 +183,8 @@ func TestLocalPipelineValues(t *testing.T) {
 				"pipeline.deploy.current_version",
 				"pipeline.deploy.namespace",
 				"pipeline.deploy.reason",
+				"pipeline.event.github.comment.body",
+				"pipeline.event.github.sender.type",
 			},
 		},
 	}


### PR DESCRIPTION
# Checklist

=========

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)
- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/main/CONTRIBUTING.md).

### Internal Checklist
- [x] I am requesting a review from my own team as well as the owning team
- [ ] I have a plan in place for the monitoring of the changes that I am making (this can include new monitors, logs to be aware of, etc...)

## Changes

=======

- Adding rollback pipeline values to LocalPipelineValues in config/pipeline.go
- Updating tests in 'config/pipeline_test.go'

## Rationale

=========

This will allow the use of the `pipeline.event.github.comment.body` and `pipeline.event.github.sender.type` pipeline values.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `pipeline.event.github.comment.body` and `pipeline.event.github.sender.type` to local pipeline values and updates tests accordingly.
> 
> - **Config**:
>   - Extend `LocalPipelineValues` in `config/pipeline.go` with:
>     - `pipeline.event.github.comment.body`
>     - `pipeline.event.github.sender.type`
> - **Tests**:
>   - Update `config/pipeline_test.go` to assert the new keys are present in returned values (both with nil and provided parameters).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c011d8d785306a6890dc1e43d58e7eaa01d8e297. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->