### PR TITLE
bring back manually decoding `SNAPCRAFT_LOGIN_FILE`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -268,6 +268,8 @@ jobs:
             # To refresh: run `snapcraft login` and `snapcraft export-login creds`
             # inside cibuilds/snapcraft:stable, then `cat creds | base64 | tr -d '\n'`
             # and store the output as SNAPCRAFT_LOGIN_FILE in CircleCI project settings.
+            mkdir -p .snapcraft
+            echo $SNAPCRAFT_LOGIN_FILE | base64 --decode --ignore-garbage > .snapcraft/snapcraft.cfg
             snapcraft push *.snap --release stable
 
   chocolatey-deploy:


### PR DESCRIPTION
Follow up to: #1187 

We deleted reading the credential: https://github.com/CircleCI-Public/circleci-cli/pull/1149/changes#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L264

It's possible that that is why we aren't able to read the credential. 

## Context

Why the commands are needed: Snapcraft 3.8 (in `cibuilds/snapcraft:stable`) doesn't read credentials from environment variables automatically. It requires a file at `.snapcraft/snapcraft.cfg`. The two lines decode the base64-encoded `SNAPCRAFT_LOGIN_FILE` env var and write it to that path so snapcraft push can authenticate.

### SNAPCRAFT_LOGIN_FILE vs SNAPCRAFT_STORE_CREDENTIALS:

`SNAPCRAFT_LOGIN_FILE` (pre-7.0): Base64-encoded login session exported via snapcraft export-login. Must be manually decoded to disk. Line 272 reads `$SNAPCRAFT_LOGIN_FILE` from the environment, base64-decodes it, and writes it to `.snapcraft/snapcraft.cfg`. The credential value itself is stored as a CircleCI environment variable; the script just converts it into the on-disk file that Snapcraft 3.8 expects.

`SNAPCRAFT_STORE_CREDENTIALS` (7.0+): A raw credential string that modern Snapcraft reads directly from the environment—no file writing needed. Since the CI image is locked to Snapcraft 3.8, restoring the mkdir/echo commands and using `SNAPCRAFT_LOGIN_FILE` could be the fix to the failing snap build. 

In order to use `SNAPCRAFT_STORE_CREDENTIALS` we would need to upgrade to Snapcraft 7.0+, which means replacing the `cibuilds/snapcraft:stable` Docker image with a newer one (e.g., ubuntu:22.04 with Snapcraft installed via snap or a modern Snapcraft image). Since that image is archived and locked to v3.8, `SNAPCRAFT_STORE_CREDENTIALS` simply isn't recognized by the tool in the current CI environment.
