### PR TITLE
Convert a bunch more commands to output markdown

### DIFF
--- a/acceptance/artifacts_test.go
+++ b/acceptance/artifacts_test.go
@@ -31,6 +31,7 @@ import (
 
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/assert/cmp"
+	"gotest.tools/v3/golden"
 
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/testing/binary"
 	testenv "github.com/CircleCI-Public/circleci-cli-v2/internal/testing/env"
@@ -106,8 +107,7 @@ func TestArtifacts_ByPipelineID(t *testing.T) {
 		env.Environ(), t.TempDir())
 
 	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
-	assert.Check(t, cmp.Contains(result.Stdout, "coverage/index.html"), "stdout: %s", result.Stdout)
-	assert.Check(t, cmp.Contains(result.Stdout, "test-results.xml"))
+	assert.Check(t, golden.String(result.Stdout, t.Name()+".txt"))
 }
 
 func TestArtifacts_ByPipelineID_JSON(t *testing.T) {
@@ -136,8 +136,7 @@ func TestArtifacts_ByJobNumber(t *testing.T) {
 		env.Environ(), t.TempDir())
 
 	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
-	assert.Check(t, cmp.Contains(result.Stdout, "coverage/index.html"))
-	assert.Check(t, cmp.Contains(result.Stdout, "test-results.xml"))
+	assert.Check(t, golden.String(result.Stdout, t.Name()+".txt"))
 }
 
 func TestJobArtifacts_ByJobNumber(t *testing.T) {
@@ -148,8 +147,7 @@ func TestJobArtifacts_ByJobNumber(t *testing.T) {
 		env.Environ(), t.TempDir())
 
 	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
-	assert.Check(t, cmp.Contains(result.Stdout, "coverage/index.html"))
-	assert.Check(t, cmp.Contains(result.Stdout, "test-results.xml"))
+	assert.Check(t, golden.String(result.Stdout, t.Name()+".txt"))
 }
 
 func TestArtifacts_Download(t *testing.T) {

--- a/acceptance/pipeline_test.go
+++ b/acceptance/pipeline_test.go
@@ -24,7 +24,6 @@ package acceptance_test
 
 import (
 	"encoding/json"
-	"strings"
 	"testing"
 	"time"
 
@@ -182,9 +181,7 @@ func TestPipelineList(t *testing.T) {
 		env.Environ(), t.TempDir())
 
 	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
-	assert.Check(t, cmp.Contains(result.Stdout, "#10"), "stdout: %s", result.Stdout)
-	assert.Check(t, cmp.Contains(result.Stdout, "#9"), "stdout: %s", result.Stdout)
-	assert.Check(t, cmp.Contains(result.Stdout, "errored"), "stdout: %s", result.Stdout)
+	assert.Check(t, golden.String(result.Stdout, t.Name()+".txt"))
 }
 
 func TestPipelineList_Limit(t *testing.T) {
@@ -205,9 +202,7 @@ func TestPipelineList_Limit(t *testing.T) {
 		env.Environ(), t.TempDir())
 
 	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
-	assert.Check(t, cmp.Contains(result.Stdout, "#10"), "stdout: %s", result.Stdout)
-	assert.Check(t, cmp.Contains(result.Stdout, "#9"), "stdout: %s", result.Stdout)
-	assert.Check(t, !strings.Contains(result.Stdout, "#8"), "should be truncated by --limit: %s", result.Stdout)
+	assert.Check(t, golden.String(result.Stdout, t.Name()+".txt"))
 }
 
 func TestPipelineList_JSON(t *testing.T) {

--- a/acceptance/project_test.go
+++ b/acceptance/project_test.go
@@ -72,8 +72,7 @@ func TestProjectList(t *testing.T) {
 	result := binary.RunCLI(t, []string{"project", "list"}, env.Environ(), t.TempDir())
 
 	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
-	assert.Check(t, cmp.Contains(result.Stdout, "gh/myorg/alpha"), "stdout: %s", result.Stdout)
-	assert.Check(t, cmp.Contains(result.Stdout, "gh/myorg/beta"), "stdout: %s", result.Stdout)
+	assert.Check(t, golden.String(result.Stdout, t.Name()+".txt"))
 }
 
 func TestProjectList_JSON(t *testing.T) {
@@ -195,7 +194,7 @@ func TestProjectEnvList(t *testing.T) {
 		env.Environ(), t.TempDir())
 
 	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
-	assert.Check(t, cmp.Contains(result.Stdout, "DATABASE_URL"), "stdout: %s", result.Stdout)
+	assert.Check(t, golden.String(result.Stdout, t.Name()+".txt"))
 }
 
 // --- env set ---

--- a/acceptance/runner_test.go
+++ b/acceptance/runner_test.go
@@ -25,11 +25,11 @@ package acceptance_test
 import (
 	"encoding/json"
 	"net/http"
-	"strings"
 	"testing"
 
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/assert/cmp"
+	"gotest.tools/v3/golden"
 
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/testing/binary"
 	testenv "github.com/CircleCI-Public/circleci-cli-v2/internal/testing/env"
@@ -95,8 +95,7 @@ func TestRunnerResourceClassList(t *testing.T) {
 		env.Environ(), t.TempDir())
 
 	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
-	assert.Check(t, cmp.Contains(result.Stdout, "my-org/linux-runner"), "stdout: %s", result.Stdout)
-	assert.Check(t, cmp.Contains(result.Stdout, "my-org/arm-runner"), "stdout: %s", result.Stdout)
+	assert.Check(t, golden.String(result.Stdout, t.Name()+".txt"))
 }
 
 func TestRunnerResourceClassList_Namespace(t *testing.T) {
@@ -107,7 +106,7 @@ func TestRunnerResourceClassList_Namespace(t *testing.T) {
 		env.Environ(), t.TempDir())
 
 	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
-	assert.Check(t, cmp.Contains(result.Stdout, "my-org/linux-runner"), "stdout: %s", result.Stdout)
+	assert.Check(t, golden.String(result.Stdout, t.Name()+".txt"))
 }
 
 func TestRunnerResourceClassList_JSON(t *testing.T) {
@@ -148,7 +147,7 @@ func TestRunnerResourceClassCreate(t *testing.T) {
 		env.Environ(), t.TempDir())
 
 	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
-	assert.Check(t, cmp.Contains(result.Stdout, "my-org/new-runner"), "stdout: %s", result.Stdout)
+	assert.Check(t, golden.String(result.Stdout, t.Name()+".txt"))
 }
 
 func TestRunnerResourceClassCreate_JSON(t *testing.T) {
@@ -214,9 +213,7 @@ func TestRunnerTokenList(t *testing.T) {
 		env.Environ(), t.TempDir())
 
 	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
-	assert.Check(t, cmp.Contains(result.Stdout, "tok-id-1"), "stdout: %s", result.Stdout)
-	assert.Check(t, cmp.Contains(result.Stdout, "prod-server-1"), "stdout: %s", result.Stdout)
-	assert.Check(t, cmp.Contains(result.Stdout, "prod-server-2"), "stdout: %s", result.Stdout)
+	assert.Check(t, golden.String(result.Stdout, t.Name()+".txt"))
 }
 
 func TestRunnerTokenList_JSON(t *testing.T) {
@@ -260,8 +257,7 @@ func TestRunnerTokenCreate(t *testing.T) {
 		env.Environ(), t.TempDir())
 
 	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
-	assert.Check(t, cmp.Contains(result.Stdout, "fake-runner-token-value"), "stdout: %s", result.Stdout)
-	assert.Check(t, cmp.Contains(result.Stdout, "my-server"), "stdout: %s", result.Stdout)
+	assert.Check(t, golden.String(result.Stdout, t.Name()+".txt"))
 }
 
 func TestRunnerTokenCreate_JSON(t *testing.T) {
@@ -328,8 +324,7 @@ func TestRunnerInstanceList(t *testing.T) {
 		env.Environ(), t.TempDir())
 
 	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
-	assert.Check(t, cmp.Contains(result.Stdout, "my-org/linux-runner"), "stdout: %s", result.Stdout)
-	assert.Check(t, cmp.Contains(result.Stdout, "my-org/arm-runner"), "stdout: %s", result.Stdout)
+	assert.Check(t, golden.String(result.Stdout, t.Name()+".txt"))
 }
 
 func TestRunnerInstanceList_ResourceClass(t *testing.T) {
@@ -340,8 +335,7 @@ func TestRunnerInstanceList_ResourceClass(t *testing.T) {
 		env.Environ(), t.TempDir())
 
 	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
-	assert.Check(t, cmp.Contains(result.Stdout, "my-org/linux-runner"), "stdout: %s", result.Stdout)
-	assert.Check(t, !strings.Contains(result.Stdout, "my-org/arm-runner"), "arm-runner should be filtered out, stdout: %s", result.Stdout)
+	assert.Check(t, golden.String(result.Stdout, t.Name()+".txt"))
 }
 
 func TestRunnerInstanceList_JSON(t *testing.T) {

--- a/acceptance/testdata/TestArtifacts_ByJobNumber.txt
+++ b/acceptance/testdata/TestArtifacts_ByJobNumber.txt
@@ -1,0 +1,3 @@
+# Artifacts
+- coverage/index.html
+- test-results.xml

--- a/acceptance/testdata/TestArtifacts_ByPipelineID.txt
+++ b/acceptance/testdata/TestArtifacts_ByPipelineID.txt
@@ -1,0 +1,3 @@
+# Artifacts
+- coverage/index.html
+- test-results.xml

--- a/acceptance/testdata/TestJobArtifacts_ByJobNumber.txt
+++ b/acceptance/testdata/TestJobArtifacts_ByJobNumber.txt
@@ -1,0 +1,2 @@
+# Artifacts- coverage/index.html
+- test-results.xml

--- a/acceptance/testdata/TestPipelineList.txt
+++ b/acceptance/testdata/TestPipelineList.txt
@@ -1,0 +1,6 @@
+# Pipelines
+| #  | Branch  | Revision | Pipeline | Created              | State   |
+| -- | ------- | -------- | -------- | -------------------- | ------- |
+| 10 | main    | abc1234  | pid-1    | 2020-01-01 12:00 UTC | created |
+| 9  | feature | abc1234  | pid-2    | 2020-01-01 12:00 UTC | errored |
+| 8  | main    | abc1234  | pid-3    | 2020-01-01 12:00 UTC | created |

--- a/acceptance/testdata/TestPipelineList_Limit.txt
+++ b/acceptance/testdata/TestPipelineList_Limit.txt
@@ -1,0 +1,5 @@
+# Pipelines
+| #  | Branch | Revision | Pipeline | Created              | State   |
+| -- | ------ | -------- | -------- | -------------------- | ------- |
+| 10 | main   | abc1234  | pid-1    | 2020-01-01 12:00 UTC | created |
+| 9  | main   | abc1234  | pid-2    | 2020-01-01 12:00 UTC | created |

--- a/acceptance/testdata/TestProjectEnvList.txt
+++ b/acceptance/testdata/TestProjectEnvList.txt
@@ -1,0 +1,5 @@
+# Environment Variables
+| Name         | Value | Created At           |
+| ------------ | ----- | -------------------- |
+| DATABASE_URL | xxxx  |                      |
+| SECRET_KEY   | xxxx  | 2020-01-01T00:00:00Z |

--- a/acceptance/testdata/TestProjectList.txt
+++ b/acceptance/testdata/TestProjectList.txt
@@ -1,0 +1,3 @@
+# Projects
+- gh/myorg/alpha
+- gh/myorg/beta

--- a/acceptance/testdata/TestRunnerInstanceList.txt
+++ b/acceptance/testdata/TestRunnerInstanceList.txt
@@ -1,0 +1,5 @@
+# Runner Instances
+| Resource Class      | Hostname | Status  | Last Connected |
+| ------------------- | -------- | ------- | -------------- |
+| my-org/linux-runner |          | unknown |                |
+| my-org/arm-runner   |          | unknown |                |

--- a/acceptance/testdata/TestRunnerInstanceList_ResourceClass.txt
+++ b/acceptance/testdata/TestRunnerInstanceList_ResourceClass.txt
@@ -1,0 +1,4 @@
+# Runner Instances
+| Resource Class      | Hostname           | Status  | Last Connected |
+| ------------------- | ------------------ | ------- | -------------- |
+| my-org/linux-runner | host-1.example.com | unknown |                |

--- a/acceptance/testdata/TestRunnerResourceClassCreate.txt
+++ b/acceptance/testdata/TestRunnerResourceClassCreate.txt
@@ -1,0 +1,4 @@
+# Created Resource Class
+- Resource Class: my-org/new-runner
+- Description: New runner
+- ID: `rc-my-org/new-runner`

--- a/acceptance/testdata/TestRunnerResourceClassList.txt
+++ b/acceptance/testdata/TestRunnerResourceClassList.txt
@@ -1,0 +1,5 @@
+# Runner Resource Classes
+| Resource Class      | Description        |
+| ------------------- | ------------------ |
+| my-org/linux-runner | Linux amd64 runner |
+| my-org/arm-runner   | ARM runner         |

--- a/acceptance/testdata/TestRunnerResourceClassList_Namespace.txt
+++ b/acceptance/testdata/TestRunnerResourceClassList_Namespace.txt
@@ -1,0 +1,5 @@
+# Runner Resource Classes
+| Resource Class      | Description        |
+| ------------------- | ------------------ |
+| my-org/linux-runner | Linux amd64 runner |
+| my-org/arm-runner   | ARM runner         |

--- a/acceptance/testdata/TestRunnerTokenCreate.txt
+++ b/acceptance/testdata/TestRunnerTokenCreate.txt
@@ -1,0 +1,7 @@
+Created token for resource class: my-org/linux-runner
+Nickname:  my-server
+ID:        tok-my-org/linux-runner
+Created:   2026-01-01T00:00:00Z
+
+Token (save this — it will not be shown again):
+fake-runner-token-value

--- a/acceptance/testdata/TestRunnerTokenList.txt
+++ b/acceptance/testdata/TestRunnerTokenList.txt
@@ -1,0 +1,5 @@
+# Runner Tokens
+| ID       | Nickname      | Created              |
+| -------- | ------------- | -------------------- |
+| tok-id-1 | prod-server-1 | 2026-01-01T00:00:00Z |
+| tok-id-2 | prod-server-2 | 2026-01-01T00:00:00Z |

--- a/acceptance/testdata/TestWorkflowGet.txt
+++ b/acceptance/testdata/TestWorkflowGet.txt
@@ -1,0 +1,16 @@
+# Workflow
+- ID: `cccccccc-0000-0000-0000-000000000010`
+- Name: build
+- Pipeline:
+  - Number: #42
+  - ID: `aaaaaaaa-0000-0000-0000-000000000010`
+- Project: gh/testorg/testrepo
+- Status: failed
+- Created: 2020-01-01 12:00:00 UTC
+- Stopped:  2020-01-01 12:00:00 UTC
+
+## Jobs
+| Name      | Status  | Number |
+| --------- | ------- | ------ |
+| run-tests | success | 201    |
+| deploy    | success | 202    |

--- a/acceptance/testdata/TestWorkflowList.txt
+++ b/acceptance/testdata/TestWorkflowList.txt
@@ -1,0 +1,5 @@
+# Workflows
+| ID          | Name   | Status  |
+| ----------- | ------ | ------- |
+| wf-uuid-aaa | build  | success |
+| wf-uuid-bbb | deploy | failed  |

--- a/acceptance/testdata/TestWorkflowList_NoArg.txt
+++ b/acceptance/testdata/TestWorkflowList_NoArg.txt
@@ -1,0 +1,18 @@
+# Recent pipelines
+## Pipeline #10
+- Branch: main
+- Commit: abc1234
+### Workflows
+| ID            | Name   | Status  |
+| ------------- | ------ | ------- |
+| wf-recent-aaa | build  | success |
+| wf-recent-bbb | deploy | failed  |
+
+## Pipeline #9
+- Branch: main
+- Commit: abc1234
+### Workflows
+| ID            | Name  | Status  |
+| ------------- | ----- | ------- |
+| wf-recent-ccc | build | running |
+

--- a/acceptance/workflow_test.go
+++ b/acceptance/workflow_test.go
@@ -31,6 +31,7 @@ import (
 
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/assert/cmp"
+	"gotest.tools/v3/golden"
 
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/testing/binary"
 	testenv "github.com/CircleCI-Public/circleci-cli-v2/internal/testing/env"
@@ -43,7 +44,7 @@ const (
 )
 
 func fakeWorkflowDetail(id, name, status, pipelineID, slug string) map[string]any {
-	now := time.Now().UTC().Format(time.RFC3339)
+	ts := time.Date(2020, 1, 1, 12, 0, 0, 0, time.UTC).Format(time.RFC3339)
 	return map[string]any{
 		"id":              id,
 		"name":            name,
@@ -52,8 +53,8 @@ func fakeWorkflowDetail(id, name, status, pipelineID, slug string) map[string]an
 		"pipeline_number": 42,
 		"project_slug":    slug,
 		"started_by":      "testuser-uuid",
-		"created_at":      now,
-		"stopped_at":      now,
+		"created_at":      ts,
+		"stopped_at":      ts,
 	}
 }
 
@@ -86,12 +87,7 @@ func TestWorkflowGet(t *testing.T) {
 		env.Environ(), t.TempDir())
 
 	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
-	assert.Check(t, cmp.Contains(result.Stdout, testWorkflowDetailID), "stdout: %s", result.Stdout)
-	assert.Check(t, cmp.Contains(result.Stdout, "build"), "stdout: %s", result.Stdout)
-	assert.Check(t, cmp.Contains(result.Stdout, "failed"), "stdout: %s", result.Stdout)
-	assert.Check(t, cmp.Contains(result.Stdout, "run-tests"), "stdout: %s", result.Stdout)
-	assert.Check(t, cmp.Contains(result.Stdout, "#201"), "stdout: %s", result.Stdout)
-	assert.Check(t, cmp.Contains(result.Stdout, "#202"), "stdout: %s", result.Stdout)
+	assert.Check(t, golden.String(result.Stdout, t.Name()+".txt"))
 }
 
 func TestWorkflowGet_JSON(t *testing.T) {
@@ -207,11 +203,7 @@ func TestWorkflowList(t *testing.T) {
 	result := binary.RunCLI(t, []string{"workflow", "list", testPipelineForWF}, env.Environ(), t.TempDir())
 
 	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
-	assert.Check(t, cmp.Contains(result.Stdout, "wf-uuid-aaa"), "stdout: %s", result.Stdout)
-	assert.Check(t, cmp.Contains(result.Stdout, "build"), "stdout: %s", result.Stdout)
-	assert.Check(t, cmp.Contains(result.Stdout, "wf-uuid-bbb"), "stdout: %s", result.Stdout)
-	assert.Check(t, cmp.Contains(result.Stdout, "deploy"), "stdout: %s", result.Stdout)
-	assert.Check(t, cmp.Contains(result.Stdout, "failed"), "stdout: %s", result.Stdout)
+	assert.Check(t, golden.String(result.Stdout, t.Name()+".txt"))
 }
 
 func TestWorkflowList_JSON(t *testing.T) {
@@ -313,11 +305,7 @@ func TestWorkflowList_NoArg(t *testing.T) {
 		env.Environ(), t.TempDir())
 
 	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
-	assert.Check(t, cmp.Contains(result.Stdout, "Pipeline #10"), "stdout: %s", result.Stdout)
-	assert.Check(t, cmp.Contains(result.Stdout, "wf-recent-aaa"), "stdout: %s", result.Stdout)
-	assert.Check(t, cmp.Contains(result.Stdout, "build"), "stdout: %s", result.Stdout)
-	assert.Check(t, cmp.Contains(result.Stdout, "Pipeline #9"), "stdout: %s", result.Stdout)
-	assert.Check(t, cmp.Contains(result.Stdout, "wf-recent-ccc"), "stdout: %s", result.Stdout)
+	assert.Check(t, golden.String(result.Stdout, t.Name()+".txt"))
 }
 
 func TestWorkflowList_NoArg_JSON(t *testing.T) {

--- a/agents/01-philosophy.md
+++ b/agents/01-philosophy.md
@@ -39,6 +39,8 @@ The right amount of output:
 - Surfaces anything the user needs to act on
 - Stays out of the way for scripting contexts
 
+Use markdown for regular (non-JSON) output. There is a markdown helper in the iostreams package.
+
 ---
 
 ## 5. Ease of Discovery

--- a/internal/cmd/artifacts/artifacts.go
+++ b/internal/cmd/artifacts/artifacts.go
@@ -26,6 +26,7 @@ package artifacts
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
@@ -36,6 +37,7 @@ import (
 	clierrors "github.com/CircleCI-Public/circleci-cli-v2/internal/errors"
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/gitremote"
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/iostream"
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/mdtable"
 )
 
 // NewArtifactsCmd returns the top-level "circleci artifacts" command.
@@ -195,17 +197,21 @@ func printArtifacts(ctx context.Context, entries []artifacts.Entry) {
 		}
 	}
 
+	md := ""
 	if multiJob {
-		iostream.Printf(ctx, "%-30s  %-6s  %s\n", "JOB", "JOB #", "PATH")
-		iostream.Printf(ctx, "%-30s  %-6s  %s\n", "---", "-----", "----")
+		table := mdtable.New("Job", "Job #", "Path")
 		for _, e := range entries {
-			iostream.Printf(ctx, "%-30s  %-6d  %s\n", e.JobName, e.JobNumber, e.Path)
+			table.Row(e.JobName, fmt.Sprintf("%d", e.JobNumber), e.Path)
 		}
+		md = table.Render()
 	} else {
+		var sb strings.Builder
 		for _, e := range entries {
-			iostream.Println(ctx, e.Path)
+			_, _ = fmt.Fprintf(&sb, "- %s\n", e.Path)
 		}
+		md = sb.String()
 	}
+	iostream.PrintMarkdown(ctx, "# Artifacts\n"+md)
 }
 
 func apiErr(err error, subject string) *clierrors.CLIError {

--- a/internal/cmd/job/artifacts.go
+++ b/internal/cmd/job/artifacts.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
@@ -144,8 +145,11 @@ func runJobArtifacts(ctx context.Context, client *apiclient.Client, jobNumber in
 		return cmdutil.WriteJSON(iostream.Out(ctx), entries)
 	}
 
+	var md strings.Builder
+	md.WriteString("# Artifacts")
 	for _, e := range entries {
-		iostream.Println(ctx, e.Path)
+		_, _ = fmt.Fprintf(&md, "- %s\n", e.Path)
 	}
+	iostream.PrintMarkdown(ctx, md.String())
 	return nil
 }

--- a/internal/cmd/pipeline/list.go
+++ b/internal/cmd/pipeline/list.go
@@ -24,6 +24,7 @@ package pipeline
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
@@ -32,6 +33,7 @@ import (
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/cmdutil"
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/gitremote"
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/iostream"
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/mdtable"
 )
 
 func newListCmd() *cobra.Command {
@@ -158,12 +160,9 @@ func pipelineToListEntry(p *apiclient.Pipeline) pipelineListEntry {
 }
 
 func printList(ctx context.Context, entries []pipelineListEntry) {
+	table := mdtable.New("#", "Branch", "Revision", "Pipeline", "Created", "State")
 	for _, e := range entries {
-		state := ""
-		if e.State == "errored" {
-			state = "  [errored]"
-		}
-		iostream.Printf(ctx, "#%-4d  %-20s  %s  %s  %s%s\n",
-			e.Number, e.Branch, e.Revision, e.ID, e.CreatedAt, state)
+		table.Row(strconv.Itoa(int(e.Number)), e.Branch, e.Revision, e.ID, e.CreatedAt, e.State)
 	}
+	iostream.PrintMarkdown(ctx, "# Pipelines\n"+table.Render())
 }

--- a/internal/cmd/project/env.go
+++ b/internal/cmd/project/env.go
@@ -26,7 +26,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/MakeNowJust/heredoc"
@@ -38,6 +37,7 @@ import (
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/gitremote"
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/httpcl"
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/iostream"
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/mdtable"
 )
 
 func newEnvCmd() *cobra.Command {
@@ -140,36 +140,15 @@ func RunEnvList(ctx context.Context, client *apiclient.Client, projectSlug strin
 		return nil
 	}
 
-	const createdHeader = "Created At"
-	nameW := len("Name")
-	valW := len("Value")
-	createdW := len(createdHeader)
-	for _, v := range vars {
-		if len(v.Name) > nameW {
-			nameW = len(v.Name)
-		}
-		if len(v.Value) > valW {
-			valW = len(v.Value)
-		}
-		if v.CreatedAt != nil {
-			if n := len(v.CreatedAt.Format(time.RFC3339)); n > createdW {
-				createdW = n
-			}
-		}
-	}
-
-	var md strings.Builder
-	md.WriteString("# Environment Variables\n")
-	_, _ = fmt.Fprintf(&md, "| %-*s | %-*s | %-*s |\n", nameW, "Name", valW, "Value", createdW, createdHeader)
-	_, _ = fmt.Fprintf(&md, "| %s | %s | %s |\n", strings.Repeat("-", nameW), strings.Repeat("-", valW), strings.Repeat("-", createdW))
+	tbl := mdtable.New("Name", "Value", "Created At")
 	for _, v := range vars {
 		created := ""
 		if v.CreatedAt != nil {
 			created = v.CreatedAt.Format(time.RFC3339)
 		}
-		_, _ = fmt.Fprintf(&md, "| %-*s | %-*s | %-*s |\n", nameW, v.Name, valW, v.Value, createdW, created)
+		tbl.Row(v.Name, v.Value, created)
 	}
-	iostream.PrintMarkdown(ctx, md.String())
+	iostream.PrintMarkdown(ctx, "# Environment Variables\n"+tbl.Render())
 	return nil
 }
 

--- a/internal/cmd/runner/instance.go
+++ b/internal/cmd/runner/instance.go
@@ -36,6 +36,7 @@ import (
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/gitremote"
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/httpcl"
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/iostream"
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/mdtable"
 )
 
 func newInstanceCmd() *cobra.Command {
@@ -197,9 +198,10 @@ func runInstanceList(ctx context.Context, client *apiclient.Client, resourceClas
 		return nil
 	}
 
+	table := mdtable.New("Resource Class", "Hostname", "Status", "Last Connected")
 	for _, inst := range out {
-		iostream.Printf(ctx, "%-40s  %-20s  %-7s  %s\n",
-			inst.ResourceClass, inst.Hostname, inst.Status, inst.LastConnected)
+		table.Row(inst.ResourceClass, inst.Hostname, inst.Status, inst.LastConnected)
 	}
+	iostream.PrintMarkdown(ctx, "# Runner Instances\n"+table.Render())
 	return nil
 }

--- a/internal/cmd/runner/resource_class.go
+++ b/internal/cmd/runner/resource_class.go
@@ -26,6 +26,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
@@ -36,6 +37,7 @@ import (
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/gitremote"
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/httpcl"
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/iostream"
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/mdtable"
 )
 
 func newResourceClassCmd() *cobra.Command {
@@ -142,13 +144,11 @@ func runResourceClassList(ctx context.Context, client *apiclient.Client, namespa
 		iostream.Printf(ctx, "No resource classes found.\n")
 		return nil
 	}
+	table := mdtable.New("Resource Class", "Description")
 	for _, rc := range out {
-		if rc.Description != "" {
-			iostream.Printf(ctx, "%-40s  %s\n", rc.ResourceClass, rc.Description)
-		} else {
-			iostream.Printf(ctx, "%s\n", rc.ResourceClass)
-		}
+		table.Row(rc.ResourceClass, rc.Description)
 	}
+	iostream.PrintMarkdown(ctx, "# Runner Resource Classes\n"+table.Render())
 	return nil
 }
 
@@ -214,11 +214,14 @@ func runResourceClassCreate(ctx context.Context, client *apiclient.Client, resou
 		return cmdutil.WriteJSON(iostream.Out(ctx), out)
 	}
 
-	iostream.Printf(ctx, "Created resource class: %s\n", out.ResourceClass)
+	var md strings.Builder
+	md.WriteString("# Created Resource Class\n")
+	_, _ = fmt.Fprintf(&md, "- Resource Class: %s\n", out.ResourceClass)
 	if out.Description != "" {
-		iostream.Printf(ctx, "Description: %s\n", out.Description)
+		_, _ = fmt.Fprintf(&md, "- Description: %s\n", out.Description)
 	}
-	iostream.Printf(ctx, "ID: %s\n", out.ID)
+	_, _ = fmt.Fprintf(&md, "- ID: `%s`\n", out.ID)
+	iostream.PrintMarkdown(ctx, md.String())
 	return nil
 }
 

--- a/internal/cmd/runner/tasks.go
+++ b/internal/cmd/runner/tasks.go
@@ -24,7 +24,9 @@ package runner
 
 import (
 	"context"
+	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
@@ -109,8 +111,11 @@ func runTasks(ctx context.Context, client *apiclient.Client, resourceClass strin
 		return cmdutil.WriteJSON(iostream.Out(ctx), out)
 	}
 
-	iostream.Printf(ctx, "Resource class: %s\n", out.ResourceClass)
-	iostream.Printf(ctx, "  Unclaimed:    %d\n", out.Unclaimed)
-	iostream.Printf(ctx, "  Running:      %d\n", out.Running)
+	var md strings.Builder
+	md.WriteString("# Tasks\n")
+	_, _ = fmt.Fprintf(&md, "## %s\n", out.ResourceClass)
+	_, _ = fmt.Fprintf(&md, "- Unclaimed: %d\n", out.Unclaimed)
+	_, _ = fmt.Fprintf(&md, "- Running: %d\n", out.Running)
+	iostream.PrintMarkdown(ctx, md.String())
 	return nil
 }

--- a/internal/cmd/runner/token.go
+++ b/internal/cmd/runner/token.go
@@ -36,6 +36,7 @@ import (
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/gitremote"
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/httpcl"
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/iostream"
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/mdtable"
 )
 
 func newTokenCmd() *cobra.Command {
@@ -170,9 +171,11 @@ func runTokenList(ctx context.Context, client *apiclient.Client, resourceClass s
 		}
 		return nil
 	}
+	table := mdtable.New("ID", "Nickname", "Created")
 	for _, t := range out {
-		iostream.Printf(ctx, "%-36s  %-20s  %s\n", t.ID, t.Nickname, t.CreatedAt)
+		table.Row(t.ID, t.Nickname, t.CreatedAt)
 	}
+	iostream.PrintMarkdown(ctx, "# Runner Tokens\n"+table.Render())
 	return nil
 }
 

--- a/internal/cmd/workflow/get.go
+++ b/internal/cmd/workflow/get.go
@@ -24,6 +24,8 @@ package workflow
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
@@ -31,6 +33,7 @@ import (
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/apiclient"
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/cmdutil"
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/iostream"
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/mdtable"
 )
 
 func newGetCmd() *cobra.Command {
@@ -135,24 +138,32 @@ func runGet(ctx context.Context, client *apiclient.Client, id string, jsonOut bo
 }
 
 func printGet(ctx context.Context, w workflowGetOutput) {
-	iostream.Printf(ctx, "Workflow  %s\n", w.ID)
-	iostream.Printf(ctx, "Name:     %s\n", w.Name)
-	iostream.Printf(ctx, "Pipeline: #%d (%s)\n", w.PipelineNumber, w.PipelineID)
-	iostream.Printf(ctx, "Project:  %s\n", w.ProjectSlug)
-	iostream.Printf(ctx, "Status:   %s\n", w.Status)
-	iostream.Printf(ctx, "Created:  %s\n", w.CreatedAt)
+	var md strings.Builder
+	md.WriteString("# Workflow\n")
+
+	_, _ = fmt.Fprintf(&md, "- ID: `%s`\n", w.ID)
+	_, _ = fmt.Fprintf(&md, "- Name: %s\n", w.Name)
+	_, _ = fmt.Fprintf(&md, "- Pipeline:\n")
+	_, _ = fmt.Fprintf(&md, "  - Number: #%d\n", w.PipelineNumber)
+	_, _ = fmt.Fprintf(&md, "  - ID: `%s`\n", w.PipelineID)
+	_, _ = fmt.Fprintf(&md, "- Project: %s\n", w.ProjectSlug)
+	_, _ = fmt.Fprintf(&md, "- Status: %s\n", w.Status)
+	_, _ = fmt.Fprintf(&md, "- Created: %s\n", w.CreatedAt)
 	if w.StoppedAt != "" {
-		iostream.Printf(ctx, "Stopped:  %s\n", w.StoppedAt)
+		_, _ = fmt.Fprintf(&md, "- Stopped:  %s\n", w.StoppedAt)
 	}
 
 	if len(w.Jobs) > 0 {
-		iostream.Printf(ctx, "\nJobs:\n")
+		_, _ = fmt.Fprintf(&md, "\n## Jobs\n")
+		table := mdtable.New("Name", "Status", "Number")
 		for _, j := range w.Jobs {
 			if j.Type == "approval" {
-				iostream.Printf(ctx, "  %-36s  %s\n", j.Name, j.Status)
+				table.Row(j.Name, j.Status, "")
 			} else {
-				iostream.Printf(ctx, "  %-36s  %s  #%d\n", j.Name, j.Status, j.Number)
+				table.Row(j.Name, j.Status, fmt.Sprintf("%d", j.Number))
 			}
 		}
+		md.WriteString(table.Render())
 	}
+	iostream.PrintMarkdown(ctx, md.String())
 }

--- a/internal/cmd/workflow/list.go
+++ b/internal/cmd/workflow/list.go
@@ -24,6 +24,7 @@ package workflow
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -35,6 +36,7 @@ import (
 	clierrors "github.com/CircleCI-Public/circleci-cli-v2/internal/errors"
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/gitremote"
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/iostream"
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/mdtable"
 )
 
 func newListCmd() *cobra.Command {
@@ -151,9 +153,12 @@ func runList(ctx context.Context, client *apiclient.Client, arg, projectSlug str
 		iostream.Printf(ctx, "No workflows found for pipeline %s.\n", arg)
 		return nil
 	}
-	for _, wf := range out {
-		iostream.Printf(ctx, "%-36s  %-28s  %s\n", wf.ID, wf.Name, wf.Status)
+
+	table := mdtable.New("ID", "Name", "Status")
+	for _, wf := range workflows {
+		table.Row(wf.ID, wf.Name, wf.Status)
 	}
+	iostream.PrintMarkdown(ctx, "# Workflows\n"+table.Render())
 	return nil
 }
 
@@ -199,10 +204,10 @@ func runListRecent(ctx context.Context, client *apiclient.Client, projectSlug, b
 		return nil
 	}
 
-	for i, p := range pipelines {
-		if i > 0 {
-			iostream.Printf(ctx, "\n")
-		}
+	var md strings.Builder
+	md.WriteString("# Recent pipelines\n")
+
+	for _, p := range pipelines {
 		branchName := ""
 		revision := ""
 		if p.VCS != nil {
@@ -212,20 +217,28 @@ func runListRecent(ctx context.Context, client *apiclient.Client, projectSlug, b
 				revision = revision[:7]
 			}
 		}
-		iostream.Printf(ctx, "Pipeline #%d  %s  %s\n", p.Number, branchName, revision)
+		_, _ = fmt.Fprintf(&md, "## Pipeline #%d\n", p.Number)
+		_, _ = fmt.Fprintf(&md, "- Branch: %s\n", branchName)
+		_, _ = fmt.Fprintf(&md, "- Commit: %s\n", revision)
 
 		workflows, wErr := client.GetPipelineWorkflows(ctx, p.ID)
 		if wErr != nil {
 			return apiErr(wErr, p.ID)
 		}
+
 		if len(workflows) == 0 {
-			iostream.Printf(ctx, "  (no workflows)\n")
+			_, _ = fmt.Fprintf(&md, "- Workflows: none\n")
 			continue
 		}
+		_, _ = fmt.Fprintf(&md, "### Workflows\n")
+		table := mdtable.New("ID", "Name", "Status")
 		for _, wf := range workflows {
-			iostream.Printf(ctx, "  %-36s  %-28s  %s\n", wf.ID, wf.Name, wf.Status)
+			table.Row(wf.ID, wf.Name, wf.Status)
 		}
+		md.WriteString(table.Render())
+		md.WriteString("\n")
 	}
+	iostream.PrintMarkdown(ctx, md.String())
 	return nil
 }
 

--- a/internal/iostream/streams.go
+++ b/internal/iostream/streams.go
@@ -314,7 +314,7 @@ func (s Streams) RenderMarkdown(md string) (string, error) {
 	}
 	r, err := glamour.NewTermRenderer(
 		glamour.WithEnvironmentConfig(),
-		glamour.WithWordWrap(100),
+		glamour.WithWordWrap(120),
 	)
 	if err != nil {
 		return md, err

--- a/internal/mdtable/mdtable.go
+++ b/internal/mdtable/mdtable.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+// Package mdtable builds GitHub-Flavored Markdown tables.
+//
+// Example:
+//
+//	t := mdtable.New("Name", "Value")
+//	t.Row("FOO", "bar")
+//	t.Row("BAZ", "qux")
+//	fmt.Print(t.Render())
+package mdtable
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Table accumulates headers and rows, then renders a GFM-aligned table.
+type Table struct {
+	headers []string
+	rows    [][]string
+	widths  []int
+}
+
+// New creates a Table with the given column headers.
+func New(headers ...string) *Table {
+	widths := make([]int, len(headers))
+	for i, h := range headers {
+		widths[i] = len(h)
+	}
+	return &Table{headers: headers, widths: widths}
+}
+
+// Row appends a data row. Values beyond the header count are ignored;
+// missing values are treated as empty strings.
+func (t *Table) Row(values ...string) {
+	row := make([]string, len(t.headers))
+	for i := range t.headers {
+		if i < len(values) {
+			row[i] = values[i]
+		}
+		if len(row[i]) > t.widths[i] {
+			t.widths[i] = len(row[i])
+		}
+	}
+	t.rows = append(t.rows, row)
+}
+
+// Render returns the GFM markdown table string.
+func (t *Table) Render() string {
+	var sb strings.Builder
+
+	// Header row
+	for i, h := range t.headers {
+		fmt.Fprintf(&sb, "| %-*s ", t.widths[i], h)
+	}
+	sb.WriteString("|\n")
+
+	// Separator row
+	for _, w := range t.widths {
+		fmt.Fprintf(&sb, "| %s ", strings.Repeat("-", w))
+	}
+	sb.WriteString("|\n")
+
+	// Data rows
+	for _, row := range t.rows {
+		for i, v := range row {
+			fmt.Fprintf(&sb, "| %-*s ", t.widths[i], v)
+		}
+		sb.WriteString("|\n")
+	}
+
+	return sb.String()
+}


### PR DESCRIPTION
- I've not screenshotted all the ones converted, but you get the general idea.
- Convert to golden assertions for command outputs.

##
<img width="947" height="374" alt="Screenshot 2026-04-27 at 10 40 46" src="https://github.com/user-attachments/assets/dbbae4a3-9b71-48e6-bff2-95929a841b00" />

##
<img width="947" height="406" alt="Screenshot 2026-04-27 at 10 35 12" src="https://github.com/user-attachments/assets/ed66fdba-63dc-4fbf-a03c-d89c95061151" />
