### PR TITLE
Add very basic logging support and use context to transport o11y

### DIFF
--- a/acceptance/workflow_test.go
+++ b/acceptance/workflow_test.go
@@ -148,7 +148,7 @@ func TestWorkflowGet_NotFound_JSON(t *testing.T) {
 	env.CircleCIURL = fake.URL()
 
 	result := binary.RunCLI(t,
-		[]string{"workflow", "get", "--json", "00000000-0000-0000-0000-000000000000"},
+		[]string{"workflow", "get", "--quiet", "--json", "00000000-0000-0000-0000-000000000000"},
 		env.Environ(), t.TempDir())
 
 	assert.Equal(t, result.ExitCode, 5, "stderr: %s", result.Stderr)

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	charm.land/bubbles/v2 v2.1.0
 	charm.land/bubbletea/v2 v2.0.6
 	charm.land/lipgloss/v2 v2.0.3
+	charm.land/log/v2 v2.0.0
 	github.com/MakeNowJust/heredoc v1.0.0
 	github.com/go-chi/chi/v5 v5.2.5
 	github.com/go-chi/render v1.0.3
@@ -90,6 +91,7 @@ require (
 	github.com/fzipp/gocyclo v0.6.0 // indirect
 	github.com/ghostiam/protogetter v0.3.20 // indirect
 	github.com/go-critic/go-critic v0.14.3 // indirect
+	github.com/go-logfmt/logfmt v0.6.0 // indirect
 	github.com/go-toolsmith/astcast v1.1.0 // indirect
 	github.com/go-toolsmith/astcopy v1.1.0 // indirect
 	github.com/go-toolsmith/astequal v1.2.0 // indirect
@@ -227,6 +229,7 @@ require (
 	go.uber.org/multierr v1.10.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
+	golang.org/x/exp v0.0.0-20250620022241-b7579e27df2b // indirect
 	golang.org/x/exp/typeparams v0.0.0-20260209203927-2842357ff358 // indirect
 	golang.org/x/mod v0.34.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ charm.land/bubbletea/v2 v2.0.6 h1:UHN/91OyuhaOFGSrBXQ/hMZD8IO1Uc4BvHlgHXL2WJo=
 charm.land/bubbletea/v2 v2.0.6/go.mod h1:MH/D8ZLlN3op37vQvijKuU29g3rqTp+aQapURFonF9g=
 charm.land/lipgloss/v2 v2.0.3 h1:yM2zJ4Cf5Y51b7RHIwioil4ApI/aypFXXVHSwlM6RzU=
 charm.land/lipgloss/v2 v2.0.3/go.mod h1:7myLU9iG/3xluAWzpY/fSxYYHCgoKTie7laxk6ATwXA=
+charm.land/log/v2 v2.0.0 h1:SY3Cey7ipx86/MBXQHwsguOT6X1exT94mmJRdzTNs+s=
+charm.land/log/v2 v2.0.0/go.mod h1:c3cZSRqm20qUVVAR1WmS/7ab8bgha3C6G7DjPcaVZz0=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
@@ -231,6 +233,8 @@ github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vb
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
+github.com/go-logfmt/logfmt v0.6.0 h1:wGYYu3uicYdqXVgoYbvnkrPVXkuLM1p1ifugDMEdRi4=
+github.com/go-logfmt/logfmt v0.6.0/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-quicktest/qt v1.101.0 h1:O1K29Txy5P2OK0dGo59b7b0LR6wKfIhttaAhHUyn7eI=

--- a/internal/cmd/api/api.go
+++ b/internal/cmd/api/api.go
@@ -90,14 +90,13 @@ func NewAPICmd() *cobra.Command {
 		`),
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
-			streams := iostream.FromCmd(cmd)
+			ctx := iostream.FromCmd(cmd.Context(), cmd)
 
 			client, cliErr := cmdutil.LoadClient(ctx, cmd)
 			if cliErr != nil {
 				return cliErr
 			}
-			return run(ctx, client, streams, args[0], method, fields, headers, jsonOut)
+			return run(ctx, client, args[0], method, fields, headers, jsonOut)
 		},
 	}
 
@@ -109,7 +108,7 @@ func NewAPICmd() *cobra.Command {
 	return cmd
 }
 
-func run(ctx context.Context, client *apiclient.Client, streams iostream.Streams, path, method string, fields, headers []string, jsonOut bool) error {
+func run(ctx context.Context, client *apiclient.Client, path, method string, fields, headers []string, jsonOut bool) error {
 	// Parse key=value fields.
 	parsedFields := make(map[string]string, len(fields))
 	for _, f := range fields {
@@ -192,14 +191,14 @@ func run(ctx context.Context, client *apiclient.Client, streams iostream.Streams
 	if jsonOut {
 		var v any
 		if jsonErr := json.Unmarshal(respBody, &v); jsonErr == nil {
-			enc := json.NewEncoder(streams.Out)
+			enc := json.NewEncoder(iostream.Out(ctx))
 			enc.SetIndent("", "  ")
 			_ = enc.Encode(v)
 		} else {
-			streams.Println(output)
+			iostream.Println(ctx, output)
 		}
 	} else {
-		streams.Println(output)
+		iostream.Println(ctx, output)
 	}
 
 	if status >= 400 {

--- a/internal/cmd/artifacts/artifacts.go
+++ b/internal/cmd/artifacts/artifacts.go
@@ -85,15 +85,14 @@ func NewArtifactsCmd() *cobra.Command {
 		`),
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
-			streams := iostream.FromCmd(cmd)
+			ctx := iostream.FromCmd(cmd.Context(), cmd)
 
 			client, err := cmdutil.LoadClient(ctx, cmd)
 			if err != nil {
 				return err
 			}
 
-			return run(ctx, client, streams, args, jobNumber, projectSlug, branch, downloadDir, jsonOut)
+			return run(ctx, client, args, jobNumber, projectSlug, branch, downloadDir, jsonOut)
 		},
 	}
 
@@ -106,7 +105,7 @@ func NewArtifactsCmd() *cobra.Command {
 	return cmd
 }
 
-func run(ctx context.Context, client *apiclient.Client, streams iostream.Streams, args []string, jobNumber int64, projectSlug, branch, downloadDir string, jsonOut bool) error {
+func run(ctx context.Context, client *apiclient.Client, args []string, jobNumber int64, projectSlug, branch, downloadDir string, jsonOut bool) error {
 	var (
 		err     error
 		entries []artifacts.Entry
@@ -130,7 +129,7 @@ func run(ctx context.Context, client *apiclient.Client, streams iostream.Streams
 	case len(args) == 1:
 		// Explicit pipeline UUID
 		pipelineID := args[0]
-		sp := streams.Spinner(!jsonOut, fmt.Sprintf("Fetching artifacts for pipeline %s", pipelineID))
+		sp := iostream.Spin(ctx, !jsonOut, fmt.Sprintf("Fetching artifacts for pipeline %s", pipelineID))
 		entries, err = artifacts.ForPipeline(ctx, client, pipelineID)
 		sp.Stop()
 		if err != nil {
@@ -147,7 +146,7 @@ func run(ctx context.Context, client *apiclient.Client, streams iostream.Streams
 		if effectiveBranch == "" {
 			effectiveBranch = info.Branch
 		}
-		sp := streams.Spinner(!jsonOut, fmt.Sprintf("Fetching latest pipeline for %s on branch %s", info.Slug, effectiveBranch))
+		sp := iostream.Spin(ctx, !jsonOut, fmt.Sprintf("Fetching latest pipeline for %s on branch %s", info.Slug, effectiveBranch))
 		pipeline, err := client.GetLatestPipeline(ctx, info.Slug, effectiveBranch)
 		sp.Stop()
 		if err != nil {
@@ -161,34 +160,34 @@ func run(ctx context.Context, client *apiclient.Client, streams iostream.Streams
 
 	if len(entries) == 0 {
 		if !jsonOut {
-			streams.ErrPrintln("No artifacts found.")
+			iostream.ErrPrintln(ctx, "No artifacts found.")
 			return nil
 		}
 		entries = []artifacts.Entry{}
 	}
 
 	if downloadDir != "" {
-		sp := streams.Spinner(!jsonOut, fmt.Sprintf("Downloading %d artifact(s) to %s", len(entries), downloadDir))
+		sp := iostream.Spin(ctx, !jsonOut, fmt.Sprintf("Downloading %d artifact(s) to %s", len(entries), downloadDir))
 		dlErr := artifacts.Download(ctx, client, entries, downloadDir)
 		sp.Stop()
 		if dlErr != nil {
 			return clierrors.New("artifacts.download_failed", "Download failed", dlErr.Error()).
 				WithExitCode(clierrors.ExitGeneralError)
 		}
-		streams.ErrPrintf("%s Downloaded %d artifact(s)\n", streams.Symbol("✓", "OK:"), len(entries))
+		iostream.ErrPrintf(ctx, "%s Downloaded %d artifact(s)\n", iostream.Symbol(ctx, "✓", "OK:"), len(entries))
 	}
 
 	if jsonOut {
-		enc := json.NewEncoder(streams.Out)
+		enc := json.NewEncoder(iostream.Out(ctx))
 		enc.SetIndent("", "  ")
 		return enc.Encode(entries)
 	}
 
-	printArtifacts(streams, entries)
+	printArtifacts(ctx, entries)
 	return nil
 }
 
-func printArtifacts(streams iostream.Streams, entries []artifacts.Entry) {
+func printArtifacts(ctx context.Context, entries []artifacts.Entry) {
 	// Print a flat table. Show job columns only when there's more than one job.
 	multiJob := false
 	first := entries[0].JobNumber
@@ -200,14 +199,14 @@ func printArtifacts(streams iostream.Streams, entries []artifacts.Entry) {
 	}
 
 	if multiJob {
-		streams.Printf("%-30s  %-6s  %s\n", "JOB", "JOB #", "PATH")
-		streams.Printf("%-30s  %-6s  %s\n", "---", "-----", "----")
+		iostream.Printf(ctx, "%-30s  %-6s  %s\n", "JOB", "JOB #", "PATH")
+		iostream.Printf(ctx, "%-30s  %-6s  %s\n", "---", "-----", "----")
 		for _, e := range entries {
-			streams.Printf("%-30s  %-6d  %s\n", e.JobName, e.JobNumber, e.Path)
+			iostream.Printf(ctx, "%-30s  %-6d  %s\n", e.JobName, e.JobNumber, e.Path)
 		}
 	} else {
 		for _, e := range entries {
-			streams.Println(e.Path)
+			iostream.Println(ctx, e.Path)
 		}
 	}
 }

--- a/internal/cmd/cmdauth/logout.go
+++ b/internal/cmd/cmdauth/logout.go
@@ -41,10 +41,9 @@ func newLogoutCmd() *cobra.Command {
 		Short: "Remove stored credentials",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
-			streams := iostream.FromCmd(cmd)
+			ctx := iostream.FromCmd(cmd.Context(), cmd)
 			secureStorage := cmdutil.IsSecureStorage(cmd)
-			return runLogout(ctx, secureStorage, streams)
+			return runLogout(ctx, secureStorage)
 		},
 	}
 
@@ -52,7 +51,7 @@ func newLogoutCmd() *cobra.Command {
 	return cmd
 }
 
-func runLogout(ctx context.Context, secureStorage bool, streams iostream.Streams) error {
+func runLogout(ctx context.Context, secureStorage bool) error {
 	cfg, err := config.Load(ctx, secureStorage)
 	if err != nil {
 		return clierrors.New("settings.load_failed", "Failed to load settings", err.Error()).
@@ -66,6 +65,6 @@ func runLogout(ctx context.Context, secureStorage bool, streams iostream.Streams
 			WithExitCode(clierrors.ExitGeneralError)
 	}
 
-	streams.ErrPrintf("%s Removed %s from keyring\n", streams.Symbol("✓", "OK:"), "token")
+	iostream.ErrPrintf(ctx, "%s Removed %s from keyring\n", iostream.Symbol(ctx, "✓", "OK:"), "token")
 	return nil
 }

--- a/internal/cmd/cmdauth/me.go
+++ b/internal/cmd/cmdauth/me.go
@@ -41,13 +41,12 @@ func newMeCmd() *cobra.Command {
 		Short: "Get info about the current user",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
-			streams := iostream.FromCmd(cmd)
+			ctx := iostream.FromCmd(cmd.Context(), cmd)
 			client, err := cmdutil.LoadClient(ctx, cmd)
 			if err != nil {
 				return err
 			}
-			return runMe(ctx, client, streams, jsonOut)
+			return runMe(ctx, client, jsonOut)
 		},
 	}
 
@@ -55,20 +54,20 @@ func newMeCmd() *cobra.Command {
 	return cmd
 }
 
-func runMe(ctx context.Context, client *apiclient.Client, streams iostream.Streams, jsonOut bool) error {
+func runMe(ctx context.Context, client *apiclient.Client, jsonOut bool) error {
 	me, err := client.GetMe(ctx)
 	if err != nil {
 		return err
 	}
 
 	if jsonOut {
-		enc := json.NewEncoder(streams.Out)
+		enc := json.NewEncoder(iostream.Out(ctx))
 		enc.SetIndent("", "  ")
 		return enc.Encode(me)
 	}
 
-	streams.Printf("User: %s\n\n", me.ID)
-	streams.Printf("%-10s  %s\n", "name", me.Name)
-	streams.Printf("%-10s  %s\n", "login", me.Login)
+	iostream.Printf(ctx, "User: %s\n\n", me.ID)
+	iostream.Printf(ctx, "%-10s  %s\n", "name", me.Name)
+	iostream.Printf(ctx, "%-10s  %s\n", "login", me.Login)
 	return nil
 }

--- a/internal/cmd/cmdauth/token.go
+++ b/internal/cmd/cmdauth/token.go
@@ -25,15 +25,14 @@ package cmdauth
 import (
 	"context"
 
-	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
-	"charm.land/lipgloss/v2"
 	"github.com/spf13/cobra"
 
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/cmdutil"
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/config"
 	clierrors "github.com/CircleCI-Public/circleci-cli-v2/internal/errors"
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/iostream"
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/ui"
 )
 
 func newTokenCmd() *cobra.Command {
@@ -42,39 +41,38 @@ func newTokenCmd() *cobra.Command {
 		Short: "Set personal access token for authenticating to CircleCI",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
-			streams := iostream.FromCmd(cmd)
-			if !streams.IsInteractive() {
+			ctx := iostream.FromCmd(cmd.Context(), cmd)
+			if !iostream.IsInteractive(ctx) {
 				return clierrors.New("auth.token.aborted", "Login aborted",
 					"Login requires an interactive session.").
 					WithExitCode(clierrors.ExitCancelled)
 			}
 			secureStorage := cmdutil.IsSecureStorage(cmd)
-			return runToken(ctx, secureStorage, streams)
+			return runToken(ctx, secureStorage)
 		},
 	}
 	return cmd
 }
 
-func runToken(ctx context.Context, secureStorage bool, streams iostream.Streams) error {
+func runToken(ctx context.Context, secureStorage bool) error {
 	cfg, err := config.Load(ctx, secureStorage)
 	if err != nil {
 		return clierrors.New("settings.load_failed", "Failed to load settings", err.Error()).
 			WithExitCode(clierrors.ExitGeneralError)
 	}
 
-	p := tea.NewProgram(initialTokenModel())
+	p := tea.NewProgram(ui.NewTokenModel())
 	anyModel, err := p.Run()
 	if err != nil {
 		return err
 	}
 
-	m := anyModel.(tokenModel)
-	if m.quitting {
+	m := anyModel.(ui.TokenModel)
+	if m.Quitting() {
 		return nil
 	}
 
-	cfg.Token = m.token
+	cfg.Token = m.Token()
 	if err := config.Save(ctx, cfg, secureStorage); err != nil {
 		return clierrors.New("settings.save_failed", "Failed to save settings", err.Error()).
 			WithExitCode(clierrors.ExitGeneralError)
@@ -84,71 +82,6 @@ func runToken(ctx context.Context, secureStorage bool, streams iostream.Streams)
 	if secureStorage {
 		path = "keyring"
 	}
-	streams.ErrPrintf("%s Saved %s to %s\n", streams.Symbol("✓", "OK:"), "token", path)
+	iostream.ErrPrintf(ctx, "%s Saved %s to %s\n", iostream.Symbol(ctx, "✓", "OK:"), "token", path)
 	return nil
 }
-
-type tokenModel struct {
-	textInput textinput.Model
-	quitting  bool
-	token     string
-}
-
-func initialTokenModel() tokenModel {
-	ti := textinput.New()
-	ti.Placeholder = "CCIPAT_XXXXXXXXXXXXXXXXXXXXXX_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
-	ti.SetVirtualCursor(false)
-	ti.Focus()
-	ti.CharLimit = len(ti.Placeholder)
-	ti.SetWidth(len(ti.Placeholder))
-	ti.EchoMode = textinput.EchoPassword
-
-	return tokenModel{textInput: ti}
-}
-
-func (m tokenModel) Init() tea.Cmd {
-	return textinput.Blink
-}
-
-func (m tokenModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	var cmd tea.Cmd
-
-	switch msg := msg.(type) {
-	case tea.KeyPressMsg:
-		switch msg.String() {
-		case "ctrl+c", "esc":
-			m.quitting = true
-			return m, tea.Quit
-		case "enter":
-			m.token = m.textInput.Value()
-			return m, tea.Quit
-		}
-	}
-
-	m.textInput, cmd = m.textInput.Update(msg)
-	return m, cmd
-}
-
-func (m tokenModel) View() tea.View {
-	if m.token != "" {
-		return tea.NewView("")
-	}
-
-	var c *tea.Cursor
-	if !m.textInput.VirtualCursor() {
-		c = m.textInput.Cursor()
-		c.Y += lipgloss.Height(m.headerView())
-	}
-
-	str := lipgloss.JoinVertical(lipgloss.Top, m.headerView(), m.textInput.View(), m.footerView())
-	if m.quitting {
-		str += "\n"
-	}
-
-	v := tea.NewView(str)
-	v.Cursor = c
-	return v
-}
-
-func (m tokenModel) headerView() string { return "Enter CircleCI personal access token\n" }
-func (m tokenModel) footerView() string { return "\n(esc to quit)" }

--- a/internal/cmd/completion/completion.go
+++ b/internal/cmd/completion/completion.go
@@ -25,6 +25,7 @@ package completion
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -112,7 +113,7 @@ func CompletionInstalled() (bool, error) {
 	return strings.Contains(string(data), completionTag), nil
 }
 
-func installCompletion(streams iostream.Streams) error {
+func installCompletion(ctx context.Context) error {
 	home := os.Getenv("HOME")
 	if home == "" {
 		return fmt.Errorf("HOME not set")
@@ -124,7 +125,7 @@ func installCompletion(streams iostream.Streams) error {
 
 	data, readErr := os.ReadFile(sh.rcFile)
 	if readErr == nil && strings.Contains(string(data), completionTag) {
-		streams.ErrPrintf("Completion already installed in %s\n", sh.rcFile)
+		iostream.ErrPrintf(ctx, "Completion already installed in %s\n", sh.rcFile)
 		return nil
 	}
 
@@ -139,8 +140,8 @@ func installCompletion(streams iostream.Streams) error {
 		return fmt.Errorf("write %s: %w", sh.rcFile, err)
 	}
 
-	streams.ErrPrintf("%s Installed %s completion in %s\n",
-		streams.Symbol("✓", "OK:"), sh.name, sh.rcFile)
+	iostream.ErrPrintf(ctx, "%s Installed %s completion in %s\n",
+		iostream.Symbol(ctx, "✓", "OK:"), sh.name, sh.rcFile)
 	return nil
 }
 
@@ -165,7 +166,7 @@ func newInstallCmd() *cobra.Command {
 			$ source <(circleci completion bash)
 		`),
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return installCompletion(iostream.FromCmd(cmd))
+			return installCompletion(iostream.FromCmd(cmd.Context(), cmd))
 		},
 	}
 }
@@ -189,7 +190,7 @@ func newUninstallCmd() *cobra.Command {
 			$ grep -l "circleci shell completion" ~/.zshrc ~/.bashrc 2>/dev/null
 		`),
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			streams := iostream.FromCmd(cmd)
+			ctx := iostream.FromCmd(cmd.Context(), cmd)
 			home := os.Getenv("HOME")
 			if home == "" {
 				return fmt.Errorf("HOME not set")
@@ -202,7 +203,7 @@ func newUninstallCmd() *cobra.Command {
 			data, err := os.ReadFile(sh.rcFile)
 			if err != nil {
 				// Nothing to uninstall.
-				streams.ErrPrintf("%s Completion not installed\n", streams.Symbol("✓", "OK:"))
+				iostream.ErrPrintf(ctx, "%s Completion not installed\n", iostream.Symbol(ctx, "✓", "OK:"))
 				return nil
 			}
 
@@ -227,7 +228,7 @@ func newUninstallCmd() *cobra.Command {
 				return fmt.Errorf("write %s: %w", sh.rcFile, err)
 			}
 
-			streams.ErrPrintf("%s Removed completion from %s\n", streams.Symbol("✓", "OK:"), sh.rcFile)
+			iostream.ErrPrintf(ctx, "%s Removed completion from %s\n", iostream.Symbol(ctx, "✓", "OK:"), sh.rcFile)
 			return nil
 		},
 	}
@@ -239,7 +240,8 @@ func newBashCmd() *cobra.Command {
 		Short:  "Generate bash completion script",
 		Hidden: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return cmd.Root().GenBashCompletion(iostream.FromCmd(cmd).Out)
+			ctx := iostream.FromCmd(cmd.Context(), cmd)
+			return cmd.Root().GenBashCompletion(iostream.Out(ctx))
 		},
 	}
 }
@@ -250,7 +252,8 @@ func newZshCmd() *cobra.Command {
 		Short:  "Generate zsh completion script",
 		Hidden: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return cmd.Root().GenZshCompletion(iostream.FromCmd(cmd).Out)
+			ctx := iostream.FromCmd(cmd.Context(), cmd)
+			return cmd.Root().GenZshCompletion(iostream.Out(ctx))
 		},
 	}
 }

--- a/internal/cmd/job/artifacts.go
+++ b/internal/cmd/job/artifacts.go
@@ -76,14 +76,13 @@ func newArtifactsCmd() *cobra.Command {
 		`),
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
+			ctx := iostream.FromCmd(cmd.Context(), cmd)
 
 			err := cmdutil.RequireArgs(args, "job-number")
 			if err != nil {
 				return err
 			}
 
-			streams := iostream.FromCmd(cmd)
 			jobNumber, err := strconv.ParseInt(args[0], 10, 64)
 			if err != nil {
 				return clierrors.New("args.invalid_job_number", "Invalid job number",
@@ -96,7 +95,7 @@ func newArtifactsCmd() *cobra.Command {
 				return err
 			}
 
-			return runJobArtifacts(ctx, client, streams, jobNumber, projectSlug, downloadDir, jsonOut)
+			return runJobArtifacts(ctx, client, jobNumber, projectSlug, downloadDir, jsonOut)
 		},
 	}
 
@@ -107,7 +106,7 @@ func newArtifactsCmd() *cobra.Command {
 	return cmd
 }
 
-func runJobArtifacts(ctx context.Context, client *apiclient.Client, streams iostream.Streams, jobNumber int64, projectSlug, downloadDir string, jsonOut bool) error {
+func runJobArtifacts(ctx context.Context, client *apiclient.Client, jobNumber int64, projectSlug, downloadDir string, jsonOut bool) error {
 	if projectSlug == "" {
 		info, err := gitremote.Detect()
 		if err != nil {
@@ -132,29 +131,29 @@ func runJobArtifacts(ctx context.Context, client *apiclient.Client, streams iost
 	}
 
 	if len(entries) == 0 {
-		streams.ErrPrintln("No artifacts found.")
+		iostream.ErrPrintln(ctx, "No artifacts found.")
 		return nil
 	}
 
 	if downloadDir != "" {
-		sp := streams.Spinner(true, fmt.Sprintf("Downloading %d artifact(s) to %s", len(entries), downloadDir))
+		sp := iostream.Spin(ctx, true, fmt.Sprintf("Downloading %d artifact(s) to %s", len(entries), downloadDir))
 		dlErr := artifacts.Download(ctx, client, entries, downloadDir)
 		sp.Stop()
 		if dlErr != nil {
 			return clierrors.New("artifacts.download_failed", "Download failed", dlErr.Error()).
 				WithExitCode(clierrors.ExitGeneralError)
 		}
-		streams.ErrPrintf("%s Downloaded %d artifact(s)\n", streams.Symbol("✓", "OK:"), len(entries))
+		iostream.ErrPrintf(ctx, "%s Downloaded %d artifact(s)\n", iostream.Symbol(ctx, "✓", "OK:"), len(entries))
 	}
 
 	if jsonOut {
-		enc := json.NewEncoder(streams.Out)
+		enc := json.NewEncoder(iostream.Out(ctx))
 		enc.SetIndent("", "  ")
 		return enc.Encode(entries)
 	}
 
 	for _, e := range entries {
-		streams.Println(e.Path)
+		iostream.Println(ctx, e.Path)
 	}
 	return nil
 }

--- a/internal/cmd/job/logs.go
+++ b/internal/cmd/job/logs.go
@@ -79,20 +79,19 @@ func newLogsCmd() *cobra.Command {
 			if cliErr := cmdutil.RequireArgs(args, "job-number"); cliErr != nil {
 				return cliErr
 			}
-			streams := iostream.FromCmd(cmd)
+			ctx := iostream.FromCmd(cmd.Context(), cmd)
 			var jobNumber int64
 			if _, err := fmt.Sscanf(args[0], "%d", &jobNumber); err != nil {
 				return clierrors.New("args.invalid_job_number", "Invalid job number",
 					fmt.Sprintf("%q is not a valid job number.", args[0])).
 					WithExitCode(clierrors.ExitBadArguments)
 			}
-			ctx := cmd.Context()
 			client, err := cmdutil.LoadClient(ctx, cmd)
 			if err != nil {
 				return err
 			}
 
-			return runJobLogs(ctx, client, streams, jobNumber, projectSlug, step, jsonOut)
+			return runJobLogs(ctx, client, jobNumber, projectSlug, step, jsonOut)
 		},
 	}
 
@@ -103,7 +102,7 @@ func newLogsCmd() *cobra.Command {
 	return cmd
 }
 
-func runJobLogs(ctx context.Context, client *apiclient.Client, streams iostream.Streams, jobNumber int64, projectSlug, step string, jsonOut bool) error {
+func runJobLogs(ctx context.Context, client *apiclient.Client, jobNumber int64, projectSlug, step string, jsonOut bool) error {
 	if projectSlug == "" {
 		info, err := gitremote.Detect()
 		if err != nil {
@@ -138,21 +137,21 @@ func runJobLogs(ctx context.Context, client *apiclient.Client, streams iostream.
 	}
 
 	if jsonOut {
-		enc := json.NewEncoder(streams.Out)
+		enc := json.NewEncoder(iostream.Out(ctx))
 		enc.SetIndent("", "  ")
 		return enc.Encode(stepLogs)
 	}
 
 	for i, sl := range stepLogs {
 		if i > 0 {
-			streams.Println()
+			iostream.Println(ctx)
 		}
 		if sl.Status == "failed" {
-			streams.Printf("=== %s (failed) ===\n", sl.Name)
+			iostream.Printf(ctx, "=== %s (failed) ===\n", sl.Name)
 		} else {
-			streams.Printf("=== %s ===\n", sl.Name)
+			iostream.Printf(ctx, "=== %s ===\n", sl.Name)
 		}
-		streams.Print(sl.Output)
+		iostream.Print(ctx, sl.Output)
 	}
 	return nil
 }

--- a/internal/cmd/logs/logs.go
+++ b/internal/cmd/logs/logs.go
@@ -89,13 +89,12 @@ func NewLogsCmd() *cobra.Command {
 		`),
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
-			streams := iostream.FromCmd(cmd)
+			ctx := iostream.FromCmd(cmd.Context(), cmd)
 			client, err := cmdutil.LoadClient(ctx, cmd)
 			if err != nil {
 				return err
 			}
-			return run(ctx, client, streams, args, lastFailed, lastJob, step, projectSlug, branch, jsonOut)
+			return run(ctx, client, args, lastFailed, lastJob, step, projectSlug, branch, jsonOut)
 		},
 	}
 
@@ -109,7 +108,7 @@ func NewLogsCmd() *cobra.Command {
 	return cmd
 }
 
-func run(ctx context.Context, client *apiclient.Client, streams iostream.Streams, args []string, lastFailed, lastJob bool, step, projectSlug, branch string, jsonOut bool) error {
+func run(ctx context.Context, client *apiclient.Client, args []string, lastFailed, lastJob bool, step, projectSlug, branch string, jsonOut bool) error {
 	// Validate: exactly one mode must be chosen.
 	modes := 0
 	if len(args) == 1 {
@@ -170,7 +169,7 @@ func run(ctx context.Context, client *apiclient.Client, streams iostream.Streams
 			}
 		}
 
-		sp1 := streams.Spinner(true, fmt.Sprintf("Fetching latest pipeline for %s on branch %s", projectSlug, effectiveBranch))
+		sp1 := iostream.Spin(ctx, true, fmt.Sprintf("Fetching latest pipeline for %s on branch %s", projectSlug, effectiveBranch))
 		pipeline, err := client.GetLatestPipeline(ctx, projectSlug, effectiveBranch)
 		sp1.Stop()
 		if err != nil {
@@ -195,7 +194,7 @@ func run(ctx context.Context, client *apiclient.Client, streams iostream.Streams
 			return apiErr(err, pipeline.ID)
 		}
 
-		fetchLogsSp = streams.Spinner(true, fmt.Sprintf("Fetching logs for job #%d", jobNumber))
+		fetchLogsSp = iostream.Spin(ctx, true, fmt.Sprintf("Fetching logs for job #%d", jobNumber))
 	}
 
 	stepLogs, err := logs.ForJob(ctx, client, projectSlug, jobNumber, step)
@@ -215,12 +214,12 @@ func run(ctx context.Context, client *apiclient.Client, streams iostream.Streams
 	}
 
 	if jsonOut {
-		enc := json.NewEncoder(streams.Out)
+		enc := json.NewEncoder(iostream.Out(ctx))
 		enc.SetIndent("", "  ")
 		return enc.Encode(stepLogs)
 	}
 
-	printLogs(streams, stepLogs)
+	printLogs(ctx, stepLogs)
 	return nil
 }
 
@@ -237,16 +236,16 @@ func apiErr(err error, subject string) *clierrors.CLIError {
 	return cmdutil.APIErr(err, subject, "logs.not_found", "No resource found for %q.")
 }
 
-func printLogs(streams iostream.Streams, stepLogs []logs.StepLog) {
+func printLogs(ctx context.Context, stepLogs []logs.StepLog) {
 	for i, sl := range stepLogs {
 		if i > 0 {
-			streams.Println()
+			iostream.Println(ctx)
 		}
 		if sl.Status == "failed" {
-			streams.Printf("=== %s (failed) ===\n", sl.Name)
+			iostream.Printf(ctx, "=== %s (failed) ===\n", sl.Name)
 		} else {
-			streams.Printf("=== %s ===\n", sl.Name)
+			iostream.Printf(ctx, "=== %s ===\n", sl.Name)
 		}
-		streams.Print(sl.Output)
+		iostream.Print(ctx, sl.Output)
 	}
 }

--- a/internal/cmd/pipeline/cancel.go
+++ b/internal/cmd/pipeline/cancel.go
@@ -73,13 +73,12 @@ func newCancelCmd() *cobra.Command {
 			if cliErr := cmdutil.RequireArgs(args, "pipeline-number-or-id"); cliErr != nil {
 				return cliErr
 			}
-			ctx := cmd.Context()
-			streams := iostream.FromCmd(cmd)
+			ctx := iostream.FromCmd(cmd.Context(), cmd)
 			client, err := cmdutil.LoadClient(ctx, cmd)
 			if err != nil {
 				return err
 			}
-			return runPipelineCancel(ctx, client, streams, args[0], projectSlug, force)
+			return runPipelineCancel(ctx, client, args[0], projectSlug, force)
 		},
 	}
 
@@ -89,7 +88,7 @@ func newCancelCmd() *cobra.Command {
 	return cmd
 }
 
-func runPipelineCancel(ctx context.Context, client *apiclient.Client, streams iostream.Streams, arg, projectSlug string, force bool) error {
+func runPipelineCancel(ctx context.Context, client *apiclient.Client, arg, projectSlug string, force bool) error {
 	pipelineID := arg
 	displayName := arg
 
@@ -116,9 +115,9 @@ func runPipelineCancel(ctx context.Context, client *apiclient.Client, streams io
 	}
 
 	if !force {
-		if streams.IsInteractive() {
+		if iostream.IsInteractive(ctx) {
 			prompt := fmt.Sprintf("Cancel pipeline %s? In-progress jobs will be stopped.", displayName)
-			if !streams.Confirm(prompt) {
+			if !iostream.Confirm(ctx, prompt) {
 				return clierrors.New("pipeline.cancel_aborted", "Cancellation aborted",
 					"Pipeline cancellation was not confirmed.").
 					WithExitCode(clierrors.ExitCancelled)
@@ -142,6 +141,6 @@ func runPipelineCancel(ctx context.Context, client *apiclient.Client, streams io
 		return apiErr(err, displayName)
 	}
 
-	streams.Printf("%s Cancelled pipeline %s\n", streams.Symbol("✓", "OK:"), displayName)
+	iostream.Printf(ctx, "%s Cancelled pipeline %s\n", iostream.Symbol(ctx, "✓", "OK:"), displayName)
 	return nil
 }

--- a/internal/cmd/pipeline/get.go
+++ b/internal/cmd/pipeline/get.go
@@ -78,13 +78,12 @@ func newGetCmd() *cobra.Command {
 		`),
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
-			streams := iostream.FromCmd(cmd)
+			ctx := iostream.FromCmd(cmd.Context(), cmd)
 			client, err := cmdutil.LoadClient(ctx, cmd)
 			if err != nil {
 				return err
 			}
-			return runGet(ctx, client, streams, args, projectSlug, branch, jsonOut)
+			return runGet(ctx, client, args, projectSlug, branch, jsonOut)
 		},
 	}
 
@@ -134,7 +133,7 @@ type jobOutput struct {
 	Type   string `json:"type"`
 }
 
-func runGet(ctx context.Context, client *apiclient.Client, streams iostream.Streams, args []string, projectSlug, branch string, jsonOut bool) error {
+func runGet(ctx context.Context, client *apiclient.Client, args []string, projectSlug, branch string, jsonOut bool) error {
 	var (
 		err      error
 		pipeline *apiclient.Pipeline
@@ -187,7 +186,7 @@ func runGet(ctx context.Context, client *apiclient.Client, streams iostream.Stre
 			effectiveBranch = info.Branch
 		}
 
-		sp := streams.Spinner(!jsonOut, fmt.Sprintf("Fetching latest pipeline for %s on branch %s", info.Slug, effectiveBranch))
+		sp := iostream.Spin(ctx, !jsonOut, fmt.Sprintf("Fetching latest pipeline for %s on branch %s", info.Slug, effectiveBranch))
 		pipeline, err = client.GetLatestPipeline(ctx, info.Slug, effectiveBranch)
 		sp.Stop()
 		if err != nil {
@@ -212,12 +211,12 @@ func runGet(ctx context.Context, client *apiclient.Client, streams iostream.Stre
 	out := buildOutput(pipeline, workflows, wfJobs)
 
 	if jsonOut {
-		enc := json.NewEncoder(streams.Out)
+		enc := json.NewEncoder(iostream.Out(ctx))
 		enc.SetIndent("", "  ")
 		return enc.Encode(out)
 	}
 
-	printPipeline(streams, out)
+	printPipeline(ctx, out)
 	return nil
 }
 
@@ -312,34 +311,34 @@ func looksLikeNumber(s string) bool {
 	return !strings.Contains(s, "-") && len(s) > 0
 }
 
-func printPipeline(streams iostream.Streams, p pipelineGetOutput) {
-	streams.Printf("Pipeline #%d  %s\n", p.Number, p.ID)
-	streams.Printf("Project:   %s\n", p.ProjectSlug)
+func printPipeline(ctx context.Context, p pipelineGetOutput) {
+	iostream.Printf(ctx, "Pipeline #%d  %s\n", p.Number, p.ID)
+	iostream.Printf(ctx, "Project:   %s\n", p.ProjectSlug)
 	if p.Branch != "" {
-		streams.Printf("Branch:    %s\n", p.Branch)
+		iostream.Printf(ctx, "Branch:    %s\n", p.Branch)
 	}
 	if p.Revision != "" {
-		streams.Printf("Commit:    %s\n", p.Revision)
+		iostream.Printf(ctx, "Commit:    %s\n", p.Revision)
 	}
-	streams.Printf("Status:    %s\n", p.Status)
-	streams.Printf("Triggered: %s by %s (%s)\n", p.CreatedAt, p.Trigger.Actor, p.Trigger.Type)
+	iostream.Printf(ctx, "Status:    %s\n", p.Status)
+	iostream.Printf(ctx, "Triggered: %s by %s (%s)\n", p.CreatedAt, p.Trigger.Actor, p.Trigger.Type)
 
 	if len(p.Errors) > 0 {
-		streams.Printf("\nErrors:\n")
+		iostream.Printf(ctx, "\nErrors:\n")
 		for _, e := range p.Errors {
-			streams.Printf("  [%s] %s\n", e.Type, e.Message)
+			iostream.Printf(ctx, "  [%s] %s\n", e.Type, e.Message)
 		}
 	}
 
 	if len(p.Workflows) > 0 {
-		streams.Printf("\nWorkflows:\n")
+		iostream.Printf(ctx, "\nWorkflows:\n")
 		for _, w := range p.Workflows {
-			streams.Printf("  %-30s  %s\n", w.Name, w.Status)
+			iostream.Printf(ctx, "  %-30s  %s\n", w.Name, w.Status)
 			for _, j := range w.Jobs {
 				if j.Type == "approval" {
-					streams.Printf("    %-36s  %s\n", j.Name, j.Status)
+					iostream.Printf(ctx, "    %-36s  %s\n", j.Name, j.Status)
 				} else {
-					streams.Printf("    %-36s  %s  #%d\n", j.Name, j.Status, j.Number)
+					iostream.Printf(ctx, "    %-36s  %s  #%d\n", j.Name, j.Status, j.Number)
 				}
 			}
 		}

--- a/internal/cmd/pipeline/list.go
+++ b/internal/cmd/pipeline/list.go
@@ -76,13 +76,12 @@ func newListCmd() *cobra.Command {
 		`),
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
-			streams := iostream.FromCmd(cmd)
+			ctx := iostream.FromCmd(cmd.Context(), cmd)
 			client, err := cmdutil.LoadClient(ctx, cmd)
 			if err != nil {
 				return err
 			}
-			return runList(ctx, client, streams, projectSlug, branch, limit, jsonOut)
+			return runList(ctx, client, projectSlug, branch, limit, jsonOut)
 		},
 	}
 
@@ -108,7 +107,7 @@ type pipelineListEntry struct {
 	} `json:"trigger"`
 }
 
-func runList(ctx context.Context, client *apiclient.Client, streams iostream.Streams, projectSlug, branch string, limit int, jsonOut bool) error {
+func runList(ctx context.Context, client *apiclient.Client, projectSlug, branch string, limit int, jsonOut bool) error {
 	if projectSlug == "" {
 		info, err := gitremote.Detect()
 		if err != nil {
@@ -134,17 +133,17 @@ func runList(ctx context.Context, client *apiclient.Client, streams iostream.Str
 	}
 
 	if jsonOut {
-		enc := json.NewEncoder(streams.Out)
+		enc := json.NewEncoder(iostream.Out(ctx))
 		enc.SetIndent("", "  ")
 		return enc.Encode(entries)
 	}
 
 	if len(pipelines) == 0 {
-		streams.ErrPrintln("No pipelines found.")
+		iostream.ErrPrintln(ctx, "No pipelines found.")
 		return nil
 	}
 
-	printList(streams, entries)
+	printList(ctx, entries)
 	return nil
 }
 
@@ -168,13 +167,13 @@ func pipelineToListEntry(p *apiclient.Pipeline) pipelineListEntry {
 	return e
 }
 
-func printList(streams iostream.Streams, entries []pipelineListEntry) {
+func printList(ctx context.Context, entries []pipelineListEntry) {
 	for _, e := range entries {
 		state := ""
 		if e.State == "errored" {
 			state = "  [errored]"
 		}
-		streams.Printf("#%-4d  %-20s  %s  %s  %s%s\n",
+		iostream.Printf(ctx, "#%-4d  %-20s  %s  %s  %s%s\n",
 			e.Number, e.Branch, e.Revision, e.ID, e.CreatedAt, state)
 	}
 }

--- a/internal/cmd/pipeline/trigger.go
+++ b/internal/cmd/pipeline/trigger.go
@@ -76,13 +76,12 @@ func newTriggerCmd() *cobra.Command {
 		`),
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
-			streams := iostream.FromCmd(cmd)
+			ctx := iostream.FromCmd(cmd.Context(), cmd)
 			client, err := cmdutil.LoadClient(ctx, cmd)
 			if err != nil {
 				return err
 			}
-			return runTrigger(ctx, client, streams, projectSlug, branch, params, jsonOut)
+			return runTrigger(ctx, client, projectSlug, branch, params, jsonOut)
 		},
 	}
 
@@ -101,7 +100,7 @@ type triggerJSONOutput struct {
 	CreatedAt string `json:"created_at"`
 }
 
-func runTrigger(ctx context.Context, client *apiclient.Client, streams iostream.Streams, projectSlug, branch string, params []string, jsonOut bool) error {
+func runTrigger(ctx context.Context, client *apiclient.Client, projectSlug, branch string, params []string, jsonOut bool) error {
 	effectiveBranch := branch
 	if projectSlug == "" || effectiveBranch == "" {
 		info, err := gitremote.Detect()
@@ -142,12 +141,12 @@ func runTrigger(ctx context.Context, client *apiclient.Client, streams iostream.
 			State:     resp.State,
 			CreatedAt: resp.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
 		}
-		enc := json.NewEncoder(streams.Out)
+		enc := json.NewEncoder(iostream.Out(ctx))
 		enc.SetIndent("", "  ")
 		return enc.Encode(out)
 	}
 
-	streams.Printf("Triggered pipeline #%d (%s) on %s\n", resp.Number, resp.ID, effectiveBranch)
+	iostream.Printf(ctx, "Triggered pipeline #%d (%s) on %s\n", resp.Number, resp.ID, effectiveBranch)
 	return nil
 }
 

--- a/internal/cmd/pipeline/watch.go
+++ b/internal/cmd/pipeline/watch.go
@@ -101,13 +101,12 @@ func newWatchCmd() *cobra.Command {
 		`),
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
-			streams := iostream.FromCmd(cmd)
+			ctx := iostream.FromCmd(cmd.Context(), cmd)
 			client, err := cmdutil.LoadClient(ctx, cmd)
 			if err != nil {
 				return err
 			}
-			return runWatch(ctx, client, streams, args, projectSlug, branch, sha, timeout)
+			return runWatch(ctx, client, args, projectSlug, branch, sha, timeout)
 		},
 	}
 
@@ -119,7 +118,7 @@ func newWatchCmd() *cobra.Command {
 	return cmd
 }
 
-func runWatch(ctx context.Context, client *apiclient.Client, streams iostream.Streams, args []string, projectSlug, branch, sha string, timeout time.Duration) error {
+func runWatch(ctx context.Context, client *apiclient.Client, args []string, projectSlug, branch, sha string, timeout time.Duration) error {
 	// If the argument looks like a UUID, we can resolve the pipeline directly
 	// without needing a project slug or branch from git.
 	isUUID := len(args) == 1 && strings.Contains(args[0], "-")
@@ -163,7 +162,7 @@ func runWatch(ctx context.Context, client *apiclient.Client, streams iostream.St
 		}
 
 	case sha != "":
-		pipeline, err = waitForPipelineBySHA(ctx, streams, client, projectSlug, branch, sha)
+		pipeline, err = waitForPipelineBySHA(ctx, client, projectSlug, branch, sha)
 		if err != nil {
 			return err
 		}
@@ -180,14 +179,14 @@ func runWatch(ctx context.Context, client *apiclient.Client, streams iostream.St
 		branch = pipeline.VCS.Branch
 	}
 
-	streams.ErrPrintf("Watching pipeline #%d (%s @ %s)\n\n", pipeline.Number, pipeline.ProjectSlug, branch)
+	iostream.ErrPrintf(ctx, "Watching pipeline #%d (%s @ %s)\n\n", pipeline.Number, pipeline.ProjectSlug, branch)
 
-	return watchUntilDone(ctx, streams, client, pipeline.ID, pipeline.Number, timeout)
+	return watchUntilDone(ctx, client, pipeline.ID, pipeline.Number, timeout)
 }
 
 // waitForPipelineBySHA searches for a pipeline matching the given commit SHA,
 // polling every 5 seconds for up to shaWaitDuration() if not immediately found.
-func waitForPipelineBySHA(ctx context.Context, streams iostream.Streams, client *apiclient.Client, projectSlug, branch, sha string) (*apiclient.Pipeline, error) {
+func waitForPipelineBySHA(ctx context.Context, client *apiclient.Client, projectSlug, branch, sha string) (*apiclient.Pipeline, error) {
 	waitDur := shaWaitDuration()
 	deadline := time.Now().Add(waitDur)
 	interval := 5 * time.Second
@@ -216,7 +215,7 @@ func waitForPipelineBySHA(ctx context.Context, streams iostream.Streams, client 
 		}
 
 		if !printed {
-			streams.ErrPrintf("Waiting for pipeline for commit %s...\n", sha)
+			iostream.ErrPrintf(ctx, "Waiting for pipeline for commit %s...\n", sha)
 			printed = true
 		}
 		time.Sleep(interval)
@@ -225,10 +224,10 @@ func waitForPipelineBySHA(ctx context.Context, streams iostream.Streams, client 
 
 // watchUntilDone polls the given pipeline until all workflows reach a terminal
 // state or the timeout elapses.
-func watchUntilDone(ctx context.Context, streams iostream.Streams, client *apiclient.Client, pipelineID string, pipelineNumber int64, timeout time.Duration) error {
+func watchUntilDone(ctx context.Context, client *apiclient.Client, pipelineID string, pipelineNumber int64, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 	start := time.Now()
-	tty := streams.IsTerminal()
+	tty := iostream.IsTerminal(ctx)
 
 	var prevLines int
 	var prevFingerprint string
@@ -248,26 +247,26 @@ func watchUntilDone(ctx context.Context, streams iostream.Streams, client *apicl
 		if tty {
 			// Erase previous table, redraw with updated elapsed.
 			if prevLines > 0 {
-				_, _ = fmt.Fprintf(streams.Err, "\033[%dA\033[J", prevLines)
+				_, _ = fmt.Fprintf(iostream.Err(ctx), "\033[%dA\033[J", prevLines)
 			}
-			prevLines = printWatchTable(streams, state, elapsed)
+			prevLines = printWatchTable(ctx, state, elapsed)
 		} else if changed {
-			printWatchLine(streams, state, elapsed)
+			printWatchLine(ctx, state, elapsed)
 		}
 		prevFingerprint = fingerprint
 
 		if allWorkflowsDone(state.Workflows) {
 			if tty && prevLines > 0 {
 				// Final redraw without the elapsed ticker line.
-				_, _ = fmt.Fprintf(streams.Err, "\033[%dA\033[J", prevLines)
-				printWatchTableFinal(streams, state)
-				streams.ErrPrintf("\n")
+				_, _ = fmt.Fprintf(iostream.Err(ctx), "\033[%dA\033[J", prevLines)
+				printWatchTableFinal(ctx, state)
+				iostream.ErrPrintf(ctx, "\n")
 			}
-			return watchFinalResult(streams, state, pipelineNumber, elapsed)
+			return watchFinalResult(ctx, state, pipelineNumber, elapsed)
 		}
 
 		if time.Now().After(deadline) {
-			streams.ErrPrintf("\n")
+			iostream.ErrPrintf(ctx, "\n")
 			return clierrors.New("pipeline.timeout", "Watch timed out",
 				fmt.Sprintf("Pipeline #%d did not complete within %s.", pipelineNumber, timeout)).
 				WithExitCode(clierrors.ExitTimeout)
@@ -342,63 +341,63 @@ func watchFingerprint(state pipelineGetOutput) string {
 
 // printWatchTable renders the workflow/job table to Err and returns the line count
 // written (used for TTY cursor rewind).
-func printWatchTable(streams iostream.Streams, state pipelineGetOutput, elapsed time.Duration) int {
+func printWatchTable(ctx context.Context, state pipelineGetOutput, elapsed time.Duration) int {
 	lines := 0
 	for _, wf := range state.Workflows {
-		streams.ErrPrintf("  %-28s  %s\n", wf.Name, wf.Status)
+		iostream.ErrPrintf(ctx, "  %-28s  %s\n", wf.Name, wf.Status)
 		lines++
 		for _, j := range wf.Jobs {
 			if j.Number > 0 {
-				streams.ErrPrintf("    %-30s  %-12s  #%d\n", j.Name, j.Status, j.Number)
+				iostream.ErrPrintf(ctx, "    %-30s  %-12s  #%d\n", j.Name, j.Status, j.Number)
 			} else {
-				streams.ErrPrintf("    %-30s  %s\n", j.Name, j.Status)
+				iostream.ErrPrintf(ctx, "    %-30s  %s\n", j.Name, j.Status)
 			}
 			lines++
 		}
 	}
-	streams.ErrPrintf("\n  Elapsed: %s\n", formatElapsed(elapsed))
+	iostream.ErrPrintf(ctx, "\n  Elapsed: %s\n", formatElapsed(elapsed))
 	lines += 2
 	return lines
 }
 
 // printWatchTableFinal renders the final workflow/job table without the elapsed line.
-func printWatchTableFinal(streams iostream.Streams, state pipelineGetOutput) {
+func printWatchTableFinal(ctx context.Context, state pipelineGetOutput) {
 	for _, wf := range state.Workflows {
-		streams.ErrPrintf("  %-28s  %s\n", wf.Name, wf.Status)
+		iostream.ErrPrintf(ctx, "  %-28s  %s\n", wf.Name, wf.Status)
 		for _, j := range wf.Jobs {
 			if j.Number > 0 {
-				streams.ErrPrintf("    %-30s  %-12s  #%d\n", j.Name, j.Status, j.Number)
+				iostream.ErrPrintf(ctx, "    %-30s  %-12s  #%d\n", j.Name, j.Status, j.Number)
 			} else {
-				streams.ErrPrintf("    %-30s  %s\n", j.Name, j.Status)
+				iostream.ErrPrintf(ctx, "    %-30s  %s\n", j.Name, j.Status)
 			}
 		}
 	}
 }
 
 // printWatchLine emits a single-line status update for non-TTY output.
-func printWatchLine(streams iostream.Streams, state pipelineGetOutput, elapsed time.Duration) {
+func printWatchLine(ctx context.Context, state pipelineGetOutput, elapsed time.Duration) {
 	var parts []string
 	for _, wf := range state.Workflows {
 		parts = append(parts, fmt.Sprintf("%s=%s", wf.Name, wf.Status))
 	}
-	streams.ErrPrintf("[%s]  %s\n", formatElapsed(elapsed), strings.Join(parts, "  "))
+	iostream.ErrPrintf(ctx, "[%s]  %s\n", formatElapsed(elapsed), strings.Join(parts, "  "))
 }
 
 // watchFinalResult prints the outcome and returns an appropriate error (or nil).
-func watchFinalResult(streams iostream.Streams, state pipelineGetOutput, number int64, elapsed time.Duration) error {
+func watchFinalResult(ctx context.Context, state pipelineGetOutput, number int64, elapsed time.Duration) error {
 	switch state.Status {
 	case "success":
-		streams.ErrPrintf("%s Pipeline #%d succeeded (%s)\n",
-			streams.Symbol("✓", "OK:"), number, formatElapsed(elapsed))
+		iostream.ErrPrintf(ctx, "%s Pipeline #%d succeeded (%s)\n",
+			iostream.Symbol(ctx, "✓", "OK:"), number, formatElapsed(elapsed))
 		return nil
 	case "canceled":
-		streams.ErrPrintf("Pipeline #%d was cancelled (%s)\n", number, formatElapsed(elapsed))
+		iostream.ErrPrintf(ctx, "Pipeline #%d was cancelled (%s)\n", number, formatElapsed(elapsed))
 		return clierrors.New("pipeline.cancelled", "Pipeline cancelled",
 			fmt.Sprintf("Pipeline #%d was cancelled.", number)).
 			WithExitCode(clierrors.ExitCancelled)
 	default:
-		streams.ErrPrintf("%s Pipeline #%d failed (%s)\n",
-			streams.Symbol("✗", "FAIL:"), number, formatElapsed(elapsed))
+		iostream.ErrPrintf(ctx, "%s Pipeline #%d failed (%s)\n",
+			iostream.Symbol(ctx, "✗", "FAIL:"), number, formatElapsed(elapsed))
 		return clierrors.New("pipeline.failed", "Pipeline failed",
 			fmt.Sprintf("Pipeline #%d failed.", number)).
 			WithExitCode(clierrors.ExitGeneralError)

--- a/internal/cmd/project/env.go
+++ b/internal/cmd/project/env.go
@@ -92,15 +92,14 @@ func NewEnvListCmd() *cobra.Command {
 			$ circleci envvar list --json
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
-			streams := iostream.FromCmd(cmd)
+			ctx := iostream.FromCmd(cmd.Context(), cmd)
 
 			client, err := cmdutil.LoadClient(ctx, cmd)
 			if err != nil {
 				return err
 			}
 
-			return RunEnvList(ctx, client, streams, projectSlug, jsonOut)
+			return RunEnvList(ctx, client, projectSlug, jsonOut)
 		},
 	}
 
@@ -112,7 +111,7 @@ func NewEnvListCmd() *cobra.Command {
 
 // RunEnvList is the business logic for listing env vars. Exported for reuse by
 // the top-level circleci env alias.
-func RunEnvList(ctx context.Context, client *apiclient.Client, streams iostream.Streams, projectSlug string, jsonOut bool) error {
+func RunEnvList(ctx context.Context, client *apiclient.Client, projectSlug string, jsonOut bool) error {
 	if projectSlug == "" {
 		info, err := gitremote.Detect()
 		if err != nil {
@@ -132,18 +131,18 @@ func RunEnvList(ctx context.Context, client *apiclient.Client, streams iostream.
 	}
 
 	if jsonOut {
-		enc := json.NewEncoder(streams.Out)
+		enc := json.NewEncoder(iostream.Out(ctx))
 		enc.SetIndent("", "  ")
 		return enc.Encode(vars)
 	}
 
 	if len(vars) == 0 {
-		streams.ErrPrintln("No environment variables found.")
+		iostream.ErrPrintln(ctx, "No environment variables found.")
 		return nil
 	}
 
 	for _, v := range vars {
-		streams.Printf("%-40s  %s\n", v.Name, v.Value)
+		iostream.Printf(ctx, "%-40s  %s\n", v.Name, v.Value)
 	}
 	return nil
 }
@@ -178,14 +177,13 @@ func NewEnvSetCmd() *cobra.Command {
 		`),
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
-			streams := iostream.FromCmd(cmd)
+			ctx := iostream.FromCmd(cmd.Context(), cmd)
 
 			client, err := cmdutil.LoadClient(ctx, cmd)
 			if err != nil {
 				return err
 			}
-			return RunEnvSet(ctx, client, streams, projectSlug, args[0], args[1])
+			return RunEnvSet(ctx, client, projectSlug, args[0], args[1])
 		},
 	}
 
@@ -195,7 +193,7 @@ func NewEnvSetCmd() *cobra.Command {
 }
 
 // RunEnvSet is the business logic for setting an env var.
-func RunEnvSet(ctx context.Context, client *apiclient.Client, streams iostream.Streams, projectSlug, name, value string) error {
+func RunEnvSet(ctx context.Context, client *apiclient.Client, projectSlug, name, value string) error {
 	if projectSlug == "" {
 		info, err := gitremote.Detect()
 		if err != nil {
@@ -213,7 +211,7 @@ func RunEnvSet(ctx context.Context, client *apiclient.Client, streams iostream.S
 		return cmdutil.APIErr(err, projectSlug, "project.not_found", "No project found for %q.")
 	}
 
-	streams.Printf("%s Set %s\n", streams.Symbol("✓", "OK:"), name)
+	iostream.Printf(ctx, "%s Set %s\n", iostream.Symbol(ctx, "✓", "OK:"), name)
 	return nil
 }
 
@@ -250,15 +248,14 @@ func NewEnvDeleteCmd() *cobra.Command {
 		`),
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
-			streams := iostream.FromCmd(cmd)
+			ctx := iostream.FromCmd(cmd.Context(), cmd)
 
 			client, err := cmdutil.LoadClient(ctx, cmd)
 			if err != nil {
 				return err
 			}
 
-			return RunEnvDelete(ctx, client, streams, projectSlug, args[0], force)
+			return RunEnvDelete(ctx, client, projectSlug, args[0], force)
 		},
 	}
 
@@ -269,11 +266,11 @@ func NewEnvDeleteCmd() *cobra.Command {
 }
 
 // RunEnvDelete is the business logic for deleting an env var.
-func RunEnvDelete(ctx context.Context, client *apiclient.Client, streams iostream.Streams, projectSlug, name string, force bool) error {
+func RunEnvDelete(ctx context.Context, client *apiclient.Client, projectSlug, name string, force bool) error {
 	if !force {
-		if streams.IsInteractive() {
+		if iostream.IsInteractive(ctx) {
 			prompt := fmt.Sprintf("Delete environment variable %q? This cannot be undone.", name)
-			if !streams.Confirm(prompt) {
+			if !iostream.Confirm(ctx, prompt) {
 				return clierrors.New("envvar.delete_aborted", "Deletion aborted",
 					"Environment variable deletion was not confirmed.").
 					WithExitCode(clierrors.ExitCancelled)
@@ -303,7 +300,7 @@ func RunEnvDelete(ctx context.Context, client *apiclient.Client, streams iostrea
 		return cmdutil.APIErr(err, name, "envvar.not_found", "No environment variable %q found.")
 	}
 
-	streams.Printf("%s Deleted %s\n", streams.Symbol("✓", "OK:"), name)
+	iostream.Printf(ctx, "%s Deleted %s\n", iostream.Symbol(ctx, "✓", "OK:"), name)
 	return nil
 }
 

--- a/internal/cmd/project/follow.go
+++ b/internal/cmd/project/follow.go
@@ -63,15 +63,14 @@ func newFollowCmd() *cobra.Command {
 			$ circleci project follow --project bb/myorg/myrepo
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
-			streams := iostream.FromCmd(cmd)
+			ctx := iostream.FromCmd(cmd.Context(), cmd)
 
 			client, err := cmdutil.LoadClient(ctx, cmd)
 			if err != nil {
 				return err
 			}
 
-			return runProjectFollow(ctx, client, streams, projectSlug)
+			return runProjectFollow(ctx, client, projectSlug)
 		},
 	}
 
@@ -80,7 +79,7 @@ func newFollowCmd() *cobra.Command {
 	return cmd
 }
 
-func runProjectFollow(ctx context.Context, client *apiclient.Client, streams iostream.Streams, projectSlug string) error {
+func runProjectFollow(ctx context.Context, client *apiclient.Client, projectSlug string) error {
 	if projectSlug == "" {
 		info, err := gitremote.Detect()
 		if err != nil {
@@ -106,7 +105,7 @@ func runProjectFollow(ctx context.Context, client *apiclient.Client, streams ios
 		return cmdutil.APIErr(apiErr, projectSlug, "project.follow_failed", "Could not follow project %q.")
 	}
 
-	streams.Printf("%s Now following %s\n", streams.Symbol("✓", "OK:"), projectSlug)
+	iostream.Printf(ctx, "%s Now following %s\n", iostream.Symbol(ctx, "✓", "OK:"), projectSlug)
 	return nil
 }
 

--- a/internal/cmd/project/list.go
+++ b/internal/cmd/project/list.go
@@ -62,15 +62,14 @@ func newListCmd() *cobra.Command {
 			$ circleci project list --json | jq '.[] | select(.username == "myorg")'
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
-			streams := iostream.FromCmd(cmd)
+			ctx := iostream.FromCmd(cmd.Context(), cmd)
 
 			client, err := cmdutil.LoadClient(ctx, cmd)
 			if err != nil {
 				return err
 			}
 
-			return runProjectList(ctx, client, streams, jsonOut)
+			return runProjectList(ctx, client, jsonOut)
 		},
 	}
 
@@ -87,7 +86,7 @@ type projectOutput struct {
 	RepoName string `json:"reponame"`
 }
 
-func runProjectList(ctx context.Context, client *apiclient.Client, streams iostream.Streams, jsonOut bool) error {
+func runProjectList(ctx context.Context, client *apiclient.Client, jsonOut bool) error {
 	projects, err := client.ListProjects(ctx)
 	if err != nil {
 		return cmdutil.APIErr(err, "projects", "project.list_failed", "Could not list projects: %s")
@@ -119,18 +118,18 @@ func runProjectList(ctx context.Context, client *apiclient.Client, streams iostr
 	}
 
 	if jsonOut {
-		enc := json.NewEncoder(streams.Out)
+		enc := json.NewEncoder(iostream.Out(ctx))
 		enc.SetIndent("", "  ")
 		return enc.Encode(out)
 	}
 
 	if len(out) == 0 {
-		streams.ErrPrintln("No followed projects found.")
+		iostream.ErrPrintln(ctx, "No followed projects found.")
 		return nil
 	}
 
 	for _, p := range out {
-		streams.Println(p.Slug)
+		iostream.Println(ctx, p.Slug)
 	}
 	return nil
 }

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -61,6 +61,7 @@ func NewRootCmd(version string) *cobra.Command {
 	cmd.SetVersionTemplate("circleci version {{.Version}}\n")
 
 	cmd.PersistentFlags().BoolP("quiet", "q", false, "suppress informational output; data on stdout is unaffected")
+	cmd.PersistentFlags().Bool("debug", false, "enable debug logging")
 
 	cmd.PersistentFlags().BoolP("insecure-storage", "", false, "do not use the system's secure storage for storing tokens")
 	_ = cmd.PersistentFlags().MarkHidden("insecure-storage")

--- a/internal/cmd/root/testdata/usage/circleci.txt
+++ b/internal/cmd/root/testdata/usage/circleci.txt
@@ -16,6 +16,7 @@ Available Commands:
   workflow    Manage workflows
 
 Flags:
+      --debug   enable debug logging
   -q, --quiet   suppress informational output; data on stdout is unaffected
 
 Use "circleci [command] --help" for more information about a command.

--- a/internal/cmd/root/testdata/usage/circleci/api.txt
+++ b/internal/cmd/root/testdata/usage/circleci/api.txt
@@ -28,4 +28,5 @@ Flags:
   -X, --method string        HTTP method (default: GET, or POST when -f is used)
 
 Global Flags:
+      --debug   enable debug logging
   -q, --quiet   suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/artifacts.txt
+++ b/internal/cmd/root/testdata/usage/circleci/artifacts.txt
@@ -29,4 +29,5 @@ Flags:
       --project string    Project slug (e.g. gh/org/repo); used with --job, defaults to git remote
 
 Global Flags:
+      --debug   enable debug logging
   -q, --quiet   suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/auth.txt
+++ b/internal/cmd/root/testdata/usage/circleci/auth.txt
@@ -7,6 +7,7 @@ Available Commands:
   token       Set personal access token for authenticating to CircleCI
 
 Global Flags:
+      --debug   enable debug logging
   -q, --quiet   suppress informational output; data on stdout is unaffected
 
 Use "circleci auth [command] --help" for more information about a command.

--- a/internal/cmd/root/testdata/usage/circleci/auth/logout.txt
+++ b/internal/cmd/root/testdata/usage/circleci/auth/logout.txt
@@ -5,4 +5,5 @@ Flags:
       --json   Output as JSON
 
 Global Flags:
+      --debug   enable debug logging
   -q, --quiet   suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/auth/me.txt
+++ b/internal/cmd/root/testdata/usage/circleci/auth/me.txt
@@ -5,4 +5,5 @@ Flags:
       --json   Output as JSON
 
 Global Flags:
+      --debug   enable debug logging
   -q, --quiet   suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/auth/token.txt
+++ b/internal/cmd/root/testdata/usage/circleci/auth/token.txt
@@ -2,4 +2,5 @@ Usage:
   circleci auth token [flags]
 
 Global Flags:
+      --debug   enable debug logging
   -q, --quiet   suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/completion.txt
+++ b/internal/cmd/root/testdata/usage/circleci/completion.txt
@@ -6,6 +6,7 @@ Available Commands:
   uninstall   Remove shell completion from your shell profile
 
 Global Flags:
+      --debug   enable debug logging
   -q, --quiet   suppress informational output; data on stdout is unaffected
 
 Use "circleci completion [command] --help" for more information about a command.

--- a/internal/cmd/root/testdata/usage/circleci/completion/bash.txt
+++ b/internal/cmd/root/testdata/usage/circleci/completion/bash.txt
@@ -2,4 +2,5 @@ Usage:
   circleci completion bash [flags]
 
 Global Flags:
+      --debug   enable debug logging
   -q, --quiet   suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/completion/install.txt
+++ b/internal/cmd/root/testdata/usage/circleci/completion/install.txt
@@ -13,4 +13,5 @@ $ source <(circleci completion bash)
 
 
 Global Flags:
+      --debug   enable debug logging
   -q, --quiet   suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/completion/uninstall.txt
+++ b/internal/cmd/root/testdata/usage/circleci/completion/uninstall.txt
@@ -13,4 +13,5 @@ $ grep -l "circleci shell completion" ~/.zshrc ~/.bashrc 2>/dev/null
 
 
 Global Flags:
+      --debug   enable debug logging
   -q, --quiet   suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/completion/zsh.txt
+++ b/internal/cmd/root/testdata/usage/circleci/completion/zsh.txt
@@ -2,4 +2,5 @@ Usage:
   circleci completion zsh [flags]
 
 Global Flags:
+      --debug   enable debug logging
   -q, --quiet   suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/envvar.txt
+++ b/internal/cmd/root/testdata/usage/circleci/envvar.txt
@@ -18,6 +18,7 @@ Available Commands:
   set         Set a project environment variable
 
 Global Flags:
+      --debug   enable debug logging
   -q, --quiet   suppress informational output; data on stdout is unaffected
 
 Use "circleci envvar [command] --help" for more information about a command.

--- a/internal/cmd/root/testdata/usage/circleci/envvar/delete.txt
+++ b/internal/cmd/root/testdata/usage/circleci/envvar/delete.txt
@@ -17,4 +17,5 @@ Flags:
       --project string   Project slug (e.g. gh/org/repo); defaults to git remote
 
 Global Flags:
+      --debug   enable debug logging
   -q, --quiet   suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/envvar/list.txt
+++ b/internal/cmd/root/testdata/usage/circleci/envvar/list.txt
@@ -17,4 +17,5 @@ Flags:
       --project string   Project slug (e.g. gh/org/repo); defaults to git remote
 
 Global Flags:
+      --debug   enable debug logging
   -q, --quiet   suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/envvar/set.txt
+++ b/internal/cmd/root/testdata/usage/circleci/envvar/set.txt
@@ -16,4 +16,5 @@ Flags:
       --project string   Project slug (e.g. gh/org/repo); defaults to git remote
 
 Global Flags:
+      --debug   enable debug logging
   -q, --quiet   suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/job.txt
+++ b/internal/cmd/root/testdata/usage/circleci/job.txt
@@ -6,6 +6,7 @@ Available Commands:
   logs        Fetch logs for a job
 
 Global Flags:
+      --debug   enable debug logging
   -q, --quiet   suppress informational output; data on stdout is unaffected
 
 Use "circleci job [command] --help" for more information about a command.

--- a/internal/cmd/root/testdata/usage/circleci/job/artifacts.txt
+++ b/internal/cmd/root/testdata/usage/circleci/job/artifacts.txt
@@ -21,4 +21,5 @@ Flags:
       --project string    Project slug (e.g. gh/org/repo); defaults to git remote
 
 Global Flags:
+      --debug   enable debug logging
   -q, --quiet   suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/job/logs.txt
+++ b/internal/cmd/root/testdata/usage/circleci/job/logs.txt
@@ -21,4 +21,5 @@ Flags:
       --step string      Filter output to a single step by name
 
 Global Flags:
+      --debug   enable debug logging
   -q, --quiet   suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/logs.txt
+++ b/internal/cmd/root/testdata/usage/circleci/logs.txt
@@ -30,4 +30,5 @@ Flags:
       --step string      Filter output to a single step by name
 
 Global Flags:
+      --debug   enable debug logging
   -q, --quiet   suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/pipeline.txt
+++ b/internal/cmd/root/testdata/usage/circleci/pipeline.txt
@@ -9,6 +9,7 @@ Available Commands:
   watch       Watch a pipeline until it completes
 
 Global Flags:
+      --debug   enable debug logging
   -q, --quiet   suppress informational output; data on stdout is unaffected
 
 Use "circleci pipeline [command] --help" for more information about a command.

--- a/internal/cmd/root/testdata/usage/circleci/pipeline/cancel.txt
+++ b/internal/cmd/root/testdata/usage/circleci/pipeline/cancel.txt
@@ -17,4 +17,5 @@ Flags:
       --project string   Project slug (e.g. gh/org/repo); used when cancelling by number
 
 Global Flags:
+      --debug   enable debug logging
   -q, --quiet   suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/pipeline/get.txt
+++ b/internal/cmd/root/testdata/usage/circleci/pipeline/get.txt
@@ -21,4 +21,5 @@ Flags:
       --project string   Project slug (e.g. gh/org/repo); used when looking up by number
 
 Global Flags:
+      --debug   enable debug logging
   -q, --quiet   suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/pipeline/list.txt
+++ b/internal/cmd/root/testdata/usage/circleci/pipeline/list.txt
@@ -28,4 +28,5 @@ Flags:
       --project string   Project slug (e.g. gh/org/repo); defaults to git remote
 
 Global Flags:
+      --debug   enable debug logging
   -q, --quiet   suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/pipeline/trigger.txt
+++ b/internal/cmd/root/testdata/usage/circleci/pipeline/trigger.txt
@@ -22,4 +22,5 @@ Flags:
       --project string          Project slug (e.g. gh/org/repo); defaults to git remote
 
 Global Flags:
+      --debug   enable debug logging
   -q, --quiet   suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/pipeline/watch.txt
+++ b/internal/cmd/root/testdata/usage/circleci/pipeline/watch.txt
@@ -28,4 +28,5 @@ Flags:
       --timeout duration   Maximum time to wait for pipeline completion (default 30m0s)
 
 Global Flags:
+      --debug   enable debug logging
   -q, --quiet   suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/project.txt
+++ b/internal/cmd/root/testdata/usage/circleci/project.txt
@@ -7,6 +7,7 @@ Available Commands:
   list        List followed projects
 
 Global Flags:
+      --debug   enable debug logging
   -q, --quiet   suppress informational output; data on stdout is unaffected
 
 Use "circleci project [command] --help" for more information about a command.

--- a/internal/cmd/root/testdata/usage/circleci/project/envvar.txt
+++ b/internal/cmd/root/testdata/usage/circleci/project/envvar.txt
@@ -7,6 +7,7 @@ Available Commands:
   set         Set a project environment variable
 
 Global Flags:
+      --debug   enable debug logging
   -q, --quiet   suppress informational output; data on stdout is unaffected
 
 Use "circleci project envvar [command] --help" for more information about a command.

--- a/internal/cmd/root/testdata/usage/circleci/project/envvar/delete.txt
+++ b/internal/cmd/root/testdata/usage/circleci/project/envvar/delete.txt
@@ -17,4 +17,5 @@ Flags:
       --project string   Project slug (e.g. gh/org/repo); defaults to git remote
 
 Global Flags:
+      --debug   enable debug logging
   -q, --quiet   suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/project/envvar/list.txt
+++ b/internal/cmd/root/testdata/usage/circleci/project/envvar/list.txt
@@ -17,4 +17,5 @@ Flags:
       --project string   Project slug (e.g. gh/org/repo); defaults to git remote
 
 Global Flags:
+      --debug   enable debug logging
   -q, --quiet   suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/project/envvar/set.txt
+++ b/internal/cmd/root/testdata/usage/circleci/project/envvar/set.txt
@@ -16,4 +16,5 @@ Flags:
       --project string   Project slug (e.g. gh/org/repo); defaults to git remote
 
 Global Flags:
+      --debug   enable debug logging
   -q, --quiet   suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/project/follow.txt
+++ b/internal/cmd/root/testdata/usage/circleci/project/follow.txt
@@ -16,4 +16,5 @@ Flags:
       --project string   Project slug (e.g. gh/org/repo); defaults to git remote
 
 Global Flags:
+      --debug   enable debug logging
   -q, --quiet   suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/project/list.txt
+++ b/internal/cmd/root/testdata/usage/circleci/project/list.txt
@@ -19,4 +19,5 @@ Flags:
       --json   Output as JSON
 
 Global Flags:
+      --debug   enable debug logging
   -q, --quiet   suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/runner.txt
+++ b/internal/cmd/root/testdata/usage/circleci/runner.txt
@@ -8,6 +8,7 @@ Available Commands:
   token          Manage runner tokens
 
 Global Flags:
+      --debug   enable debug logging
   -q, --quiet   suppress informational output; data on stdout is unaffected
 
 Use "circleci runner [command] --help" for more information about a command.

--- a/internal/cmd/root/testdata/usage/circleci/runner/instance.txt
+++ b/internal/cmd/root/testdata/usage/circleci/runner/instance.txt
@@ -5,6 +5,7 @@ Available Commands:
   list        List connected runner instances
 
 Global Flags:
+      --debug   enable debug logging
   -q, --quiet   suppress informational output; data on stdout is unaffected
 
 Use "circleci runner instance [command] --help" for more information about a command.

--- a/internal/cmd/root/testdata/usage/circleci/runner/instance/list.txt
+++ b/internal/cmd/root/testdata/usage/circleci/runner/instance/list.txt
@@ -21,4 +21,5 @@ Flags:
       --resource-class string   Filter by resource class (namespace/name)
 
 Global Flags:
+      --debug   enable debug logging
   -q, --quiet   suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/runner/resource-class.txt
+++ b/internal/cmd/root/testdata/usage/circleci/runner/resource-class.txt
@@ -7,6 +7,7 @@ Available Commands:
   list        List runner resource classes
 
 Global Flags:
+      --debug   enable debug logging
   -q, --quiet   suppress informational output; data on stdout is unaffected
 
 Use "circleci runner resource-class [command] --help" for more information about a command.

--- a/internal/cmd/root/testdata/usage/circleci/runner/resource-class/create.txt
+++ b/internal/cmd/root/testdata/usage/circleci/runner/resource-class/create.txt
@@ -17,4 +17,5 @@ Flags:
       --json                 Output as JSON
 
 Global Flags:
+      --debug   enable debug logging
   -q, --quiet   suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/runner/resource-class/delete.txt
+++ b/internal/cmd/root/testdata/usage/circleci/runner/resource-class/delete.txt
@@ -16,4 +16,5 @@ Flags:
   -f, --force   skip confirmation prompt
 
 Global Flags:
+      --debug   enable debug logging
   -q, --quiet   suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/runner/resource-class/list.txt
+++ b/internal/cmd/root/testdata/usage/circleci/runner/resource-class/list.txt
@@ -20,4 +20,5 @@ Flags:
       --namespace string   Filter by namespace (organization)
 
 Global Flags:
+      --debug   enable debug logging
   -q, --quiet   suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/runner/task.txt
+++ b/internal/cmd/root/testdata/usage/circleci/runner/task.txt
@@ -19,4 +19,5 @@ Flags:
       --resource-class string   Resource class to query (namespace/name)
 
 Global Flags:
+      --debug   enable debug logging
   -q, --quiet   suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/runner/token.txt
+++ b/internal/cmd/root/testdata/usage/circleci/runner/token.txt
@@ -7,6 +7,7 @@ Available Commands:
   list        List tokens for a resource class
 
 Global Flags:
+      --debug   enable debug logging
   -q, --quiet   suppress informational output; data on stdout is unaffected
 
 Use "circleci runner token [command] --help" for more information about a command.

--- a/internal/cmd/root/testdata/usage/circleci/runner/token/create.txt
+++ b/internal/cmd/root/testdata/usage/circleci/runner/token/create.txt
@@ -17,4 +17,5 @@ Flags:
       --nickname string   Human-readable nickname for the token
 
 Global Flags:
+      --debug   enable debug logging
   -q, --quiet   suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/runner/token/delete.txt
+++ b/internal/cmd/root/testdata/usage/circleci/runner/token/delete.txt
@@ -17,4 +17,5 @@ Flags:
   -f, --force   skip confirmation prompt
 
 Global Flags:
+      --debug   enable debug logging
   -q, --quiet   suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/runner/token/list.txt
+++ b/internal/cmd/root/testdata/usage/circleci/runner/token/list.txt
@@ -23,4 +23,5 @@ Flags:
       --resource-class string   Filter by resource class (namespace/name)
 
 Global Flags:
+      --debug   enable debug logging
   -q, --quiet   suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/settings.txt
+++ b/internal/cmd/root/testdata/usage/circleci/settings.txt
@@ -6,6 +6,7 @@ Available Commands:
   set         Set a CLI setting
 
 Global Flags:
+      --debug   enable debug logging
   -q, --quiet   suppress informational output; data on stdout is unaffected
 
 Use "circleci settings [command] --help" for more information about a command.

--- a/internal/cmd/root/testdata/usage/circleci/settings/list.txt
+++ b/internal/cmd/root/testdata/usage/circleci/settings/list.txt
@@ -13,4 +13,5 @@ Flags:
       --json   Output as JSON
 
 Global Flags:
+      --debug   enable debug logging
   -q, --quiet   suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/settings/set.txt
+++ b/internal/cmd/root/testdata/usage/circleci/settings/set.txt
@@ -13,4 +13,5 @@ $ CIRCLECI_TOKEN=mytoken123 circleci pipeline get
 
 
 Global Flags:
+      --debug   enable debug logging
   -q, --quiet   suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/workflow.txt
+++ b/internal/cmd/root/testdata/usage/circleci/workflow.txt
@@ -8,6 +8,7 @@ Available Commands:
   rerun       Rerun a workflow
 
 Global Flags:
+      --debug   enable debug logging
   -q, --quiet   suppress informational output; data on stdout is unaffected
 
 Use "circleci workflow [command] --help" for more information about a command.

--- a/internal/cmd/root/testdata/usage/circleci/workflow/cancel.txt
+++ b/internal/cmd/root/testdata/usage/circleci/workflow/cancel.txt
@@ -16,4 +16,5 @@ Flags:
   -f, --force   skip confirmation prompt
 
 Global Flags:
+      --debug   enable debug logging
   -q, --quiet   suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/workflow/get.txt
+++ b/internal/cmd/root/testdata/usage/circleci/workflow/get.txt
@@ -16,4 +16,5 @@ Flags:
       --json   Output as JSON
 
 Global Flags:
+      --debug   enable debug logging
   -q, --quiet   suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/workflow/list.txt
+++ b/internal/cmd/root/testdata/usage/circleci/workflow/list.txt
@@ -31,4 +31,5 @@ Flags:
       --project string   Project slug (e.g. gh/org/repo); defaults to git remote
 
 Global Flags:
+      --debug   enable debug logging
   -q, --quiet   suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/workflow/rerun.txt
+++ b/internal/cmd/root/testdata/usage/circleci/workflow/rerun.txt
@@ -16,4 +16,5 @@ Flags:
       --from-failed   Rerun only failed jobs
 
 Global Flags:
+      --debug   enable debug logging
   -q, --quiet   suppress informational output; data on stdout is unaffected

--- a/internal/cmd/runner/instance.go
+++ b/internal/cmd/runner/instance.go
@@ -88,13 +88,12 @@ func newInstanceListCmd() *cobra.Command {
 			$ circleci runner instance list --resource-class my-org/my-runner --json
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
-			streams := iostream.FromCmd(cmd)
+			ctx := iostream.FromCmd(cmd.Context(), cmd)
 			client, err := cmdutil.LoadClient(ctx, cmd)
 			if err != nil {
 				return err
 			}
-			return runInstanceList(ctx, client, streams, resourceClass, namespace, jsonOut)
+			return runInstanceList(ctx, client, resourceClass, namespace, jsonOut)
 		},
 	}
 
@@ -146,7 +145,7 @@ func instanceStatus(lastConnectedAt string) string {
 	}
 }
 
-func runInstanceList(ctx context.Context, client *apiclient.Client, streams iostream.Streams, resourceClass, namespace string, jsonOut bool) error {
+func runInstanceList(ctx context.Context, client *apiclient.Client, resourceClass, namespace string, jsonOut bool) error {
 	if resourceClass == "" && namespace == "" {
 		ns, err := gitremote.DetectNamespace()
 		if err != nil {
@@ -187,22 +186,22 @@ func runInstanceList(ctx context.Context, client *apiclient.Client, streams iost
 	}
 
 	if jsonOut {
-		enc := json.NewEncoder(streams.Out)
+		enc := json.NewEncoder(iostream.Out(ctx))
 		enc.SetIndent("", "  ")
 		return enc.Encode(out)
 	}
 
 	if len(out) == 0 {
 		if resourceClass != "" {
-			streams.Printf("No runner instances found for %s.\n", resourceClass)
+			iostream.Printf(ctx, "No runner instances found for %s.\n", resourceClass)
 		} else {
-			streams.Printf("No runner instances found.\n")
+			iostream.Printf(ctx, "No runner instances found.\n")
 		}
 		return nil
 	}
 
 	for _, inst := range out {
-		streams.Printf("%-40s  %-20s  %-7s  %s\n",
+		iostream.Printf(ctx, "%-40s  %-20s  %-7s  %s\n",
 			inst.ResourceClass, inst.Hostname, inst.Status, inst.LastConnected)
 	}
 	return nil

--- a/internal/cmd/runner/resource_class.go
+++ b/internal/cmd/runner/resource_class.go
@@ -86,13 +86,12 @@ func newResourceClassListCmd() *cobra.Command {
 			$ circleci runner resource-class list --namespace my-org --json
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
-			streams := iostream.FromCmd(cmd)
+			ctx := iostream.FromCmd(cmd.Context(), cmd)
 			client, err := cmdutil.LoadClient(ctx, cmd)
 			if err != nil {
 				return err
 			}
-			return runResourceClassList(ctx, client, streams, namespace, jsonOut)
+			return runResourceClassList(ctx, client, namespace, jsonOut)
 		},
 	}
 
@@ -107,7 +106,7 @@ type resourceClassOutput struct {
 	Description   string `json:"description"`
 }
 
-func runResourceClassList(ctx context.Context, client *apiclient.Client, streams iostream.Streams, namespace string, jsonOut bool) error {
+func runResourceClassList(ctx context.Context, client *apiclient.Client, namespace string, jsonOut bool) error {
 	if namespace == "" {
 		ns, err := gitremote.DetectNamespace()
 		if err != nil {
@@ -137,20 +136,20 @@ func runResourceClassList(ctx context.Context, client *apiclient.Client, streams
 	}
 
 	if jsonOut {
-		enc := json.NewEncoder(streams.Out)
+		enc := json.NewEncoder(iostream.Out(ctx))
 		enc.SetIndent("", "  ")
 		return enc.Encode(out)
 	}
 
 	if len(out) == 0 {
-		streams.Printf("No resource classes found.\n")
+		iostream.Printf(ctx, "No resource classes found.\n")
 		return nil
 	}
 	for _, rc := range out {
 		if rc.Description != "" {
-			streams.Printf("%-40s  %s\n", rc.ResourceClass, rc.Description)
+			iostream.Printf(ctx, "%-40s  %s\n", rc.ResourceClass, rc.Description)
 		} else {
-			streams.Printf("%s\n", rc.ResourceClass)
+			iostream.Printf(ctx, "%s\n", rc.ResourceClass)
 		}
 	}
 	return nil
@@ -188,13 +187,12 @@ func newResourceClassCreateCmd() *cobra.Command {
 			if cliErr := cmdutil.RequireArgs(args, "namespace/name"); cliErr != nil {
 				return cliErr
 			}
-			ctx := cmd.Context()
-			streams := iostream.FromCmd(cmd)
+			ctx := iostream.FromCmd(cmd.Context(), cmd)
 			client, err := cmdutil.LoadClient(ctx, cmd)
 			if err != nil {
 				return err
 			}
-			return runResourceClassCreate(ctx, client, streams, args[0], description, jsonOut)
+			return runResourceClassCreate(ctx, client, args[0], description, jsonOut)
 		},
 	}
 
@@ -203,7 +201,7 @@ func newResourceClassCreateCmd() *cobra.Command {
 	return cmd
 }
 
-func runResourceClassCreate(ctx context.Context, client *apiclient.Client, streams iostream.Streams, resourceClass, description string, jsonOut bool) error {
+func runResourceClassCreate(ctx context.Context, client *apiclient.Client, resourceClass, description string, jsonOut bool) error {
 	rc, err := client.CreateResourceClass(ctx, resourceClass, description)
 	if err != nil {
 		return apiErr(err, resourceClass)
@@ -216,16 +214,16 @@ func runResourceClassCreate(ctx context.Context, client *apiclient.Client, strea
 	}
 
 	if jsonOut {
-		enc := json.NewEncoder(streams.Out)
+		enc := json.NewEncoder(iostream.Out(ctx))
 		enc.SetIndent("", "  ")
 		return enc.Encode(out)
 	}
 
-	streams.Printf("Created resource class: %s\n", out.ResourceClass)
+	iostream.Printf(ctx, "Created resource class: %s\n", out.ResourceClass)
 	if out.Description != "" {
-		streams.Printf("Description: %s\n", out.Description)
+		iostream.Printf(ctx, "Description: %s\n", out.Description)
 	}
-	streams.Printf("ID: %s\n", out.ID)
+	iostream.Printf(ctx, "ID: %s\n", out.ID)
 	return nil
 }
 
@@ -261,13 +259,12 @@ func newResourceClassDeleteCmd() *cobra.Command {
 			if cliErr := cmdutil.RequireArgs(args, "namespace/name"); cliErr != nil {
 				return cliErr
 			}
-			ctx := cmd.Context()
-			streams := iostream.FromCmd(cmd)
+			ctx := iostream.FromCmd(cmd.Context(), cmd)
 			client, err := cmdutil.LoadClient(ctx, cmd)
 			if err != nil {
 				return err
 			}
-			return runResourceClassDelete(ctx, client, streams, args[0], force)
+			return runResourceClassDelete(ctx, client, args[0], force)
 		},
 	}
 
@@ -275,11 +272,11 @@ func newResourceClassDeleteCmd() *cobra.Command {
 	return cmd
 }
 
-func runResourceClassDelete(ctx context.Context, client *apiclient.Client, streams iostream.Streams, resourceClass string, force bool) error {
+func runResourceClassDelete(ctx context.Context, client *apiclient.Client, resourceClass string, force bool) error {
 	if !force {
-		if streams.IsInteractive() {
+		if iostream.IsInteractive(ctx) {
 			prompt := fmt.Sprintf("Delete resource class %q? All tokens and runner connections will be removed.", resourceClass)
-			if !streams.Confirm(prompt) {
+			if !iostream.Confirm(ctx, prompt) {
 				return clierrors.New("runner.delete_aborted", "Deletion aborted",
 					"Resource class deletion was not confirmed.").
 					WithExitCode(clierrors.ExitCancelled)
@@ -296,6 +293,6 @@ func runResourceClassDelete(ctx context.Context, client *apiclient.Client, strea
 		return apiErr(err, resourceClass)
 	}
 
-	streams.ErrPrintf("%s Deleted resource class %s\n", streams.Symbol("✓", "OK:"), resourceClass)
+	iostream.ErrPrintf(ctx, "%s Deleted resource class %s\n", iostream.Symbol(ctx, "✓", "OK:"), resourceClass)
 	return nil
 }

--- a/internal/cmd/runner/tasks.go
+++ b/internal/cmd/runner/tasks.go
@@ -27,13 +27,14 @@ import (
 	"encoding/json"
 	"net/http"
 
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/apiclient"
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/cmdutil"
 	clierrors "github.com/CircleCI-Public/circleci-cli-v2/internal/errors"
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/httpcl"
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/iostream"
-	"github.com/MakeNowJust/heredoc"
-	"github.com/spf13/cobra"
 )
 
 func newTasksCmd() *cobra.Command {
@@ -65,13 +66,12 @@ func newTasksCmd() *cobra.Command {
 			  done
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
-			streams := iostream.FromCmd(cmd)
+			ctx := iostream.FromCmd(cmd.Context(), cmd)
 			client, err := cmdutil.LoadClient(ctx, cmd)
 			if err != nil {
 				return err
 			}
-			return runTasks(ctx, client, streams, resourceClass, jsonOut)
+			return runTasks(ctx, client, resourceClass, jsonOut)
 		},
 	}
 
@@ -88,7 +88,7 @@ type tasksOutput struct {
 	Running       int    `json:"running"`
 }
 
-func runTasks(ctx context.Context, client *apiclient.Client, streams iostream.Streams, resourceClass string, jsonOut bool) error {
+func runTasks(ctx context.Context, client *apiclient.Client, resourceClass string, jsonOut bool) error {
 	counts, err := client.GetRunnerTaskCounts(ctx, resourceClass)
 	if err != nil {
 		if httpcl.HasStatusCode(err, http.StatusNotFound) {
@@ -107,13 +107,13 @@ func runTasks(ctx context.Context, client *apiclient.Client, streams iostream.St
 	}
 
 	if jsonOut {
-		enc := json.NewEncoder(streams.Out)
+		enc := json.NewEncoder(iostream.Out(ctx))
 		enc.SetIndent("", "  ")
 		return enc.Encode(out)
 	}
 
-	streams.Printf("Resource class: %s\n", out.ResourceClass)
-	streams.Printf("  Unclaimed:    %d\n", out.Unclaimed)
-	streams.Printf("  Running:      %d\n", out.Running)
+	iostream.Printf(ctx, "Resource class: %s\n", out.ResourceClass)
+	iostream.Printf(ctx, "  Unclaimed:    %d\n", out.Unclaimed)
+	iostream.Printf(ctx, "  Running:      %d\n", out.Running)
 	return nil
 }

--- a/internal/cmd/runner/token.go
+++ b/internal/cmd/runner/token.go
@@ -95,13 +95,12 @@ func newTokenListCmd() *cobra.Command {
 			$ circleci runner token list --resource-class my-org/my-runner --json | jq '.[].id'
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
-			streams := iostream.FromCmd(cmd)
+			ctx := iostream.FromCmd(cmd.Context(), cmd)
 			client, err := cmdutil.LoadClient(ctx, cmd)
 			if err != nil {
 				return err
 			}
-			return runTokenList(ctx, client, streams, resourceClass, jsonOut)
+			return runTokenList(ctx, client, resourceClass, jsonOut)
 		},
 	}
 
@@ -117,7 +116,7 @@ type tokenOutput struct {
 	CreatedAt     string `json:"created_at"`
 }
 
-func runTokenList(ctx context.Context, client *apiclient.Client, streams iostream.Streams, resourceClass string, jsonOut bool) error {
+func runTokenList(ctx context.Context, client *apiclient.Client, resourceClass string, jsonOut bool) error {
 	var resourceClasses []string
 	if resourceClass != "" {
 		resourceClasses = []string{resourceClass}
@@ -161,21 +160,21 @@ func runTokenList(ctx context.Context, client *apiclient.Client, streams iostrea
 		if out == nil {
 			out = []tokenOutput{}
 		}
-		enc := json.NewEncoder(streams.Out)
+		enc := json.NewEncoder(iostream.Out(ctx))
 		enc.SetIndent("", "  ")
 		return enc.Encode(out)
 	}
 
 	if len(out) == 0 {
 		if resourceClass != "" {
-			streams.Printf("No tokens found for %s.\n", resourceClass)
+			iostream.Printf(ctx, "No tokens found for %s.\n", resourceClass)
 		} else {
-			streams.Printf("No tokens found.\n")
+			iostream.Printf(ctx, "No tokens found.\n")
 		}
 		return nil
 	}
 	for _, t := range out {
-		streams.Printf("%-36s  %-20s  %s\n", t.ID, t.Nickname, t.CreatedAt)
+		iostream.Printf(ctx, "%-36s  %-20s  %s\n", t.ID, t.Nickname, t.CreatedAt)
 	}
 	return nil
 }
@@ -213,13 +212,12 @@ func newTokenCreateCmd() *cobra.Command {
 			if cliErr := cmdutil.RequireArgs(args, "resource-class"); cliErr != nil {
 				return cliErr
 			}
-			ctx := cmd.Context()
-			streams := iostream.FromCmd(cmd)
+			ctx := iostream.FromCmd(cmd.Context(), cmd)
 			client, err := cmdutil.LoadClient(ctx, cmd)
 			if err != nil {
 				return err
 			}
-			return runTokenCreate(ctx, client, streams, args[0], nickname, jsonOut)
+			return runTokenCreate(ctx, client, args[0], nickname, jsonOut)
 		},
 	}
 
@@ -236,7 +234,7 @@ type tokenCreateOutput struct {
 	Token         string `json:"token"`
 }
 
-func runTokenCreate(ctx context.Context, client *apiclient.Client, streams iostream.Streams, resourceClass, nickname string, jsonOut bool) error {
+func runTokenCreate(ctx context.Context, client *apiclient.Client, resourceClass, nickname string, jsonOut bool) error {
 	tok, err := client.CreateRunnerToken(ctx, resourceClass, nickname)
 	if err != nil {
 		return apiErr(err, resourceClass)
@@ -251,18 +249,18 @@ func runTokenCreate(ctx context.Context, client *apiclient.Client, streams iostr
 	}
 
 	if jsonOut {
-		enc := json.NewEncoder(streams.Out)
+		enc := json.NewEncoder(iostream.Out(ctx))
 		enc.SetIndent("", "  ")
 		return enc.Encode(out)
 	}
 
-	streams.Printf("Created token for resource class: %s\n", out.ResourceClass)
+	iostream.Printf(ctx, "Created token for resource class: %s\n", out.ResourceClass)
 	if out.Nickname != "" {
-		streams.Printf("Nickname:  %s\n", out.Nickname)
+		iostream.Printf(ctx, "Nickname:  %s\n", out.Nickname)
 	}
-	streams.Printf("ID:        %s\n", out.ID)
-	streams.Printf("Created:   %s\n", out.CreatedAt)
-	streams.Printf("\nToken (save this — it will not be shown again):\n%s\n", out.Token)
+	iostream.Printf(ctx, "ID:        %s\n", out.ID)
+	iostream.Printf(ctx, "Created:   %s\n", out.CreatedAt)
+	iostream.Printf(ctx, "\nToken (save this — it will not be shown again):\n%s\n", out.Token)
 	return nil
 }
 
@@ -301,13 +299,12 @@ func newTokenDeleteCmd() *cobra.Command {
 			if cliErr := cmdutil.RequireArgs(args, "token-id"); cliErr != nil {
 				return cliErr
 			}
-			ctx := cmd.Context()
-			streams := iostream.FromCmd(cmd)
+			ctx := iostream.FromCmd(cmd.Context(), cmd)
 			client, err := cmdutil.LoadClient(ctx, cmd)
 			if err != nil {
 				return err
 			}
-			return runTokenDelete(ctx, client, streams, args[0], force)
+			return runTokenDelete(ctx, client, args[0], force)
 		},
 	}
 
@@ -315,11 +312,11 @@ func newTokenDeleteCmd() *cobra.Command {
 	return cmd
 }
 
-func runTokenDelete(ctx context.Context, client *apiclient.Client, streams iostream.Streams, tokenID string, force bool) error {
+func runTokenDelete(ctx context.Context, client *apiclient.Client, tokenID string, force bool) error {
 	if !force {
-		if streams.IsInteractive() {
+		if iostream.IsInteractive(ctx) {
 			prompt := fmt.Sprintf("Delete token %q? Agents using this token will lose the ability to claim new jobs.", tokenID)
-			if !streams.Confirm(prompt) {
+			if !iostream.Confirm(ctx, prompt) {
 				return clierrors.New("runner.delete_aborted", "Deletion aborted",
 					"Token deletion was not confirmed.").
 					WithExitCode(clierrors.ExitCancelled)
@@ -336,6 +333,6 @@ func runTokenDelete(ctx context.Context, client *apiclient.Client, streams iostr
 		return apiErr(err, tokenID)
 	}
 
-	streams.Printf("Deleted token: %s\n", tokenID)
+	iostream.Printf(ctx, "Deleted token: %s\n", tokenID)
 	return nil
 }

--- a/internal/cmd/settings/list.go
+++ b/internal/cmd/settings/list.go
@@ -59,12 +59,11 @@ func newListCmd() *cobra.Command {
 		`),
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
-			streams := iostream.FromCmd(cmd)
+			ctx := iostream.FromCmd(cmd.Context(), cmd)
 
 			secureStorage := cmdutil.IsSecureStorage(cmd)
 
-			return runList(ctx, secureStorage, streams, jsonOut)
+			return runList(ctx, secureStorage, jsonOut)
 		},
 	}
 
@@ -72,7 +71,7 @@ func newListCmd() *cobra.Command {
 	return cmd
 }
 
-func runList(ctx context.Context, secureStorage bool, streams iostream.Streams, jsonOut bool) error {
+func runList(ctx context.Context, secureStorage bool, jsonOut bool) error {
 	cfg, err := config.Load(ctx, secureStorage)
 	if err != nil {
 		return clierrors.New("settings.load_failed", "Failed to load settings", err.Error()).
@@ -88,14 +87,14 @@ func runList(ctx context.Context, secureStorage bool, streams iostream.Streams, 
 			"token_set": tokenSet,
 			"host":      cfg.EffectiveHost(),
 		}
-		enc := json.NewEncoder(streams.Out)
+		enc := json.NewEncoder(iostream.Out(ctx))
 		enc.SetIndent("", "  ")
 		return enc.Encode(out)
 	}
 
-	streams.Printf("Config file: %s\n\n", path)
-	streams.Printf("%-10s  %s\n", "token", maskToken(cfg.EffectiveToken()))
-	streams.Printf("%-10s  %s\n", "host", cfg.EffectiveHost())
+	iostream.Printf(ctx, "Config file: %s\n\n", path)
+	iostream.Printf(ctx, "%-10s  %s\n", "token", maskToken(cfg.EffectiveToken()))
+	iostream.Printf(ctx, "%-10s  %s\n", "host", cfg.EffectiveHost())
 	return nil
 }
 

--- a/internal/cmd/settings/set.go
+++ b/internal/cmd/settings/set.go
@@ -57,19 +57,18 @@ func newSetCmd() *cobra.Command {
 		`),
 		Args: cobra.MaximumNArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
+			ctx := iostream.FromCmd(cmd.Context(), cmd)
 			if cliErr := cmdutil.RequireArgs(args, "key", "value"); cliErr != nil {
 				return cliErr
 			}
-			streams := iostream.FromCmd(cmd)
 			secureStorage := cmdutil.IsSecureStorage(cmd)
-			return runSet(ctx, secureStorage, streams, args[0], args[1])
+			return runSet(ctx, secureStorage, args[0], args[1])
 		},
 	}
 	return cmd
 }
 
-func runSet(ctx context.Context, secureStorage bool, streams iostream.Streams, key, value string) error {
+func runSet(ctx context.Context, secureStorage bool, key, value string) error {
 	cfg, err := config.Load(ctx, secureStorage)
 	if err != nil {
 		return clierrors.New("settings.load_failed", "Failed to load settings", err.Error()).
@@ -94,10 +93,9 @@ func runSet(ctx context.Context, secureStorage bool, streams iostream.Streams, k
 
 	path, _ := config.Path()
 	if key == "token" && secureStorage {
-		streams.ErrPrintf("%s Saved %s to keyring\n", streams.Symbol("✓", "OK:"), key)
+		iostream.ErrPrintf(ctx, "%s Saved %s to keyring\n", iostream.Symbol(ctx, "✓", "OK:"), key)
 	} else {
-		streams.ErrPrintf("%s Saved %s to %s\n", streams.Symbol("✓", "OK:"), key, path)
-
+		iostream.ErrPrintf(ctx, "%s Saved %s to %s\n", iostream.Symbol(ctx, "✓", "OK:"), key, path)
 	}
 	return nil
 }

--- a/internal/cmd/workflow/cancel.go
+++ b/internal/cmd/workflow/cancel.go
@@ -67,14 +67,13 @@ func newCancelCmd() *cobra.Command {
 			if cliErr := cmdutil.RequireArgs(args, "workflow-id"); cliErr != nil {
 				return cliErr
 			}
-			ctx := cmd.Context()
-			streams := iostream.FromCmd(cmd)
+			ctx := iostream.FromCmd(cmd.Context(), cmd)
 			client, err := cmdutil.LoadClient(ctx, cmd)
 			if err != nil {
 				return err
 			}
 
-			return runCancel(ctx, client, streams, args[0], force)
+			return runCancel(ctx, client, args[0], force)
 		},
 	}
 
@@ -82,11 +81,11 @@ func newCancelCmd() *cobra.Command {
 	return cmd
 }
 
-func runCancel(ctx context.Context, client *apiclient.Client, streams iostream.Streams, id string, force bool) error {
+func runCancel(ctx context.Context, client *apiclient.Client, id string, force bool) error {
 	if !force {
-		if streams.IsInteractive() {
+		if iostream.IsInteractive(ctx) {
 			prompt := fmt.Sprintf("Cancel workflow %s? In-progress jobs will be stopped.", id)
-			if !streams.Confirm(prompt) {
+			if !iostream.Confirm(ctx, prompt) {
 				return clierrors.New("workflow.cancel_aborted", "Cancellation aborted",
 					"Workflow cancellation was not confirmed.").
 					WithExitCode(clierrors.ExitCancelled)
@@ -103,6 +102,6 @@ func runCancel(ctx context.Context, client *apiclient.Client, streams iostream.S
 		return apiErr(err, id)
 	}
 
-	streams.Printf("%s Cancelled workflow %s\n", streams.Symbol("✓", "OK:"), id)
+	iostream.Printf(ctx, "%s Cancelled workflow %s\n", iostream.Symbol(ctx, "✓", "OK:"), id)
 	return nil
 }

--- a/internal/cmd/workflow/get.go
+++ b/internal/cmd/workflow/get.go
@@ -63,13 +63,12 @@ func newGetCmd() *cobra.Command {
 			if cliErr := cmdutil.RequireArgs(args, "workflow-id"); cliErr != nil {
 				return cliErr
 			}
-			ctx := cmd.Context()
-			streams := iostream.FromCmd(cmd)
+			ctx := iostream.FromCmd(cmd.Context(), cmd)
 			client, err := cmdutil.LoadClient(ctx, cmd)
 			if err != nil {
 				return err
 			}
-			return runGet(ctx, client, streams, args[0], jsonOut)
+			return runGet(ctx, client, args[0], jsonOut)
 		},
 	}
 
@@ -96,7 +95,7 @@ type jobOutput struct {
 	Type   string `json:"type"`
 }
 
-func runGet(ctx context.Context, client *apiclient.Client, streams iostream.Streams, id string, jsonOut bool) error {
+func runGet(ctx context.Context, client *apiclient.Client, id string, jsonOut bool) error {
 	wf, err := client.GetWorkflow(ctx, id)
 	if err != nil {
 		return apiErr(err, id)
@@ -129,33 +128,33 @@ func runGet(ctx context.Context, client *apiclient.Client, streams iostream.Stre
 	}
 
 	if jsonOut {
-		enc := json.NewEncoder(streams.Out)
+		enc := json.NewEncoder(iostream.Out(ctx))
 		enc.SetIndent("", "  ")
 		return enc.Encode(out)
 	}
 
-	printGet(streams, out)
+	printGet(ctx, out)
 	return nil
 }
 
-func printGet(streams iostream.Streams, w workflowGetOutput) {
-	streams.Printf("Workflow  %s\n", w.ID)
-	streams.Printf("Name:     %s\n", w.Name)
-	streams.Printf("Pipeline: #%d (%s)\n", w.PipelineNumber, w.PipelineID)
-	streams.Printf("Project:  %s\n", w.ProjectSlug)
-	streams.Printf("Status:   %s\n", w.Status)
-	streams.Printf("Created:  %s\n", w.CreatedAt)
+func printGet(ctx context.Context, w workflowGetOutput) {
+	iostream.Printf(ctx, "Workflow  %s\n", w.ID)
+	iostream.Printf(ctx, "Name:     %s\n", w.Name)
+	iostream.Printf(ctx, "Pipeline: #%d (%s)\n", w.PipelineNumber, w.PipelineID)
+	iostream.Printf(ctx, "Project:  %s\n", w.ProjectSlug)
+	iostream.Printf(ctx, "Status:   %s\n", w.Status)
+	iostream.Printf(ctx, "Created:  %s\n", w.CreatedAt)
 	if w.StoppedAt != "" {
-		streams.Printf("Stopped:  %s\n", w.StoppedAt)
+		iostream.Printf(ctx, "Stopped:  %s\n", w.StoppedAt)
 	}
 
 	if len(w.Jobs) > 0 {
-		streams.Printf("\nJobs:\n")
+		iostream.Printf(ctx, "\nJobs:\n")
 		for _, j := range w.Jobs {
 			if j.Type == "approval" {
-				streams.Printf("  %-36s  %s\n", j.Name, j.Status)
+				iostream.Printf(ctx, "  %-36s  %s\n", j.Name, j.Status)
 			} else {
-				streams.Printf("  %-36s  %s  #%d\n", j.Name, j.Status, j.Number)
+				iostream.Printf(ctx, "  %-36s  %s  #%d\n", j.Name, j.Status, j.Number)
 			}
 		}
 	}

--- a/internal/cmd/workflow/list.go
+++ b/internal/cmd/workflow/list.go
@@ -88,16 +88,15 @@ func newListCmd() *cobra.Command {
 		`),
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
-			streams := iostream.FromCmd(cmd)
+			ctx := iostream.FromCmd(cmd.Context(), cmd)
 			client, err := cmdutil.LoadClient(ctx, cmd)
 			if err != nil {
 				return err
 			}
 			if len(args) == 0 {
-				return runListRecent(ctx, client, streams, projectSlug, branch, limit, jsonOut)
+				return runListRecent(ctx, client, projectSlug, branch, limit, jsonOut)
 			}
-			return runList(ctx, client, streams, args[0], projectSlug, jsonOut)
+			return runList(ctx, client, args[0], projectSlug, jsonOut)
 		},
 	}
 
@@ -122,7 +121,7 @@ type workflowRecentOutput struct {
 	Status         string `json:"status"`
 }
 
-func runList(ctx context.Context, client *apiclient.Client, streams iostream.Streams, arg, projectSlug string, jsonOut bool) error {
+func runList(ctx context.Context, client *apiclient.Client, arg, projectSlug string, jsonOut bool) error {
 	pipelineID, err := resolvePipelineID(ctx, client, arg, projectSlug)
 	if err != nil {
 		return err
@@ -146,22 +145,22 @@ func runList(ctx context.Context, client *apiclient.Client, streams iostream.Str
 		if out == nil {
 			out = []workflowListOutput{}
 		}
-		enc := json.NewEncoder(streams.Out)
+		enc := json.NewEncoder(iostream.Out(ctx))
 		enc.SetIndent("", "  ")
 		return enc.Encode(out)
 	}
 
 	if len(out) == 0 {
-		streams.Printf("No workflows found for pipeline %s.\n", arg)
+		iostream.Printf(ctx, "No workflows found for pipeline %s.\n", arg)
 		return nil
 	}
 	for _, wf := range out {
-		streams.Printf("%-36s  %-28s  %s\n", wf.ID, wf.Name, wf.Status)
+		iostream.Printf(ctx, "%-36s  %-28s  %s\n", wf.ID, wf.Name, wf.Status)
 	}
 	return nil
 }
 
-func runListRecent(ctx context.Context, client *apiclient.Client, streams iostream.Streams, projectSlug, branch string, limit int, jsonOut bool) error {
+func runListRecent(ctx context.Context, client *apiclient.Client, projectSlug, branch string, limit int, jsonOut bool) error {
 	if projectSlug == "" {
 		info, gitErr := gitremote.Detect()
 		if gitErr != nil {
@@ -200,19 +199,19 @@ func runListRecent(ctx context.Context, client *apiclient.Client, streams iostre
 		if out == nil {
 			out = []workflowRecentOutput{}
 		}
-		enc := json.NewEncoder(streams.Out)
+		enc := json.NewEncoder(iostream.Out(ctx))
 		enc.SetIndent("", "  ")
 		return enc.Encode(out)
 	}
 
 	if len(pipelines) == 0 {
-		streams.Printf("No pipelines found for project %s.\n", projectSlug)
+		iostream.Printf(ctx, "No pipelines found for project %s.\n", projectSlug)
 		return nil
 	}
 
 	for i, p := range pipelines {
 		if i > 0 {
-			streams.Printf("\n")
+			iostream.Printf(ctx, "\n")
 		}
 		branchName := ""
 		revision := ""
@@ -223,18 +222,18 @@ func runListRecent(ctx context.Context, client *apiclient.Client, streams iostre
 				revision = revision[:7]
 			}
 		}
-		streams.Printf("Pipeline #%d  %s  %s\n", p.Number, branchName, revision)
+		iostream.Printf(ctx, "Pipeline #%d  %s  %s\n", p.Number, branchName, revision)
 
 		workflows, wErr := client.GetPipelineWorkflows(ctx, p.ID)
 		if wErr != nil {
 			return apiErr(wErr, p.ID)
 		}
 		if len(workflows) == 0 {
-			streams.Printf("  (no workflows)\n")
+			iostream.Printf(ctx, "  (no workflows)\n")
 			continue
 		}
 		for _, wf := range workflows {
-			streams.Printf("  %-36s  %-28s  %s\n", wf.ID, wf.Name, wf.Status)
+			iostream.Printf(ctx, "  %-36s  %-28s  %s\n", wf.ID, wf.Name, wf.Status)
 		}
 	}
 	return nil

--- a/internal/cmd/workflow/rerun.go
+++ b/internal/cmd/workflow/rerun.go
@@ -63,13 +63,12 @@ func newRerunCmd() *cobra.Command {
 			if cliErr := cmdutil.RequireArgs(args, "workflow-id"); cliErr != nil {
 				return cliErr
 			}
-			ctx := cmd.Context()
-			streams := iostream.FromCmd(cmd)
+			ctx := iostream.FromCmd(cmd.Context(), cmd)
 			client, err := cmdutil.LoadClient(ctx, cmd)
 			if err != nil {
 				return err
 			}
-			return runRerun(ctx, client, streams, args[0], fromFailed)
+			return runRerun(ctx, client, args[0], fromFailed)
 		},
 	}
 
@@ -77,15 +76,15 @@ func newRerunCmd() *cobra.Command {
 	return cmd
 }
 
-func runRerun(ctx context.Context, client *apiclient.Client, streams iostream.Streams, id string, fromFailed bool) error {
+func runRerun(ctx context.Context, client *apiclient.Client, id string, fromFailed bool) error {
 	if err := client.RerunWorkflow(ctx, id, fromFailed); err != nil {
 		return apiErr(err, id)
 	}
 
 	if fromFailed {
-		streams.Printf("Rerunning failed jobs in workflow %s\n", id)
+		iostream.Printf(ctx, "Rerunning failed jobs in workflow %s\n", id)
 	} else {
-		streams.Printf("Rerunning workflow %s from scratch\n", id)
+		iostream.Printf(ctx, "Rerunning workflow %s from scratch\n", id)
 	}
 	return nil
 }

--- a/internal/httpcl/client.go
+++ b/internal/httpcl/client.go
@@ -36,6 +36,8 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
+
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/iostream"
 )
 
 const jsonContentType = "application/json; charset=utf-8"
@@ -103,7 +105,9 @@ func New(cfg Config) *Client {
 // Call executes the request and returns the HTTP status code.
 // Non-2xx responses return an *HTTPError. If a decoder is set and the
 // response is 2xx, the response body is decoded.
-func (c *Client) Call(ctx context.Context, r Request) (int, error) {
+func (c *Client) Call(ctx context.Context, r Request) (status int, err error) {
+	start := time.Now()
+
 	u, err := url.Parse(c.baseURL + r.route)
 	if err != nil {
 		return 0, fmt.Errorf("httpcl: bad url: %w", err)
@@ -111,6 +115,15 @@ func (c *Client) Call(ctx context.Context, r Request) (int, error) {
 	if len(r.query) > 0 {
 		u.RawQuery = r.query.Encode()
 	}
+	defer func() {
+		duration := time.Since(start)
+		iostream.DebugContext(ctx, r.method+" "+r.route,
+			"http.request.method", r.method,
+			"http.response.status_code", status,
+			"duration", duration,
+			"url.full", u.String(),
+		)
+	}()
 
 	var bodyReader io.Reader
 	if r.body != nil {
@@ -160,7 +173,7 @@ func (c *Client) Call(ctx context.Context, r Request) (int, error) {
 		_ = resp.Body.Close()
 	}()
 
-	status := resp.StatusCode
+	status = resp.StatusCode
 
 	if status >= 200 && status < 300 {
 		if r.decoder != nil {

--- a/internal/iostream/streams.go
+++ b/internal/iostream/streams.go
@@ -24,11 +24,14 @@ package iostream
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"strings"
 
+	"charm.land/log/v2"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 )
@@ -49,6 +52,82 @@ func colorDisabled() bool {
 	return false
 }
 
+type contextKey struct{}
+
+func fromContext(ctx context.Context) Streams {
+	v := ctx.Value(contextKey{})
+	if v == nil {
+		return Streams{Out: io.Discard, Err: io.Discard, In: strings.NewReader(""), Quiet: true}
+	}
+	return v.(Streams)
+}
+
+func WithStreams(ctx context.Context, s Streams) context.Context {
+	return context.WithValue(ctx, contextKey{}, s)
+}
+
+// Package-level accessors for Steam functions
+
+func IsTerminal(ctx context.Context) bool {
+	return fromContext(ctx).IsTerminal()
+}
+
+func ColorEnabled(ctx context.Context) bool {
+	return fromContext(ctx).ColorEnabled()
+}
+
+func IsInteractive(ctx context.Context) bool {
+	return fromContext(ctx).IsInteractive()
+}
+
+func Symbol(ctx context.Context, unicode, ascii string) string {
+	return fromContext(ctx).Symbol(unicode, ascii)
+}
+
+func Print(ctx context.Context, v string) {
+	fromContext(ctx).Print(v)
+}
+
+func Printf(ctx context.Context, format string, a ...any) {
+	fromContext(ctx).Printf(format, a...)
+}
+
+func Println(ctx context.Context, a ...any) {
+	fromContext(ctx).Println(a...)
+}
+
+func ErrPrintf(ctx context.Context, format string, a ...any) {
+	fromContext(ctx).ErrPrintf(format, a...)
+}
+
+func ErrPrintln(ctx context.Context, a ...any) {
+	fromContext(ctx).ErrPrintln(a...)
+}
+
+func Confirm(ctx context.Context, prompt string) bool {
+	return fromContext(ctx).Confirm(prompt)
+}
+
+func DebugContext(ctx context.Context, msg string, args ...any) {
+	fromContext(ctx).DebugContext(ctx, msg, args...)
+}
+
+func Out(ctx context.Context) io.Writer {
+	return fromContext(ctx).Out
+}
+
+func Err(ctx context.Context) io.Writer {
+	return fromContext(ctx).Err
+}
+
+func In(ctx context.Context) io.Reader {
+	return fromContext(ctx).In
+}
+
+func Spin(ctx context.Context, active bool, msg string) *Spinner {
+	return fromContext(ctx).Spinner(active, msg)
+}
+
 // Streams bundles the I/O channels passed through every command.
 // All output must go through Streams — never write to os.Stdout directly.
 type Streams struct {
@@ -56,24 +135,39 @@ type Streams struct {
 	Err   io.Writer // status messages, errors, progress
 	In    io.Reader // user input for interactive prompts
 	Quiet bool      // when true, ErrPrintf/ErrPrintln produce no output
+	slog  *slog.Logger
 }
 
 // OS returns a Streams wired to the real os.Stdin / os.Stdout / os.Stderr.
-func OS() Streams {
-	return Streams{Out: os.Stdout, Err: os.Stderr, In: os.Stdin}
+func OS(ctx context.Context) context.Context {
+	return WithStreams(ctx, Streams{Out: os.Stdout, Err: os.Stderr, In: os.Stdin})
 }
 
 // FromCmd extracts Streams from a cobra.Command's Out/Err/In and reads the
 // --quiet persistent flag if registered on the root command.
-func FromCmd(cmd *cobra.Command) Streams {
+func FromCmd(ctx context.Context, cmd *cobra.Command) context.Context {
+	lvl := log.InfoLevel
+	verbose, _ := cmd.Flags().GetBool("debug")
+	if verbose {
+		lvl = log.DebugLevel
+	}
+
 	quiet, _ := cmd.Flags().GetBool("quiet")
-	return Streams{Out: cmd.OutOrStdout(), Err: cmd.ErrOrStderr(), In: cmd.InOrStdin(), Quiet: quiet}
+	return WithStreams(ctx, Streams{
+		Out:   cmd.OutOrStdout(),
+		Err:   cmd.ErrOrStderr(),
+		In:    cmd.InOrStdin(),
+		Quiet: quiet,
+		slog: slog.New(log.NewWithOptions(cmd.ErrOrStderr(), log.Options{
+			Level: lvl,
+		})),
+	})
 }
 
 // Test returns a Streams backed by the provided writers with no-op stdin,
 // useful in tests that don't exercise interactive prompts.
-func Test(out, err io.Writer) Streams {
-	return Streams{Out: out, Err: err, In: strings.NewReader("")}
+func Test(ctx context.Context, out, err io.Writer) context.Context {
+	return WithStreams(ctx, Streams{Out: out, Err: err, In: strings.NewReader("")})
 }
 
 // IsTerminal reports whether Out is a terminal (i.e. a human is watching).
@@ -160,4 +254,8 @@ func (s Streams) Confirm(prompt string) bool {
 	}
 	response := strings.TrimSpace(strings.ToLower(scanner.Text()))
 	return response == "y" || response == "yes"
+}
+
+func (s Streams) DebugContext(ctx context.Context, msg string, args ...any) {
+	s.slog.DebugContext(ctx, msg, args...)
 }

--- a/internal/testing/binary/binary.go
+++ b/internal/testing/binary/binary.go
@@ -33,6 +33,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -92,10 +93,16 @@ func RunCLI(t *testing.T, args []string, env []string, workDir string) CLIResult
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	argsWithInsecure := append([]string{"--insecure-storage=true"}, args...)
-	t.Logf("Running CLI: %s %s\n", binaryPath, argsWithInsecure)
+	fullArgs := []string{
+		"--insecure-storage",
+	}
+	if !slices.Contains(args, "--quiet") {
+		fullArgs = append(fullArgs, "--debug")
+	}
+	fullArgs = append(fullArgs, args...)
+	t.Logf("Running CLI: %s %s\n", binaryPath, fullArgs)
 
-	cmd := exec.CommandContext(ctx, binaryPath, argsWithInsecure...)
+	cmd := exec.CommandContext(ctx, binaryPath, fullArgs...)
 	cmd.Dir = workDir
 	cmd.Env = env
 

--- a/internal/testing/fakes/router.go
+++ b/internal/testing/fakes/router.go
@@ -33,8 +33,8 @@ import (
 // All fake servers share this setup.
 func newRouter() *chi.Mux {
 	r := chi.NewRouter()
-	r.Use(middleware.Recoverer)
 	r.Use(middleware.Logger)
+	r.Use(middleware.Recoverer)
 	// Force chi to route on the decoded r.URL.Path rather than r.URL.RawPath,
 	// so routes with literal slashes in path segments (e.g. vcs/org/repo) match correctly.
 	r.Use(func(next http.Handler) http.Handler {

--- a/internal/ui/token.go
+++ b/internal/ui/token.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package ui
+
+import (
+	"charm.land/bubbles/v2/textinput"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+)
+
+type TokenModel struct {
+	textInput textinput.Model
+	quitting  bool
+	token     string
+}
+
+func NewTokenModel() TokenModel {
+	ti := textinput.New()
+	ti.Placeholder = "CCIPAT_XXXXXXXXXXXXXXXXXXXXXX_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+	ti.SetVirtualCursor(false)
+	ti.Focus()
+	ti.CharLimit = len(ti.Placeholder)
+	ti.SetWidth(len(ti.Placeholder))
+	ti.EchoMode = textinput.EchoPassword
+
+	return TokenModel{textInput: ti}
+}
+
+func (m TokenModel) Quitting() bool {
+	return m.quitting
+}
+
+func (m TokenModel) Token() string {
+	return m.token
+}
+
+func (m TokenModel) Init() tea.Cmd {
+	return textinput.Blink
+}
+
+func (m TokenModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+
+	switch msg := msg.(type) {
+	case tea.KeyPressMsg:
+		switch msg.String() {
+		case "ctrl+c", "esc":
+			m.quitting = true
+			return m, tea.Quit
+		case "enter":
+			m.token = m.textInput.Value()
+			return m, tea.Quit
+		}
+	}
+
+	m.textInput, cmd = m.textInput.Update(msg)
+	return m, cmd
+}
+
+func (m TokenModel) View() tea.View {
+	if m.token != "" {
+		return tea.NewView("")
+	}
+
+	var c *tea.Cursor
+	if !m.textInput.VirtualCursor() {
+		c = m.textInput.Cursor()
+		c.Y += lipgloss.Height(m.headerView())
+	}
+
+	str := lipgloss.JoinVertical(lipgloss.Top, m.headerView(), m.textInput.View(), m.footerView())
+	if m.quitting {
+		str += "\n"
+	}
+
+	v := tea.NewView(str)
+	v.Cursor = c
+	return v
+}
+
+func (m TokenModel) headerView() string { return "Enter CircleCI personal access token\n" }
+func (m TokenModel) footerView() string { return "\n(esc to quit)" }


### PR DESCRIPTION
- Pass our o11y around via context.
- Wire in charm logger for debug mode.
- Very basic debug output for HTTP client.

<img width="1184" height="96" alt="Screenshot 2026-04-24 at 10 55 07" src="https://github.com/user-attachments/assets/a8f08f5d-b90f-4c98-a1f5-f71880921e76" />


## TODO
- Adding `hc.RouteParam()` to internalise the route formatting inside the client.