### PR TITLE
Add standard flag approaches throughout

### DIFF
--- a/internal/cmd/api/api.go
+++ b/internal/cmd/api/api.go
@@ -191,9 +191,7 @@ func run(ctx context.Context, client *apiclient.Client, path, method string, fie
 	if jsonOut {
 		var v any
 		if jsonErr := json.Unmarshal(respBody, &v); jsonErr == nil {
-			enc := json.NewEncoder(iostream.Out(ctx))
-			enc.SetIndent("", "  ")
-			_ = enc.Encode(v)
+			_ = cmdutil.WriteJSON(iostream.Out(ctx), v)
 		} else {
 			iostream.Println(ctx, output)
 		}

--- a/internal/cmd/artifacts/artifacts.go
+++ b/internal/cmd/artifacts/artifacts.go
@@ -25,7 +25,6 @@ package artifacts
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/MakeNowJust/heredoc"
@@ -117,7 +116,7 @@ func run(ctx context.Context, client *apiclient.Client, args []string, jobNumber
 		if projectSlug == "" {
 			info, err := gitremote.Detect()
 			if err != nil {
-				return gitDetectErr(err)
+				return cmdutil.GitDetectErr(err, "Or provide a pipeline UUID: circleci artifacts <id>")
 			}
 			projectSlug = info.Slug
 		}
@@ -140,7 +139,7 @@ func run(ctx context.Context, client *apiclient.Client, args []string, jobNumber
 		// Infer pipeline from git context
 		info, err := gitremote.Detect()
 		if err != nil {
-			return gitDetectErr(err)
+			return cmdutil.GitDetectErr(err, "Or provide a pipeline UUID: circleci artifacts <id>")
 		}
 		effectiveBranch := branch
 		if effectiveBranch == "" {
@@ -178,9 +177,7 @@ func run(ctx context.Context, client *apiclient.Client, args []string, jobNumber
 	}
 
 	if jsonOut {
-		enc := json.NewEncoder(iostream.Out(ctx))
-		enc.SetIndent("", "  ")
-		return enc.Encode(entries)
+		return cmdutil.WriteJSON(iostream.Out(ctx), entries)
 	}
 
 	printArtifacts(ctx, entries)
@@ -209,15 +206,6 @@ func printArtifacts(ctx context.Context, entries []artifacts.Entry) {
 			iostream.Println(ctx, e.Path)
 		}
 	}
-}
-
-func gitDetectErr(err error) *clierrors.CLIError {
-	return clierrors.New("git.detect_failed", "Could not detect project from git", err.Error()).
-		WithSuggestions(
-			"Run from inside a git repository with a GitHub, Bitbucket, or GitLab remote",
-			"Or provide a pipeline UUID: circleci artifacts <id>",
-		).
-		WithExitCode(clierrors.ExitBadArguments)
 }
 
 func apiErr(err error, subject string) *clierrors.CLIError {

--- a/internal/cmd/job/artifacts.go
+++ b/internal/cmd/job/artifacts.go
@@ -24,7 +24,6 @@ package job
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -110,12 +109,7 @@ func runJobArtifacts(ctx context.Context, client *apiclient.Client, jobNumber in
 	if projectSlug == "" {
 		info, err := gitremote.Detect()
 		if err != nil {
-			return clierrors.New("git.detect_failed", "Could not detect project from git", err.Error()).
-				WithSuggestions(
-					"Run from inside a git repository with a GitHub, Bitbucket, or GitLab remote",
-					"Or specify the project: circleci job artifacts <number> --project gh/org/repo",
-				).
-				WithExitCode(clierrors.ExitBadArguments)
+			return cmdutil.GitDetectErr(err, "Or specify the project: circleci job artifacts <number> --project gh/org/repo")
 		}
 		projectSlug = info.Slug
 	}
@@ -147,9 +141,7 @@ func runJobArtifacts(ctx context.Context, client *apiclient.Client, jobNumber in
 	}
 
 	if jsonOut {
-		enc := json.NewEncoder(iostream.Out(ctx))
-		enc.SetIndent("", "  ")
-		return enc.Encode(entries)
+		return cmdutil.WriteJSON(iostream.Out(ctx), entries)
 	}
 
 	for _, e := range entries {

--- a/internal/cmd/job/logs.go
+++ b/internal/cmd/job/logs.go
@@ -24,7 +24,6 @@ package job
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 
@@ -106,12 +105,7 @@ func runJobLogs(ctx context.Context, client *apiclient.Client, jobNumber int64, 
 	if projectSlug == "" {
 		info, err := gitremote.Detect()
 		if err != nil {
-			return clierrors.New("git.detect_failed", "Could not detect project from git", err.Error()).
-				WithSuggestions(
-					"Run from inside a git repository with a GitHub, Bitbucket, or GitLab remote",
-					"Or specify the project: circleci job logs <number> --project gh/org/repo",
-				).
-				WithExitCode(clierrors.ExitBadArguments)
+			return cmdutil.GitDetectErr(err, "Or specify the project: circleci job logs <number> --project gh/org/repo")
 		}
 		projectSlug = info.Slug
 	}
@@ -137,9 +131,7 @@ func runJobLogs(ctx context.Context, client *apiclient.Client, jobNumber int64, 
 	}
 
 	if jsonOut {
-		enc := json.NewEncoder(iostream.Out(ctx))
-		enc.SetIndent("", "  ")
-		return enc.Encode(stepLogs)
+		return cmdutil.WriteJSON(iostream.Out(ctx), stepLogs)
 	}
 
 	for i, sl := range stepLogs {

--- a/internal/cmd/logs/logs.go
+++ b/internal/cmd/logs/logs.go
@@ -25,7 +25,6 @@ package logs
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -149,7 +148,7 @@ func run(ctx context.Context, client *apiclient.Client, args []string, lastFaile
 		if projectSlug == "" {
 			info, err := gitremote.Detect()
 			if err != nil {
-				return gitDetectErr(err)
+				return cmdutil.GitDetectErr(err, "Or specify the project with --project gh/org/repo")
 			}
 			projectSlug = info.Slug
 		}
@@ -159,7 +158,7 @@ func run(ctx context.Context, client *apiclient.Client, args []string, lastFaile
 		if projectSlug == "" || effectiveBranch == "" {
 			info, gitErr := gitremote.Detect()
 			if gitErr != nil {
-				return gitDetectErr(gitErr)
+				return cmdutil.GitDetectErr(gitErr, "Or specify the project with --project gh/org/repo")
 			}
 			if projectSlug == "" {
 				projectSlug = info.Slug
@@ -214,22 +213,11 @@ func run(ctx context.Context, client *apiclient.Client, args []string, lastFaile
 	}
 
 	if jsonOut {
-		enc := json.NewEncoder(iostream.Out(ctx))
-		enc.SetIndent("", "  ")
-		return enc.Encode(stepLogs)
+		return cmdutil.WriteJSON(iostream.Out(ctx), stepLogs)
 	}
 
 	printLogs(ctx, stepLogs)
 	return nil
-}
-
-func gitDetectErr(err error) *clierrors.CLIError {
-	return clierrors.New("git.detect_failed", "Could not detect project from git", err.Error()).
-		WithSuggestions(
-			"Run from inside a git repository with a GitHub, Bitbucket, or GitLab remote",
-			"Or specify the project with --project gh/org/repo",
-		).
-		WithExitCode(clierrors.ExitBadArguments)
 }
 
 func apiErr(err error, subject string) *clierrors.CLIError {

--- a/internal/cmd/pipeline/cancel.go
+++ b/internal/cmd/pipeline/cancel.go
@@ -97,12 +97,7 @@ func runPipelineCancel(ctx context.Context, client *apiclient.Client, arg, proje
 		if projectSlug == "" {
 			info, err := gitremote.Detect()
 			if err != nil {
-				return clierrors.New("git.detect_failed", "Could not detect project from git", err.Error()).
-					WithSuggestions(
-						"Run from inside a git repository with a GitHub, Bitbucket, or GitLab remote",
-						"Or specify the project: circleci pipeline cancel "+arg+" --project gh/org/repo",
-					).
-					WithExitCode(clierrors.ExitBadArguments)
+				return cmdutil.GitDetectErr(err, "Or specify the project: circleci pipeline cancel "+arg+" --project gh/org/repo")
 			}
 			projectSlug = info.Slug
 		}
@@ -114,20 +109,16 @@ func runPipelineCancel(ctx context.Context, client *apiclient.Client, arg, proje
 		displayName = fmt.Sprintf("#%d", p.Number)
 	}
 
-	if !force {
-		if iostream.IsInteractive(ctx) {
-			prompt := fmt.Sprintf("Cancel pipeline %s? In-progress jobs will be stopped.", displayName)
-			if !iostream.Confirm(ctx, prompt) {
-				return clierrors.New("pipeline.cancel_aborted", "Cancellation aborted",
-					"Pipeline cancellation was not confirmed.").
-					WithExitCode(clierrors.ExitCancelled)
-			}
-		} else {
-			return clierrors.New("pipeline.cancel_requires_force", "Cancellation requires --force",
-				fmt.Sprintf("Cancelling pipeline %s will stop all in-progress jobs.", displayName)).
-				WithSuggestions("Pass --force (-f) to confirm cancellation in non-interactive mode").
-				WithExitCode(clierrors.ExitCancelled)
-		}
+	if err := cmdutil.ConfirmOrForce(ctx, iostream.Get(ctx), force,
+		fmt.Sprintf("Cancel pipeline %s? In-progress jobs will be stopped.", displayName),
+		clierrors.New("pipeline.cancel_aborted", "Cancellation aborted",
+			"Pipeline cancellation was not confirmed.").
+			WithExitCode(clierrors.ExitCancelled),
+		clierrors.New("pipeline.cancel_requires_force", "Cancellation requires --force",
+			fmt.Sprintf("Cancelling pipeline %s will stop all in-progress jobs.", displayName)).
+			WithExitCode(clierrors.ExitCancelled),
+	); err != nil {
+		return err
 	}
 
 	if err := pipeline.Cancel(ctx, client, pipelineID); err != nil {

--- a/internal/cmd/pipeline/get.go
+++ b/internal/cmd/pipeline/get.go
@@ -24,7 +24,6 @@ package pipeline
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -34,7 +33,6 @@ import (
 
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/apiclient"
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/cmdutil"
-	clierrors "github.com/CircleCI-Public/circleci-cli-v2/internal/errors"
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/gitremote"
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/iostream"
 )
@@ -147,13 +145,7 @@ func runGet(ctx context.Context, client *apiclient.Client, args []string, projec
 			if projectSlug == "" {
 				info, err := gitremote.Detect()
 				if err != nil {
-					return clierrors.New("git.detect_failed", "Could not detect project from git",
-						err.Error()).
-						WithSuggestions(
-							"Run from inside a git repository with a GitHub, Bitbucket, or GitLab remote",
-							"Or specify the project: circleci pipeline get "+arg+" --project gh/org/repo",
-						).
-						WithExitCode(clierrors.ExitBadArguments)
+					return cmdutil.GitDetectErr(err, "Or specify the project: circleci pipeline get "+arg+" --project gh/org/repo")
 				}
 				projectSlug = info.Slug
 			}
@@ -172,13 +164,7 @@ func runGet(ctx context.Context, client *apiclient.Client, args []string, projec
 		// No arg: infer from git context.
 		info, err := gitremote.Detect()
 		if err != nil {
-			return clierrors.New("git.detect_failed", "Could not detect project from git",
-				err.Error()).
-				WithSuggestions(
-					"Run from inside a git repository with a GitHub remote",
-					"Or provide a pipeline number or UUID: circleci pipeline get <number>",
-				).
-				WithExitCode(clierrors.ExitBadArguments)
+			return cmdutil.GitDetectErr(err, "Or provide a pipeline number or UUID: circleci pipeline get <number>")
 		}
 
 		effectiveBranch := branch
@@ -211,9 +197,7 @@ func runGet(ctx context.Context, client *apiclient.Client, args []string, projec
 	out := buildOutput(pipeline, workflows, wfJobs)
 
 	if jsonOut {
-		enc := json.NewEncoder(iostream.Out(ctx))
-		enc.SetIndent("", "  ")
-		return enc.Encode(out)
+		return cmdutil.WriteJSON(iostream.Out(ctx), out)
 	}
 
 	printPipeline(ctx, out)

--- a/internal/cmd/pipeline/list.go
+++ b/internal/cmd/pipeline/list.go
@@ -24,14 +24,12 @@ package pipeline
 
 import (
 	"context"
-	"encoding/json"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
 
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/apiclient"
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/cmdutil"
-	clierrors "github.com/CircleCI-Public/circleci-cli-v2/internal/errors"
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/gitremote"
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/iostream"
 )
@@ -111,13 +109,7 @@ func runList(ctx context.Context, client *apiclient.Client, projectSlug, branch 
 	if projectSlug == "" {
 		info, err := gitremote.Detect()
 		if err != nil {
-			return clierrors.New("git.detect_failed", "Could not detect project from git",
-				err.Error()).
-				WithSuggestions(
-					"Run from inside a git repository with a GitHub, Bitbucket, or GitLab remote",
-					"Or specify the project: circleci pipeline list --project gh/org/repo",
-				).
-				WithExitCode(clierrors.ExitBadArguments)
+			return cmdutil.GitDetectErr(err, "Or specify the project: circleci pipeline list --project gh/org/repo")
 		}
 		projectSlug = info.Slug
 	}
@@ -133,9 +125,7 @@ func runList(ctx context.Context, client *apiclient.Client, projectSlug, branch 
 	}
 
 	if jsonOut {
-		enc := json.NewEncoder(iostream.Out(ctx))
-		enc.SetIndent("", "  ")
-		return enc.Encode(entries)
+		return cmdutil.WriteJSON(iostream.Out(ctx), entries)
 	}
 
 	if len(pipelines) == 0 {

--- a/internal/cmd/pipeline/trigger.go
+++ b/internal/cmd/pipeline/trigger.go
@@ -24,7 +24,6 @@ package pipeline
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -105,13 +104,7 @@ func runTrigger(ctx context.Context, client *apiclient.Client, projectSlug, bran
 	if projectSlug == "" || effectiveBranch == "" {
 		info, err := gitremote.Detect()
 		if err != nil {
-			return clierrors.New("git.detect_failed", "Could not detect project from git",
-				err.Error()).
-				WithSuggestions(
-					"Run from inside a git repository with a GitHub, Bitbucket, or GitLab remote",
-					"Or specify the project and branch explicitly",
-				).
-				WithExitCode(clierrors.ExitBadArguments)
+			return cmdutil.GitDetectErr(err, "Or specify the project and branch explicitly")
 		}
 		if projectSlug == "" {
 			projectSlug = info.Slug
@@ -141,9 +134,7 @@ func runTrigger(ctx context.Context, client *apiclient.Client, projectSlug, bran
 			State:     resp.State,
 			CreatedAt: resp.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
 		}
-		enc := json.NewEncoder(iostream.Out(ctx))
-		enc.SetIndent("", "  ")
-		return enc.Encode(out)
+		return cmdutil.WriteJSON(iostream.Out(ctx), out)
 	}
 
 	iostream.Printf(ctx, "Triggered pipeline #%d (%s) on %s\n", resp.Number, resp.ID, effectiveBranch)

--- a/internal/cmd/pipeline/watch.go
+++ b/internal/cmd/pipeline/watch.go
@@ -128,12 +128,7 @@ func runWatch(ctx context.Context, client *apiclient.Client, args []string, proj
 	if needsGit {
 		info, err := gitremote.Detect()
 		if err != nil {
-			return clierrors.New("git.detect_failed", "Could not detect project from git", err.Error()).
-				WithSuggestions(
-					"Run from inside a git repository with a GitHub, Bitbucket, or GitLab remote",
-					"Or specify --project and --branch explicitly",
-				).
-				WithExitCode(clierrors.ExitBadArguments)
+			return cmdutil.GitDetectErr(err, "Or specify --project and --branch explicitly")
 		}
 		if projectSlug == "" {
 			projectSlug = info.Slug

--- a/internal/cmd/project/env.go
+++ b/internal/cmd/project/env.go
@@ -24,7 +24,6 @@ package project
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
@@ -117,7 +116,7 @@ func RunEnvList(ctx context.Context, client *apiclient.Client, projectSlug strin
 	if projectSlug == "" {
 		info, err := gitremote.Detect()
 		if err != nil {
-			return gitDetectErr(err, "list")
+			return cmdutil.GitDetectErr(err, "Or specify the project: circleci envvar list --project gh/org/repo")
 		}
 		projectSlug = info.Slug
 	}
@@ -133,9 +132,7 @@ func RunEnvList(ctx context.Context, client *apiclient.Client, projectSlug strin
 	}
 
 	if jsonOut {
-		enc := json.NewEncoder(iostream.Out(ctx))
-		enc.SetIndent("", "  ")
-		return enc.Encode(vars)
+		return cmdutil.WriteJSON(iostream.Out(ctx), vars)
 	}
 
 	if len(vars) == 0 {
@@ -226,7 +223,7 @@ func RunEnvSet(ctx context.Context, client *apiclient.Client, projectSlug, name,
 	if projectSlug == "" {
 		info, err := gitremote.Detect()
 		if err != nil {
-			return gitDetectErr(err, "set")
+			return cmdutil.GitDetectErr(err, "Or specify the project: circleci envvar set --project gh/org/repo")
 		}
 		projectSlug = info.Slug
 	}
@@ -296,26 +293,22 @@ func NewEnvDeleteCmd() *cobra.Command {
 
 // RunEnvDelete is the business logic for deleting an env var.
 func RunEnvDelete(ctx context.Context, client *apiclient.Client, projectSlug, name string, force bool) error {
-	if !force {
-		if iostream.IsInteractive(ctx) {
-			prompt := fmt.Sprintf("Delete environment variable %q? This cannot be undone.", name)
-			if !iostream.Confirm(ctx, prompt) {
-				return clierrors.New("envvar.delete_aborted", "Deletion aborted",
-					"Environment variable deletion was not confirmed.").
-					WithExitCode(clierrors.ExitCancelled)
-			}
-		} else {
-			return clierrors.New("envvar.delete_requires_force", "Deletion requires --force",
-				fmt.Sprintf("Deleting environment variable %q is irreversible.", name)).
-				WithSuggestions("Pass --force (-f) to confirm deletion in non-interactive mode").
-				WithExitCode(clierrors.ExitCancelled)
-		}
+	if err := cmdutil.ConfirmOrForce(ctx, iostream.Get(ctx), force,
+		fmt.Sprintf("Delete environment variable %q? This cannot be undone.", name),
+		clierrors.New("envvar.delete_aborted", "Deletion aborted",
+			"Environment variable deletion was not confirmed.").
+			WithExitCode(clierrors.ExitCancelled),
+		clierrors.New("envvar.delete_requires_force", "Deletion requires --force",
+			fmt.Sprintf("Deleting environment variable %q is irreversible.", name)).
+			WithExitCode(clierrors.ExitCancelled),
+	); err != nil {
+		return err
 	}
 
 	if projectSlug == "" {
 		info, err := gitremote.Detect()
 		if err != nil {
-			return gitDetectErr(err, "delete")
+			return cmdutil.GitDetectErr(err, "Or specify the project: circleci envvar delete --project gh/org/repo")
 		}
 		projectSlug = info.Slug
 	}
@@ -331,13 +324,4 @@ func RunEnvDelete(ctx context.Context, client *apiclient.Client, projectSlug, na
 
 	iostream.Printf(ctx, "%s Deleted %s\n", iostream.Symbol(ctx, "✓", "OK:"), name)
 	return nil
-}
-
-func gitDetectErr(err error, subcmd string) *clierrors.CLIError {
-	return clierrors.New("git.detect_failed", "Could not detect project from git", err.Error()).
-		WithSuggestions(
-			"Run from inside a git repository with a GitHub, Bitbucket, or GitLab remote",
-			fmt.Sprintf("Or specify the project: circleci envvar %s --project gh/org/repo", subcmd),
-		).
-		WithExitCode(clierrors.ExitBadArguments)
 }

--- a/internal/cmd/project/follow.go
+++ b/internal/cmd/project/follow.go
@@ -83,12 +83,7 @@ func runProjectFollow(ctx context.Context, client *apiclient.Client, projectSlug
 	if projectSlug == "" {
 		info, err := gitremote.Detect()
 		if err != nil {
-			return clierrors.New("git.detect_failed", "Could not detect project from git", err.Error()).
-				WithSuggestions(
-					"Run from inside a git repository with a GitHub, Bitbucket, or GitLab remote",
-					"Or specify the project: circleci project follow --project gh/org/repo",
-				).
-				WithExitCode(clierrors.ExitBadArguments)
+			return cmdutil.GitDetectErr(err, "Or specify the project: circleci project follow --project gh/org/repo")
 		}
 		projectSlug = info.Slug
 	}

--- a/internal/cmd/project/list.go
+++ b/internal/cmd/project/list.go
@@ -24,7 +24,6 @@ package project
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -119,9 +118,7 @@ func runProjectList(ctx context.Context, client *apiclient.Client, jsonOut bool)
 	}
 
 	if jsonOut {
-		enc := json.NewEncoder(iostream.Out(ctx))
-		enc.SetIndent("", "  ")
-		return enc.Encode(out)
+		return cmdutil.WriteJSON(iostream.Out(ctx), out)
 	}
 
 	if len(out) == 0 {

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -38,6 +38,7 @@ import (
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/cmd/runner"
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/cmd/settings"
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/cmd/workflow"
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/cmdutil"
 )
 
 // NewRootCmd builds the root cobra command and wires all subcommands.
@@ -55,11 +56,18 @@ func NewRootCmd(version string) *cobra.Command {
 		`),
 		SilenceErrors: true, // main.go handles error printing
 		SilenceUsage:  true,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			configPath, _ := cmd.Flags().GetString("config")
+			ctx := cmdutil.WithConfigPath(cmd.Context(), configPath)
+			cmd.SetContext(ctx)
+			return nil
+		},
 	}
 
 	cmd.Version = version
 	cmd.SetVersionTemplate("circleci version {{.Version}}\n")
 
+	cmd.PersistentFlags().StringP("config", "c", "", "path to config file (default: ~/.config/circleci/config.yml)")
 	cmd.PersistentFlags().BoolP("quiet", "q", false, "suppress informational output; data on stdout is unaffected")
 	cmd.PersistentFlags().Bool("debug", false, "enable debug logging")
 

--- a/internal/cmd/root/testdata/usage/circleci.txt
+++ b/internal/cmd/root/testdata/usage/circleci.txt
@@ -16,7 +16,8 @@ Available Commands:
   workflow    Manage workflows
 
 Flags:
-      --debug   enable debug logging
-  -q, --quiet   suppress informational output; data on stdout is unaffected
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected
 
 Use "circleci [command] --help" for more information about a command.

--- a/internal/cmd/root/testdata/usage/circleci/api.txt
+++ b/internal/cmd/root/testdata/usage/circleci/api.txt
@@ -28,5 +28,6 @@ Flags:
   -X, --method string        HTTP method (default: GET, or POST when -f is used)
 
 Global Flags:
-      --debug   enable debug logging
-  -q, --quiet   suppress informational output; data on stdout is unaffected
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/artifacts.txt
+++ b/internal/cmd/root/testdata/usage/circleci/artifacts.txt
@@ -29,5 +29,6 @@ Flags:
       --project string    Project slug (e.g. gh/org/repo); used with --job, defaults to git remote
 
 Global Flags:
-      --debug   enable debug logging
-  -q, --quiet   suppress informational output; data on stdout is unaffected
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/auth.txt
+++ b/internal/cmd/root/testdata/usage/circleci/auth.txt
@@ -7,7 +7,8 @@ Available Commands:
   token       Set personal access token for authenticating to CircleCI
 
 Global Flags:
-      --debug   enable debug logging
-  -q, --quiet   suppress informational output; data on stdout is unaffected
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected
 
 Use "circleci auth [command] --help" for more information about a command.

--- a/internal/cmd/root/testdata/usage/circleci/auth/logout.txt
+++ b/internal/cmd/root/testdata/usage/circleci/auth/logout.txt
@@ -5,5 +5,6 @@ Flags:
       --json   Output as JSON
 
 Global Flags:
-      --debug   enable debug logging
-  -q, --quiet   suppress informational output; data on stdout is unaffected
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/auth/me.txt
+++ b/internal/cmd/root/testdata/usage/circleci/auth/me.txt
@@ -5,5 +5,6 @@ Flags:
       --json   Output as JSON
 
 Global Flags:
-      --debug   enable debug logging
-  -q, --quiet   suppress informational output; data on stdout is unaffected
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/auth/token.txt
+++ b/internal/cmd/root/testdata/usage/circleci/auth/token.txt
@@ -2,5 +2,6 @@ Usage:
   circleci auth token [flags]
 
 Global Flags:
-      --debug   enable debug logging
-  -q, --quiet   suppress informational output; data on stdout is unaffected
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/completion.txt
+++ b/internal/cmd/root/testdata/usage/circleci/completion.txt
@@ -6,7 +6,8 @@ Available Commands:
   uninstall   Remove shell completion from your shell profile
 
 Global Flags:
-      --debug   enable debug logging
-  -q, --quiet   suppress informational output; data on stdout is unaffected
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected
 
 Use "circleci completion [command] --help" for more information about a command.

--- a/internal/cmd/root/testdata/usage/circleci/completion/bash.txt
+++ b/internal/cmd/root/testdata/usage/circleci/completion/bash.txt
@@ -2,5 +2,6 @@ Usage:
   circleci completion bash [flags]
 
 Global Flags:
-      --debug   enable debug logging
-  -q, --quiet   suppress informational output; data on stdout is unaffected
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/completion/install.txt
+++ b/internal/cmd/root/testdata/usage/circleci/completion/install.txt
@@ -13,5 +13,6 @@ $ source <(circleci completion bash)
 
 
 Global Flags:
-      --debug   enable debug logging
-  -q, --quiet   suppress informational output; data on stdout is unaffected
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/completion/uninstall.txt
+++ b/internal/cmd/root/testdata/usage/circleci/completion/uninstall.txt
@@ -13,5 +13,6 @@ $ grep -l "circleci shell completion" ~/.zshrc ~/.bashrc 2>/dev/null
 
 
 Global Flags:
-      --debug   enable debug logging
-  -q, --quiet   suppress informational output; data on stdout is unaffected
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/completion/zsh.txt
+++ b/internal/cmd/root/testdata/usage/circleci/completion/zsh.txt
@@ -2,5 +2,6 @@ Usage:
   circleci completion zsh [flags]
 
 Global Flags:
-      --debug   enable debug logging
-  -q, --quiet   suppress informational output; data on stdout is unaffected
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/envvar.txt
+++ b/internal/cmd/root/testdata/usage/circleci/envvar.txt
@@ -18,7 +18,8 @@ Available Commands:
   set         Set a project environment variable
 
 Global Flags:
-      --debug   enable debug logging
-  -q, --quiet   suppress informational output; data on stdout is unaffected
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected
 
 Use "circleci envvar [command] --help" for more information about a command.

--- a/internal/cmd/root/testdata/usage/circleci/envvar/delete.txt
+++ b/internal/cmd/root/testdata/usage/circleci/envvar/delete.txt
@@ -17,5 +17,6 @@ Flags:
       --project string   Project slug (e.g. gh/org/repo); defaults to git remote
 
 Global Flags:
-      --debug   enable debug logging
-  -q, --quiet   suppress informational output; data on stdout is unaffected
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/envvar/list.txt
+++ b/internal/cmd/root/testdata/usage/circleci/envvar/list.txt
@@ -17,5 +17,6 @@ Flags:
       --project string   Project slug (e.g. gh/org/repo); defaults to git remote
 
 Global Flags:
-      --debug   enable debug logging
-  -q, --quiet   suppress informational output; data on stdout is unaffected
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/envvar/set.txt
+++ b/internal/cmd/root/testdata/usage/circleci/envvar/set.txt
@@ -16,5 +16,6 @@ Flags:
       --project string   Project slug (e.g. gh/org/repo); defaults to git remote
 
 Global Flags:
-      --debug   enable debug logging
-  -q, --quiet   suppress informational output; data on stdout is unaffected
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/job.txt
+++ b/internal/cmd/root/testdata/usage/circleci/job.txt
@@ -6,7 +6,8 @@ Available Commands:
   logs        Fetch logs for a job
 
 Global Flags:
-      --debug   enable debug logging
-  -q, --quiet   suppress informational output; data on stdout is unaffected
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected
 
 Use "circleci job [command] --help" for more information about a command.

--- a/internal/cmd/root/testdata/usage/circleci/job/artifacts.txt
+++ b/internal/cmd/root/testdata/usage/circleci/job/artifacts.txt
@@ -21,5 +21,6 @@ Flags:
       --project string    Project slug (e.g. gh/org/repo); defaults to git remote
 
 Global Flags:
-      --debug   enable debug logging
-  -q, --quiet   suppress informational output; data on stdout is unaffected
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/job/logs.txt
+++ b/internal/cmd/root/testdata/usage/circleci/job/logs.txt
@@ -21,5 +21,6 @@ Flags:
       --step string      Filter output to a single step by name
 
 Global Flags:
-      --debug   enable debug logging
-  -q, --quiet   suppress informational output; data on stdout is unaffected
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/logs.txt
+++ b/internal/cmd/root/testdata/usage/circleci/logs.txt
@@ -30,5 +30,6 @@ Flags:
       --step string      Filter output to a single step by name
 
 Global Flags:
-      --debug   enable debug logging
-  -q, --quiet   suppress informational output; data on stdout is unaffected
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/pipeline.txt
+++ b/internal/cmd/root/testdata/usage/circleci/pipeline.txt
@@ -9,7 +9,8 @@ Available Commands:
   watch       Watch a pipeline until it completes
 
 Global Flags:
-      --debug   enable debug logging
-  -q, --quiet   suppress informational output; data on stdout is unaffected
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected
 
 Use "circleci pipeline [command] --help" for more information about a command.

--- a/internal/cmd/root/testdata/usage/circleci/pipeline/cancel.txt
+++ b/internal/cmd/root/testdata/usage/circleci/pipeline/cancel.txt
@@ -17,5 +17,6 @@ Flags:
       --project string   Project slug (e.g. gh/org/repo); used when cancelling by number
 
 Global Flags:
-      --debug   enable debug logging
-  -q, --quiet   suppress informational output; data on stdout is unaffected
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/pipeline/get.txt
+++ b/internal/cmd/root/testdata/usage/circleci/pipeline/get.txt
@@ -21,5 +21,6 @@ Flags:
       --project string   Project slug (e.g. gh/org/repo); used when looking up by number
 
 Global Flags:
-      --debug   enable debug logging
-  -q, --quiet   suppress informational output; data on stdout is unaffected
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/pipeline/list.txt
+++ b/internal/cmd/root/testdata/usage/circleci/pipeline/list.txt
@@ -28,5 +28,6 @@ Flags:
       --project string   Project slug (e.g. gh/org/repo); defaults to git remote
 
 Global Flags:
-      --debug   enable debug logging
-  -q, --quiet   suppress informational output; data on stdout is unaffected
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/pipeline/trigger.txt
+++ b/internal/cmd/root/testdata/usage/circleci/pipeline/trigger.txt
@@ -22,5 +22,6 @@ Flags:
       --project string          Project slug (e.g. gh/org/repo); defaults to git remote
 
 Global Flags:
-      --debug   enable debug logging
-  -q, --quiet   suppress informational output; data on stdout is unaffected
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/pipeline/watch.txt
+++ b/internal/cmd/root/testdata/usage/circleci/pipeline/watch.txt
@@ -28,5 +28,6 @@ Flags:
       --timeout duration   Maximum time to wait for pipeline completion (default 30m0s)
 
 Global Flags:
-      --debug   enable debug logging
-  -q, --quiet   suppress informational output; data on stdout is unaffected
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/project.txt
+++ b/internal/cmd/root/testdata/usage/circleci/project.txt
@@ -7,7 +7,8 @@ Available Commands:
   list        List followed projects
 
 Global Flags:
-      --debug   enable debug logging
-  -q, --quiet   suppress informational output; data on stdout is unaffected
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected
 
 Use "circleci project [command] --help" for more information about a command.

--- a/internal/cmd/root/testdata/usage/circleci/project/envvar.txt
+++ b/internal/cmd/root/testdata/usage/circleci/project/envvar.txt
@@ -7,7 +7,8 @@ Available Commands:
   set         Set a project environment variable
 
 Global Flags:
-      --debug   enable debug logging
-  -q, --quiet   suppress informational output; data on stdout is unaffected
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected
 
 Use "circleci project envvar [command] --help" for more information about a command.

--- a/internal/cmd/root/testdata/usage/circleci/project/envvar/delete.txt
+++ b/internal/cmd/root/testdata/usage/circleci/project/envvar/delete.txt
@@ -17,5 +17,6 @@ Flags:
       --project string   Project slug (e.g. gh/org/repo); defaults to git remote
 
 Global Flags:
-      --debug   enable debug logging
-  -q, --quiet   suppress informational output; data on stdout is unaffected
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/project/envvar/list.txt
+++ b/internal/cmd/root/testdata/usage/circleci/project/envvar/list.txt
@@ -17,5 +17,6 @@ Flags:
       --project string   Project slug (e.g. gh/org/repo); defaults to git remote
 
 Global Flags:
-      --debug   enable debug logging
-  -q, --quiet   suppress informational output; data on stdout is unaffected
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/project/envvar/set.txt
+++ b/internal/cmd/root/testdata/usage/circleci/project/envvar/set.txt
@@ -16,5 +16,6 @@ Flags:
       --project string   Project slug (e.g. gh/org/repo); defaults to git remote
 
 Global Flags:
-      --debug   enable debug logging
-  -q, --quiet   suppress informational output; data on stdout is unaffected
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/project/follow.txt
+++ b/internal/cmd/root/testdata/usage/circleci/project/follow.txt
@@ -16,5 +16,6 @@ Flags:
       --project string   Project slug (e.g. gh/org/repo); defaults to git remote
 
 Global Flags:
-      --debug   enable debug logging
-  -q, --quiet   suppress informational output; data on stdout is unaffected
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/project/list.txt
+++ b/internal/cmd/root/testdata/usage/circleci/project/list.txt
@@ -19,5 +19,6 @@ Flags:
       --json   Output as JSON
 
 Global Flags:
-      --debug   enable debug logging
-  -q, --quiet   suppress informational output; data on stdout is unaffected
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/runner.txt
+++ b/internal/cmd/root/testdata/usage/circleci/runner.txt
@@ -8,7 +8,8 @@ Available Commands:
   token          Manage runner tokens
 
 Global Flags:
-      --debug   enable debug logging
-  -q, --quiet   suppress informational output; data on stdout is unaffected
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected
 
 Use "circleci runner [command] --help" for more information about a command.

--- a/internal/cmd/root/testdata/usage/circleci/runner/instance.txt
+++ b/internal/cmd/root/testdata/usage/circleci/runner/instance.txt
@@ -5,7 +5,8 @@ Available Commands:
   list        List connected runner instances
 
 Global Flags:
-      --debug   enable debug logging
-  -q, --quiet   suppress informational output; data on stdout is unaffected
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected
 
 Use "circleci runner instance [command] --help" for more information about a command.

--- a/internal/cmd/root/testdata/usage/circleci/runner/instance/list.txt
+++ b/internal/cmd/root/testdata/usage/circleci/runner/instance/list.txt
@@ -21,5 +21,6 @@ Flags:
       --resource-class string   Filter by resource class (namespace/name)
 
 Global Flags:
-      --debug   enable debug logging
-  -q, --quiet   suppress informational output; data on stdout is unaffected
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/runner/resource-class.txt
+++ b/internal/cmd/root/testdata/usage/circleci/runner/resource-class.txt
@@ -7,7 +7,8 @@ Available Commands:
   list        List runner resource classes
 
 Global Flags:
-      --debug   enable debug logging
-  -q, --quiet   suppress informational output; data on stdout is unaffected
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected
 
 Use "circleci runner resource-class [command] --help" for more information about a command.

--- a/internal/cmd/root/testdata/usage/circleci/runner/resource-class/create.txt
+++ b/internal/cmd/root/testdata/usage/circleci/runner/resource-class/create.txt
@@ -17,5 +17,6 @@ Flags:
       --json                 Output as JSON
 
 Global Flags:
-      --debug   enable debug logging
-  -q, --quiet   suppress informational output; data on stdout is unaffected
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/runner/resource-class/delete.txt
+++ b/internal/cmd/root/testdata/usage/circleci/runner/resource-class/delete.txt
@@ -16,5 +16,6 @@ Flags:
   -f, --force   skip confirmation prompt
 
 Global Flags:
-      --debug   enable debug logging
-  -q, --quiet   suppress informational output; data on stdout is unaffected
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/runner/resource-class/list.txt
+++ b/internal/cmd/root/testdata/usage/circleci/runner/resource-class/list.txt
@@ -20,5 +20,6 @@ Flags:
       --namespace string   Filter by namespace (organization)
 
 Global Flags:
-      --debug   enable debug logging
-  -q, --quiet   suppress informational output; data on stdout is unaffected
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/runner/task.txt
+++ b/internal/cmd/root/testdata/usage/circleci/runner/task.txt
@@ -19,5 +19,6 @@ Flags:
       --resource-class string   Resource class to query (namespace/name)
 
 Global Flags:
-      --debug   enable debug logging
-  -q, --quiet   suppress informational output; data on stdout is unaffected
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/runner/token.txt
+++ b/internal/cmd/root/testdata/usage/circleci/runner/token.txt
@@ -7,7 +7,8 @@ Available Commands:
   list        List tokens for a resource class
 
 Global Flags:
-      --debug   enable debug logging
-  -q, --quiet   suppress informational output; data on stdout is unaffected
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected
 
 Use "circleci runner token [command] --help" for more information about a command.

--- a/internal/cmd/root/testdata/usage/circleci/runner/token/create.txt
+++ b/internal/cmd/root/testdata/usage/circleci/runner/token/create.txt
@@ -17,5 +17,6 @@ Flags:
       --nickname string   Human-readable nickname for the token
 
 Global Flags:
-      --debug   enable debug logging
-  -q, --quiet   suppress informational output; data on stdout is unaffected
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/runner/token/delete.txt
+++ b/internal/cmd/root/testdata/usage/circleci/runner/token/delete.txt
@@ -17,5 +17,6 @@ Flags:
   -f, --force   skip confirmation prompt
 
 Global Flags:
-      --debug   enable debug logging
-  -q, --quiet   suppress informational output; data on stdout is unaffected
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/runner/token/list.txt
+++ b/internal/cmd/root/testdata/usage/circleci/runner/token/list.txt
@@ -23,5 +23,6 @@ Flags:
       --resource-class string   Filter by resource class (namespace/name)
 
 Global Flags:
-      --debug   enable debug logging
-  -q, --quiet   suppress informational output; data on stdout is unaffected
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/settings.txt
+++ b/internal/cmd/root/testdata/usage/circleci/settings.txt
@@ -6,7 +6,8 @@ Available Commands:
   set         Set a CLI setting
 
 Global Flags:
-      --debug   enable debug logging
-  -q, --quiet   suppress informational output; data on stdout is unaffected
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected
 
 Use "circleci settings [command] --help" for more information about a command.

--- a/internal/cmd/root/testdata/usage/circleci/settings/list.txt
+++ b/internal/cmd/root/testdata/usage/circleci/settings/list.txt
@@ -13,5 +13,6 @@ Flags:
       --json   Output as JSON
 
 Global Flags:
-      --debug   enable debug logging
-  -q, --quiet   suppress informational output; data on stdout is unaffected
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/settings/set.txt
+++ b/internal/cmd/root/testdata/usage/circleci/settings/set.txt
@@ -5,6 +5,9 @@ Examples:
 # Store your personal API token
 $ circleci settings set token mytoken123
 
+# Read the token from stdin to avoid shell history exposure
+$ echo "mytoken123" | circleci settings set token -
+
 # Point to a self-hosted CircleCI server
 $ circleci settings set host https://circleci.mycompany.com
 
@@ -13,5 +16,6 @@ $ CIRCLECI_TOKEN=mytoken123 circleci pipeline get
 
 
 Global Flags:
-      --debug   enable debug logging
-  -q, --quiet   suppress informational output; data on stdout is unaffected
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/workflow.txt
+++ b/internal/cmd/root/testdata/usage/circleci/workflow.txt
@@ -8,7 +8,8 @@ Available Commands:
   rerun       Rerun a workflow
 
 Global Flags:
-      --debug   enable debug logging
-  -q, --quiet   suppress informational output; data on stdout is unaffected
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected
 
 Use "circleci workflow [command] --help" for more information about a command.

--- a/internal/cmd/root/testdata/usage/circleci/workflow/cancel.txt
+++ b/internal/cmd/root/testdata/usage/circleci/workflow/cancel.txt
@@ -16,5 +16,6 @@ Flags:
   -f, --force   skip confirmation prompt
 
 Global Flags:
-      --debug   enable debug logging
-  -q, --quiet   suppress informational output; data on stdout is unaffected
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/workflow/get.txt
+++ b/internal/cmd/root/testdata/usage/circleci/workflow/get.txt
@@ -16,5 +16,6 @@ Flags:
       --json   Output as JSON
 
 Global Flags:
-      --debug   enable debug logging
-  -q, --quiet   suppress informational output; data on stdout is unaffected
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/workflow/list.txt
+++ b/internal/cmd/root/testdata/usage/circleci/workflow/list.txt
@@ -31,5 +31,6 @@ Flags:
       --project string   Project slug (e.g. gh/org/repo); defaults to git remote
 
 Global Flags:
-      --debug   enable debug logging
-  -q, --quiet   suppress informational output; data on stdout is unaffected
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/workflow/rerun.txt
+++ b/internal/cmd/root/testdata/usage/circleci/workflow/rerun.txt
@@ -16,5 +16,6 @@ Flags:
       --from-failed   Rerun only failed jobs
 
 Global Flags:
-      --debug   enable debug logging
-  -q, --quiet   suppress informational output; data on stdout is unaffected
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected

--- a/internal/cmd/runner/instance.go
+++ b/internal/cmd/runner/instance.go
@@ -24,7 +24,6 @@ package runner
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 	"time"
 
@@ -186,9 +185,7 @@ func runInstanceList(ctx context.Context, client *apiclient.Client, resourceClas
 	}
 
 	if jsonOut {
-		enc := json.NewEncoder(iostream.Out(ctx))
-		enc.SetIndent("", "  ")
-		return enc.Encode(out)
+		return cmdutil.WriteJSON(iostream.Out(ctx), out)
 	}
 
 	if len(out) == 0 {

--- a/internal/cmd/runner/resource_class.go
+++ b/internal/cmd/runner/resource_class.go
@@ -24,7 +24,6 @@ package runner
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 
@@ -136,9 +135,7 @@ func runResourceClassList(ctx context.Context, client *apiclient.Client, namespa
 	}
 
 	if jsonOut {
-		enc := json.NewEncoder(iostream.Out(ctx))
-		enc.SetIndent("", "  ")
-		return enc.Encode(out)
+		return cmdutil.WriteJSON(iostream.Out(ctx), out)
 	}
 
 	if len(out) == 0 {
@@ -214,9 +211,7 @@ func runResourceClassCreate(ctx context.Context, client *apiclient.Client, resou
 	}
 
 	if jsonOut {
-		enc := json.NewEncoder(iostream.Out(ctx))
-		enc.SetIndent("", "  ")
-		return enc.Encode(out)
+		return cmdutil.WriteJSON(iostream.Out(ctx), out)
 	}
 
 	iostream.Printf(ctx, "Created resource class: %s\n", out.ResourceClass)
@@ -273,20 +268,16 @@ func newResourceClassDeleteCmd() *cobra.Command {
 }
 
 func runResourceClassDelete(ctx context.Context, client *apiclient.Client, resourceClass string, force bool) error {
-	if !force {
-		if iostream.IsInteractive(ctx) {
-			prompt := fmt.Sprintf("Delete resource class %q? All tokens and runner connections will be removed.", resourceClass)
-			if !iostream.Confirm(ctx, prompt) {
-				return clierrors.New("runner.delete_aborted", "Deletion aborted",
-					"Resource class deletion was not confirmed.").
-					WithExitCode(clierrors.ExitCancelled)
-			}
-		} else {
-			return clierrors.New("runner.delete_requires_force", "Deletion requires --force",
-				fmt.Sprintf("Deleting resource class %q is irreversible.", resourceClass)).
-				WithSuggestions("Pass --force (-f) to confirm deletion in non-interactive mode").
-				WithExitCode(clierrors.ExitCancelled)
-		}
+	if err := cmdutil.ConfirmOrForce(ctx, iostream.Get(ctx), force,
+		fmt.Sprintf("Delete resource class %q? All tokens and runner connections will be removed.", resourceClass),
+		clierrors.New("runner.delete_aborted", "Deletion aborted",
+			"Resource class deletion was not confirmed.").
+			WithExitCode(clierrors.ExitCancelled),
+		clierrors.New("runner.delete_requires_force", "Deletion requires --force",
+			fmt.Sprintf("Deleting resource class %q is irreversible.", resourceClass)).
+			WithExitCode(clierrors.ExitCancelled),
+	); err != nil {
+		return err
 	}
 
 	if err := client.DeleteResourceClass(ctx, resourceClass); err != nil {

--- a/internal/cmd/runner/tasks.go
+++ b/internal/cmd/runner/tasks.go
@@ -24,7 +24,6 @@ package runner
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 
 	"github.com/MakeNowJust/heredoc"
@@ -107,9 +106,7 @@ func runTasks(ctx context.Context, client *apiclient.Client, resourceClass strin
 	}
 
 	if jsonOut {
-		enc := json.NewEncoder(iostream.Out(ctx))
-		enc.SetIndent("", "  ")
-		return enc.Encode(out)
+		return cmdutil.WriteJSON(iostream.Out(ctx), out)
 	}
 
 	iostream.Printf(ctx, "Resource class: %s\n", out.ResourceClass)

--- a/internal/cmd/runner/token.go
+++ b/internal/cmd/runner/token.go
@@ -24,7 +24,6 @@ package runner
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 
@@ -160,9 +159,7 @@ func runTokenList(ctx context.Context, client *apiclient.Client, resourceClass s
 		if out == nil {
 			out = []tokenOutput{}
 		}
-		enc := json.NewEncoder(iostream.Out(ctx))
-		enc.SetIndent("", "  ")
-		return enc.Encode(out)
+		return cmdutil.WriteJSON(iostream.Out(ctx), out)
 	}
 
 	if len(out) == 0 {
@@ -249,9 +246,7 @@ func runTokenCreate(ctx context.Context, client *apiclient.Client, resourceClass
 	}
 
 	if jsonOut {
-		enc := json.NewEncoder(iostream.Out(ctx))
-		enc.SetIndent("", "  ")
-		return enc.Encode(out)
+		return cmdutil.WriteJSON(iostream.Out(ctx), out)
 	}
 
 	iostream.Printf(ctx, "Created token for resource class: %s\n", out.ResourceClass)
@@ -313,20 +308,16 @@ func newTokenDeleteCmd() *cobra.Command {
 }
 
 func runTokenDelete(ctx context.Context, client *apiclient.Client, tokenID string, force bool) error {
-	if !force {
-		if iostream.IsInteractive(ctx) {
-			prompt := fmt.Sprintf("Delete token %q? Agents using this token will lose the ability to claim new jobs.", tokenID)
-			if !iostream.Confirm(ctx, prompt) {
-				return clierrors.New("runner.delete_aborted", "Deletion aborted",
-					"Token deletion was not confirmed.").
-					WithExitCode(clierrors.ExitCancelled)
-			}
-		} else {
-			return clierrors.New("runner.delete_requires_force", "Deletion requires --force",
-				fmt.Sprintf("Deleting token %q is irreversible.", tokenID)).
-				WithSuggestions("Pass --force (-f) to confirm deletion in non-interactive mode").
-				WithExitCode(clierrors.ExitCancelled)
-		}
+	if err := cmdutil.ConfirmOrForce(ctx, iostream.Get(ctx), force,
+		fmt.Sprintf("Delete token %q? Agents using this token will lose the ability to claim new jobs.", tokenID),
+		clierrors.New("runner.delete_aborted", "Deletion aborted",
+			"Token deletion was not confirmed.").
+			WithExitCode(clierrors.ExitCancelled),
+		clierrors.New("runner.delete_requires_force", "Deletion requires --force",
+			fmt.Sprintf("Deleting token %q is irreversible.", tokenID)).
+			WithExitCode(clierrors.ExitCancelled),
+	); err != nil {
+		return err
 	}
 
 	if err := client.DeleteRunnerToken(ctx, tokenID); err != nil {

--- a/internal/cmd/settings/list.go
+++ b/internal/cmd/settings/list.go
@@ -24,7 +24,6 @@ package settings
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/MakeNowJust/heredoc"
@@ -87,9 +86,7 @@ func runList(ctx context.Context, secureStorage bool, jsonOut bool) error {
 			"token_set": tokenSet,
 			"host":      cfg.EffectiveHost(),
 		}
-		enc := json.NewEncoder(iostream.Out(ctx))
-		enc.SetIndent("", "  ")
-		return enc.Encode(out)
+		return cmdutil.WriteJSON(iostream.Out(ctx), out)
 	}
 
 	iostream.Printf(ctx, "Config file: %s\n\n", path)

--- a/internal/cmd/settings/set.go
+++ b/internal/cmd/settings/set.go
@@ -44,10 +44,16 @@ func newSetCmd() *cobra.Command {
 			Supported keys:
 			  token   Your CircleCI personal API token
 			  host    CircleCI server host (default: https://circleci.com)
+
+			Pass "-" as the value to read it from stdin, keeping secrets out of
+			shell history and process listings.
 		`),
 		Example: heredoc.Doc(`
 			# Store your personal API token
 			$ circleci settings set token mytoken123
+
+			# Read the token from stdin to avoid shell history exposure
+			$ echo "mytoken123" | circleci settings set token -
 
 			# Point to a self-hosted CircleCI server
 			$ circleci settings set host https://circleci.mycompany.com
@@ -61,8 +67,13 @@ func newSetCmd() *cobra.Command {
 			if cliErr := cmdutil.RequireArgs(args, "key", "value"); cliErr != nil {
 				return cliErr
 			}
+			value, err := iostream.ReadSecret(ctx, args[1])
+			if err != nil {
+				return clierrors.New("args.stdin_read_failed", "Failed to read value from stdin", err.Error()).
+					WithExitCode(clierrors.ExitBadArguments)
+			}
 			secureStorage := cmdutil.IsSecureStorage(cmd)
-			return runSet(ctx, secureStorage, args[0], args[1])
+			return runSet(ctx, secureStorage, args[0], value)
 		},
 	}
 	return cmd

--- a/internal/cmd/workflow/cancel.go
+++ b/internal/cmd/workflow/cancel.go
@@ -82,20 +82,16 @@ func newCancelCmd() *cobra.Command {
 }
 
 func runCancel(ctx context.Context, client *apiclient.Client, id string, force bool) error {
-	if !force {
-		if iostream.IsInteractive(ctx) {
-			prompt := fmt.Sprintf("Cancel workflow %s? In-progress jobs will be stopped.", id)
-			if !iostream.Confirm(ctx, prompt) {
-				return clierrors.New("workflow.cancel_aborted", "Cancellation aborted",
-					"Workflow cancellation was not confirmed.").
-					WithExitCode(clierrors.ExitCancelled)
-			}
-		} else {
-			return clierrors.New("workflow.cancel_requires_force", "Cancellation requires --force",
-				fmt.Sprintf("Cancelling workflow %s will stop all in-progress jobs.", id)).
-				WithSuggestions("Pass --force (-f) to confirm cancellation in non-interactive mode").
-				WithExitCode(clierrors.ExitCancelled)
-		}
+	if err := cmdutil.ConfirmOrForce(ctx, iostream.Get(ctx), force,
+		fmt.Sprintf("Cancel workflow %s? In-progress jobs will be stopped.", id),
+		clierrors.New("workflow.cancel_aborted", "Cancellation aborted",
+			"Workflow cancellation was not confirmed.").
+			WithExitCode(clierrors.ExitCancelled),
+		clierrors.New("workflow.cancel_requires_force", "Cancellation requires --force",
+			fmt.Sprintf("Cancelling workflow %s will stop all in-progress jobs.", id)).
+			WithExitCode(clierrors.ExitCancelled),
+	); err != nil {
+		return err
 	}
 
 	if err := client.CancelWorkflow(ctx, id); err != nil {

--- a/internal/cmd/workflow/get.go
+++ b/internal/cmd/workflow/get.go
@@ -24,7 +24,6 @@ package workflow
 
 import (
 	"context"
-	"encoding/json"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
@@ -128,9 +127,7 @@ func runGet(ctx context.Context, client *apiclient.Client, id string, jsonOut bo
 	}
 
 	if jsonOut {
-		enc := json.NewEncoder(iostream.Out(ctx))
-		enc.SetIndent("", "  ")
-		return enc.Encode(out)
+		return cmdutil.WriteJSON(iostream.Out(ctx), out)
 	}
 
 	printGet(ctx, out)

--- a/internal/cmd/workflow/list.go
+++ b/internal/cmd/workflow/list.go
@@ -24,7 +24,6 @@ package workflow
 
 import (
 	"context"
-	"encoding/json"
 	"strconv"
 	"strings"
 
@@ -145,9 +144,7 @@ func runList(ctx context.Context, client *apiclient.Client, arg, projectSlug str
 		if out == nil {
 			out = []workflowListOutput{}
 		}
-		enc := json.NewEncoder(iostream.Out(ctx))
-		enc.SetIndent("", "  ")
-		return enc.Encode(out)
+		return cmdutil.WriteJSON(iostream.Out(ctx), out)
 	}
 
 	if len(out) == 0 {
@@ -164,12 +161,7 @@ func runListRecent(ctx context.Context, client *apiclient.Client, projectSlug, b
 	if projectSlug == "" {
 		info, gitErr := gitremote.Detect()
 		if gitErr != nil {
-			return clierrors.New("git.detect_failed", "Could not detect project from git", gitErr.Error()).
-				WithSuggestions(
-					"Run from inside a git repository with a GitHub, Bitbucket, or GitLab remote",
-					"Or specify --project explicitly",
-				).
-				WithExitCode(clierrors.ExitBadArguments)
+			return cmdutil.GitDetectErr(gitErr, "Or specify --project explicitly")
 		}
 		projectSlug = info.Slug
 	}
@@ -199,9 +191,7 @@ func runListRecent(ctx context.Context, client *apiclient.Client, projectSlug, b
 		if out == nil {
 			out = []workflowRecentOutput{}
 		}
-		enc := json.NewEncoder(iostream.Out(ctx))
-		enc.SetIndent("", "  ")
-		return enc.Encode(out)
+		return cmdutil.WriteJSON(iostream.Out(ctx), out)
 	}
 
 	if len(pipelines) == 0 {
@@ -257,12 +247,7 @@ func resolvePipelineID(ctx context.Context, client *apiclient.Client, arg, proje
 	if projectSlug == "" {
 		info, gitErr := gitremote.Detect()
 		if gitErr != nil {
-			return "", clierrors.New("git.detect_failed", "Could not detect project from git", gitErr.Error()).
-				WithSuggestions(
-					"Run from inside a git repository with a GitHub, Bitbucket, or GitLab remote",
-					"Or specify --project explicitly",
-				).
-				WithExitCode(clierrors.ExitBadArguments)
+			return "", cmdutil.GitDetectErr(gitErr, "Or specify --project explicitly")
 		}
 		projectSlug = info.Slug
 	}

--- a/internal/cmdutil/client.go
+++ b/internal/cmdutil/client.go
@@ -38,6 +38,14 @@ import (
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/httpcl"
 )
 
+type configPathKey struct{}
+
+// WithConfigPath returns a copy of ctx carrying the given config file path.
+// The path is read by LoadClient to locate the config file.
+func WithConfigPath(ctx context.Context, path string) context.Context {
+	return context.WithValue(ctx, configPathKey{}, path)
+}
+
 func IsSecureStorage(cmd *cobra.Command) bool {
 	insecureStorage, _ := cmd.Flags().GetBool("insecure-storage")
 	secureStorage := !insecureStorage
@@ -47,8 +55,11 @@ func IsSecureStorage(cmd *cobra.Command) bool {
 // LoadClient reads the CLI config, validates that a token is present, and
 // returns an authenticated API client. On failure it returns a structured
 // CLIError ready to be returned directly from a RunE handler.
+//
+// Honors a --config path set by the root PersistentPreRunE via WithConfigPath.
 func LoadClient(ctx context.Context, cmd *cobra.Command) (*apiclient.Client, error) {
-	cfg, err := config.Load(ctx, IsSecureStorage(cmd))
+	configPath, _ := ctx.Value(configPathKey{}).(string)
+	cfg, err := config.LoadFrom(configPath, ctx, IsSecureStorage(cmd))
 	if err != nil {
 		return nil, clierrors.New("config.load_failed", "Failed to load config", err.Error()).
 			WithExitCode(clierrors.ExitGeneralError)

--- a/internal/cmdutil/helpers.go
+++ b/internal/cmdutil/helpers.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package cmdutil
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+
+	clierrors "github.com/CircleCI-Public/circleci-cli-v2/internal/errors"
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/iostream"
+)
+
+// WriteJSON encodes v as indented JSON to w. Use streams.Out as the writer.
+// Returns the encoder error, if any.
+func WriteJSON(w io.Writer, v any) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(v)
+}
+
+// GitDetectErr wraps a gitremote.Detect error into a structured CLIError.
+//
+// The standard "run from inside a git repository" suggestion is always included
+// as the first suggestion. Pass additional command-specific suggestions as
+// variadic args (e.g. "Or specify the project with --project gh/org/repo").
+func GitDetectErr(err error, suggestions ...string) *clierrors.CLIError {
+	all := append(
+		[]string{"Run from inside a git repository with a GitHub, Bitbucket, or GitLab remote"},
+		suggestions...,
+	)
+	return clierrors.New("git.detect_failed", "Could not detect project from git", err.Error()).
+		WithSuggestions(all...).
+		WithExitCode(clierrors.ExitBadArguments)
+}
+
+// ConfirmOrForce requires user confirmation of a destructive operation.
+//
+//   - If force is true, returns nil immediately (scripting / non-interactive path).
+//   - In a TTY, shows prompt and returns abortErr if the user declines.
+//   - Outside a TTY, returns requireForceErr with the standard --force suggestion
+//     appended so callers don't have to repeat it.
+//
+// Construct abortErr and requireForceErr with domain-specific codes and messages;
+// the standard suggestion text is added automatically to requireForceErr.
+func ConfirmOrForce(ctx context.Context, streams iostream.Streams, force bool, prompt string, abortErr, requireForceErr *clierrors.CLIError) error {
+	if force {
+		return nil
+	}
+	if streams.IsInteractive() {
+		if !streams.Confirm(ctx, prompt) {
+			return abortErr
+		}
+		return nil
+	}
+	return requireForceErr.WithSuggestions("Pass --force (-f) to skip this prompt in non-interactive mode")
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -49,14 +49,21 @@ type Config struct {
 // DefaultHost is the CircleCI API host used when none is configured.
 const DefaultHost = "https://circleci.com"
 
-// Load reads the config file, returning an empty Config if the file does not exist.
+// Load reads the config file from the default path, returning an empty Config
+// if the file does not exist.
 func Load(ctx context.Context, secureStorage bool) (*Config, error) {
-	path, err := configPath()
+	return LoadFrom("", ctx, secureStorage)
+}
+
+// LoadFrom reads the config file from the given path. If path is empty the
+// default XDG path is used. Returns an empty Config if the file does not exist.
+func LoadFrom(path string, ctx context.Context, secureStorage bool) (*Config, error) {
+	resolved, err := resolvePath(path)
 	if err != nil {
 		return nil, err
 	}
 
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(resolved)
 	if os.IsNotExist(err) {
 		cfg := &Config{}
 		if secureStorage {
@@ -73,7 +80,7 @@ func Load(ctx context.Context, secureStorage bool) (*Config, error) {
 
 	var cfg Config
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
-		return nil, fmt.Errorf("parsing config file %s: %w", path, err)
+		return nil, fmt.Errorf("parsing config file %s: %w", resolved, err)
 	}
 
 	if secureStorage {
@@ -86,14 +93,21 @@ func Load(ctx context.Context, secureStorage bool) (*Config, error) {
 	return &cfg, nil
 }
 
-// Save writes cfg to the config file, creating parent directories as needed.
+// Save writes cfg to the default config file path, creating parent directories
+// as needed.
 func Save(ctx context.Context, cfg *Config, secureStorage bool) error {
-	path, err := configPath()
+	return SaveTo("", ctx, cfg, secureStorage)
+}
+
+// SaveTo writes cfg to the given path, creating parent directories as needed.
+// If path is empty the default XDG path is used.
+func SaveTo(path string, ctx context.Context, cfg *Config, secureStorage bool) error {
+	resolved, err := resolvePath(path)
 	if err != nil {
 		return err
 	}
 
-	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+	if err := os.MkdirAll(filepath.Dir(resolved), 0o700); err != nil {
 		return fmt.Errorf("creating config directory: %w", err)
 	}
 
@@ -112,15 +126,21 @@ func Save(ctx context.Context, cfg *Config, secureStorage bool) error {
 		return fmt.Errorf("serialising config: %w", err)
 	}
 
-	if err := os.WriteFile(path, data, 0o600); err != nil {
+	if err := os.WriteFile(resolved, data, 0o600); err != nil {
 		return fmt.Errorf("writing config file: %w", err)
 	}
 	return nil
 }
 
-// Path returns the resolved path to the config file.
+// Path returns the resolved path to the default config file.
 func Path() (string, error) {
 	return configPath()
+}
+
+// PathFrom returns the resolved path for the given override. If override is
+// empty, returns the default XDG path.
+func PathFrom(override string) (string, error) {
+	return resolvePath(override)
 }
 
 // EffectiveHost returns the host, checked in priority order:
@@ -176,6 +196,14 @@ func (c *Config) storeToken(ctx context.Context) error {
 	}
 
 	return keyring.Set(ctx, c.EffectiveHost(), u.Username, c.Token)
+}
+
+// resolvePath returns override if non-empty, otherwise the default XDG path.
+func resolvePath(override string) (string, error) {
+	if override != "" {
+		return override, nil
+	}
+	return configPath()
 }
 
 func configPath() (string, error) {

--- a/internal/iostream/streams.go
+++ b/internal/iostream/streams.go
@@ -23,6 +23,7 @@
 package iostream
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"io"
@@ -67,6 +68,14 @@ func fromContext(ctx context.Context) Streams {
 
 func WithStreams(ctx context.Context, s Streams) context.Context {
 	return context.WithValue(ctx, contextKey{}, s)
+}
+
+// Get returns the Streams stored in ctx, or a discard-everything Streams if
+// none was set. Use this when you need to pass a Streams value to a helper
+// function (e.g. cmdutil.ConfirmOrForce) rather than calling the ctx-based
+// package-level wrappers.
+func Get(ctx context.Context) Streams {
+	return fromContext(ctx)
 }
 
 // Package-level accessors for Steam functions
@@ -247,6 +256,32 @@ func (s Streams) ErrPrintln(a ...any) {
 		return
 	}
 	_, _ = fmt.Fprintln(s.Err, a...)
+}
+
+// ReadSecret returns value as-is, unless value is "-", in which case it reads
+// one line from In. Use this for flags or arguments that accept sensitive
+// values (tokens, passwords, secrets) to allow callers to pipe the value in
+// without exposing it in shell history or process listings:
+//
+//	echo "mytoken" | circleci settings set token -
+func (s Streams) ReadSecret(value string) (string, error) {
+	if value != "-" {
+		return value, nil
+	}
+	scanner := bufio.NewScanner(s.In)
+	if !scanner.Scan() {
+		if err := scanner.Err(); err != nil {
+			return "", err
+		}
+		return "", fmt.Errorf("expected value on stdin but got EOF")
+	}
+	return scanner.Text(), nil
+}
+
+// ReadSecret reads a sensitive value from the streams in context.
+// Returns value as-is unless value is "-", in which case reads one line from stdin.
+func ReadSecret(ctx context.Context, value string) (string, error) {
+	return fromContext(ctx).ReadSecret(value)
 }
 
 // Confirm presents a y/N confirmation prompt via bubbletea.


### PR DESCRIPTION
Based on agents/checklist.md, implement expected command flags where they are missing.

Review cycles also exposed a couple other things:
 * extract some helpers to remove duplication
 * don't cache acceptance tests because it misses changes
 * fix an acceptance test