### PR TITLE
Use charm for y/n confirm dialogs

### DIFF
--- a/internal/cmd/cmdauth/token.go
+++ b/internal/cmd/cmdauth/token.go
@@ -61,7 +61,11 @@ func runToken(ctx context.Context, secureStorage bool) error {
 			WithExitCode(clierrors.ExitGeneralError)
 	}
 
-	p := tea.NewProgram(ui.NewTokenModel())
+	p := tea.NewProgram(ui.NewTokenModel(),
+		tea.WithContext(ctx),
+		tea.WithInput(iostream.In(ctx)),
+		tea.WithOutput(iostream.Err(ctx)),
+	)
 	anyModel, err := p.Run()
 	if err != nil {
 		return err

--- a/internal/iostream/streams.go
+++ b/internal/iostream/streams.go
@@ -23,7 +23,6 @@
 package iostream
 
 import (
-	"bufio"
 	"context"
 	"fmt"
 	"io"
@@ -31,9 +30,12 @@ import (
 	"os"
 	"strings"
 
+	tea "charm.land/bubbletea/v2"
 	"charm.land/log/v2"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
+
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/ui"
 )
 
 // colorDisabled returns true when any of the standard "no color" signals are present.
@@ -105,7 +107,7 @@ func ErrPrintln(ctx context.Context, a ...any) {
 }
 
 func Confirm(ctx context.Context, prompt string) bool {
-	return fromContext(ctx).Confirm(prompt)
+	return fromContext(ctx).Confirm(ctx, prompt)
 }
 
 func DebugContext(ctx context.Context, msg string, args ...any) {
@@ -242,18 +244,21 @@ func (s Streams) ErrPrintln(a ...any) {
 	_, _ = fmt.Fprintln(s.Err, a...)
 }
 
-// Confirm prints prompt followed by " [y/N] " to stderr and reads one line
-// from In. Returns true only if the user types "y" or "yes" (case-insensitive).
-// Returns false on empty input, "n"/"no", EOF, or any read error — the safe
-// answer is always No.
-func (s Streams) Confirm(prompt string) bool {
-	_, _ = fmt.Fprintf(s.Err, "%s [y/N] ", prompt)
-	scanner := bufio.NewScanner(s.In)
-	if !scanner.Scan() {
+// Confirm presents a y/N confirmation prompt via bubbletea.
+// Returns true only if the user presses y/Y. Returns false on n/N, esc,
+// ctrl+c, enter, or any program error — the safe answer is always No.
+func (s Streams) Confirm(ctx context.Context, prompt string) bool {
+	p := tea.NewProgram(
+		ui.NewConfirmModel(prompt),
+		tea.WithContext(ctx),
+		tea.WithInput(s.In),
+		tea.WithOutput(s.Err),
+	)
+	anyModel, err := p.Run()
+	if err != nil {
 		return false
 	}
-	response := strings.TrimSpace(strings.ToLower(scanner.Text()))
-	return response == "y" || response == "yes"
+	return anyModel.(ui.ConfirmModel).Confirmed()
 }
 
 func (s Streams) DebugContext(ctx context.Context, msg string, args ...any) {

--- a/internal/ui/confirm.go
+++ b/internal/ui/confirm.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package ui
+
+import (
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+)
+
+var confirmTitleStyle = lipgloss.NewStyle().Bold(true).MarginRight(2)
+
+// ConfirmModel is a bubbletea model for a y/N confirmation prompt.
+// Press y/Y to confirm, n/N/esc/ctrl+c to decline.
+type ConfirmModel struct {
+	prompt    string
+	confirmed bool
+	done      bool
+}
+
+func NewConfirmModel(prompt string) ConfirmModel {
+	return ConfirmModel{prompt: prompt}
+}
+
+func (m ConfirmModel) Confirmed() bool { return m.confirmed }
+func (m ConfirmModel) Done() bool      { return m.done }
+
+func (m ConfirmModel) Init() tea.Cmd { return nil }
+
+func (m ConfirmModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyPressMsg:
+		switch msg.String() {
+		case "y", "Y":
+			m.confirmed = true
+			m.done = true
+			return m, tea.Quit
+		case "n", "N", "esc", "ctrl+c", "enter":
+			m.done = true
+			return m, tea.Quit
+		}
+	}
+	return m, nil
+}
+
+func (m ConfirmModel) View() tea.View {
+	title := confirmTitleStyle.Render(m.prompt)
+
+	var input string
+	if m.done {
+		answer := "N"
+		if m.confirmed {
+			answer = "y"
+		}
+		input = "[y/N] " + answer + "\n"
+	} else {
+		input = "[y/N] "
+	}
+
+	return tea.NewView(lipgloss.JoinHorizontal(lipgloss.Top, title, input))
+}


### PR DESCRIPTION
<img width="725" height="50" alt="Screenshot 2026-04-24 at 11 20 10" src="https://github.com/user-attachments/assets/dd545a2f-f755-44eb-815c-e22ea144f104" />

All the UIs can be made fancier at some point, but I want to start off using a UI toolkit, so we don't roll our own output for interactive operations.