### PR TITLE
First pass at an MCP-capable CLI

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/go-chi/chi/v5 v5.2.5
 	github.com/go-chi/render v1.0.3
 	github.com/hashicorp/go-retryablehttp v0.7.8
+	github.com/modelcontextprotocol/go-sdk v1.5.0
 	github.com/spf13/cobra v1.10.2
 	github.com/zalando/go-keyring v0.2.8
 	golang.org/x/term v0.42.0
@@ -122,6 +123,7 @@ require (
 	github.com/golangci/unconvert v0.0.0-20250410112200-a129a6e6413e // indirect
 	github.com/google/addlicense v1.2.0 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
+	github.com/google/jsonschema-go v0.4.2 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/gordonklaus/ineffassign v0.2.0 // indirect
 	github.com/gorilla/css v1.0.1 // indirect
@@ -198,6 +200,8 @@ require (
 	github.com/sashamelentyev/interfacebloat v1.1.0 // indirect
 	github.com/sashamelentyev/usestdlibvars v1.29.0 // indirect
 	github.com/securego/gosec/v2 v2.24.8-0.20260309165252-619ce2117e08 // indirect
+	github.com/segmentio/asm v1.1.3 // indirect
+	github.com/segmentio/encoding v0.5.4 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/sivchari/containedctx v1.0.3 // indirect
 	github.com/sonatard/noctx v0.5.1 // indirect
@@ -226,6 +230,7 @@ require (
 	github.com/yagipy/maintidx v1.0.0 // indirect
 	github.com/yeya24/promlinter v0.3.0 // indirect
 	github.com/ykadowak/zerologlint v0.1.5 // indirect
+	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	github.com/yuin/goldmark v1.7.8 // indirect
 	github.com/yuin/goldmark-emoji v1.0.5 // indirect
 	gitlab.com/bosi/decorder v0.4.2 // indirect
@@ -240,6 +245,7 @@ require (
 	golang.org/x/exp/typeparams v0.0.0-20260209203927-2842357ff358 // indirect
 	golang.org/x/mod v0.34.0 // indirect
 	golang.org/x/net v0.52.0 // indirect
+	golang.org/x/oauth2 v0.35.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/text v0.35.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -280,6 +280,8 @@ github.com/godoc-lint/godoc-lint v0.11.2/go.mod h1:iVpGdL1JCikNH2gGeAn3Hh+AgN5Gx
 github.com/gofrs/flock v0.13.0 h1:95JolYOvGMqeH31+FC7D2+uULf6mG61mEZ/A8dRYMzw=
 github.com/gofrs/flock v0.13.0/go.mod h1:jxeyy9R1auM5S6JYDBhDt+E2TCo7DkratH4Pgi8P+Z0=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -349,6 +351,8 @@ github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/jsonschema-go v0.4.2 h1:tmrUohrwoLZZS/P3x7ex0WAVknEkBZM46iALbcqoRA8=
+github.com/google/jsonschema-go v0.4.2/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
@@ -493,6 +497,8 @@ github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/modelcontextprotocol/go-sdk v1.5.0 h1:CHU0FIX9kpueNkxuYtfYQn1Z0slhFzBZuq+x6IiblIU=
+github.com/modelcontextprotocol/go-sdk v1.5.0/go.mod h1:gggDIhoemhWs3BGkGwd1umzEXCEMMvAnhTrnbXJKKKA=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
@@ -588,6 +594,10 @@ github.com/sashamelentyev/usestdlibvars v1.29.0 h1:8J0MoRrw4/NAXtjQqTHrbW9NN+3iM
 github.com/sashamelentyev/usestdlibvars v1.29.0/go.mod h1:8PpnjHMk5VdeWlVb4wCdrB8PNbLqZ3wBZTZWkrpZZL8=
 github.com/securego/gosec/v2 v2.24.8-0.20260309165252-619ce2117e08 h1:AoLtJX4WUtZkhhUUMFy3GgecAALp/Mb4S1iyQOA2s0U=
 github.com/securego/gosec/v2 v2.24.8-0.20260309165252-619ce2117e08/go.mod h1:+XLCJiRE95ga77XInNELh2M6zQP+PdqiT9Zpm0D9Wpk=
+github.com/segmentio/asm v1.1.3 h1:WM03sfUOENvvKexOLp+pCqgb/WDjsi7EK8gIsICtzhc=
+github.com/segmentio/asm v1.1.3/go.mod h1:Ld3L4ZXGNcSLRg4JBsZ3//1+f/TjYl0Mzen/DQy1EJg=
+github.com/segmentio/encoding v0.5.4 h1:OW1VRern8Nw6ITAtwSZ7Idrl3MXCFwXHPgqESYfvNt0=
+github.com/segmentio/encoding v0.5.4/go.mod h1:HS1ZKa3kSN32ZHVZ7ZLPLXWvOVIiZtyJnO1gPH1sKt0=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
 github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/shurcooL/go v0.0.0-20180423040247-9e1955d9fb6e/go.mod h1:TDJrrUr11Vxrven61rcy3hJMUqaf/CLWYhHNPmT14Lk=
@@ -664,6 +674,8 @@ github.com/yeya24/promlinter v0.3.0 h1:JVDbMp08lVCP7Y6NP3qHroGAO6z2yGKQtS5Jsjqto
 github.com/yeya24/promlinter v0.3.0/go.mod h1:cDfJQQYv9uYciW60QT0eeHlFodotkYZlL+YcPQN+mW4=
 github.com/ykadowak/zerologlint v0.1.5 h1:Gy/fMz1dFQN9JZTPjv1hxEk+sRWm05row04Yoolgdiw=
 github.com/ykadowak/zerologlint v0.1.5/go.mod h1:KaUskqF3e/v59oPmdq1U1DnKcuHokl2/K1U4pmIELKg=
+github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
+github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -803,6 +815,8 @@ golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4Iltr
 golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
+golang.org/x/oauth2 v0.35.0 h1:Mv2mzuHuZuY2+bkyWXIHMfhNdJAdwW3FuWeCPYN5GVQ=
+golang.org/x/oauth2 v0.35.0/go.mod h1:lzm5WQJQwKZ3nwavOZ3IS5Aulzxi68dUSgRHujetwEA=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/internal/cmd/mcp/mcp.go
+++ b/internal/cmd/mcp/mcp.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package mcp
+
+import (
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+)
+
+// NewMCPCmd returns the "circleci mcp" command group.
+func NewMCPCmd(version string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "mcp <command>",
+		Short: "Expose CircleCI CLI as an MCP server",
+		Long: heredoc.Doc(`
+			Expose CircleCI CLI functionality as Model Context Protocol (MCP) tools,
+			allowing AI agents such as Claude to interact with CircleCI on your behalf.
+
+			Configure your MCP client to run 'circleci mcp serve'. The server reads
+			your existing CircleCI credentials and inherits your working directory,
+			so git-based project detection works the same as in the CLI.
+		`),
+	}
+
+	cmd.AddCommand(newServeCmd(version))
+	return cmd
+}

--- a/internal/cmd/mcp/serve.go
+++ b/internal/cmd/mcp/serve.go
@@ -1,0 +1,257 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+
+	"github.com/MakeNowJust/heredoc"
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/spf13/cobra"
+
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/cmd/pipeline"
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/cmdutil"
+	clierrors "github.com/CircleCI-Public/circleci-cli-v2/internal/errors"
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/gitremote"
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/iostream"
+)
+
+func newServeCmd(version string) *cobra.Command {
+	return &cobra.Command{
+		Use:   "serve",
+		Short: "Start the MCP server over stdio",
+		Long: heredoc.Doc(`
+			Start an MCP server over stdio, exposing CircleCI pipeline operations
+			as tools for AI agents such as Claude Code.
+
+			The server reads your existing CircleCI credentials (token, host) from
+			the standard config file or environment variables, and inherits your
+			current working directory so git-based project detection works exactly
+			as it does in the CLI.
+
+			JSON fields for each tool are documented in the tool descriptions.
+		`),
+		Example: heredoc.Doc(`
+			# Add to Claude Code's MCP configuration (~/.claude.json or project .claude.json):
+			{
+			  "mcpServers": {
+			    "circleci": {
+			      "command": "circleci",
+			      "args": ["mcp", "serve"]
+			    }
+			  }
+			}
+
+			# Verify the server starts cleanly
+			$ echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"0"}}}' | circleci mcp serve
+
+			# Run with a custom config file
+			$ circleci --config /path/to/config.yml mcp serve
+		`),
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := iostream.FromCmd(cmd.Context(), cmd)
+			return runServe(ctx, version)
+		},
+	}
+}
+
+func runServe(ctx context.Context, version string) error {
+	server := sdkmcp.NewServer(&sdkmcp.Implementation{
+		Name:    "circleci",
+		Version: version,
+	}, nil)
+
+	sdkmcp.AddTool(server, &sdkmcp.Tool{
+		Name: "pipeline_list",
+		Description: "List recent pipelines for a CircleCI project. " +
+			"JSON fields: id, number, state, project_slug, branch, revision, created_at, trigger{type,actor}.",
+	}, pipelineListHandler)
+
+	sdkmcp.AddTool(server, &sdkmcp.Tool{
+		Name: "pipeline_get",
+		Description: "Get a pipeline's status, including its workflows and job details. " +
+			"JSON fields: id, number, status, project_slug, branch, revision, created_at, updated_at, " +
+			"trigger{type,actor}, errors[], workflows[]{id,name,status,jobs[]{number,name,status,type}}.",
+	}, pipelineGetHandler)
+
+	sdkmcp.AddTool(server, &sdkmcp.Tool{
+		Name: "pipeline_trigger",
+		Description: "Trigger a new pipeline for a CircleCI project. " +
+			"JSON fields: id, number, state, created_at.",
+	}, pipelineTriggerHandler)
+
+	sdkmcp.AddTool(server, &sdkmcp.Tool{
+		Name: "pipeline_cancel",
+		Description: "Cancel a running pipeline by number or UUID. " +
+			"Cancels all active workflows within it; completed workflows are unaffected.",
+	}, pipelineCancelHandler)
+
+	return server.Run(ctx, &sdkmcp.StdioTransport{})
+}
+
+// --- pipeline_list ---
+
+type pipelineListArgs struct {
+	ProjectSlug string `json:"project_slug,omitempty" jsonschema:"Project slug (e.g. gh/org/repo); inferred from the git remote of the current directory if omitted"`
+	Branch      string `json:"branch,omitempty"       jsonschema:"Filter results to this branch; optional"`
+	Limit       int    `json:"limit,omitempty"        jsonschema:"Maximum number of pipelines to return; defaults to 10"`
+}
+
+func pipelineListHandler(ctx context.Context, _ *sdkmcp.CallToolRequest, args *pipelineListArgs) (*sdkmcp.CallToolResult, any, error) {
+	client, err := cmdutil.LoadClientForMCP(ctx)
+	if err != nil {
+		return toolErr(err)
+	}
+	limit := args.Limit
+	if limit <= 0 {
+		limit = 10
+	}
+	var buf bytes.Buffer
+	runCtx := iostream.Test(ctx, &buf, io.Discard)
+	if err := pipeline.RunList(runCtx, client, args.ProjectSlug, args.Branch, limit, true); err != nil {
+		return toolErr(err)
+	}
+	return toolText(buf.String())
+}
+
+// --- pipeline_get ---
+
+type pipelineGetArgs struct {
+	PipelineID  string `json:"pipeline_id,omitempty"  jsonschema:"Pipeline UUID or number; inferred from the current branch if omitted"`
+	ProjectSlug string `json:"project_slug,omitempty" jsonschema:"Project slug (e.g. gh/org/repo); required when pipeline_id is a number"`
+	Branch      string `json:"branch,omitempty"       jsonschema:"Branch name; used when pipeline_id is omitted to find the latest pipeline"`
+}
+
+func pipelineGetHandler(ctx context.Context, _ *sdkmcp.CallToolRequest, args *pipelineGetArgs) (*sdkmcp.CallToolResult, any, error) {
+	client, err := cmdutil.LoadClientForMCP(ctx)
+	if err != nil {
+		return toolErr(err)
+	}
+	var cmdArgs []string
+	if args.PipelineID != "" {
+		cmdArgs = []string{args.PipelineID}
+	}
+	var buf bytes.Buffer
+	runCtx := iostream.Test(ctx, &buf, io.Discard)
+	if err := pipeline.RunGet(runCtx, client, cmdArgs, args.ProjectSlug, args.Branch, true); err != nil {
+		return toolErr(err)
+	}
+	return toolText(buf.String())
+}
+
+// --- pipeline_trigger ---
+
+type pipelineTriggerArgs struct {
+	ProjectSlug string         `json:"project_slug,omitempty" jsonschema:"Project slug (e.g. gh/org/repo); inferred from the git remote if omitted"`
+	Branch      string         `json:"branch,omitempty"       jsonschema:"Branch to trigger; defaults to the current branch"`
+	Parameters  map[string]any `json:"parameters,omitempty"   jsonschema:"Pipeline parameters as a key-value map; optional"`
+}
+
+func pipelineTriggerHandler(ctx context.Context, _ *sdkmcp.CallToolRequest, args *pipelineTriggerArgs) (*sdkmcp.CallToolResult, any, error) {
+	client, err := cmdutil.LoadClientForMCP(ctx)
+	if err != nil {
+		return toolErr(err)
+	}
+
+	projectSlug := args.ProjectSlug
+	branch := args.Branch
+	if projectSlug == "" || branch == "" {
+		info, gitErr := gitremote.Detect()
+		if gitErr != nil {
+			return toolErr(cmdutil.GitDetectErr(gitErr, "Or specify project_slug and branch explicitly"))
+		}
+		if projectSlug == "" {
+			projectSlug = info.Slug
+		}
+		if branch == "" {
+			branch = info.Branch
+		}
+	}
+
+	resp, err := client.TriggerPipeline(ctx, projectSlug, branch, args.Parameters)
+	if err != nil {
+		return toolErr(cmdutil.APIErr(err, projectSlug,
+			"pipeline.not_found", "No project found for %q.",
+			"Check the project slug and try again"))
+	}
+
+	out, _ := json.Marshal(map[string]any{
+		"id":         resp.ID,
+		"number":     resp.Number,
+		"state":      resp.State,
+		"created_at": resp.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
+	})
+	return toolText(string(out))
+}
+
+// --- pipeline_cancel ---
+
+type pipelineCancelArgs struct {
+	PipelineID  string `json:"pipeline_id"            jsonschema:"Pipeline UUID or number to cancel"`
+	ProjectSlug string `json:"project_slug,omitempty" jsonschema:"Project slug (e.g. gh/org/repo); required when pipeline_id is a number"`
+}
+
+func pipelineCancelHandler(ctx context.Context, _ *sdkmcp.CallToolRequest, args *pipelineCancelArgs) (*sdkmcp.CallToolResult, any, error) {
+	if args.PipelineID == "" {
+		return toolErr(clierrors.New("args.missing", "Missing pipeline_id",
+			"pipeline_id is required").WithExitCode(clierrors.ExitBadArguments))
+	}
+	client, err := cmdutil.LoadClientForMCP(ctx)
+	if err != nil {
+		return toolErr(err)
+	}
+	var buf bytes.Buffer
+	runCtx := iostream.Test(ctx, &buf, io.Discard)
+	if err := pipeline.RunPipelineCancel(runCtx, client, args.PipelineID, args.ProjectSlug, true); err != nil {
+		return toolErr(err)
+	}
+	return toolText(buf.String())
+}
+
+// --- helpers ---
+
+func toolText(text string) (*sdkmcp.CallToolResult, any, error) {
+	return &sdkmcp.CallToolResult{
+		Content: []sdkmcp.Content{&sdkmcp.TextContent{Text: text}},
+	}, nil, nil
+}
+
+func toolErr(err error) (*sdkmcp.CallToolResult, any, error) {
+	msg := err.Error()
+	var cliErr *clierrors.CLIError
+	if errors.As(err, &cliErr) {
+		msg = cliErr.Message
+		for _, s := range cliErr.Suggestions {
+			msg += "\n  - " + s
+		}
+	}
+	return &sdkmcp.CallToolResult{
+		IsError: true,
+		Content: []sdkmcp.Content{&sdkmcp.TextContent{Text: msg}},
+	}, nil, nil
+}

--- a/internal/cmd/mcp/serve_test.go
+++ b/internal/cmd/mcp/serve_test.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package mcp
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+	"gotest.tools/v3/assert"
+
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/testing/fakes"
+)
+
+// fakePipeline returns a minimal pipeline payload for the fake MCP server tests.
+func fakePipelinePayload(id string, number int, slug, branch string) map[string]any {
+	now := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	return map[string]any{
+		"id":           id,
+		"state":        "created",
+		"number":       number,
+		"project_slug": slug,
+		"created_at":   now.Format(time.RFC3339),
+		"updated_at":   now.Format(time.RFC3339),
+		"trigger": map[string]any{
+			"type":        "webhook",
+			"received_at": now.Format(time.RFC3339),
+			"actor":       map[string]any{"login": "testuser", "avatar_url": ""},
+		},
+		"vcs": map[string]any{
+			"revision": "abc1234",
+			"branch":   branch,
+		},
+	}
+}
+
+// TestPipelineListHandler_DebugLoggingDoesNotPanic is a regression test for a
+// nil-slog panic that crashed the MCP server process on every tool call.
+// iostream.Test() previously left slog nil; the HTTP client's debug defer
+// hit s.slog.DebugContext and the server exited with "connection closed".
+func TestPipelineListHandler_DebugLoggingDoesNotPanic(t *testing.T) {
+	const slug = "gh/testorg/testrepo"
+
+	fake := fakes.NewCircleCI(t)
+	fake.AddProjectPipelines(slug, fakePipelinePayload("pipeline-abc", 1, slug, "main"))
+
+	t.Setenv("CIRCLECI_TOKEN", "testtoken")
+	t.Setenv("CIRCLECI_HOST", fake.URL())
+
+	result, _, err := pipelineListHandler(context.Background(), nil, &pipelineListArgs{
+		ProjectSlug: slug,
+	})
+
+	assert.NilError(t, err)
+	assert.Assert(t, !result.IsError, "expected success, got error result")
+	text := result.Content[0].(*sdkmcp.TextContent).Text
+	assert.Assert(t, strings.Contains(text, "pipeline-abc"), "expected pipeline ID in output, got: %s", text)
+}

--- a/internal/cmd/pipeline/cancel.go
+++ b/internal/cmd/pipeline/cancel.go
@@ -78,7 +78,7 @@ func newCancelCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return runPipelineCancel(ctx, client, args[0], projectSlug, force)
+			return RunPipelineCancel(ctx, client, args[0], projectSlug, force)
 		},
 	}
 
@@ -88,7 +88,7 @@ func newCancelCmd() *cobra.Command {
 	return cmd
 }
 
-func runPipelineCancel(ctx context.Context, client *apiclient.Client, arg, projectSlug string, force bool) error {
+func RunPipelineCancel(ctx context.Context, client *apiclient.Client, arg, projectSlug string, force bool) error {
 	pipelineID := arg
 	displayName := arg
 

--- a/internal/cmd/pipeline/get.go
+++ b/internal/cmd/pipeline/get.go
@@ -81,7 +81,7 @@ func newGetCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return runGet(ctx, client, args, projectSlug, branch, jsonOut)
+			return RunGet(ctx, client, args, projectSlug, branch, jsonOut)
 		},
 	}
 
@@ -131,7 +131,7 @@ type jobOutput struct {
 	Type   string `json:"type"`
 }
 
-func runGet(ctx context.Context, client *apiclient.Client, args []string, projectSlug, branch string, jsonOut bool) error {
+func RunGet(ctx context.Context, client *apiclient.Client, args []string, projectSlug, branch string, jsonOut bool) error {
 	var (
 		err      error
 		pipeline *apiclient.Pipeline

--- a/internal/cmd/pipeline/list.go
+++ b/internal/cmd/pipeline/list.go
@@ -79,7 +79,7 @@ func newListCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return runList(ctx, client, projectSlug, branch, limit, jsonOut)
+			return RunList(ctx, client, projectSlug, branch, limit, jsonOut)
 		},
 	}
 
@@ -105,7 +105,7 @@ type pipelineListEntry struct {
 	} `json:"trigger"`
 }
 
-func runList(ctx context.Context, client *apiclient.Client, projectSlug, branch string, limit int, jsonOut bool) error {
+func RunList(ctx context.Context, client *apiclient.Client, projectSlug, branch string, limit int, jsonOut bool) error {
 	if projectSlug == "" {
 		info, err := gitremote.Detect()
 		if err != nil {

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -33,6 +33,7 @@ import (
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/cmd/envvar"
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/cmd/job"
 	cmdlogs "github.com/CircleCI-Public/circleci-cli-v2/internal/cmd/logs"
+	cmdmcp "github.com/CircleCI-Public/circleci-cli-v2/internal/cmd/mcp"
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/cmd/pipeline"
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/cmd/project"
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/cmd/runner"
@@ -76,6 +77,7 @@ func NewRootCmd(version string) *cobra.Command {
 
 	cmd.AddCommand(cmdauth.NewAuthCmd())
 	cmd.AddCommand(cmdapi.NewAPICmd())
+	cmd.AddCommand(cmdmcp.NewMCPCmd(version))
 	cmd.AddCommand(artifacts.NewArtifactsCmd())
 	cmd.AddCommand(completion.NewCompletionCmd())
 	cmd.AddCommand(envvar.NewEnvVarCmd())

--- a/internal/cmd/root/testdata/usage/circleci.txt
+++ b/internal/cmd/root/testdata/usage/circleci.txt
@@ -9,6 +9,7 @@ Available Commands:
   envvar      Manage project environment variables
   job         Manage jobs
   logs        Fetch job logs
+  mcp         Expose CircleCI CLI as an MCP server
   pipeline    Manage pipelines
   project     Manage CircleCI projects
   runner      Manage self-hosted runners

--- a/internal/cmd/root/testdata/usage/circleci/mcp.txt
+++ b/internal/cmd/root/testdata/usage/circleci/mcp.txt
@@ -1,0 +1,12 @@
+Usage:
+  circleci mcp [command]
+
+Available Commands:
+  serve       Start the MCP server over stdio
+
+Global Flags:
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected
+
+Use "circleci mcp [command] --help" for more information about a command.

--- a/internal/cmd/root/testdata/usage/circleci/mcp/serve.txt
+++ b/internal/cmd/root/testdata/usage/circleci/mcp/serve.txt
@@ -1,0 +1,25 @@
+Usage:
+  circleci mcp serve [flags]
+
+Examples:
+# Add to Claude Code's MCP configuration (~/.claude.json or project .claude.json):
+{
+  "mcpServers": {
+    "circleci": {
+      "command": "circleci",
+      "args": ["mcp", "serve"]
+    }
+  }
+}
+
+# Verify the server starts cleanly
+$ echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"0"}}}' | circleci mcp serve
+
+# Run with a custom config file
+$ circleci --config /path/to/config.yml mcp serve
+
+
+Global Flags:
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected

--- a/internal/cmdutil/client.go
+++ b/internal/cmdutil/client.go
@@ -78,6 +78,30 @@ func LoadClient(ctx context.Context, cmd *cobra.Command) (*apiclient.Client, err
 	return apiclient.New(cfg.EffectiveHost(), token, nil), nil
 }
 
+// LoadClientForMCP creates an authenticated API client for use outside of a
+// Cobra command (e.g. the MCP server). It uses the default config path and
+// secure storage; the CIRCLECI_TOKEN env var is honoured as usual.
+func LoadClientForMCP(ctx context.Context) (*apiclient.Client, error) {
+	configPath, _ := ctx.Value(configPathKey{}).(string)
+	cfg, err := config.LoadFrom(configPath, ctx, true /* secureStorage */)
+	if err != nil {
+		return nil, clierrors.New("config.load_failed", "Failed to load config", err.Error()).
+			WithExitCode(clierrors.ExitGeneralError)
+	}
+	token := cfg.EffectiveToken()
+	if token == "" {
+		return nil, clierrors.New("auth.token_missing", "Authentication required",
+			"No CircleCI API token found.").
+			WithSuggestions(
+				"Run: circleci settings set token <your-token>",
+				"Or set the CIRCLECI_TOKEN environment variable",
+			).
+			WithRef("https://app.circleci.com/settings/user/tokens").
+			WithExitCode(clierrors.ExitAuthError)
+	}
+	return apiclient.New(cfg.EffectiveHost(), token, nil), nil
+}
+
 // APIErr converts an apiclient error into a structured CLIError.
 //
 // notFoundCode and notFoundMsg customise the 404 case for the calling resource

--- a/internal/iostream/streams.go
+++ b/internal/iostream/streams.go
@@ -61,7 +61,13 @@ type contextKey struct{}
 func fromContext(ctx context.Context) Streams {
 	v := ctx.Value(contextKey{})
 	if v == nil {
-		return Streams{Out: io.Discard, Err: io.Discard, In: strings.NewReader(""), Quiet: true}
+		return Streams{
+			Out:   io.Discard,
+			Err:   io.Discard,
+			In:    strings.NewReader(""),
+			Quiet: true,
+			slog:  slog.New(slog.NewTextHandler(io.Discard, nil)),
+		}
 	}
 	return v.(Streams)
 }
@@ -183,7 +189,12 @@ func FromCmd(ctx context.Context, cmd *cobra.Command) context.Context {
 // Test returns a Streams backed by the provided writers with no-op stdin,
 // useful in tests that don't exercise interactive prompts.
 func Test(ctx context.Context, out, err io.Writer) context.Context {
-	return WithStreams(ctx, Streams{Out: out, Err: err, In: strings.NewReader("")})
+	return WithStreams(ctx, Streams{
+		Out:  out,
+		Err:  err,
+		In:   strings.NewReader(""),
+		slog: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
 }
 
 // IsTerminal reports whether Out is a terminal (i.e. a human is watching).


### PR DESCRIPTION
Expose a subset of commands (pipelines) to validate the approach. Intended to be the smallest amount of extra work possible.

*NB:* Creating as draft for directional input. This seemed like the fastest way to have a chat, but a couple things worth discussing:

1. 3rd-party lib choice: claude found this for me. seems fine?
2. per-command implementation. rather than magic to expose everything. not hard to implement, but requires maintenance. given that the MCP paradigm is a bit different from the CLI, felt worth it. but curious what others think.
3. using the CLI as the MCP server. this feels obvious for the vast reduction in overhead, but also curious if anyone has concerns. also claude told me it didn't need because the CLI is great. but different people have different use cases...