### PR TITLE
feat: add XDG Base Directory spec support for config files

### DIFF
--- a/cmd/create_telemetry_test.go
+++ b/cmd/create_telemetry_test.go
@@ -250,7 +250,7 @@ func TestLoadTelemetrySettings(t *testing.T) {
 			assert.DeepEqual(t, telemetryClient.events, expectedEvents)
 
 			// Verify if settings file exist
-			exist, err := settings.FS.Exists(filepath.Join(settings.SettingsPath(), "telemetry.yml"))
+			exist, err := settings.FS.Exists(filepath.Join(settings.StatePath(), "telemetry.yml"))
 			assert.NilError(t, err)
 			assert.Equal(t, exist, !tt.want.fileNotCreated)
 			if tt.want.fileNotCreated {

--- a/cmd/telemetry_unit_test.go
+++ b/cmd/telemetry_unit_test.go
@@ -125,7 +125,7 @@ func TestSetIsTelemetryActive(t *testing.T) {
 			err := setIsTelemetryActive(tt.args.apiClient, tt.args.isActive)
 			assert.NilError(t, err)
 
-			exist, err := settings.FS.Exists(filepath.Join(settings.SettingsPath(), "telemetry.yml"))
+			exist, err := settings.FS.Exists(filepath.Join(settings.StatePath(), "telemetry.yml"))
 			assert.NilError(t, err)
 			if tt.want.settings == nil {
 				assert.Equal(t, exist, false)


### PR DESCRIPTION
Implements XDG Base Directory specification (issue #1177) with backwards compatibility for existing users.

Changes:
- Add ConfigPath(), CachePath(), StatePath() functions that respect XDG environment variables (XDG_CONFIG_HOME, XDG_CACHE_HOME, XDG_STATE_HOME)
- Default paths when XDG vars not set:
  - Config: ~/.config/circleci-cli/
  - Cache: ~/.cache/circleci-cli/
  - State: ~/.local/state/circleci-cli/
- Backwards compatibility: if legacy ~/.circleci files exist, use those instead to avoid breaking existing installations
- Update Config, UpdateCheck, and TelemetrySettings Load/Write methods to use appropriate XDG paths
- Update tests to use StatePath() for telemetry file checks

Testing:
- All existing unit tests pass
- Backwards compatibility verified with existing test suite

Fixes: https://github.com/CircleCI-Public/circleci-cli/issues/1177

# Checklist

=========

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have checked for similar issues and haven't found anything relevant.
- [X] This is not a security issue (which should be reported here: https://circleci.com/security/)
- [X] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/main/CONTRIBUTING.md).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes where user config/telemetry/update-check data is read and written, which can affect upgrades and persistence if path resolution or legacy detection is wrong.
> 
> **Overview**
> Implements XDG Base Directory support by splitting persisted CLI files across **config**, **cache**, and **state** locations via new `ConfigPath()`, `CachePath()`, and `StatePath()` helpers, while retaining backwards compatibility by preferring existing legacy `~/.circleci` files when present.
> 
> Updates `Config`, `UpdateCheck`, and `TelemetrySettings` load/write paths accordingly (including defaulting `FileUsed` when unset), and adjusts telemetry unit tests to assert against the new state path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb7a47b3437617ce0cae2667deb52210c9b50559. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->