### PR TITLE
Fix orb init failing when orb-publishing context already exists

### DIFF
--- a/cmd/orb.go
+++ b/cmd/orb.go
@@ -1405,7 +1405,7 @@ func initOrb(opts orbOptions) error {
 		contextAPI := context.NewContextClient(opts.cfg, "", vcsProvider, ownerName)
 		err = contextAPI.CreateContext("orb-publishing")
 		if err != nil {
-			if strings.Contains(err.Error(), "A context named orb-publishing already exists") {
+			if strings.Contains(strings.ToLower(err.Error()), "already exists") {
 				fmt.Println("`orb-publishing` context already exists, continuing on")
 			} else {
 				return err


### PR DESCRIPTION
## Summary

- Fixes a string mismatch in `initOrb` that causes `circleci orb init` to fail with `"Error: A context already exists with this name"` when the `orb-publishing` context already exists in the organization (e.g., created by a teammate).
- The existing check looked for `"A context named orb-publishing already exists"`, which doesn't match what the REST API (`"A context already exists with this name"`) or GQL API (`"Error creating context: ALREADY_EXISTS"`) actually returns.
- Replaced with a case-insensitive check for `"already exists"` so the CLI gracefully continues regardless of API path.

Fixes #1192

## Test plan

- [x] Run `circleci orb init` in an org where `orb-publishing` context already exists, select "Yes, set up a publishing context with my API key" — should print `` `orb-publishing` context already exists, continuing on `` and proceed
- [x] Run `circleci orb init` in an org with no existing `orb-publishing` context — should create the context normally
- [x] Run `circleci orb init` and select "No, I'll do this later" — should skip context creation as before