### PR TITLE
[DR-342] feat: add `circleci deploy init` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,27 @@ Config file at .circleci/config.yml is valid
 ```
 
 
+## Set Up Deploy Markers
+
+If your project already deploys something from CircleCI, `circleci deploy init`
+will wire up [deploy markers](https://circleci.com/docs/guides/deploy/configure-deploy-markers/)
+for you without any manual YAML editing. From the root of your repo:
+
+```
+$ circleci deploy init
+```
+
+The command scans `.circleci/config.yml`, detects jobs that look like
+deployments (by name), asks a couple of questions (component and
+environment name), and appends a `circleci run release log` step to each
+matching job. It does not commit, push, or make any API calls — you
+review the diff and commit the change yourself. Re-running it on an
+already instrumented config is a no-op.
+
+For richer workflows (status tracking, rollbacks, etc.) see the
+[deploy markers guide](https://circleci.com/docs/guides/deploy/configure-deploy-markers/).
+
+
 ## Docker
 
 The CLI may also be used without installation by using Docker.

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -1,0 +1,66 @@
+// Package deploy implements the `circleci deploy` command group,
+// including the `init` subcommand that wires deploy markers into
+// an existing .circleci/config.yml with zero manual editing.
+package deploy
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/CircleCI-Public/circleci-cli/prompt"
+	"github.com/CircleCI-Public/circleci-cli/settings"
+)
+
+// UserInputReader displays a message and reads a user input value.
+// It mirrors the pattern used by other command groups so tests can
+// supply canned answers without a real TTY.
+type UserInputReader interface {
+	ReadStringFromUser(msg string, defaultValue string) string
+}
+
+type deployOpts struct {
+	reader UserInputReader
+}
+
+// Option configures a command created by NewDeployCommand.
+type Option interface {
+	apply(*deployOpts)
+}
+
+type promptReader struct{}
+
+func (p promptReader) ReadStringFromUser(msg string, defaultValue string) string {
+	return prompt.ReadStringFromUser(msg, defaultValue)
+}
+
+// NewDeployCommand returns the top-level `circleci deploy` command group.
+func NewDeployCommand(config *settings.Config, opts ...Option) *cobra.Command {
+	dopts := deployOpts{
+		reader: &promptReader{},
+	}
+	for _, o := range opts {
+		o.apply(&dopts)
+	}
+
+	command := &cobra.Command{
+		Use:   "deploy",
+		Short: "Set up and manage CircleCI deploy markers",
+	}
+
+	command.AddCommand(newInitCommand(config, &dopts))
+
+	return command
+}
+
+type customReaderOption struct {
+	r UserInputReader
+}
+
+func (c customReaderOption) apply(opts *deployOpts) {
+	opts.reader = c.r
+}
+
+// CustomReader returns an Option that replaces the default interactive
+// prompt reader with the supplied implementation. Useful for tests.
+func CustomReader(r UserInputReader) Option {
+	return customReaderOption{r}
+}

--- a/cmd/deploy/detect.go
+++ b/cmd/deploy/detect.go
@@ -1,0 +1,189 @@
+package deploy
+
+import (
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// deployJobKeywords lists substrings that, when found in a job name,
+// strongly suggest the job performs a deployment and is a candidate
+// for adding a deploy marker step.
+var deployJobKeywords = []string{
+	"deploy",
+	"release",
+	"publish",
+	"ship",
+}
+
+// DetectedJob describes a job in config.yml that matched the deploy heuristics.
+type DetectedJob struct {
+	// Name is the job name as it appears under the top-level `jobs:` key.
+	Name string
+	// AlreadyInstrumented is true when at least one of the job's existing
+	// steps already invokes `circleci run release log` (or a compatible
+	// marker command). Such jobs are skipped during patching to keep the
+	// command idempotent.
+	AlreadyInstrumented bool
+}
+
+// DetectDeployJobs scans the root YAML document of a CircleCI config and
+// returns every job whose name matches the deploy heuristics. It never
+// modifies the node tree.
+func DetectDeployJobs(root *yaml.Node) []DetectedJob {
+	jobsNode := findJobsNode(root)
+	if jobsNode == nil {
+		return nil
+	}
+
+	var detected []DetectedJob
+	// A YAML mapping node stores keys and values as alternating entries in
+	// Content; we iterate in pairs and skip entries where the value is not
+	// itself a mapping (malformed configs, anchors resolved elsewhere, etc.)
+	for i := 0; i+1 < len(jobsNode.Content); i += 2 {
+		nameNode := jobsNode.Content[i]
+		valueNode := jobsNode.Content[i+1]
+		if nameNode.Kind != yaml.ScalarNode {
+			continue
+		}
+		if !isDeployJobName(nameNode.Value) {
+			continue
+		}
+		detected = append(detected, DetectedJob{
+			Name:                nameNode.Value,
+			AlreadyInstrumented: jobAlreadyInstrumented(valueNode),
+		})
+	}
+	return detected
+}
+
+// findJobsNode returns the mapping node stored under the top-level `jobs:`
+// key, or nil when the config has no jobs section.
+func findJobsNode(root *yaml.Node) *yaml.Node {
+	if root == nil {
+		return nil
+	}
+	doc := root
+	if doc.Kind == yaml.DocumentNode && len(doc.Content) > 0 {
+		doc = doc.Content[0]
+	}
+	if doc.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(doc.Content); i += 2 {
+		keyNode := doc.Content[i]
+		if keyNode.Kind == yaml.ScalarNode && keyNode.Value == "jobs" {
+			valueNode := doc.Content[i+1]
+			if valueNode.Kind == yaml.MappingNode {
+				return valueNode
+			}
+			return nil
+		}
+	}
+	return nil
+}
+
+// isDeployJobName reports whether the supplied job name contains any of
+// the deploy-related keywords, case-insensitively.
+func isDeployJobName(name string) bool {
+	lower := strings.ToLower(name)
+	for _, kw := range deployJobKeywords {
+		if strings.Contains(lower, kw) {
+			return true
+		}
+	}
+	return false
+}
+
+// jobAlreadyInstrumented walks the supplied job mapping node looking for
+// a `run` step whose command text includes `circleci run release log` or
+// `circleci run release plan`. Those are the commands this tool adds (or
+// that a user may have added themselves), so finding either means we
+// should leave the job untouched.
+func jobAlreadyInstrumented(jobNode *yaml.Node) bool {
+	if jobNode == nil || jobNode.Kind != yaml.MappingNode {
+		return false
+	}
+	stepsNode := findChild(jobNode, "steps")
+	if stepsNode == nil || stepsNode.Kind != yaml.SequenceNode {
+		return false
+	}
+	for _, step := range stepsNode.Content {
+		if stepContainsDeployMarker(step) {
+			return true
+		}
+	}
+	return false
+}
+
+// stepContainsDeployMarker inspects a single step node to determine
+// whether it already runs the deploy marker CLI. Steps can appear as a
+// bare scalar (e.g. `- checkout`) or as a mapping with a `run` key
+// holding either a scalar command or a nested mapping with
+// `command:` / `name:` fields.
+func stepContainsDeployMarker(step *yaml.Node) bool {
+	switch step.Kind {
+	case yaml.ScalarNode:
+		return containsDeployMarker(step.Value)
+	case yaml.MappingNode:
+		run := findChild(step, "run")
+		if run == nil {
+			return false
+		}
+		switch run.Kind {
+		case yaml.ScalarNode:
+			return containsDeployMarker(run.Value)
+		case yaml.MappingNode:
+			cmd := findChild(run, "command")
+			if cmd != nil && cmd.Kind == yaml.ScalarNode && containsDeployMarker(cmd.Value) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// containsDeployMarker checks whether a command string invokes the
+// deploy marker CLI in any of its supported forms.
+func containsDeployMarker(cmd string) bool {
+	if cmd == "" {
+		return false
+	}
+	normalized := strings.Join(strings.Fields(cmd), " ")
+	return strings.Contains(normalized, "circleci run release log") ||
+		strings.Contains(normalized, "circleci run release plan")
+}
+
+// findChild returns the first value node associated with the given key
+// in a mapping node, or nil if the mapping does not contain that key.
+func findChild(mapping *yaml.Node, key string) *yaml.Node {
+	if mapping == nil || mapping.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(mapping.Content); i += 2 {
+		k := mapping.Content[i]
+		if k.Kind == yaml.ScalarNode && k.Value == key {
+			return mapping.Content[i+1]
+		}
+	}
+	return nil
+}
+
+// InferEnvironmentName returns a best-effort environment name derived
+// from the job name (e.g. `deploy-prod` → `production`). The boolean
+// return reports whether the heuristic matched; callers should prompt
+// the user when it did not.
+func InferEnvironmentName(jobName string) (string, bool) {
+	lower := strings.ToLower(jobName)
+	switch {
+	case strings.Contains(lower, "production"), strings.Contains(lower, "prod"):
+		return "production", true
+	case strings.Contains(lower, "staging"), strings.Contains(lower, "stage"):
+		return "staging", true
+	case strings.Contains(lower, "development"), strings.Contains(lower, "dev"):
+		return "development", true
+	case strings.Contains(lower, "test"):
+		return "test", true
+	}
+	return "", false
+}

--- a/cmd/deploy/detect_test.go
+++ b/cmd/deploy/detect_test.go
@@ -1,0 +1,119 @@
+package deploy
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
+)
+
+func parseFixture(t *testing.T, name string) *yaml.Node {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("testdata", name))
+	if err != nil {
+		t.Fatalf("reading fixture %s: %v", name, err)
+	}
+	var root yaml.Node
+	if err := yaml.Unmarshal(data, &root); err != nil {
+		t.Fatalf("parsing fixture %s: %v", name, err)
+	}
+	return &root
+}
+
+func TestDetectDeployJobs(t *testing.T) {
+	t.Run("single deploy job is detected", func(t *testing.T) {
+		root := parseFixture(t, "simple-deploy.yml")
+		detected := DetectDeployJobs(root)
+		if assert.Len(t, detected, 1) {
+			assert.Equal(t, "deploy-prod", detected[0].Name)
+			assert.False(t, detected[0].AlreadyInstrumented)
+		}
+	})
+
+	t.Run("multiple deploy-ish jobs are all detected", func(t *testing.T) {
+		root := parseFixture(t, "multiple-deploys.yml")
+		detected := DetectDeployJobs(root)
+		names := make([]string, 0, len(detected))
+		for _, d := range detected {
+			names = append(names, d.Name)
+		}
+		assert.ElementsMatch(t, []string{"deploy-staging", "deploy-prod", "release-docs"}, names)
+	})
+
+	t.Run("already instrumented jobs are flagged", func(t *testing.T) {
+		root := parseFixture(t, "already-instrumented.yml")
+		detected := DetectDeployJobs(root)
+		if assert.Len(t, detected, 1) {
+			assert.True(t, detected[0].AlreadyInstrumented, "expected deploy-prod to be flagged as already instrumented")
+		}
+	})
+
+	t.Run("no deploy jobs means empty result", func(t *testing.T) {
+		root := parseFixture(t, "no-deploy-jobs.yml")
+		assert.Empty(t, DetectDeployJobs(root))
+	})
+
+	t.Run("missing jobs section is handled", func(t *testing.T) {
+		var root yaml.Node
+		err := yaml.Unmarshal([]byte("version: 2.1\n"), &root)
+		assert.NoError(t, err)
+		assert.Empty(t, DetectDeployJobs(&root))
+	})
+
+	t.Run("nil input does not panic", func(t *testing.T) {
+		assert.NotPanics(t, func() {
+			DetectDeployJobs(nil)
+		})
+	})
+}
+
+func TestIsDeployJobName(t *testing.T) {
+	cases := []struct {
+		name string
+		want bool
+	}{
+		{"deploy", true},
+		{"deploy-prod", true},
+		{"PublishDocs", true},
+		{"release-to-staging", true},
+		{"ship-it", true},
+		{"Deploy_Production", true},
+		{"build", false},
+		{"test", false},
+		{"lint", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.want, isDeployJobName(c.name))
+		})
+	}
+}
+
+func TestInferEnvironmentName(t *testing.T) {
+	cases := []struct {
+		job       string
+		wantEnv   string
+		wantMatch bool
+	}{
+		{"deploy-prod", "production", true},
+		{"deploy-production", "production", true},
+		{"deploy-staging", "staging", true},
+		{"stage-deploy", "staging", true},
+		{"deploy-dev", "development", true},
+		{"deploy-development", "development", true},
+		{"deploy-test", "test", true},
+		{"release", "", false},
+		{"publish", "", false},
+		{"ship-it", "", false},
+	}
+	for _, c := range cases {
+		t.Run(c.job, func(t *testing.T) {
+			got, ok := InferEnvironmentName(c.job)
+			assert.Equal(t, c.wantEnv, got)
+			assert.Equal(t, c.wantMatch, ok)
+		})
+	}
+}

--- a/cmd/deploy/init.go
+++ b/cmd/deploy/init.go
@@ -1,0 +1,221 @@
+package deploy
+
+import (
+	"fmt"
+	"io"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/CircleCI-Public/circleci-cli/config"
+	"github.com/CircleCI-Public/circleci-cli/git"
+	"github.com/CircleCI-Public/circleci-cli/settings"
+)
+
+// deploysDashboardURL is the base URL printed at the end of a
+// successful init. We intentionally do not try to build an org-scoped
+// URL here: doing so reliably across OAuth orgs (gh/bb slug) and
+// standalone CircleCI orgs (opaque CIAM id) requires an authenticated
+// API call, which would break the "works offline" design goal. The
+// dashboard landing page redirects users to their most recent org.
+const deploysDashboardURL = "https://app.circleci.com/deploys"
+
+type initOptions struct {
+	// configPath points to the .circleci/config.yml the command reads
+	// and writes back. Defaults to config.DefaultConfigPath; exposed as
+	// a hidden flag so tests can redirect it at a temp file.
+	configPath string
+}
+
+func newInitCommand(_ *settings.Config, deployOpts *deployOpts) *cobra.Command {
+	iopts := initOptions{
+		configPath: config.DefaultConfigPath,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "init",
+		Short: "Wire deploy markers into your .circleci/config.yml",
+		Long: `Scan the project's .circleci/config.yml, detect jobs that look like
+deployments, and append a step that records a deploy marker on every run.
+
+The command is idempotent: re-running it against an already instrumented
+config leaves it untouched. It never commits or pushes any changes —
+after it finishes you are prompted to review the diff and commit
+yourself.`,
+		Example: `  # Run from the root of your repository:
+  circleci deploy init`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runInit(cmd.OutOrStdout(), deployOpts, iopts)
+		},
+	}
+
+	cmd.Flags().StringVar(&iopts.configPath, "config", iopts.configPath, "Path to the config file to patch")
+	_ = cmd.Flags().MarkHidden("config")
+
+	return cmd
+}
+
+// runInit drives the whole interactive flow: read config → detect
+// deploy jobs → gather component/environment answers → patch config →
+// print follow-up instructions. It always writes through the supplied
+// writer so tests can capture the output.
+func runInit(out io.Writer, deployOpts *deployOpts, iopts initOptions) error {
+	fmt.Fprintf(out, "Scanning %s...\n\n", iopts.configPath)
+
+	_, root, err := ReadConfig(iopts.configPath)
+	if err != nil {
+		return err
+	}
+
+	detected := DetectDeployJobs(root)
+	if len(detected) == 0 {
+		fmt.Fprintln(out, "No deploy jobs detected.")
+		fmt.Fprintln(out, "")
+		fmt.Fprintln(out, "We look for jobs whose names contain \"deploy\", \"release\", \"publish\" or \"ship\".")
+		fmt.Fprintln(out, "If one of your jobs performs a deployment under a different name, you can wire it up")
+		fmt.Fprintln(out, "manually by adding this step:")
+		fmt.Fprintln(out, "")
+		fmt.Fprintln(out, "  - run:")
+		fmt.Fprintln(out, "      name: Log deploy marker")
+		fmt.Fprintln(out, "      command: |")
+		fmt.Fprintln(out, "        circleci run release log \\")
+		fmt.Fprintln(out, "          --component-name=<your-service> \\")
+		fmt.Fprintln(out, "          --environment-name=<your-environment> \\")
+		fmt.Fprintln(out, "          --target-version=$CIRCLE_SHA1")
+		return nil
+	}
+
+	fmt.Fprintf(out, "Found %d deploy job%s:\n", len(detected), pluralS(len(detected)))
+	for _, j := range detected {
+		marker := ""
+		if j.AlreadyInstrumented {
+			marker = "  (already instrumented — will be skipped)"
+		}
+		fmt.Fprintf(out, "  - %s%s\n", j.Name, marker)
+	}
+	fmt.Fprintln(out, "")
+
+	// If every detected job is already instrumented there is no need to
+	// ask any questions or touch the file.
+	if allInstrumented(detected) {
+		fmt.Fprintln(out, "Every detected deploy job already logs a marker. Nothing to do.")
+		fmt.Fprintf(out, "\nDashboard: %s\n", deploysDashboardURL)
+		return nil
+	}
+
+	componentDefault := defaultComponentName(iopts.configPath)
+	componentName := deployOpts.reader.ReadStringFromUser(
+		"What is this service called?",
+		componentDefault,
+	)
+	if componentName == "" {
+		componentName = componentDefault
+	}
+
+	steps := make([]MarkerStep, 0, len(detected))
+	for _, j := range detected {
+		if j.AlreadyInstrumented {
+			continue
+		}
+		envDefault, inferred := InferEnvironmentName(j.Name)
+		if !inferred {
+			envDefault = "production"
+		}
+		env := deployOpts.reader.ReadStringFromUser(
+			fmt.Sprintf("What environment does %q target?", j.Name),
+			envDefault,
+		)
+		if env == "" {
+			env = envDefault
+		}
+		steps = append(steps, MarkerStep{
+			JobName:         j.Name,
+			ComponentName:   componentName,
+			EnvironmentName: env,
+		})
+	}
+
+	result, err := PatchConfig(root, steps)
+	if err != nil {
+		return err
+	}
+
+	if len(result.Modified) == 0 {
+		fmt.Fprintln(out, "\nNo changes were needed — all detected jobs were already instrumented.")
+		fmt.Fprintf(out, "\nDashboard: %s\n", deploysDashboardURL)
+		return nil
+	}
+
+	if err := WriteConfig(iopts.configPath, root); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(out, "\nUpdated %s.\n", iopts.configPath)
+	fmt.Fprintf(out, "Added deploy marker step to: %s\n", joinJobs(result.Modified))
+	if len(result.Skipped) > 0 {
+		fmt.Fprintf(out, "Left untouched (already instrumented): %s\n", joinJobs(result.Skipped))
+	}
+
+	fmt.Fprintln(out, "")
+	fmt.Fprintln(out, "Next steps:")
+	fmt.Fprintln(out, "  1. Review the diff:")
+	fmt.Fprintf(out, "       git diff %s\n", iopts.configPath)
+	fmt.Fprintln(out, "  2. Commit and push when you're happy with it:")
+	fmt.Fprintf(out, "       git add %s\n", iopts.configPath)
+	fmt.Fprintln(out, "       git commit -m \"Wire up CircleCI deploy markers\"")
+	fmt.Fprintln(out, "       git push")
+	fmt.Fprintln(out, "")
+	fmt.Fprintln(out, "After your next pipeline run you'll see deploy markers on the dashboard:")
+	fmt.Fprintf(out, "  %s\n", deploysDashboardURL)
+
+	return nil
+}
+
+// defaultComponentName proposes a sensible default for the component
+// name prompt. We prefer the project name inferred from git remotes
+// (works for GitHub / Bitbucket) and fall back to the repo directory
+// name so the command still has a reasonable default when run in a
+// checkout without a recognisable remote.
+func defaultComponentName(configPath string) string {
+	if remote, err := git.InferProjectFromGitRemotes(); err == nil && remote.Project != "" {
+		return remote.Project
+	}
+	abs, err := filepath.Abs(configPath)
+	if err == nil {
+		// configPath is typically ".circleci/config.yml"; walk two
+		// levels up to reach the repo root.
+		return filepath.Base(filepath.Dir(filepath.Dir(abs)))
+	}
+	return ""
+}
+
+func allInstrumented(jobs []DetectedJob) bool {
+	for _, j := range jobs {
+		if !j.AlreadyInstrumented {
+			return false
+		}
+	}
+	return len(jobs) > 0
+}
+
+func joinJobs(names []string) string {
+	switch len(names) {
+	case 0:
+		return ""
+	case 1:
+		return names[0]
+	}
+	out := names[0]
+	for _, n := range names[1:] {
+		out += ", " + n
+	}
+	return out
+}
+
+func pluralS(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
+}

--- a/cmd/deploy/init.go
+++ b/cmd/deploy/init.go
@@ -20,6 +20,12 @@ import (
 // dashboard landing page redirects users to their most recent org.
 const deploysDashboardURL = "https://app.circleci.com/deploys"
 
+// deployMarkersDocsURL points to the canonical guide for deploy markers.
+// We print it alongside the dashboard URL so users who outgrow the
+// `log`-only setup this command produces (for example, users who want
+// the full plan/update lifecycle with statuses) can find the next step.
+const deployMarkersDocsURL = "https://circleci.com/docs/guides/deploy/configure-deploy-markers/"
+
 type initOptions struct {
 	// configPath points to the .circleci/config.yml the command reads
 	// and writes back. Defaults to config.DefaultConfigPath; exposed as
@@ -83,6 +89,8 @@ func runInit(out io.Writer, deployOpts *deployOpts, iopts initOptions) error {
 		fmt.Fprintln(out, "          --component-name=<your-service> \\")
 		fmt.Fprintln(out, "          --environment-name=<your-environment> \\")
 		fmt.Fprintln(out, "          --target-version=$CIRCLE_SHA1")
+		fmt.Fprintln(out, "")
+		fmt.Fprintf(out, "More options (status tracking, rollbacks, etc.): %s\n", deployMarkersDocsURL)
 		return nil
 	}
 
@@ -101,6 +109,7 @@ func runInit(out io.Writer, deployOpts *deployOpts, iopts initOptions) error {
 	if allInstrumented(detected) {
 		fmt.Fprintln(out, "Every detected deploy job already logs a marker. Nothing to do.")
 		fmt.Fprintf(out, "\nDashboard: %s\n", deploysDashboardURL)
+		fmt.Fprintf(out, "Docs:      %s\n", deployMarkersDocsURL)
 		return nil
 	}
 
@@ -144,6 +153,7 @@ func runInit(out io.Writer, deployOpts *deployOpts, iopts initOptions) error {
 	if len(result.Modified) == 0 {
 		fmt.Fprintln(out, "\nNo changes were needed — all detected jobs were already instrumented.")
 		fmt.Fprintf(out, "\nDashboard: %s\n", deploysDashboardURL)
+		fmt.Fprintf(out, "Docs:      %s\n", deployMarkersDocsURL)
 		return nil
 	}
 
@@ -168,6 +178,9 @@ func runInit(out io.Writer, deployOpts *deployOpts, iopts initOptions) error {
 	fmt.Fprintln(out, "")
 	fmt.Fprintln(out, "After your next pipeline run you'll see deploy markers on the dashboard:")
 	fmt.Fprintf(out, "  %s\n", deploysDashboardURL)
+	fmt.Fprintln(out, "")
+	fmt.Fprintln(out, "Want status tracking, rollbacks, or more control? See the deploy markers guide:")
+	fmt.Fprintf(out, "  %s\n", deployMarkersDocsURL)
 
 	return nil
 }

--- a/cmd/deploy/init.go
+++ b/cmd/deploy/init.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -162,9 +163,9 @@ func runInit(out io.Writer, deployOpts *deployOpts, iopts initOptions) error {
 	}
 
 	fmt.Fprintf(out, "\nUpdated %s.\n", iopts.configPath)
-	fmt.Fprintf(out, "Added deploy marker step to: %s\n", joinJobs(result.Modified))
+	fmt.Fprintf(out, "Added deploy marker step to: %s\n", strings.Join(result.Modified, ", "))
 	if len(result.Skipped) > 0 {
-		fmt.Fprintf(out, "Left untouched (already instrumented): %s\n", joinJobs(result.Skipped))
+		fmt.Fprintf(out, "Left untouched (already instrumented): %s\n", strings.Join(result.Skipped, ", "))
 	}
 
 	fmt.Fprintln(out, "")
@@ -210,20 +211,6 @@ func allInstrumented(jobs []DetectedJob) bool {
 		}
 	}
 	return len(jobs) > 0
-}
-
-func joinJobs(names []string) string {
-	switch len(names) {
-	case 0:
-		return ""
-	case 1:
-		return names[0]
-	}
-	out := names[0]
-	for _, n := range names[1:] {
-		out += ", " + n
-	}
-	return out
 }
 
 func pluralS(n int) string {

--- a/cmd/deploy/init_test.go
+++ b/cmd/deploy/init_test.go
@@ -1,0 +1,158 @@
+package deploy
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/CircleCI-Public/circleci-cli/settings"
+)
+
+// scriptedReader replays a fixed sequence of answers and records which
+// prompt+default pairs it was asked. It stands in for the interactive
+// terminal prompt during tests.
+type scriptedReader struct {
+	answers []string
+	calls   []scriptedCall
+}
+
+type scriptedCall struct {
+	msg          string
+	defaultValue string
+}
+
+func (s *scriptedReader) ReadStringFromUser(msg string, defaultValue string) string {
+	s.calls = append(s.calls, scriptedCall{msg: msg, defaultValue: defaultValue})
+	if len(s.answers) == 0 {
+		return defaultValue
+	}
+	next := s.answers[0]
+	s.answers = s.answers[1:]
+	if next == "" {
+		return defaultValue
+	}
+	return next
+}
+
+// setupTempConfig copies a testdata fixture into a fresh temp directory
+// and returns the path to the copy. Tests mutate this copy freely.
+func setupTempConfig(t *testing.T, fixture string) string {
+	t.Helper()
+	src, err := os.ReadFile(filepath.Join("testdata", fixture))
+	require.NoError(t, err)
+	dir := t.TempDir()
+	cfgDir := filepath.Join(dir, ".circleci")
+	require.NoError(t, os.Mkdir(cfgDir, 0o755))
+	dst := filepath.Join(cfgDir, "config.yml")
+	require.NoError(t, os.WriteFile(dst, src, 0o644))
+	return dst
+}
+
+// runInitCmd builds the deploy init command with the supplied reader
+// and captures its stdout/stderr.
+func runInitCmd(t *testing.T, configPath string, reader UserInputReader) (string, error) {
+	t.Helper()
+	dopts := deployOpts{reader: reader}
+	cmd := newInitCommand(&settings.Config{}, &dopts)
+
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"--config", configPath})
+
+	// Root-style prerun hooks are not wired here; the init subcommand
+	// does not require any beyond what cobra provides.
+	parent := &cobra.Command{Use: "deploy"}
+	parent.AddCommand(cmd)
+	parent.SetOut(&out)
+	parent.SetErr(&out)
+	parent.SetArgs([]string{"init", "--config", configPath})
+
+	err := parent.Execute()
+	return out.String(), err
+}
+
+func TestInit_HappyPath(t *testing.T) {
+	configPath := setupTempConfig(t, "simple-deploy.yml")
+	reader := &scriptedReader{answers: []string{"api", "production"}}
+
+	output, err := runInitCmd(t, configPath, reader)
+	require.NoError(t, err, output)
+
+	assert.Contains(t, output, "Found 1 deploy job")
+	assert.Contains(t, output, "deploy-prod")
+	assert.Contains(t, output, "Updated")
+	assert.Contains(t, output, "https://app.circleci.com/deploys")
+	assert.NotContains(t, output, "git commit -m \"Wire up CircleCI deploy markers\" && git push",
+		"output should not chain commit and push on one line")
+
+	// The config file should now contain a deploy marker step.
+	patched, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(patched), "circleci run release log")
+	assert.Contains(t, string(patched), "--component-name=api")
+	assert.Contains(t, string(patched), "--environment-name=production")
+}
+
+func TestInit_NoDeployJobsExitsCleanly(t *testing.T) {
+	configPath := setupTempConfig(t, "no-deploy-jobs.yml")
+	original, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+
+	reader := &scriptedReader{}
+	output, err := runInitCmd(t, configPath, reader)
+	require.NoError(t, err, output)
+
+	assert.Contains(t, output, "No deploy jobs detected")
+	// The config file must be untouched when nothing matched.
+	after, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	assert.Equal(t, string(original), string(after), "config file should not be modified when no deploy jobs are detected")
+	// With no prompts needed we expect a reader that was never called.
+	assert.Empty(t, reader.calls)
+}
+
+func TestInit_IdempotentOnAlreadyInstrumentedConfig(t *testing.T) {
+	configPath := setupTempConfig(t, "already-instrumented.yml")
+	original, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+
+	reader := &scriptedReader{}
+	output, err := runInitCmd(t, configPath, reader)
+	require.NoError(t, err, output)
+
+	assert.Contains(t, output, "already instrumented")
+	after, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	assert.Equal(t, string(original), string(after), "config should not be rewritten when everything is already instrumented")
+	// No user questions should be asked either.
+	assert.Empty(t, reader.calls)
+}
+
+func TestInit_PromptsPerUninferredJob(t *testing.T) {
+	configPath := setupTempConfig(t, "multiple-deploys.yml")
+	// Script answers: component name, then one environment per
+	// job that could not be inferred. deploy-staging → staging,
+	// deploy-prod → production (both inferred); release-docs
+	// is not inferable so we supply "docs".
+	reader := &scriptedReader{answers: []string{"api", "", "", "docs"}}
+
+	output, err := runInitCmd(t, configPath, reader)
+	require.NoError(t, err, output)
+
+	// First prompt is always component name.
+	require.NotEmpty(t, reader.calls)
+	assert.Contains(t, reader.calls[0].msg, "service")
+
+	patched, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	body := string(patched)
+	assert.Contains(t, body, "--environment-name=staging")
+	assert.Contains(t, body, "--environment-name=production")
+	assert.Contains(t, body, "--environment-name=docs")
+}

--- a/cmd/deploy/init_test.go
+++ b/cmd/deploy/init_test.go
@@ -88,6 +88,8 @@ func TestInit_HappyPath(t *testing.T) {
 	assert.Contains(t, output, "deploy-prod")
 	assert.Contains(t, output, "Updated")
 	assert.Contains(t, output, "https://app.circleci.com/deploys")
+	assert.Contains(t, output, "https://circleci.com/docs/guides/deploy/configure-deploy-markers/",
+		"output should link to the deploy markers docs for users who want more than log-only setup")
 	assert.NotContains(t, output, "git commit -m \"Wire up CircleCI deploy markers\" && git push",
 		"output should not chain commit and push on one line")
 
@@ -109,6 +111,8 @@ func TestInit_NoDeployJobsExitsCleanly(t *testing.T) {
 	require.NoError(t, err, output)
 
 	assert.Contains(t, output, "No deploy jobs detected")
+	assert.Contains(t, output, "https://circleci.com/docs/guides/deploy/configure-deploy-markers/",
+		"no-deploy-jobs path should still point users at the docs")
 	// The config file must be untouched when nothing matched.
 	after, err := os.ReadFile(configPath)
 	require.NoError(t, err)
@@ -127,6 +131,8 @@ func TestInit_IdempotentOnAlreadyInstrumentedConfig(t *testing.T) {
 	require.NoError(t, err, output)
 
 	assert.Contains(t, output, "already instrumented")
+	assert.Contains(t, output, "https://circleci.com/docs/guides/deploy/configure-deploy-markers/",
+		"already-instrumented path should still point users at the docs")
 	after, err := os.ReadFile(configPath)
 	require.NoError(t, err)
 	assert.Equal(t, string(original), string(after), "config should not be rewritten when everything is already instrumented")

--- a/cmd/deploy/patch.go
+++ b/cmd/deploy/patch.go
@@ -1,0 +1,167 @@
+package deploy
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// MarkerStep describes the deploy marker step we want to add to a single job.
+type MarkerStep struct {
+	JobName         string
+	ComponentName   string
+	EnvironmentName string
+}
+
+// PatchResult summarises what PatchConfig did so the caller can report
+// useful feedback to the user.
+type PatchResult struct {
+	// Modified lists the names of jobs that had a new deploy marker step
+	// appended to them in this invocation.
+	Modified []string
+	// Skipped lists jobs that were already instrumented and therefore
+	// left untouched.
+	Skipped []string
+}
+
+// ReadConfig reads the config file at path and parses it into a YAML
+// Document node that preserves formatting, comments and ordering for a
+// subsequent round-trip.
+func ReadConfig(path string) ([]byte, *yaml.Node, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("reading %s: %w", path, err)
+	}
+	var root yaml.Node
+	if err := yaml.Unmarshal(data, &root); err != nil {
+		return nil, nil, fmt.Errorf("parsing %s: %w", path, err)
+	}
+	return data, &root, nil
+}
+
+// WriteConfig marshals the document node back to YAML and writes it to
+// path. It uses two-space indentation to match the style used across
+// CircleCI config examples.
+func WriteConfig(path string, root *yaml.Node) error {
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(root); err != nil {
+		return fmt.Errorf("encoding config: %w", err)
+	}
+	if err := enc.Close(); err != nil {
+		return fmt.Errorf("closing encoder: %w", err)
+	}
+	if err := os.WriteFile(path, buf.Bytes(), 0o644); err != nil {
+		return fmt.Errorf("writing %s: %w", path, err)
+	}
+	return nil
+}
+
+// PatchConfig mutates root so that each requested job gains a new step
+// that records a deploy marker. Jobs that already contain such a step
+// are left untouched so the command is safely re-runnable.
+func PatchConfig(root *yaml.Node, steps []MarkerStep) (PatchResult, error) {
+	jobsNode := findJobsNode(root)
+	if jobsNode == nil {
+		return PatchResult{}, fmt.Errorf("config has no top-level `jobs:` section")
+	}
+
+	var result PatchResult
+	for _, step := range steps {
+		jobNode := findChild(jobsNode, step.JobName)
+		if jobNode == nil {
+			return result, fmt.Errorf("job %q not found in config", step.JobName)
+		}
+		if jobAlreadyInstrumented(jobNode) {
+			result.Skipped = append(result.Skipped, step.JobName)
+			continue
+		}
+		if err := appendMarkerStep(jobNode, step); err != nil {
+			return result, fmt.Errorf("patching job %q: %w", step.JobName, err)
+		}
+		result.Modified = append(result.Modified, step.JobName)
+	}
+	return result, nil
+}
+
+// appendMarkerStep adds a single `run` step to the `steps:` sequence of
+// the supplied job. If the job has no `steps:` key the function returns
+// an error rather than guessing where to insert one, since a job
+// without steps is almost certainly a config error the user should see.
+func appendMarkerStep(jobNode *yaml.Node, step MarkerStep) error {
+	if jobNode.Kind != yaml.MappingNode {
+		return fmt.Errorf("expected mapping node for job")
+	}
+	stepsNode := findChild(jobNode, "steps")
+	if stepsNode == nil {
+		return fmt.Errorf("job has no `steps:` section")
+	}
+	if stepsNode.Kind != yaml.SequenceNode {
+		return fmt.Errorf("job `steps:` is not a sequence")
+	}
+
+	stepsNode.Content = append(stepsNode.Content, newMarkerStepNode(step))
+	return nil
+}
+
+// newMarkerStepNode constructs the YAML node tree representing a single
+// `run` step that invokes `circleci run release log`. Using an explicit
+// mapping (rather than parsing a template string) lets us control
+// indentation and style without relying on round-trip quirks.
+//
+// The generated step looks like:
+//
+//   - run:
+//     name: Log deploy marker
+//     command: |
+//     circleci run release log \
+//     --component-name=<name> \
+//     --environment-name=<env> \
+//     --target-version=$CIRCLE_SHA1
+func newMarkerStepNode(step MarkerStep) *yaml.Node {
+	commandLiteral := fmt.Sprintf(
+		"circleci run release log \\\n  --component-name=%s \\\n  --environment-name=%s \\\n  --target-version=$CIRCLE_SHA1\n",
+		step.ComponentName,
+		step.EnvironmentName,
+	)
+
+	runMapping := &yaml.Node{
+		Kind: yaml.MappingNode,
+		Tag:  "!!map",
+		Content: []*yaml.Node{
+			scalar("name"),
+			scalar("Log deploy marker"),
+			scalar("command"),
+			literalBlock(commandLiteral),
+		},
+	}
+
+	return &yaml.Node{
+		Kind: yaml.MappingNode,
+		Tag:  "!!map",
+		Content: []*yaml.Node{
+			scalar("run"),
+			runMapping,
+		},
+	}
+}
+
+func scalar(value string) *yaml.Node {
+	return &yaml.Node{
+		Kind:  yaml.ScalarNode,
+		Tag:   "!!str",
+		Value: value,
+	}
+}
+
+func literalBlock(value string) *yaml.Node {
+	return &yaml.Node{
+		Kind:  yaml.ScalarNode,
+		Tag:   "!!str",
+		Style: yaml.LiteralStyle,
+		Value: value,
+	}
+}

--- a/cmd/deploy/patch_test.go
+++ b/cmd/deploy/patch_test.go
@@ -1,0 +1,113 @@
+package deploy
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// copyFixture copies a file from testdata/ into a fresh temp file so the
+// test can safely write to it. Returns the path to the copy.
+func copyFixture(t *testing.T, fixture string) string {
+	t.Helper()
+	src, err := os.ReadFile(filepath.Join("testdata", fixture))
+	require.NoError(t, err)
+	dir := t.TempDir()
+	dst := filepath.Join(dir, "config.yml")
+	require.NoError(t, os.WriteFile(dst, src, 0o644))
+	return dst
+}
+
+func TestPatchConfig_AddsMarkerStep(t *testing.T) {
+	path := copyFixture(t, "simple-deploy.yml")
+	_, root, err := ReadConfig(path)
+	require.NoError(t, err)
+
+	result, err := PatchConfig(root, []MarkerStep{{
+		JobName:         "deploy-prod",
+		ComponentName:   "api",
+		EnvironmentName: "production",
+	}})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"deploy-prod"}, result.Modified)
+	assert.Empty(t, result.Skipped)
+
+	require.NoError(t, WriteConfig(path, root))
+
+	written, err := os.ReadFile(path)
+	require.NoError(t, err)
+	out := string(written)
+	assert.Contains(t, out, "circleci run release log")
+	assert.Contains(t, out, "--component-name=api")
+	assert.Contains(t, out, "--environment-name=production")
+	assert.Contains(t, out, "--target-version=$CIRCLE_SHA1")
+}
+
+func TestPatchConfig_IsIdempotent(t *testing.T) {
+	path := copyFixture(t, "already-instrumented.yml")
+	_, root, err := ReadConfig(path)
+	require.NoError(t, err)
+
+	result, err := PatchConfig(root, []MarkerStep{{
+		JobName:         "deploy-prod",
+		ComponentName:   "api",
+		EnvironmentName: "production",
+	}})
+	require.NoError(t, err)
+	assert.Empty(t, result.Modified)
+	assert.Equal(t, []string{"deploy-prod"}, result.Skipped)
+}
+
+func TestPatchConfig_AppliedTwiceDoesNotDuplicate(t *testing.T) {
+	path := copyFixture(t, "simple-deploy.yml")
+	_, root, err := ReadConfig(path)
+	require.NoError(t, err)
+
+	step := MarkerStep{JobName: "deploy-prod", ComponentName: "api", EnvironmentName: "production"}
+	_, err = PatchConfig(root, []MarkerStep{step})
+	require.NoError(t, err)
+	require.NoError(t, WriteConfig(path, root))
+
+	_, root2, err := ReadConfig(path)
+	require.NoError(t, err)
+	result, err := PatchConfig(root2, []MarkerStep{step})
+	require.NoError(t, err)
+	assert.Empty(t, result.Modified, "second patch should modify nothing")
+	assert.Equal(t, []string{"deploy-prod"}, result.Skipped)
+}
+
+func TestPatchConfig_UnknownJobReturnsError(t *testing.T) {
+	path := copyFixture(t, "simple-deploy.yml")
+	_, root, err := ReadConfig(path)
+	require.NoError(t, err)
+
+	_, err = PatchConfig(root, []MarkerStep{{
+		JobName:         "does-not-exist",
+		ComponentName:   "api",
+		EnvironmentName: "production",
+	}})
+	assert.Error(t, err)
+}
+
+func TestPatchConfig_MultipleJobsAreIndependent(t *testing.T) {
+	path := copyFixture(t, "multiple-deploys.yml")
+	_, root, err := ReadConfig(path)
+	require.NoError(t, err)
+
+	result, err := PatchConfig(root, []MarkerStep{
+		{JobName: "deploy-staging", ComponentName: "api", EnvironmentName: "staging"},
+		{JobName: "deploy-prod", ComponentName: "api", EnvironmentName: "production"},
+	})
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"deploy-staging", "deploy-prod"}, result.Modified)
+
+	require.NoError(t, WriteConfig(path, root))
+	written, err := os.ReadFile(path)
+	require.NoError(t, err)
+	out := string(written)
+	assert.Contains(t, out, "--environment-name=staging")
+	assert.Contains(t, out, "--environment-name=production")
+}

--- a/cmd/deploy/testdata/already-instrumented.yml
+++ b/cmd/deploy/testdata/already-instrumented.yml
@@ -1,0 +1,16 @@
+version: 2.1
+
+jobs:
+  deploy-prod:
+    docker:
+      - image: cimg/base:current
+    steps:
+      - checkout
+      - run: ./deploy.sh
+      - run:
+          name: Log deploy marker
+          command: |
+            circleci run release log \
+              --component-name=api \
+              --environment-name=production \
+              --target-version=$CIRCLE_SHA1

--- a/cmd/deploy/testdata/multiple-deploys.yml
+++ b/cmd/deploy/testdata/multiple-deploys.yml
@@ -1,0 +1,28 @@
+version: 2.1
+
+jobs:
+  build:
+    docker:
+      - image: cimg/base:current
+    steps:
+      - checkout
+
+  deploy-staging:
+    docker:
+      - image: cimg/base:current
+    steps:
+      - checkout
+      - run: ./deploy-staging.sh
+
+  deploy-prod:
+    docker:
+      - image: cimg/base:current
+    steps:
+      - checkout
+      - run: ./deploy-prod.sh
+
+  release-docs:
+    docker:
+      - image: cimg/base:current
+    steps:
+      - run: ./publish-docs.sh

--- a/cmd/deploy/testdata/no-deploy-jobs.yml
+++ b/cmd/deploy/testdata/no-deploy-jobs.yml
@@ -1,0 +1,16 @@
+version: 2.1
+
+jobs:
+  build:
+    docker:
+      - image: cimg/base:current
+    steps:
+      - checkout
+      - run: echo "build"
+
+  test:
+    docker:
+      - image: cimg/base:current
+    steps:
+      - checkout
+      - run: make test

--- a/cmd/deploy/testdata/simple-deploy.yml
+++ b/cmd/deploy/testdata/simple-deploy.yml
@@ -1,0 +1,24 @@
+version: 2.1
+
+jobs:
+  build:
+    docker:
+      - image: cimg/base:current
+    steps:
+      - checkout
+      - run: echo "build"
+
+  deploy-prod:
+    docker:
+      - image: cimg/base:current
+    steps:
+      - checkout
+      - run: ./deploy.sh
+
+workflows:
+  main:
+    jobs:
+      - build
+      - deploy-prod:
+          requires:
+            - build

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/CircleCI-Public/circleci-cli/api/header"
+	"github.com/CircleCI-Public/circleci-cli/cmd/deploy"
 	"github.com/CircleCI-Public/circleci-cli/cmd/info"
 	"github.com/CircleCI-Public/circleci-cli/cmd/pipeline"
 	"github.com/CircleCI-Public/circleci-cli/cmd/policy"
@@ -179,6 +180,7 @@ func MakeCommands() *cobra.Command {
 	rootCmd.AddCommand(newDiagnosticCommand(rootOptions))
 	rootCmd.AddCommand(newSetupCommand(rootOptions))
 	rootCmd.AddCommand(newInitCommand(rootOptions))
+	rootCmd.AddCommand(deploy.NewDeployCommand(rootOptions))
 
 	rootCmd.AddCommand(followProjectCommand(rootOptions))
 	rootCmd.AddCommand(policy.NewCommand(rootOptions, validator))

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -16,7 +16,7 @@ var _ = Describe("Root", func() {
 	Describe("subcommands", func() {
 		It("can create commands", func() {
 			commands := cmd.MakeCommands()
-			Expect(len(commands.Commands())).To(Equal(29))
+			Expect(len(commands.Commands())).To(Equal(30))
 		})
 	})
 


### PR DESCRIPTION
## Changes

- Add a new `cmd/deploy` package exposing a top-level `deploy` command group with an `init` subcommand.
- `deploy init` reads `.circleci/config.yml`, detects jobs whose names contain deploy-related keywords (`deploy`, `release`, `publish`, `ship`), prompts for a component name (defaulting to the inferred repo name) and an environment name (inferred from the job name when possible), and appends a `circleci run release log` step to each detected job.
- Register the new command group in `cmd/root.go`.
- Bump the expected top-level subcommand count in `cmd/root_test.go` from 29 to 30.
- Add unit tests and YAML fixtures covering detection, patching, idempotency, the no-deploy-jobs path, and the full interactive flow (via an injected `UserInputReader`).

## Rationale

Setting up deploy markers today requires reading docs, understanding the `circleci run release` CLI syntax, and hand-editing `config.yml`. This PR ships the zero-to-one experience described in [DR-342](https://linear.app/circleci/issue/DR-342/circleci-deploy-init-zero-to-one-deploy-marker-setup-command): an engineer runs one command from their repo, answers at most two questions per detected job, and their config is wired up for deploy markers.

Design principles (from the ticket):

- Two questions maximum per job; infer when possible.
- Never fails the engineer's pipeline — missing config, no deploy jobs, or an already-instrumented config all exit cleanly.
- Idempotent — re-running the command leaves an already-instrumented config untouched.
- Works offline — no API calls during setup, just local file parsing.
- Never commits or pushes on the user's behalf. The command prints a `git diff` / `git commit` / `git push` checklist and stops.

## Considerations

### Dashboard URL

The output prints the base dashboard URL `https://app.circleci.com/deploys`. Building an org-scoped URL reliably would require either a network round-trip to `/me/collaborations` or parsing `CIRCLE_BUILD_URL` (not available on a developer's laptop). Neither fits the "works offline" design principle, so the base URL is printed and WUC redirects the user to their most recently viewed org on arrival.

### YAML round-trip

Patching uses `gopkg.in/yaml.v3`'s node API, which preserves comments and relative ordering. It does not preserve blank lines between top-level keys — a known `yaml.v3` limitation. In practice this means a reformatted but semantically identical config; the step we add is always well-formed.

### Job detection heuristics

The keyword list (`deploy`, `release`, `publish`, `ship`) is intentionally conservative. Jobs with non-obvious names (e.g. `production-push`) won't be detected; the no-deploy-jobs branch prints a ready-to-paste snippet so users can wire those up by hand.

### Prompts

Follows the same `UserInputReader` pattern used by `cmd/pipeline`, so tests can run the whole flow without a TTY. The public `CustomReader` option lets future integration tests (or embedders) override the reader.

## Testing

- `go test ./cmd/deploy/...` — 13 new tests covering detection, patching (including idempotency), and the full init flow via scripted prompts.
- `go test ./cmd/...` — existing suites still pass; `cmd/root_test.go` updated for the new subcommand count.
- `go build ./...` and `go vet ./...` clean.
- Manual smoke tests against all three branches (no deploy jobs / already instrumented / happy path).

## Related

- Linear: [DR-342](https://linear.app/circleci/issue/DR-342/circleci-deploy-init-zero-to-one-deploy-marker-setup-command)
- Complements DR-341 (rich terminal output from `run release` commands in `task-agent-subcommand-release`), which prints a matching dashboard link from inside CI jobs.

## Checklist

- [x] Self-review of the diff
- [x] Comments on non-obvious intent (YAML node construction, idempotency, URL trade-off)
- [x] Checked for similar issues / prior work
- [x] Not a security issue
- [x] Read the Contributing guidelines
