### PR TITLE
Improve watch refresh

### DIFF
--- a/acceptance/pipeline_test.go
+++ b/acceptance/pipeline_test.go
@@ -162,6 +162,78 @@ func TestPipelineGet_NoToken(t *testing.T) {
 	assert.Check(t, cmp.Contains(result.Stderr, "No CircleCI API token found"), "stderr: %s", result.Stderr)
 }
 
+// --- pagination ---
+
+func TestPipelineGet_PaginatedWorkflowJobs(t *testing.T) {
+	fake := fakes.NewCircleCI(t)
+	pipelineID := "paginated-pipeline-001"
+	wfID := "paginated-wf-001"
+	slug := "gh/testorg/testrepo"
+
+	fake.AddPipeline(pipelineID, fakePipeline(pipelineID, 99, "created", slug, "main"))
+	fake.AddPipelineWorkflows(pipelineID, fakeWorkflow(wfID, "build"))
+	fake.AddWorkflowJobs(wfID,
+		fakeJob("job-1", "lint", 1, slug),
+		fakeJob("job-2", "test", 2, slug),
+		fakeJob("job-3", "build", 3, slug),
+		fakeJob("job-4", "deploy", 4, slug),
+		fakeJob("job-5", "notify", 5, slug),
+	)
+	fake.SetWorkflowJobsPageSize(2) // 5 jobs → 3 pages (2, 2, 1)
+
+	env := testenv.New(t)
+	env.Token = "testtoken"
+	env.CircleCIURL = fake.URL()
+
+	result := binary.RunCLI(t, []string{"pipeline", "get", "--json", pipelineID}, env.Environ(), t.TempDir())
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	var out map[string]any
+	assert.NilError(t, json.Unmarshal([]byte(result.Stdout), &out))
+	wfs := out["workflows"].([]any)
+	assert.Check(t, cmp.Len(wfs, 1))
+	jobs := wfs[0].(map[string]any)["jobs"].([]any)
+	assert.Check(t, cmp.Len(jobs, 5), "expected all 5 paginated jobs, got %d", len(jobs))
+
+	names := make([]string, len(jobs))
+	for i, j := range jobs {
+		names[i] = j.(map[string]any)["name"].(string)
+	}
+	assert.Check(t, cmp.DeepEqual(names, []string{"lint", "test", "build", "deploy", "notify"}))
+}
+
+func TestPipelineGet_PaginatedWorkflows(t *testing.T) {
+	fake := fakes.NewCircleCI(t)
+	pipelineID := "paginated-pipeline-002"
+	slug := "gh/testorg/testrepo"
+
+	fake.AddPipeline(pipelineID, fakePipeline(pipelineID, 100, "created", slug, "main"))
+	fake.AddPipelineWorkflows(pipelineID,
+		fakeWorkflow("wf-p-1", "build"),
+		fakeWorkflow("wf-p-2", "test"),
+		fakeWorkflow("wf-p-3", "deploy"),
+	)
+	fake.SetPipelineWorkflowsPageSize(2) // 3 workflows → 2 pages (2, 1)
+
+	env := testenv.New(t)
+	env.Token = "testtoken"
+	env.CircleCIURL = fake.URL()
+
+	result := binary.RunCLI(t, []string{"pipeline", "get", "--json", pipelineID}, env.Environ(), t.TempDir())
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	var out map[string]any
+	assert.NilError(t, json.Unmarshal([]byte(result.Stdout), &out))
+	wfs := out["workflows"].([]any)
+	assert.Check(t, cmp.Len(wfs, 3), "expected all 3 paginated workflows, got %d", len(wfs))
+
+	names := make([]string, len(wfs))
+	for i, w := range wfs {
+		names[i] = w.(map[string]any)["name"].(string)
+	}
+	assert.Check(t, cmp.DeepEqual(names, []string{"build", "test", "deploy"}))
+}
+
 // --- pipeline list ---
 
 func TestPipelineList(t *testing.T) {

--- a/internal/apiclient/pipeline.go
+++ b/internal/apiclient/pipeline.go
@@ -197,13 +197,26 @@ type PipelineWorkflowSummary struct {
 	Status string `json:"status"`
 }
 
-// GetPipelineWorkflows returns the workflows for a pipeline.
+// GetPipelineWorkflows returns all workflows for a pipeline, paginating automatically.
 func (c *Client) GetPipelineWorkflows(ctx context.Context, pipelineID string) ([]PipelineWorkflowSummary, error) {
-	var resp struct {
-		Items []PipelineWorkflowSummary `json:"items"`
+	var all []PipelineWorkflowSummary
+	pageToken := ""
+	for {
+		var resp struct {
+			Items         []PipelineWorkflowSummary `json:"items"`
+			NextPageToken string                    `json:"next_page_token"`
+		}
+		opts := []func(*httpcl.Request){}
+		if pageToken != "" {
+			opts = append(opts, httpcl.QueryParam("page-token", pageToken))
+		}
+		if err := c.get(ctx, "/pipeline/"+pipelineID+"/workflow", &resp, opts...); err != nil {
+			return nil, err
+		}
+		all = append(all, resp.Items...)
+		if resp.NextPageToken == "" {
+			return all, nil
+		}
+		pageToken = resp.NextPageToken
 	}
-	if err := c.get(ctx, "/pipeline/"+pipelineID+"/workflow", &resp); err != nil {
-		return nil, err
-	}
-	return resp.Items, nil
 }

--- a/internal/apiclient/workflow.go
+++ b/internal/apiclient/workflow.go
@@ -26,6 +26,8 @@ import (
 	"context"
 	"fmt"
 	"time"
+
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/httpcl"
 )
 
 // WorkflowDetail holds the full details of a single workflow.
@@ -80,13 +82,26 @@ type WorkflowJob struct {
 	StoppedAt   time.Time `json:"stopped_at"`
 }
 
-// GetWorkflowJobs returns all jobs belonging to a workflow.
+// GetWorkflowJobs returns all jobs belonging to a workflow, paginating automatically.
 func (c *Client) GetWorkflowJobs(ctx context.Context, workflowID string) ([]WorkflowJob, error) {
-	var resp struct {
-		Items []WorkflowJob `json:"items"`
+	var all []WorkflowJob
+	pageToken := ""
+	for {
+		var resp struct {
+			Items         []WorkflowJob `json:"items"`
+			NextPageToken string        `json:"next_page_token"`
+		}
+		opts := []func(*httpcl.Request){}
+		if pageToken != "" {
+			opts = append(opts, httpcl.QueryParam("page-token", pageToken))
+		}
+		if err := c.get(ctx, "/workflow/"+workflowID+"/job", &resp, opts...); err != nil {
+			return nil, err
+		}
+		all = append(all, resp.Items...)
+		if resp.NextPageToken == "" {
+			return all, nil
+		}
+		pageToken = resp.NextPageToken
 	}
-	if err := c.get(ctx, "/workflow/"+workflowID+"/job", &resp); err != nil {
-		return nil, err
-	}
-	return resp.Items, nil
 }

--- a/internal/cmd/pipeline/watch.go
+++ b/internal/cmd/pipeline/watch.go
@@ -219,58 +219,90 @@ func waitForPipelineBySHA(ctx context.Context, client *apiclient.Client, project
 
 // watchUntilDone polls the given pipeline until all workflows reach a terminal
 // state or the timeout elapses.
+//
+// For TTY output, polling and rendering are decoupled: a 1-second display
+// ticker keeps the elapsed timer smooth while the poll interval ramps up to
+// 30s. For non-TTY output a nil displayC disables the ticker branch entirely.
 func watchUntilDone(ctx context.Context, client *apiclient.Client, pipelineID string, pipelineNumber int64, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 	start := time.Now()
 	tty := iostream.IsTerminal(ctx)
 
+	var state pipelineGetOutput
 	var prevLines int
-	var prevFingerprint string
+
 	pollInterval := 5 * time.Second
+	pollTimer := time.NewTimer(0) // fire immediately for the first fetch
+	defer pollTimer.Stop()
+
+	// displayC is nil for non-TTY; a nil channel is never selected, so the
+	// display case is a no-op without any extra branching.
+	var displayC <-chan time.Time
+	if tty {
+		t := time.NewTicker(time.Second)
+		defer t.Stop()
+		displayC = t.C
+	}
+
+	redraw := func(elapsed time.Duration) {
+		if prevLines > 0 {
+			_, _ = fmt.Fprintf(iostream.Err(ctx), "\033[%dA\033[J", prevLines)
+		}
+		prevLines = printWatchTable(ctx, state, elapsed)
+	}
 
 	for {
-		state, err := fetchWatchState(ctx, client, pipelineID)
-		if err != nil {
-			return clierrors.New("api.error", "API error while watching pipeline", err.Error()).
-				WithExitCode(clierrors.ExitAPIError)
-		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
 
-		elapsed := time.Since(start)
-		fingerprint := watchFingerprint(state)
-		changed := fingerprint != prevFingerprint
-
-		if tty {
-			// Erase previous table, redraw with updated elapsed.
-			if prevLines > 0 {
-				_, _ = fmt.Fprintf(iostream.Err(ctx), "\033[%dA\033[J", prevLines)
-			}
-			prevLines = printWatchTable(ctx, state, elapsed)
-		} else if changed {
-			printWatchLine(ctx, state, elapsed)
-		}
-		prevFingerprint = fingerprint
-
-		if allWorkflowsDone(state.Workflows) {
-			if tty && prevLines > 0 {
-				// Final redraw without the elapsed ticker line.
-				_, _ = fmt.Fprintf(iostream.Err(ctx), "\033[%dA\033[J", prevLines)
-				printWatchTableFinal(ctx, state)
+		case <-displayC:
+			// TTY only: redraw with a fresh elapsed value between polls.
+			redraw(time.Since(start))
+			if time.Now().After(deadline) {
 				iostream.ErrPrintf(ctx, "\n")
+				return clierrors.New("pipeline.timeout", "Watch timed out",
+					fmt.Sprintf("Pipeline #%d did not complete within %s.", pipelineNumber, timeout)).
+					WithExitCode(clierrors.ExitTimeout)
 			}
-			return watchFinalResult(ctx, state, pipelineNumber, elapsed)
-		}
 
-		if time.Now().After(deadline) {
-			iostream.ErrPrintf(ctx, "\n")
-			return clierrors.New("pipeline.timeout", "Watch timed out",
-				fmt.Sprintf("Pipeline #%d did not complete within %s.", pipelineNumber, timeout)).
-				WithExitCode(clierrors.ExitTimeout)
-		}
+		case <-pollTimer.C:
+			newState, err := fetchWatchState(ctx, client, pipelineID)
+			if err != nil {
+				return clierrors.New("api.error", "API error while watching pipeline", err.Error()).
+					WithExitCode(clierrors.ExitAPIError)
+			}
 
-		time.Sleep(pollInterval)
-		// Ramp from 5s to 30s over the first few polls.
-		if pollInterval < 30*time.Second {
-			pollInterval += 5 * time.Second
+			elapsed := time.Since(start)
+			state = newState
+
+			if tty {
+				redraw(elapsed)
+			} else {
+				printWatchLine(ctx, state, elapsed)
+			}
+
+			if allWorkflowsDone(state.Workflows) {
+				if tty && prevLines > 0 {
+					_, _ = fmt.Fprintf(iostream.Err(ctx), "\033[%dA\033[J", prevLines)
+					printWatchTableFinal(ctx, state)
+					iostream.ErrPrintf(ctx, "\n")
+				}
+				return watchFinalResult(ctx, state, pipelineNumber, elapsed)
+			}
+
+			if time.Now().After(deadline) {
+				iostream.ErrPrintf(ctx, "\n")
+				return clierrors.New("pipeline.timeout", "Watch timed out",
+					fmt.Sprintf("Pipeline #%d did not complete within %s.", pipelineNumber, timeout)).
+					WithExitCode(clierrors.ExitTimeout)
+			}
+
+			// Ramp poll interval from 5s to 30s over the first few cycles.
+			pollTimer.Reset(pollInterval)
+			if pollInterval < 30*time.Second {
+				pollInterval += 5 * time.Second
+			}
 		}
 	}
 }
@@ -315,25 +347,6 @@ func allWorkflowsDone(workflows []workflowOutput) bool {
 	return true
 }
 
-// watchFingerprint returns a string that changes whenever workflow or job
-// statuses change, used to detect updates for non-TTY output.
-func watchFingerprint(state pipelineGetOutput) string {
-	var b strings.Builder
-	for _, wf := range state.Workflows {
-		b.WriteString(wf.Name)
-		b.WriteByte('=')
-		b.WriteString(wf.Status)
-		b.WriteByte(';')
-		for _, j := range wf.Jobs {
-			b.WriteString(j.Name)
-			b.WriteByte('=')
-			b.WriteString(j.Status)
-			b.WriteByte(';')
-		}
-	}
-	return b.String()
-}
-
 // printWatchTable renders the workflow/job table to Err and returns the line count
 // written (used for TTY cursor rewind).
 func printWatchTable(ctx context.Context, state pipelineGetOutput, elapsed time.Duration) int {
@@ -369,13 +382,20 @@ func printWatchTableFinal(ctx context.Context, state pipelineGetOutput) {
 	}
 }
 
-// printWatchLine emits a single-line status update for non-TTY output.
+// printWatchLine emits a status block for non-TTY output. Each workflow gets
+// a timestamped header line; its jobs are indented beneath it.
 func printWatchLine(ctx context.Context, state pipelineGetOutput, elapsed time.Duration) {
-	var parts []string
 	for _, wf := range state.Workflows {
-		parts = append(parts, fmt.Sprintf("%s=%s", wf.Name, wf.Status))
+		iostream.ErrPrintf(ctx, "[%s]  %-28s  %s\n", formatElapsed(elapsed), wf.Name, wf.Status)
+		for _, j := range wf.Jobs {
+			if j.Number > 0 {
+				iostream.ErrPrintf(ctx, "        %-30s  %-12s  #%d\n", j.Name, j.Status, j.Number)
+			} else {
+				iostream.ErrPrintf(ctx, "        %-30s  %s\n", j.Name, j.Status)
+			}
+		}
 	}
-	iostream.ErrPrintf(ctx, "[%s]  %s\n", formatElapsed(elapsed), strings.Join(parts, "  "))
+	iostream.ErrPrintf(ctx, "\n")
 }
 
 // watchFinalResult prints the outcome and returns an appropriate error (or nil).

--- a/internal/testing/fakes/circleci.go
+++ b/internal/testing/fakes/circleci.go
@@ -72,6 +72,10 @@ type CircleCI struct {
 
 	// Auth state.
 	me any // response for GET /api/v2/me
+
+	// Pagination controls — 0 means no pagination (all items on one page).
+	workflowJobsPageSize int
+	workflowsPageSize    int
 }
 
 // NewCircleCI starts a fake CircleCI API server and registers t.Cleanup to close it.
@@ -205,6 +209,24 @@ func (f *CircleCI) AddWorkflowJobs(workflowID string, jobs ...any) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.workflowJobs[workflowID] = jobs
+}
+
+// SetWorkflowJobsPageSize causes GET /api/v2/workflow/<id>/job to paginate,
+// returning n items per page. n <= 0 disables pagination (the default).
+// Call before running any CLI commands against the fake.
+func (f *CircleCI) SetWorkflowJobsPageSize(n int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.workflowJobsPageSize = n
+}
+
+// SetPipelineWorkflowsPageSize causes GET /api/v2/pipeline/<id>/workflow to
+// paginate, returning n items per page. n <= 0 disables pagination (the default).
+// Call before running any CLI commands against the fake.
+func (f *CircleCI) SetPipelineWorkflowsPageSize(n int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.workflowsPageSize = n
 }
 
 // AddJobArtifacts registers artifact responses for a job.
@@ -343,6 +365,7 @@ func (f *CircleCI) handleGetPipelineWorkflows(w http.ResponseWriter, r *http.Req
 	f.mu.RLock()
 	_, pipelineExists := f.pipelines[id]
 	workflows := f.workflows[id]
+	pageSize := f.workflowsPageSize
 	f.mu.RUnlock()
 
 	if !pipelineExists {
@@ -353,19 +376,22 @@ func (f *CircleCI) handleGetPipelineWorkflows(w http.ResponseWriter, r *http.Req
 	if workflows == nil {
 		workflows = []any{}
 	}
-	render.JSON(w, r, map[string]any{"items": workflows, "next_page_token": nil})
+	items, nextToken := fakePaginate(workflows, r.URL.Query().Get("page-token"), pageSize)
+	render.JSON(w, r, map[string]any{"items": items, "next_page_token": nextToken})
 }
 
 func (f *CircleCI) handleGetWorkflowJobs(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 	f.mu.RLock()
 	jobs := f.workflowJobs[id]
+	pageSize := f.workflowJobsPageSize
 	f.mu.RUnlock()
 
 	if jobs == nil {
 		jobs = []any{}
 	}
-	render.JSON(w, r, map[string]any{"items": jobs, "next_page_token": nil})
+	items, nextToken := fakePaginate(jobs, r.URL.Query().Get("page-token"), pageSize)
+	render.JSON(w, r, map[string]any{"items": items, "next_page_token": nextToken})
 }
 
 func (f *CircleCI) handleGetJobArtifacts(w http.ResponseWriter, r *http.Request) {
@@ -494,6 +520,29 @@ func (f *CircleCI) handleStepOutput(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	render.PlainText(w, r, content)
+}
+
+// fakePaginate returns a page of items and the next-page token string.
+// When pageSize <= 0, all items are returned and the token is empty.
+// The token is the decimal string offset of the next page's first item.
+func fakePaginate(items []any, token string, pageSize int) ([]any, string) {
+	if pageSize <= 0 {
+		return items, ""
+	}
+	offset := 0
+	if token != "" {
+		if n, err := strconv.Atoi(token); err == nil {
+			offset = n
+		}
+	}
+	if offset >= len(items) {
+		return []any{}, ""
+	}
+	end := offset + pageSize
+	if end >= len(items) {
+		return items[offset:], ""
+	}
+	return items[offset:end], strconv.Itoa(end)
 }
 
 // --- Runner helpers ---


### PR DESCRIPTION
In non-TTY mode, report more regularly, even if there is no new information.

In TTY mode, separate the ticks on "elapsed" time from the actual API polling, so we can back off polling but refresh regularly.

Also fix add pagination because claude guessed that was the problem. It wasn't but it would be for someone!
