### PR TITLE
Update agent guidance based on fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,8 +162,10 @@ NO_COLOR=1 ./dist/circleci --help      # verify color is disabled
 CI=true ./dist/circleci --help         # verify CI mode
 ```
 
-`task test` runs `./...` which includes `acceptance/`. There is no separate unit-only target;
-the acceptance tests are fast enough (fake HTTP servers, no real network) to always run.
+`task test` runs unit tests (cached) then acceptance tests with `-count=1` (never cached).
+Acceptance tests exec the compiled binary as a subprocess, so `go test` cannot invalidate their
+cache when source files change — a stale green result is possible if caching is allowed. The
+`-count=1` flag on the acceptance run prevents this.
 
 Tools (golangci-lint, gotestsum, gosimports) are pinned via the `tool` directive in
 `go.mod` and invoked as `go tool <name>` — no separate install step needed.
@@ -198,6 +200,10 @@ Tools (golangci-lint, gotestsum, gosimports) are pinned via the `tool` directive
 2. Add individual verb files alongside it.
 3. Register the group in `internal/cmd/root/root.go`.
 4. Add `internal/<domain>/` for any shared business logic.
+5. Set `RunE: cmdutil.GroupRunE` and `FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true}`
+   on the group command. Without this, unknown subcommands silently show help and exit 0 (looks like
+   success), and unknown flags after an unknown subcommand produce a misleading "unknown flag" error
+   instead of "unknown command".
 
 ---
 

--- a/agents/05-errors.md
+++ b/agents/05-errors.md
@@ -160,6 +160,34 @@ Did you mean '--verbose'?
 
 ---
 
+## Returning CLIError from Functions
+
+**Always return `error`, not `*clierrors.CLIError`, from functions that may return nil.**
+
+Go's interface rules mean that a typed nil (`(*clierrors.CLIError)(nil)`) assigned to an `error` interface produces a *non-nil* interface value. This breaks `if err != nil` checks and causes `assert.NilError` to fail even though the function "succeeded".
+
+```go
+// ❌ BAD — typed nil becomes non-nil error interface
+func parseParams(params []string) (map[string]any, *clierrors.CLIError) {
+    if ok {
+        return result, nil  // nil *CLIError → non-nil error interface at call site
+    }
+    ...
+}
+
+// ✅ GOOD — return error; nil remains nil
+func parseParams(params []string) (map[string]any, error) {
+    if !ok {
+        return nil, clierrors.New(...)  // CLIError implements error
+    }
+    return result, nil  // true nil interface
+}
+```
+
+The rule: use `*clierrors.CLIError` only in local variables and when chaining builder methods (`.WithSuggestions`, `.WithExitCode`). Any function signature that could return nil must use the `error` interface.
+
+---
+
 ## What Not to Do
 
 - **Don't silently fail.** If something goes wrong, say so. Silent failures leave users confused and scripts broken.

--- a/agents/08-subcommands.md
+++ b/agents/08-subcommands.md
@@ -193,6 +193,34 @@ Global flags typically go *before* the subcommand. Subcommand flags go *after*.
 
 ---
 
+## Group Command Implementation
+
+Group commands (commands that only contain subcommands and have no action of their own) must
+handle the case where the user passes an unknown subcommand. Without intervention, Cobra silently
+shows the parent's help and exits 0 — indistinguishable from success.
+
+Set `RunE` and `FParseErrWhitelist` on every group command:
+
+```go
+cmd := &cobra.Command{
+    Use:                "pipeline <command>",
+    RunE:               cmdutil.GroupRunE,
+    FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
+}
+```
+
+`GroupRunE` shows help when called with no arguments, and returns a structured "unknown command"
+error when any arguments are present. `FParseErrWhitelist{UnknownFlags: true}` is required so
+that unknown flags following an unknown subcommand (e.g. `pipeline foobar --branch main`) are
+passed through to `GroupRunE` rather than being rejected by Cobra's flag parser first — which
+would produce a misleading "unknown flag" error.
+
+Without both, these two failure modes go undetected:
+- `circleci pipeline foobar` → exits 0 (looks like success)
+- `circleci pipeline foobar --branch main` → "unknown flag: --branch" (wrong diagnosis)
+
+---
+
 ## Summary Checklist
 
 - [ ] Subcommands used for logically distinct operations, not just namespacing
@@ -203,3 +231,4 @@ Global flags typically go *before* the subcommand. Subcommand flags go *after*.
 - [ ] Most-used subcommands listed first in help
 - [ ] Nesting kept shallow (one level preferred, two levels max)
 - [ ] Global vs. subcommand-specific flags clearly distinguished
+- [ ] Group commands use `RunE: cmdutil.GroupRunE` + `FParseErrWhitelist{UnknownFlags: true}`

--- a/agents/14-testing.md
+++ b/agents/14-testing.md
@@ -107,6 +107,34 @@ Skip the message when the comparison is already self-documenting — `cmp.Equal`
 `cmp.DeepEqual`, `cmp.Len`, and `cmp.ErrorIs` all produce structured failure
 messages that include the values involved, so they rarely need extra annotation.
 
+## Acceptance Test Caching
+
+Acceptance tests exec the compiled binary as a subprocess. `go test` cannot invalidate their
+cache when source files change — it only tracks direct Go imports, not what went into the
+binary. Always run acceptance tests with `-count=1` (cache-busting). `task test` does this
+automatically; `task acceptance-test` does too. Do not add `-count=1` to unit test runs, which
+can cache safely.
+
+---
+
+## Asserting on CLIError Output
+
+`CLIError.Format()` renders `Message` to stderr, not `Title`. Test assertions on stderr must
+match text from the `Message` field (the full explanation), never the `Title` (the short label).
+
+```go
+// CLIError{Title: "Unsupported shell", Message: `Shell "/bin/fish" is not supported.`}
+// stderr contains: "error: Shell \"/bin/fish\" is not supported."
+
+// ❌ BAD — Title never appears in formatted output
+assert.Check(t, cmp.Contains(result.Stderr, "unsupported shell"))
+
+// ✅ GOOD — Message text appears in formatted output
+assert.Check(t, cmp.Contains(result.Stderr, "not supported"))
+```
+
+---
+
 ## Examples
 
 ```go


### PR DESCRIPTION
Fixing a few issues has created new patterns. Document those so that we use them consistently in future.