### PR TITLE
Fix local config branch mismatch in pipeline run

### DIFF
--- a/cmd/pipeline/run.go
+++ b/cmd/pipeline/run.go
@@ -99,7 +99,6 @@ Examples:
 
 			// If a config file path is supplied and confirmed, check if the file is empty
 			if useLocalConfig && localConfigFilePath != "" {
-				configBranch = "cli-run"
 				data, err := os.ReadFile(localConfigFilePath)
 				if err != nil {
 					return fmt.Errorf("failed to read config file: %w", err)
@@ -131,6 +130,11 @@ Examples:
 			trackPipelineRunStep(client, "checkout_ref_provided", invID, map[string]interface{}{
 				"used_branch": checkoutBranch != "",
 			})
+
+			if useLocalConfig {
+				configBranch = checkoutBranch
+				configTag = checkoutTag
+			}
 
 			// Convert string parameters to interface map
 			paramMap := make(map[string]interface{})

--- a/cmd/pipeline/run_test.go
+++ b/cmd/pipeline/run_test.go
@@ -174,7 +174,7 @@ func Test_newRunCommand(t *testing.T) {
 				Organization:         "my-org",
 				Project:              "my-project",
 				PipelineDefinitionID: "abc123",
-				ConfigBranch:         "cli-run",
+				ConfigBranch:         "feature",
 				ConfigTag:            "",
 				CheckoutBranch:       "feature",
 				CheckoutTag:          "",
@@ -199,7 +199,7 @@ func Test_newRunCommand(t *testing.T) {
 				Organization:         "my-org",
 				Project:              "my-project",
 				PipelineDefinitionID: "abc123",
-				ConfigBranch:         "cli-run",
+				ConfigBranch:         "feature",
 				ConfigTag:            "",
 				CheckoutBranch:       "feature",
 				CheckoutTag:          "",
@@ -223,9 +223,24 @@ func Test_newRunCommand(t *testing.T) {
 				Organization:         "my-org",
 				Project:              "my-project",
 				PipelineDefinitionID: "abc123",
-				ConfigBranch:         "cli-run",
+				ConfigBranch:         "feature",
 				ConfigTag:            "",
 				CheckoutBranch:       "feature",
+				CheckoutTag:          "",
+				ConfigFilePath:       "/path/to/config.yml",
+				Parameters:           map[string]interface{}{},
+			},
+		},
+		{
+			name: "with local config file via flag with checkout branch",
+			args: []string{"my-org", "my-project", "--pipeline-definition-id", "abc123", "--local-config-file", "/path/to/config.yml", "--checkout-branch", "develop"},
+			expectedConfig: pipeline.PipelineRunOptions{
+				Organization:         "my-org",
+				Project:              "my-project",
+				PipelineDefinitionID: "abc123",
+				ConfigBranch:         "develop",
+				ConfigTag:            "",
+				CheckoutBranch:       "develop",
 				CheckoutTag:          "",
 				ConfigFilePath:       "/path/to/config.yml",
 				Parameters:           map[string]interface{}{},
@@ -275,6 +290,11 @@ func Test_newRunCommand(t *testing.T) {
 				defer cleanup()
 				// Patch the expected config to use the temp file path
 				tt.expectedConfig.ConfigFilePath = tempConfigFile
+				for i, arg := range tt.args {
+					if arg == "/path/to/config.yml" {
+						tt.args[i] = tempConfigFile
+					}
+				}
 				if tt.reader != nil {
 					for k, v := range tt.reader.responses {
 						if v == "/path/to/config.yml" {


### PR DESCRIPTION
## Summary
- Fixes `--local-config-file` which hardcoded `configBranch` to `"cli-run"`, causing server rejection with "Config ref must match checkout ref when both are from the same repository"
- Now sets `configBranch`/`configTag` to match the checkout ref when using a local config
- Adds test case for `--local-config-file` passed directly via flag with `--checkout-branch`

Fixes [WEBXP-545](https://linear.app/circleci/issue/WEBXP-545)

## Test plan
- [x] All existing `Test_newRunCommand` tests updated and passing
- [x] New test case: local config file via flag with checkout branch verifies config branch matches checkout branch
- [x] Manual validation: run `circleci pipeline run` with `--local-config-file` and `--checkout-branch` against a real project

🤖 Generated with [Claude Code](https://claude.com/claude-code)