### PR TITLE
updates policy urls to use public endpoints at circleci.com

### DIFF
--- a/api/policy/policy.go
+++ b/api/policy/policy.go
@@ -48,7 +48,7 @@ func (c Client) CreatePolicyBundle(ownerID string, context string, request Creat
 		return nil, fmt.Errorf("failed to encode policy payload: %w", err)
 	}
 
-	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/api/v1/owner/%s/context/%s/policy-bundle", c.serverUrl, ownerID, context), bytes.NewReader(data))
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/api/v2/owner/%s/context/%s/policy-bundle", c.serverUrl, ownerID, context), bytes.NewReader(data))
 	if err != nil {
 		return nil, fmt.Errorf("failed to construct request: %v", err)
 	}
@@ -87,7 +87,7 @@ func (c Client) CreatePolicyBundle(ownerID string, context string, request Creat
 // If policyName is empty, the full policy bundle would be fetched for given ownerID+context
 // If a policyName is provided, only that matching policy would be fetched for given ownerID+context+policyName
 func (c Client) FetchPolicyBundle(ownerID, context, policyName string) (interface{}, error) {
-	req, err := http.NewRequest("GET", fmt.Sprintf("%s/api/v1/owner/%s/context/%s/policy-bundle/%s", c.serverUrl, ownerID, context, policyName), nil)
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/api/v2/owner/%s/context/%s/policy-bundle/%s", c.serverUrl, ownerID, context, policyName), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to construct request: %v", err)
 	}
@@ -126,7 +126,7 @@ type DecisionQueryRequest struct {
 // GetDecisionLogs calls the GET decision query API of policy-service. The endpoint accepts multiple filter values as
 // path query parameters (start-time, end-time, branch-name, project-id and offset).
 func (c Client) GetDecisionLogs(ownerID string, context string, request DecisionQueryRequest) ([]interface{}, error) {
-	req, err := http.NewRequest("GET", fmt.Sprintf("%s/api/v1/owner/%s/context/%s/decision", c.serverUrl, ownerID, context), nil)
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/api/v2/owner/%s/context/%s/decision", c.serverUrl, ownerID, context), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to construct request: %v", err)
 	}
@@ -178,7 +178,7 @@ func (c Client) GetDecisionLogs(ownerID string, context string, request Decision
 // GetDecisionLog calls the GET decision query API of policy-service for a DecisionID.
 // It also accepts a policyBundle bool param; If set to true will return only the policy bundle corresponding to that decision log.
 func (c Client) GetDecisionLog(ownerID string, context string, decisionID string, policyBundle bool) (interface{}, error) {
-	path := fmt.Sprintf("%s/api/v1/owner/%s/context/%s/decision/%s", c.serverUrl, ownerID, context, decisionID)
+	path := fmt.Sprintf("%s/api/v2/owner/%s/context/%s/decision/%s", c.serverUrl, ownerID, context, decisionID)
 	if policyBundle {
 		path += "/policy-bundle"
 	}
@@ -218,7 +218,7 @@ type DecisionRequest struct {
 
 // GetSettings calls the GET decision-settings API of policy-service.
 func (c Client) GetSettings(ownerID string, context string) (interface{}, error) {
-	path := fmt.Sprintf("%s/api/v1/owner/%s/context/%s/decision/settings", c.serverUrl, ownerID, context)
+	path := fmt.Sprintf("%s/api/v2/owner/%s/context/%s/decision/settings", c.serverUrl, ownerID, context)
 	req, err := http.NewRequest("GET", path, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to construct request: %v", err)
@@ -257,7 +257,7 @@ func (c Client) SetSettings(ownerID string, context string, request DecisionSett
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
-	path := fmt.Sprintf("%s/api/v1/owner/%s/context/%s/decision/settings", c.serverUrl, ownerID, context)
+	path := fmt.Sprintf("%s/api/v2/owner/%s/context/%s/decision/settings", c.serverUrl, ownerID, context)
 	req, err := http.NewRequest("PATCH", path, bytes.NewReader(payload))
 	if err != nil {
 		return nil, fmt.Errorf("failed to construct request: %v", err)
@@ -292,7 +292,7 @@ func (c Client) MakeDecision(ownerID string, context string, req DecisionRequest
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	endpoint := fmt.Sprintf("%s/api/v1/owner/%s/context/%s/decision", c.serverUrl, ownerID, context)
+	endpoint := fmt.Sprintf("%s/api/v2/owner/%s/context/%s/decision", c.serverUrl, ownerID, context)
 
 	request, err := http.NewRequest("POST", endpoint, bytes.NewReader(payload))
 	if err != nil {

--- a/api/policy/policy_test.go
+++ b/api/policy/policy_test.go
@@ -26,7 +26,7 @@ func TestClientFetchPolicyBundle(t *testing.T) {
 			assert.Equal(t, r.Header.Get("circle-token"), "testtoken")
 
 			assert.Equal(t, r.Method, "GET")
-			assert.Equal(t, r.URL.Path, "/api/v1/owner/ownerId/context/config/policy-bundle/my_policy")
+			assert.Equal(t, r.URL.Path, "/api/v2/owner/ownerId/context/config/policy-bundle/my_policy")
 
 			w.WriteHeader(http.StatusOK)
 			_, err := w.Write([]byte("{}"))
@@ -147,7 +147,7 @@ func TestClientCreatePolicy(t *testing.T) {
 			assert.Equal(t, r.Header.Get("circle-token"), "testtoken")
 
 			assert.Equal(t, r.Method, "POST")
-			assert.Equal(t, r.URL.Path, "/api/v1/owner/ownerId/context/config/policy-bundle")
+			assert.Equal(t, r.URL.Path, "/api/v2/owner/ownerId/context/config/policy-bundle")
 
 			var actual CreatePolicyBundleRequest
 			assert.NilError(t, json.NewDecoder(r.Body).Decode(&actual))
@@ -179,7 +179,7 @@ func TestClientCreatePolicy(t *testing.T) {
 			assert.Equal(t, r.Header.Get("circle-token"), "testtoken")
 
 			assert.Equal(t, r.Method, "POST")
-			assert.Equal(t, r.URL.Path, "/api/v1/owner/ownerId/context/config/policy-bundle")
+			assert.Equal(t, r.URL.Path, "/api/v2/owner/ownerId/context/config/policy-bundle")
 			assert.Equal(t, r.URL.RawQuery, "dry=true")
 
 			var actual CreatePolicyBundleRequest
@@ -225,8 +225,8 @@ func TestClientGetDecisionLogs(t *testing.T) {
 			assert.Equal(t, r.Header.Get("circle-token"), "testtoken")
 
 			assert.Equal(t, r.Method, "GET")
-			assert.Equal(t, r.URL.Path, "/api/v1/owner/ownerId/context/config/decision")
-			assert.Equal(t, r.URL.String(), "/api/v1/owner/ownerId/context/config/decision")
+			assert.Equal(t, r.URL.Path, "/api/v2/owner/ownerId/context/config/decision")
+			assert.Equal(t, r.URL.String(), "/api/v2/owner/ownerId/context/config/decision")
 
 			w.WriteHeader(http.StatusOK)
 			_, err := w.Write([]byte("[]"))
@@ -250,7 +250,7 @@ func TestClientGetDecisionLogs(t *testing.T) {
 			assert.Equal(t, r.Header.Get("circle-token"), "testtoken")
 
 			assert.Equal(t, r.Method, "GET")
-			assert.Equal(t, r.URL.Path, "/api/v1/owner/ownerId/context/config/decision")
+			assert.Equal(t, r.URL.Path, "/api/v2/owner/ownerId/context/config/decision")
 			assert.Equal(t, r.URL.RawQuery, "project_id=projectIDValue")
 
 			w.WriteHeader(http.StatusOK)
@@ -277,7 +277,7 @@ func TestClientGetDecisionLogs(t *testing.T) {
 			assert.Equal(t, r.Header.Get("circle-token"), "testtoken")
 
 			assert.Equal(t, r.Method, "GET")
-			assert.Equal(t, r.URL.Path, "/api/v1/owner/ownerId/context/config/decision")
+			assert.Equal(t, r.URL.Path, "/api/v2/owner/ownerId/context/config/decision")
 			assert.Equal(
 				t,
 				r.URL.RawQuery,
@@ -423,8 +423,8 @@ func TestClientGetDecisionLog(t *testing.T) {
 			assert.Equal(t, r.Header.Get("circle-token"), "testtoken")
 
 			assert.Equal(t, r.Method, "GET")
-			assert.Equal(t, r.URL.Path, "/api/v1/owner/ownerId/context/config/decision/decisionID")
-			assert.Equal(t, r.URL.String(), "/api/v1/owner/ownerId/context/config/decision/decisionID")
+			assert.Equal(t, r.URL.Path, "/api/v2/owner/ownerId/context/config/decision/decisionID")
+			assert.Equal(t, r.URL.String(), "/api/v2/owner/ownerId/context/config/decision/decisionID")
 
 			w.WriteHeader(http.StatusOK)
 			_, err := w.Write([]byte("[]"))
@@ -448,8 +448,8 @@ func TestClientGetDecisionLog(t *testing.T) {
 			assert.Equal(t, r.Header.Get("circle-token"), "testtoken")
 
 			assert.Equal(t, r.Method, "GET")
-			assert.Equal(t, r.URL.Path, "/api/v1/owner/ownerId/context/config/decision/decisionID/policy-bundle")
-			assert.Equal(t, r.URL.String(), "/api/v1/owner/ownerId/context/config/decision/decisionID/policy-bundle")
+			assert.Equal(t, r.URL.Path, "/api/v2/owner/ownerId/context/config/decision/decisionID/policy-bundle")
+			assert.Equal(t, r.URL.String(), "/api/v2/owner/ownerId/context/config/decision/decisionID/policy-bundle")
 
 			w.WriteHeader(http.StatusOK)
 			_, err := w.Write([]byte("[]"))
@@ -567,7 +567,7 @@ func TestMakeDecision(t *testing.T) {
 				Input: "test-input",
 			},
 			Handler: func(w http.ResponseWriter, r *http.Request) {
-				assert.Equal(t, r.URL.Path, "/api/v1/owner/test-owner/context/config/decision")
+				assert.Equal(t, r.URL.Path, "/api/v2/owner/test-owner/context/config/decision")
 				assert.Equal(t, r.Method, "POST")
 				assert.Equal(t, r.Header.Get("Circle-Token"), "test-token")
 
@@ -645,7 +645,7 @@ func TestGetSettings(t *testing.T) {
 			Name:    "gets expected response",
 			OwnerID: "test-owner",
 			Handler: func(w http.ResponseWriter, r *http.Request) {
-				assert.Equal(t, r.URL.Path, "/api/v1/owner/test-owner/context/config/decision/settings")
+				assert.Equal(t, r.URL.Path, "/api/v2/owner/test-owner/context/config/decision/settings")
 				assert.Equal(t, r.Method, "GET")
 				assert.Equal(t, r.Header.Get("Circle-Token"), "test-token")
 				_ = json.NewEncoder(w).Encode(interface{}(`{"enabled": true}`))
@@ -718,7 +718,7 @@ func TestSetSettings(t *testing.T) {
 			OwnerID:  "test-owner",
 			Settings: DecisionSettings{Enabled: &trueVar},
 			Handler: func(w http.ResponseWriter, r *http.Request) {
-				assert.Equal(t, r.URL.Path, "/api/v1/owner/test-owner/context/config/decision/settings")
+				assert.Equal(t, r.URL.Path, "/api/v2/owner/test-owner/context/config/decision/settings")
 				assert.Equal(t, r.Method, "PATCH")
 				assert.Equal(t, r.Header.Get("Circle-Token"), "test-token")
 				var payload map[string]interface{}
@@ -736,7 +736,7 @@ func TestSetSettings(t *testing.T) {
 			OwnerID:  "test-owner",
 			Settings: DecisionSettings{Enabled: &falseVar},
 			Handler: func(w http.ResponseWriter, r *http.Request) {
-				assert.Equal(t, r.URL.Path, "/api/v1/owner/test-owner/context/config/decision/settings")
+				assert.Equal(t, r.URL.Path, "/api/v2/owner/test-owner/context/config/decision/settings")
 				assert.Equal(t, r.Method, "PATCH")
 				assert.Equal(t, r.Header.Get("Circle-Token"), "test-token")
 				var payload map[string]interface{}
@@ -754,7 +754,7 @@ func TestSetSettings(t *testing.T) {
 			OwnerID:  "test-owner",
 			Settings: DecisionSettings{Enabled: nil},
 			Handler: func(w http.ResponseWriter, r *http.Request) {
-				assert.Equal(t, r.URL.Path, "/api/v1/owner/test-owner/context/config/decision/settings")
+				assert.Equal(t, r.URL.Path, "/api/v2/owner/test-owner/context/config/decision/settings")
 				assert.Equal(t, r.Method, "PATCH")
 				assert.Equal(t, r.Header.Get("Circle-Token"), "test-token")
 				var payload map[string]interface{}

--- a/cmd/policy/policy.go
+++ b/cmd/policy/policy.go
@@ -51,7 +51,7 @@ func NewCommand(globalConfig *settings.Config, preRunE validator.Validator) *cob
 This group of commands allows the management of polices to be verified against build configs.`,
 	}
 
-	policyBaseURL := cmd.PersistentFlags().String("policy-base-url", "https://internal.circleci.com", "base url for policy api")
+	policyBaseURL := cmd.PersistentFlags().String("policy-base-url", "https://circleci.com", "base url for policy api")
 
 	push := func() *cobra.Command {
 		var ownerID, context string

--- a/cmd/policy/policy_test.go
+++ b/cmd/policy/policy_test.go
@@ -36,8 +36,8 @@ func TestPushPolicyWithPrompt(t *testing.T) {
 	var requestCount int
 
 	expectedURLs := []string{
-		"/api/v1/owner/test-org/context/config/policy-bundle?dry=true",
-		"/api/v1/owner/test-org/context/config/policy-bundle",
+		"/api/v2/owner/test-org/context/config/policy-bundle?dry=true",
+		"/api/v2/owner/test-org/context/config/policy-bundle",
 	}
 
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -130,7 +130,7 @@ func TestPushPolicyBundleNoPrompt(t *testing.T) {
 			ServerHandler: func(w http.ResponseWriter, r *http.Request) {
 				var body map[string]interface{}
 				assert.Equal(t, "POST", r.Method)
-				assert.Equal(t, "/api/v1/owner/test-org/context/custom/policy-bundle", r.URL.String())
+				assert.Equal(t, "/api/v2/owner/test-org/context/custom/policy-bundle", r.URL.String())
 				assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
 				assert.Equal(t, map[string]interface{}{
 					"policies": map[string]interface{}{},
@@ -147,7 +147,7 @@ func TestPushPolicyBundleNoPrompt(t *testing.T) {
 			ServerHandler: func(w http.ResponseWriter, r *http.Request) {
 				var body map[string]interface{}
 				assert.Equal(t, "POST", r.Method)
-				assert.Equal(t, "/api/v1/owner/test-org/context/custom/policy-bundle", r.URL.String())
+				assert.Equal(t, "/api/v2/owner/test-org/context/custom/policy-bundle", r.URL.String())
 				assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
 				assert.Equal(t, map[string]interface{}{
 					"policies": map[string]interface{}{
@@ -225,7 +225,7 @@ func TestDiffPolicyBundle(t *testing.T) {
 			ServerHandler: func(w http.ResponseWriter, r *http.Request) {
 				var body map[string]interface{}
 				assert.Equal(t, "POST", r.Method)
-				assert.Equal(t, "/api/v1/owner/test-org/context/custom/policy-bundle?dry=true", r.URL.String())
+				assert.Equal(t, "/api/v2/owner/test-org/context/custom/policy-bundle?dry=true", r.URL.String())
 				assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
 				assert.Equal(t, map[string]interface{}{
 					"policies": map[string]interface{}{},
@@ -241,7 +241,7 @@ func TestDiffPolicyBundle(t *testing.T) {
 			ServerHandler: func(w http.ResponseWriter, r *http.Request) {
 				var body map[string]interface{}
 				assert.Equal(t, "POST", r.Method)
-				assert.Equal(t, "/api/v1/owner/test-org/context/custom/policy-bundle?dry=true", r.URL.String())
+				assert.Equal(t, "/api/v2/owner/test-org/context/custom/policy-bundle?dry=true", r.URL.String())
 				assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
 				assert.Equal(t, map[string]interface{}{
 					"policies": map[string]interface{}{
@@ -302,7 +302,7 @@ func TestFetchPolicyBundle(t *testing.T) {
 			ExpectedErr: "failed to fetch policy bundle: unexpected status-code: 403 - Forbidden",
 			ServerHandler: func(w http.ResponseWriter, r *http.Request) {
 				assert.Equal(t, "GET", r.Method)
-				assert.Equal(t, "/api/v1/owner/ownerID/context/someContext/policy-bundle/policyName", r.URL.String())
+				assert.Equal(t, "/api/v2/owner/ownerID/context/someContext/policy-bundle/policyName", r.URL.String())
 				w.WriteHeader(http.StatusForbidden)
 				_, err := w.Write([]byte(`{"error": "Forbidden"}`))
 				assert.NoError(t, err)
@@ -313,7 +313,7 @@ func TestFetchPolicyBundle(t *testing.T) {
 			Args: []string{"fetch", "my_policy", "--owner-id", "462d67f8-b232-4da4-a7de-0c86dd667d3f"},
 			ServerHandler: func(w http.ResponseWriter, r *http.Request) {
 				assert.Equal(t, "GET", r.Method)
-				assert.Equal(t, "/api/v1/owner/462d67f8-b232-4da4-a7de-0c86dd667d3f/context/config/policy-bundle/my_policy", r.URL.String())
+				assert.Equal(t, "/api/v2/owner/462d67f8-b232-4da4-a7de-0c86dd667d3f/context/config/policy-bundle/my_policy", r.URL.String())
 				_, err := w.Write([]byte(`{
 						"content": "package org\n\npolicy_name[\"my_policy\"] { true }",
 						"created_at": "2022-08-10T10:47:01.859756-04:00",
@@ -336,7 +336,7 @@ func TestFetchPolicyBundle(t *testing.T) {
 			Args: []string{"fetch", "--owner-id", "462d67f8-b232-4da4-a7de-0c86dd667d3f"},
 			ServerHandler: func(w http.ResponseWriter, r *http.Request) {
 				assert.Equal(t, "GET", r.Method)
-				assert.Equal(t, "/api/v1/owner/462d67f8-b232-4da4-a7de-0c86dd667d3f/context/config/policy-bundle/", r.URL.String())
+				assert.Equal(t, "/api/v2/owner/462d67f8-b232-4da4-a7de-0c86dd667d3f/context/config/policy-bundle/", r.URL.String())
 				_, err := w.Write([]byte(`{
 	 "a": {
 	   "content": "package org\n\npolicy_name[\"a\"] { true }",
@@ -437,7 +437,7 @@ func TestGetDecisionLogs(t *testing.T) {
 			Args: []string{"logs", "--owner-id", "ownerID"},
 			ServerHandler: func(w http.ResponseWriter, r *http.Request) {
 				assert.Equal(t, "GET", r.Method)
-				assert.Equal(t, "/api/v1/owner/ownerID/context/config/decision", r.URL.String())
+				assert.Equal(t, "/api/v2/owner/ownerID/context/config/decision", r.URL.String())
 				_, err := w.Write([]byte("[]"))
 				assert.NoError(t, err)
 			},
@@ -451,7 +451,7 @@ func TestGetDecisionLogs(t *testing.T) {
 			},
 			ServerHandler: func(w http.ResponseWriter, r *http.Request) {
 				assert.Equal(t, "GET", r.Method)
-				assert.Equal(t, "/api/v1/owner/ownerID/context/config/decision?after=2022-03-14T00%3A00%3A00Z&before=2022-03-15T00%3A00%3A00Z&branch=branchValue&project_id=projectIDValue&status=PASS", r.URL.String())
+				assert.Equal(t, "/api/v2/owner/ownerID/context/config/decision?after=2022-03-14T00%3A00%3A00Z&before=2022-03-15T00%3A00%3A00Z&branch=branchValue&project_id=projectIDValue&status=PASS", r.URL.String())
 				_, err := w.Write([]byte("[]"))
 				assert.NoError(t, err)
 			},
@@ -463,7 +463,7 @@ func TestGetDecisionLogs(t *testing.T) {
 			ExpectedErr: "failed to get policy decision logs: unexpected status-code: 403 - Forbidden",
 			ServerHandler: func(w http.ResponseWriter, r *http.Request) {
 				assert.Equal(t, "GET", r.Method)
-				assert.Equal(t, "/api/v1/owner/ownerID/context/config/decision", r.URL.String())
+				assert.Equal(t, "/api/v2/owner/ownerID/context/config/decision", r.URL.String())
 				w.WriteHeader(http.StatusForbidden)
 				_, err := w.Write([]byte(`{"error": "Forbidden"}`))
 				assert.NoError(t, err)
@@ -480,7 +480,7 @@ func TestGetDecisionLogs(t *testing.T) {
 					assert.Equal(t, "GET", r.Method)
 
 					if count == 0 {
-						assert.Equal(t, "/api/v1/owner/ownerID/context/config/decision", r.URL.String())
+						assert.Equal(t, "/api/v2/owner/ownerID/context/config/decision", r.URL.String())
 						_, err := w.Write([]byte(`
 								[
 								  {
@@ -502,7 +502,7 @@ func TestGetDecisionLogs(t *testing.T) {
 						)
 						assert.NoError(t, err)
 					} else if count == 1 {
-						assert.Equal(t, "/api/v1/owner/ownerID/context/config/decision?offset=1", r.URL.String())
+						assert.Equal(t, "/api/v2/owner/ownerID/context/config/decision?offset=1", r.URL.String())
 						_, err := w.Write([]byte("[]"))
 						assert.NoError(t, err)
 					} else {
@@ -536,7 +536,7 @@ func TestGetDecisionLogs(t *testing.T) {
 			ServerHandler: func() http.HandlerFunc {
 				return func(w http.ResponseWriter, r *http.Request) {
 					assert.Equal(t, "GET", r.Method)
-					assert.Equal(t, "/api/v1/owner/ownerID/context/config/decision/decisionID", r.URL.String())
+					assert.Equal(t, "/api/v2/owner/ownerID/context/config/decision/decisionID", r.URL.String())
 					_, err := w.Write([]byte("{}"))
 					assert.NoError(t, err)
 				}
@@ -549,7 +549,7 @@ func TestGetDecisionLogs(t *testing.T) {
 			ServerHandler: func() http.HandlerFunc {
 				return func(w http.ResponseWriter, r *http.Request) {
 					assert.Equal(t, "GET", r.Method)
-					assert.Equal(t, "/api/v1/owner/ownerID/context/config/decision/decisionID/policy-bundle", r.URL.String())
+					assert.Equal(t, "/api/v2/owner/ownerID/context/config/decision/decisionID/policy-bundle", r.URL.String())
 					_, err := w.Write([]byte("{}"))
 					assert.NoError(t, err)
 				}
@@ -602,7 +602,7 @@ func TestMakeDecisionCommand(t *testing.T) {
 			Args: []string{"decide", "--owner-id", "test-owner", "--input", "./testdata/test1/test.yml", "--no-compile"},
 			ServerHandler: func(w http.ResponseWriter, r *http.Request) {
 				assert.Equal(t, "POST", r.Method)
-				assert.Equal(t, "/api/v1/owner/test-owner/context/config/decision", r.URL.Path)
+				assert.Equal(t, "/api/v2/owner/test-owner/context/config/decision", r.URL.Path)
 
 				payload, err := io.ReadAll(r.Body)
 				require.NoError(t, err)
@@ -618,7 +618,7 @@ func TestMakeDecisionCommand(t *testing.T) {
 			Args: []string{"decide", "--owner-id", "test-owner", "--input", "./testdata/test4/config.yml"},
 			ServerHandler: func(w http.ResponseWriter, r *http.Request) {
 				assert.Equal(t, "POST", r.Method)
-				assert.Equal(t, "/api/v1/owner/test-owner/context/config/decision", r.URL.Path)
+				assert.Equal(t, "/api/v2/owner/test-owner/context/config/decision", r.URL.Path)
 
 				var payload map[string]interface{}
 				assert.NoError(t, json.NewDecoder(r.Body).Decode(&payload))
@@ -664,7 +664,7 @@ test: config
 			Args: []string{"decide", "--owner-id", "test-owner", "--input", "./testdata/test1/test.yml"},
 			ServerHandler: func(w http.ResponseWriter, r *http.Request) {
 				assert.Equal(t, "POST", r.Method)
-				assert.Equal(t, "/api/v1/owner/test-owner/context/config/decision", r.URL.Path)
+				assert.Equal(t, "/api/v2/owner/test-owner/context/config/decision", r.URL.Path)
 
 				var payload map[string]interface{}
 				assert.NoError(t, json.NewDecoder(r.Body).Decode(&payload))
@@ -702,7 +702,7 @@ test: config
 			Args: []string{"decide", "--owner-id", "test-owner", "--input", "./testdata/test1/test.yml", "--no-compile"},
 			ServerHandler: func(w http.ResponseWriter, r *http.Request) {
 				assert.Equal(t, "POST", r.Method)
-				assert.Equal(t, "/api/v1/owner/test-owner/context/config/decision", r.URL.Path)
+				assert.Equal(t, "/api/v2/owner/test-owner/context/config/decision", r.URL.Path)
 
 				payload, err := io.ReadAll(r.Body)
 				require.NoError(t, err)
@@ -717,7 +717,7 @@ test: config
 			Args: []string{"decide", "--owner-id", "test-owner", "--input", "./testdata/test1/test.yml", "--strict", "--no-compile"},
 			ServerHandler: func(w http.ResponseWriter, r *http.Request) {
 				assert.Equal(t, "POST", r.Method)
-				assert.Equal(t, "/api/v1/owner/test-owner/context/config/decision", r.URL.Path)
+				assert.Equal(t, "/api/v2/owner/test-owner/context/config/decision", r.URL.Path)
 
 				payload, err := io.ReadAll(r.Body)
 				require.NoError(t, err)
@@ -732,7 +732,7 @@ test: config
 			Args: []string{"decide", "--owner-id", "test-owner", "--input", "./testdata/test1/test.yml", "--no-compile"},
 			ServerHandler: func(w http.ResponseWriter, r *http.Request) {
 				assert.Equal(t, "POST", r.Method)
-				assert.Equal(t, "/api/v1/owner/test-owner/context/config/decision", r.URL.Path)
+				assert.Equal(t, "/api/v2/owner/test-owner/context/config/decision", r.URL.Path)
 
 				payload, err := io.ReadAll(r.Body)
 				require.NoError(t, err)
@@ -747,7 +747,7 @@ test: config
 			Args: []string{"decide", "--owner-id", "test-owner", "--input", "./testdata/test1/test.yml", "--strict", "--no-compile"},
 			ServerHandler: func(w http.ResponseWriter, r *http.Request) {
 				assert.Equal(t, "POST", r.Method)
-				assert.Equal(t, "/api/v1/owner/test-owner/context/config/decision", r.URL.Path)
+				assert.Equal(t, "/api/v2/owner/test-owner/context/config/decision", r.URL.Path)
 
 				payload, err := io.ReadAll(r.Body)
 				require.NoError(t, err)
@@ -762,7 +762,7 @@ test: config
 			Args: []string{"decide", "--owner-id", "test-owner", "--input", "./testdata/test1/test.yml", "--context", "custom", "--no-compile"},
 			ServerHandler: func(w http.ResponseWriter, r *http.Request) {
 				assert.Equal(t, "POST", r.Method)
-				assert.Equal(t, "/api/v1/owner/test-owner/context/custom/decision", r.URL.Path)
+				assert.Equal(t, "/api/v2/owner/test-owner/context/custom/decision", r.URL.Path)
 
 				payload, err := io.ReadAll(r.Body)
 				require.NoError(t, err)
@@ -777,7 +777,7 @@ test: config
 			Args: []string{"decide", "--owner-id", "test-owner", "--input", "./testdata/test1/test.yml", "--context", "custom", "--meta", `{"project_id": "test-project-id","vcs": {"branch": "main"}}`, "--no-compile"},
 			ServerHandler: func(w http.ResponseWriter, r *http.Request) {
 				assert.Equal(t, "POST", r.Method)
-				assert.Equal(t, "/api/v1/owner/test-owner/context/custom/decision", r.URL.Path)
+				assert.Equal(t, "/api/v2/owner/test-owner/context/custom/decision", r.URL.Path)
 
 				payload, err := io.ReadAll(r.Body)
 				require.NoError(t, err)
@@ -792,7 +792,7 @@ test: config
 			Args: []string{"decide", "--owner-id", "test-owner", "--input", "./testdata/test1/test.yml", "--context", "custom", "--metafile", "./testdata/test1/meta.yml", "--no-compile"},
 			ServerHandler: func(w http.ResponseWriter, r *http.Request) {
 				assert.Equal(t, "POST", r.Method)
-				assert.Equal(t, "/api/v1/owner/test-owner/context/custom/decision", r.URL.Path)
+				assert.Equal(t, "/api/v2/owner/test-owner/context/custom/decision", r.URL.Path)
 
 				payload, err := io.ReadAll(r.Body)
 				require.NoError(t, err)
@@ -1058,7 +1058,7 @@ func TestRawOPAEvaluationCommand(t *testing.T) {
 			Args: []string{"eval", "./testdata/test0/policy.rego", "--owner-id", "test-owner", "--input", "./testdata/test1/test.yml", "--no-compile"},
 			ServerHandler: func(w http.ResponseWriter, r *http.Request) {
 				assert.Equal(t, "POST", r.Method)
-				assert.Equal(t, "/api/v1/owner/test-owner/context/config/decision", r.URL.Path)
+				assert.Equal(t, "/api/v2/owner/test-owner/context/config/decision", r.URL.Path)
 
 				payload, err := io.ReadAll(r.Body)
 				require.NoError(t, err)
@@ -1074,7 +1074,7 @@ func TestRawOPAEvaluationCommand(t *testing.T) {
 			Args: []string{"eval", "./testdata/test0/policy.rego", "--owner-id", "test-owner", "--input", "./testdata/test1/test.yml"},
 			ServerHandler: func(w http.ResponseWriter, r *http.Request) {
 				assert.Equal(t, "POST", r.Method)
-				assert.Equal(t, "/api/v1/owner/test-owner/context/config/decision", r.URL.Path)
+				assert.Equal(t, "/api/v2/owner/test-owner/context/config/decision", r.URL.Path)
 
 				var payload map[string]interface{}
 				assert.NoError(t, json.NewDecoder(r.Body).Decode(&payload))
@@ -1167,7 +1167,7 @@ func TestGetSetSettings(t *testing.T) {
 			ExpectedErr: "failed to run settings : unexpected status-code: 403 - Forbidden",
 			ServerHandler: func(w http.ResponseWriter, r *http.Request) {
 				assert.Equal(t, "GET", r.Method)
-				assert.Equal(t, "/api/v1/owner/ownerID/context/someContext/decision/settings", r.URL.String())
+				assert.Equal(t, "/api/v2/owner/ownerID/context/someContext/decision/settings", r.URL.String())
 				w.WriteHeader(http.StatusForbidden)
 				_, err := w.Write([]byte(`{"error": "Forbidden"}`))
 				assert.NoError(t, err)
@@ -1178,7 +1178,7 @@ func TestGetSetSettings(t *testing.T) {
 			Args: []string{"settings", "--owner-id", "462d67f8-b232-4da4-a7de-0c86dd667d3f"},
 			ServerHandler: func(w http.ResponseWriter, r *http.Request) {
 				assert.Equal(t, "GET", r.Method)
-				assert.Equal(t, "/api/v1/owner/462d67f8-b232-4da4-a7de-0c86dd667d3f/context/config/decision/settings", r.URL.String())
+				assert.Equal(t, "/api/v2/owner/462d67f8-b232-4da4-a7de-0c86dd667d3f/context/config/decision/settings", r.URL.String())
 				w.WriteHeader(http.StatusOK)
 				_, err := w.Write([]byte(`{"enabled": true}`))
 				assert.NoError(t, err)
@@ -1191,7 +1191,7 @@ func TestGetSetSettings(t *testing.T) {
 			ServerHandler: func(w http.ResponseWriter, r *http.Request) {
 				var body map[string]interface{}
 				assert.Equal(t, "PATCH", r.Method)
-				assert.Equal(t, "/api/v1/owner/462d67f8-b232-4da4-a7de-0c86dd667d3f/context/config/decision/settings", r.URL.String())
+				assert.Equal(t, "/api/v2/owner/462d67f8-b232-4da4-a7de-0c86dd667d3f/context/config/decision/settings", r.URL.String())
 				assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
 				assert.Equal(t, map[string]interface{}{"enabled": true}, body)
 				w.WriteHeader(http.StatusOK)
@@ -1206,7 +1206,7 @@ func TestGetSetSettings(t *testing.T) {
 			ServerHandler: func(w http.ResponseWriter, r *http.Request) {
 				var body map[string]interface{}
 				assert.Equal(t, "PATCH", r.Method)
-				assert.Equal(t, "/api/v1/owner/462d67f8-b232-4da4-a7de-0c86dd667d3f/context/config/decision/settings", r.URL.String())
+				assert.Equal(t, "/api/v2/owner/462d67f8-b232-4da4-a7de-0c86dd667d3f/context/config/decision/settings", r.URL.String())
 				assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
 				assert.Equal(t, map[string]interface{}{"enabled": true}, body)
 				w.WriteHeader(http.StatusOK)
@@ -1221,7 +1221,7 @@ func TestGetSetSettings(t *testing.T) {
 			ServerHandler: func(w http.ResponseWriter, r *http.Request) {
 				var body map[string]interface{}
 				assert.Equal(t, "PATCH", r.Method)
-				assert.Equal(t, "/api/v1/owner/462d67f8-b232-4da4-a7de-0c86dd667d3f/context/config/decision/settings", r.URL.String())
+				assert.Equal(t, "/api/v2/owner/462d67f8-b232-4da4-a7de-0c86dd667d3f/context/config/decision/settings", r.URL.String())
 				assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
 				assert.Equal(t, map[string]interface{}{"enabled": false}, body)
 				w.WriteHeader(http.StatusOK)

--- a/cmd/policy/testdata/policy-expected-usage.txt
+++ b/cmd/policy/testdata/policy-expected-usage.txt
@@ -12,6 +12,6 @@ Available Commands:
   test        runs policy tests
 
 Flags:
-      --policy-base-url string   base url for policy api (default "https://internal.circleci.com")
+      --policy-base-url string   base url for policy api (default "https://circleci.com")
 
 Use "policy [command] --help" for more information about a command.

--- a/cmd/policy/testdata/policy/decide-expected-usage.txt
+++ b/cmd/policy/testdata/policy/decide-expected-usage.txt
@@ -15,4 +15,4 @@ Flags:
       --strict                       return non-zero status code for decision resulting in HARD_FAIL
 
 Global Flags:
-      --policy-base-url string   base url for policy api (default "https://internal.circleci.com")
+      --policy-base-url string   base url for policy api (default "https://circleci.com")

--- a/cmd/policy/testdata/policy/diff-expected-usage.txt
+++ b/cmd/policy/testdata/policy/diff-expected-usage.txt
@@ -9,4 +9,4 @@ Flags:
       --owner-id string   the id of the policy's owner
 
 Global Flags:
-      --policy-base-url string   base url for policy api (default "https://internal.circleci.com")
+      --policy-base-url string   base url for policy api (default "https://circleci.com")

--- a/cmd/policy/testdata/policy/eval-expected-usage.txt
+++ b/cmd/policy/testdata/policy/eval-expected-usage.txt
@@ -15,4 +15,4 @@ Flags:
       --query string                 policy decision query (default "data")
 
 Global Flags:
-      --policy-base-url string   base url for policy api (default "https://internal.circleci.com")
+      --policy-base-url string   base url for policy api (default "https://circleci.com")

--- a/cmd/policy/testdata/policy/fetch-expected-usage.txt
+++ b/cmd/policy/testdata/policy/fetch-expected-usage.txt
@@ -9,4 +9,4 @@ Flags:
       --owner-id string   the id of the policy's owner
 
 Global Flags:
-      --policy-base-url string   base url for policy api (default "https://internal.circleci.com")
+      --policy-base-url string   base url for policy api (default "https://circleci.com")

--- a/cmd/policy/testdata/policy/logs-expected-usage.txt
+++ b/cmd/policy/testdata/policy/logs-expected-usage.txt
@@ -16,4 +16,4 @@ Flags:
       --status string       filter decision logs based on their status
 
 Global Flags:
-      --policy-base-url string   base url for policy api (default "https://internal.circleci.com")
+      --policy-base-url string   base url for policy api (default "https://circleci.com")

--- a/cmd/policy/testdata/policy/push-expected-usage.txt
+++ b/cmd/policy/testdata/policy/push-expected-usage.txt
@@ -10,4 +10,4 @@ Flags:
       --owner-id string   the id of the policy's owner
 
 Global Flags:
-      --policy-base-url string   base url for policy api (default "https://internal.circleci.com")
+      --policy-base-url string   base url for policy api (default "https://circleci.com")

--- a/cmd/policy/testdata/policy/settings-expected-usage.txt
+++ b/cmd/policy/testdata/policy/settings-expected-usage.txt
@@ -10,4 +10,4 @@ Flags:
       --owner-id string   the id of the policy's owner
 
 Global Flags:
-      --policy-base-url string   base url for policy api (default "https://internal.circleci.com")
+      --policy-base-url string   base url for policy api (default "https://circleci.com")

--- a/cmd/policy/testdata/policy/test-expected-usage.txt
+++ b/cmd/policy/testdata/policy/test-expected-usage.txt
@@ -12,4 +12,4 @@ Flags:
   -v, --verbose           print all tests instead of only failed tests
 
 Global Flags:
-      --policy-base-url string   base url for policy api (default "https://internal.circleci.com")
+      --policy-base-url string   base url for policy api (default "https://circleci.com")


### PR DESCRIPTION
https://circleci.atlassian.net/browse/CIAMP-2331

### Changes

We are updating the policy logic in the cli to call `circleci.com/api/v2` apis instead of calling `internal.circleci.com`
- Updated all the code and related tests.
- Have tested the endpoints by building a local version of the cli and trying all policy related commands with that.


### **Here are some helpful tips you can follow when submitting a pull request:**

1. Fork [the repository](https://github.com/CircleCI-Public/circleci-cli) and create your branch from `main`.
2. Run `make build` in the repository root.
3. If you've fixed a bug or added code that should be tested, add tests!
4. Ensure the test suite passes (`make test`).
5. The `--debug` flag is often helpful for debugging HTTP client requests and responses.
6. Format your code with [gofmt](https://golang.org/cmd/gofmt/).
7. Make sure your code lints (`make lint`). Note: This requires Docker to run inside a local job.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches policy-service interactions to public `circleci.com/api/v2`.
> 
> - Updates all policy client calls (`CreatePolicyBundle`, `FetchPolicyBundle`, `GetDecisionLogs`, `GetDecisionLog`, `GetSettings`, `SetSettings`, `MakeDecision`) from `/api/v1` to `/api/v2`
> - Changes CLI default `--policy-base-url` from `https://internal.circleci.com` to `https://circleci.com`
> - Adjusts tests and usage docs to new paths and base URL
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9983f4b3a02fad3758edd4016536c702c22256b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->