### PR TITLE
Update root_commands.feature

### DIFF
--- a/integration_tests/features/root_commands.feature
+++ b/integration_tests/features/root_commands.feature
@@ -17,7 +17,7 @@ Feature: Root Commands
     When I run `circleci help`
     Then the output should not contain:
     """
-    For more help, see the documentation here: https://circleci.com/docs/2.0/local-cli/
+    For more help, see the documentation here: https://circleci.com/docs/guides/toolkit/local-cli/
     """
     And the exit status should be 0
 


### PR DESCRIPTION
Fix docs link

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the expected help docs URL in `integration_tests/features/root_commands.feature` to `/docs/guides/toolkit/local-cli`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 27cdf27af5cf229ec931cdd05d517a26449a3284. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->