### PR TITLE
Fix docs link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ Think you've found a bug? Let us know!
 
 Security is a top priority for us. If you have encountered a security issue
 please responsibly disclose it by following our [security
-disclosure](https://circleci.com/docs/2.0/security/) document.
+disclosure](https://circleci.com/security/) process.
 
 # Creating an Issue
 


### PR DESCRIPTION
Link in contributors guide was going to the wrong location.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the security disclosure link in `CONTRIBUTING.md` to point to the correct `/security/` page.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c090144947b6e4922adcae860c73bcc59c1a9d34. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->