### PR TITLE
TEST-96 Update run command to forward telemetry setting

### DIFF
--- a/cmd/create_telemetry_test.go
+++ b/cmd/create_telemetry_test.go
@@ -5,10 +5,11 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/CircleCI-Public/circleci-cli/settings"
-	"github.com/CircleCI-Public/circleci-cli/telemetry"
 	"github.com/spf13/afero"
 	"gotest.tools/v3/assert"
+
+	"github.com/CircleCI-Public/circleci-cli/settings"
+	"github.com/CircleCI-Public/circleci-cli/telemetry"
 )
 
 func TestLoadTelemetrySettings(t *testing.T) {
@@ -269,6 +270,8 @@ type testTelemetry struct {
 	events []telemetry.Event
 	User   telemetry.User
 }
+
+func (cli *testTelemetry) Enabled() bool { return true }
 
 func (cli *testTelemetry) Close() error { return nil }
 

--- a/cmd/info/info_test.go
+++ b/cmd/info/info_test.go
@@ -8,11 +8,12 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/spf13/cobra"
+	"gotest.tools/v3/assert"
+
 	"github.com/CircleCI-Public/circleci-cli/cmd/validator"
 	"github.com/CircleCI-Public/circleci-cli/settings"
 	"github.com/CircleCI-Public/circleci-cli/telemetry"
-	"github.com/spf13/cobra"
-	"gotest.tools/v3/assert"
 )
 
 func TestGetOrgSuccess(t *testing.T) {
@@ -116,6 +117,8 @@ func (cli *testTelemetryClient) Track(event telemetry.Event) error {
 	cli.events = append(cli.events, event)
 	return nil
 }
+
+func (cli *testTelemetryClient) Enabled() bool { return true }
 
 func (cli *testTelemetryClient) Close() error { return nil }
 

--- a/cmd/runner/telemetry_test.go
+++ b/cmd/runner/telemetry_test.go
@@ -5,8 +5,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/CircleCI-Public/circleci-cli/telemetry"
 	"gotest.tools/v3/assert"
+
+	"github.com/CircleCI-Public/circleci-cli/telemetry"
 )
 
 type testTelemetryClient struct {
@@ -17,6 +18,8 @@ func (c *testTelemetryClient) Track(event telemetry.Event) error {
 	c.events = append(c.events, event)
 	return nil
 }
+
+func (c *testTelemetryClient) Enabled() bool { return true }
 
 func (c *testTelemetryClient) Close() error { return nil }
 

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -29,6 +29,7 @@ type Client interface {
 	io.Closer
 	// Send a telemetry event. This method is not to be called directly. Use config.Track instead
 	Track(event Event) error
+	Enabled() bool
 }
 
 // A segment event to be sent to the telemetry
@@ -78,6 +79,8 @@ type nullClient struct{}
 func (cli nullClient) Close() error { return nil }
 
 func (cli nullClient) Track(_ Event) error { return nil }
+
+func (cli nullClient) Enabled() bool { return false }
 
 // Segment client
 // Used when telemetry is enabled
@@ -157,6 +160,8 @@ func (segment *segmentClient) Track(event Event) error {
 	})
 }
 
+func (segment *segmentClient) Enabled() bool { return true }
+
 func (segment *segmentClient) Close() error {
 	return segment.analyticsClient.Close()
 }
@@ -195,3 +200,5 @@ func (cli *fileTelemetry) Close() error {
 
 	return file.Close()
 }
+
+func (cli *fileTelemetry) Enabled() bool { return true }


### PR DESCRIPTION
## Changes

=======

- Update run command to forward telemetry setting

## Rationale

=========

The `run` command now forwards a `CIRCLE_TELEMETRY_ENABLED` envar to the plugin so that it can respect the telemetry settings.

## Considerations

==============

Why you made some of the technical decisions that you made, especially if the
reasoning is not immediately obvious

## **Here are some helpful tips you can follow when submitting a pull request:**

1. Fork [the repository](https://github.com/CircleCI-Public/circleci-cli) and create your branch from `main`.
2. Run `make build` in the repository root.
3. If you've fixed a bug or added code that should be tested, add tests!
4. Ensure the test suite passes (`make test`).
5. The `--debug` flag is often helpful for debugging HTTP client requests and responses.
6. Format your code with [gofmt](https://golang.org/cmd/gofmt/).
7. Make sure your code lints (`make lint`). Note: This requires Docker to run inside a local job.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces plugin awareness of CLI telemetry state and plumbs support across the telemetry layer.
> 
> - `cmd/run.go`: Exports `CIRCLE_TELEMETRY_ENABLED` to plugin processes based on `telemetry.FromContext().Enabled()`
> - `telemetry.Client`: Adds `Enabled()`; implemented by null, segment, and file clients
> - Tests: Update/extend test clients to implement `Enabled()` and add assertions for the new env var in `run` plugin execution; minor import cleanups
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a3d5d7ce083612b4d5589c0b527ee71e8781b4e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->