### PR TITLE
Revert snap publishing to use SNAPCRAFT_LOGIN_FILE with snapcraft 3.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -264,12 +264,11 @@ jobs:
       - run:
           name: Publish to store
           command: |
-            # The cibuilds/snapcraft:stable image is archived and has a pre-7 version of snapcraft.
-            # Upgrade to snapcraft 7+ which reads SNAPCRAFT_STORE_CREDENTIALS env var automatically.
-            # To refresh credentials: run `snapcraft export-login --snaps=circleci --channels=stable -`
-            # and store the output as SNAPCRAFT_STORE_CREDENTIALS in CircleCI project settings.
-            pip3 install --upgrade snapcraft
-            snapcraft upload *.snap --release stable
+            # Credentials are read from the SNAPCRAFT_LOGIN_FILE env var (base64-encoded).
+            # To refresh: run `snapcraft login` and `snapcraft export-login creds`
+            # inside cibuilds/snapcraft:stable, then `cat creds | base64 | tr -d '\n'`
+            # and store the output as SNAPCRAFT_LOGIN_FILE in CircleCI project settings.
+            snapcraft push *.snap --release stable
 
   chocolatey-deploy:
     executor: windows/default


### PR DESCRIPTION
## Background

The snap publishing job has been failing with No valid credentials found since the SNAPCRAFT_LOGIN_FILE credential expired or was incorrectly set.

## What we tried

1. fix/snapcraft-credentials (#1185, merged) — Switched from snapcraft push to snapcraft upload and documented SNAPCRAFT_STORE_CREDENTIALS as the auth mechanism. This didn't fix the issue because the CI image (cibuilds/snapcraft:stable) runs snapcraft 3.8, which doesn't support SNAPCRAFT_STORE_CREDENTIALS or snapcraft upload.

2. fix/snapcraft-publish-upgrade (#1186, merged) — Added pip3 install --upgrade snapcraft before publishing to upgrade snapcraft at runtime. Failed because the archived cibuilds/snapcraft:stable image doesn't have pip3 installed.

3. Replacing the Docker image with ubuntu:22.04 — Attempted to install snapcraft on a fresh Ubuntu image. apt install snapcraft installs a transitional package that requires snapd (doesn't work in Docker). pip install snapcraft only has the old 4.x on PyPI. Modern snapcraft 7+ is only distributed as a snap. The working solution was to download and extract the snapcraft snap from the Snap Store API directly (the same approach used by Remmina's CI and the original cibuilds/snapcraft image), packaged as a custom Dockerfile. This could work but adds significant complexity and requires publishing/maintaining a custom image. 
  - There were talks in the foundations channel about getting rid of snap. So didn't take this route further. 

## Why this approach should work

While we are on an outdated snap version, the root cause could be a credential format mismatch. Credentials were generated using snapcraft 8 (on a local Mac), but the CI image runs snapcraft 3.8 which expects a different format. The two versions produce incompatible credential files. 

Previous attempts generated credentials using snapcraft 8.13.2 (installed locally via Homebrew on macOS). Snapcraft 8 produces credentials in a format incompatible with snapcraft 3.8 in the CI image.

This time, credentials were generated inside the same Docker image used by CI (cibuilds/snapcraft:stable, which runs snapcraft 3.8):

```
docker run --rm -it --platform linux/amd64 cibuilds/snapcraft:stable bash
snapcraft login          # authenticate with bot-ponicode@circleci.com
snapcraft export-login creds
cat creds | base64 | tr -d '\n'   # base64 encode for SNAPCRAFT_LOGIN_FILE
```

This ensures the credential format matches exactly what the CI environment expects.

## This PR:

1. Reverts to snapcraft push (the correct command for snapcraft 3.8)
2. Reverts to SNAPCRAFT_LOGIN_FILE (the correct env var for snapcraft 3.8)
3. Updates comments with accurate credential refresh instructions
5. The SNAPCRAFT_LOGIN_FILE env var has been regenerated inside the cibuilds/snapcraft:stable container using snapcraft 3.8, ensuring the credential format matches what the CI image expects

## Future consideration

The cibuilds/snapcraft:stable image was archived in February 2023. If it stops working in the future, the custom Docker image approach (extracting the snapcraft snap into an Ubuntu base image) is the viable path forward.