### PR TITLE
[FACT-160] Add `circleci open` command to `next`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,7 @@ internal/
 │   ├── config/           circleci config validate/process/pack/generate
 │   ├── context/          circleci context + circleci context secret
 │   ├── job/              circleci job artifacts (deep path; wraps internal/artifacts)
+│   ├── open/             circleci open (opens current project in the CircleCI web UI)
 │   ├── pipeline/         circleci pipeline list/get/trigger
 │   ├── workflow/         circleci workflow list/get/cancel/rerun
 │   ├── orb/              circleci orb list/info/validate/publish/...

--- a/internal/cmd/open/open.go
+++ b/internal/cmd/open/open.go
@@ -1,0 +1,96 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+// Package open implements the "circleci open" command.
+package open
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/pkg/browser"
+	"github.com/spf13/cobra"
+
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/cmdutil"
+	clierrors "github.com/CircleCI-Public/circleci-cli-v2/internal/errors"
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/gitremote"
+)
+
+// projectURL builds the CircleCI pipelines URL for the given project slug.
+func projectURL(appURL, slug string) (string, error) {
+	parts := strings.SplitN(slug, "/", 3)
+	if len(parts) != 3 {
+		return "", fmt.Errorf("invalid slug: %q", slug)
+	}
+	return fmt.Sprintf("%s/pipelines/%s/%s/%s",
+		appURL,
+		url.PathEscape(parts[0]),
+		url.PathEscape(parts[1]),
+		url.PathEscape(parts[2]),
+	), nil
+}
+
+// NewOpenCmd returns the "circleci open" command.
+func NewOpenCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "open",
+		Short: "Open the current project in the browser",
+		Long: heredoc.Doc(`
+			Open the CircleCI pipelines page for the current project in your
+			default web browser.
+
+			The project is inferred from the current git repository's remote.
+			Supports GitHub, Bitbucket, and GitLab remotes.
+		`),
+		Example: heredoc.Doc(`
+			# Open pipelines for the current repo
+			$ circleci open
+		`),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			ctx := cmd.Context()
+
+			info, err := gitremote.Detect()
+			if err != nil {
+				return clierrors.New("git.detect_failed",
+					"Could not detect project from git remote", err.Error()).
+					WithSuggestions(
+						"Run from inside a git repository with a GitHub, Bitbucket, or GitLab remote",
+					).
+					WithExitCode(clierrors.ExitBadArguments)
+			}
+
+			appURL, err := cmdutil.AppURL(ctx, cmd)
+			if err != nil {
+				return err
+			}
+
+			u, err := projectURL(appURL, info.Slug)
+			if err != nil {
+				return err
+			}
+
+			return browser.OpenURL(u)
+		},
+	}
+}

--- a/internal/cmd/open/open_test.go
+++ b/internal/cmd/open/open_test.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package open
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+)
+
+func TestProjectURL(t *testing.T) {
+	const appURL = "https://app.circleci.com"
+	t.Run("github project", func(t *testing.T) {
+		got, err := projectURL(appURL, "gh/bar/foo")
+		assert.NilError(t, err)
+		assert.Check(t, cmp.Equal(got, "https://app.circleci.com/pipelines/gh/bar/foo"))
+	})
+
+	t.Run("bitbucket project", func(t *testing.T) {
+		got, err := projectURL(appURL, "bb/myorg/myrepo")
+		assert.NilError(t, err)
+		assert.Check(t, cmp.Equal(got, "https://app.circleci.com/pipelines/bb/myorg/myrepo"))
+	})
+
+	t.Run("gitlab project", func(t *testing.T) {
+		got, err := projectURL(appURL, "gl/my-group/my-project")
+		assert.NilError(t, err)
+		assert.Check(t, cmp.Equal(got, "https://app.circleci.com/pipelines/gl/my-group/my-project"))
+	})
+
+	t.Run("invalid slug", func(t *testing.T) {
+		_, err := projectURL(appURL, "invalid")
+		assert.Check(t, err != nil, "expected error for invalid slug")
+	})
+}

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -36,6 +36,7 @@ import (
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/cmd/envvar"
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/cmd/job"
 	cmdlogs "github.com/CircleCI-Public/circleci-cli-v2/internal/cmd/logs"
+	cmdopen "github.com/CircleCI-Public/circleci-cli-v2/internal/cmd/open"
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/cmd/pipeline"
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/cmd/project"
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/cmd/runner"
@@ -98,6 +99,7 @@ func NewRootCmd(version string) *cobra.Command {
 	cmd.AddCommand(envvar.NewEnvVarCmd())
 	cmd.AddCommand(job.NewJobCmd())
 	cmd.AddCommand(cmdlogs.NewLogsCmd())
+	cmd.AddCommand(cmdopen.NewOpenCmd())
 	cmd.AddCommand(pipeline.NewPipelineCmd())
 	cmd.AddCommand(project.NewProjectCmd())
 	cmd.AddCommand(runner.NewRunnerCmd())

--- a/internal/cmd/root/testdata/usage/circleci.txt
+++ b/internal/cmd/root/testdata/usage/circleci.txt
@@ -11,6 +11,7 @@ Available Commands:
   job         Manage jobs
   logs        Fetch job logs
   mcp         MCP server management
+  open        Open the current project in the browser
   pipeline    Manage pipelines
   project     Manage CircleCI projects
   runner      Manage self-hosted runners

--- a/internal/cmd/root/testdata/usage/circleci/open.txt
+++ b/internal/cmd/root/testdata/usage/circleci/open.txt
@@ -1,0 +1,12 @@
+Usage:
+  circleci open [flags]
+
+Examples:
+# Open pipelines for the current repo
+$ circleci open
+
+
+Global Flags:
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected

--- a/internal/cmdutil/client.go
+++ b/internal/cmdutil/client.go
@@ -30,6 +30,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/spf13/cobra"
 
@@ -77,6 +78,22 @@ func LoadClient(ctx context.Context, cmd *cobra.Command) (*apiclient.Client, err
 			WithExitCode(clierrors.ExitAuthError)
 	}
 	return apiclient.New(cfg.EffectiveHost(), token, nil), nil
+}
+
+func AppURL(ctx context.Context, cmd *cobra.Command) (string, error) {
+	configPath, _ := ctx.Value(configPathKey{}).(string)
+	cfg, err := config.LoadFrom(ctx, configPath, IsSecureStorage(cmd))
+	if err != nil {
+		return "", clierrors.New("config.load_failed", "Failed to load config", err.Error()).
+			WithExitCode(clierrors.ExitGeneralError)
+	}
+	u, err := url.Parse(cfg.EffectiveHost())
+	if err != nil {
+		return "", err
+	}
+
+	u.Host = "app." + u.Host
+	return u.String(), nil
 }
 
 // APIErr converts an apiclient error into a structured CLIError.


### PR DESCRIPTION
# Checklist

=========

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)
- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/main/CONTRIBUTING.md).

### Internal Checklist
- [x] I am requesting a review from my own team as well as the owning team
- [x] I have a plan in place for the monitoring of the changes that I am making (this can include new monitors, logs to be aware of, etc...)

## Changes

=======

- Add `circleci open` command in `internal/cmd/open/`
- Register `open` command in `internal/cmd/root/root.go`
- Add `github.com/pkg/browser` dependency for opening URLs in the default browser
- Add tests for `ProjectURL` covering GitHub, Bitbucket, GitLab, and invalid slug cases

## Rationale

=========

The `circleci open` command existed on the `main` branch (`cmd/open.go`) but was
not carried over during the migration to the `next` branch. I missed it! This restores the
feature, adapted to the new project structure and conventions (structured errors
via `clierrors`, git remote detection via `internal/gitremote`, `gotest.tools`
for tests).

## Considerations

==============

- Reused the existing `internal/gitremote.Detect()` package rather than
  reimplementing git remote parsing. This is the same package used by
  `circleci project follow`.
- The old implementation only supported GitHub and Bitbucket. This version
  also supports GitLab since `gitremote.Detect()` already handles it.
- `url.PathEscape` is applied to slug segments as a safety net, though in
  practice VCS hosts restrict org/repo names to characters that don't need
  escaping.

## Screenshots

============

<h4>After</h4>

https://github.com/user-attachments/assets/0bdb6421-6da9-4d0c-b2f1-05de1ed28da4


