### PR TITLE
Update orb.go

### DIFF
--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -1668,7 +1668,7 @@ func finalizeOrbInit(ownerName string, vcsProvider string, vcsShort string, name
 
 	if !opts.private {
 		fmt.Printf("Once the first public version is published, you'll be able to see it here: https://circleci.com/developer/orbs/orb/%s/%s\n", namespace, orbName)
-		fmt.Println("View orb publishing doc: https://circleci.com/docs/2.0/orb-author")
+		fmt.Println("View orb publishing doc: https://circleci.com/docs/orbs/author/orb-author/")
 	}
 
 	return nil


### PR DESCRIPTION
Fix docs link

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the orb publishing docs URL shown by `circleci orb init` for public orbs.
> 
> - **CLI (orb)**:
>   - Update publishing docs link in `cmd/orb.go` (`finalizeOrbInit`) to `https://circleci.com/docs/orbs/author/orb-author/`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff042c0db9f47a074602575c3cc065e2dd44c208. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->