### PR TITLE
add `check`/`ci:check` commands that run all static checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,16 +113,15 @@ executors:
       GOCACHE: 'C:\Users\circleci\.cache\go-build'
 
 jobs:
-  lint:
+  check:
     executor: linux
     steps:
       - setup
       - go/with-cache:
           golangci-lint: true
           steps:
-            - run: task ci:lint
+            - run: task ci:check
             - store_results
-            - run: task ci:diff
 
   test:
     parameters:
@@ -141,7 +140,7 @@ jobs:
 workflows:
   ci:
     jobs:
-      - lint
+      - check
       - test:
           matrix:
             parameters:

--- a/README.md
+++ b/README.md
@@ -1,2 +1,33 @@
 # circleci-cli-v2
 Use CircleCI from the command line
+
+## Development
+
+### Local
+
+This repository makes use [Task](https://taskfile.dev/#/) which can be installed (on MacOS) with:
+
+```
+$ brew install go-task/tap/go-task
+```
+
+Most other tools referenced in the `Taskfile.yml` are managed by the go.mod tool section.
+
+TODO: add instructions to install other tools.
+
+See the full list of available tasks by running `task -l`, or, see the [Taskfile.yml](./Taskfile.yml) script.
+
+```sh
+# Run all static checks
+task check
+# Format all the code
+task fmt
+# Apply licence headers
+task licence
+
+# Run all the tests
+task test
+# Run the quick tests
+task test -- -short ./...
+# Run the quick tests for one package
+task test -- -short ./api/...

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -40,6 +40,17 @@ tasks:
     cmds:
       - go tool gotestsum -- -race {{.ARGS}}
 
+  check:
+    desc: Run all static checks
+    cmds:
+      - task: lint
+      - task: license
+        vars:
+          CLI_ARGS: -check .
+      - task: mod-tidy
+        vars:
+          CLI_ARGS: -diff
+
   lint:
     desc: Run golangci-lint
     vars:
@@ -54,10 +65,28 @@ tasks:
     cmds:
       - go tool golangci-lint fmt {{.ARGS}}
 
+  license:
+    desc: Manage license headers
+    vars:
+      ARGS: '{{default "." .CLI_ARGS}}'
+    cmds:
+      - |
+        go tool addlicense \
+          -c "Circle Internet Services, Inc." \
+          -l mit \
+          -s \
+          -ignore ".idea/**" \
+          -ignore ".circleci/**" \
+          -ignore ".claude/**" \
+          -ignore "test-reports/**" \
+          {{.ARGS}}
+
   mod-tidy:
     desc: Run 'go mod tidy'
+    vars:
+      ARGS: '{{default "-v" .CLI_ARGS}}'
     cmds:
-      - go mod tidy -v
+      - go mod tidy {{.ARGS}}
 
   mod-download:
     desc: Run 'go mod download'
@@ -144,10 +173,15 @@ tasks:
       - mkdir -p {{.RESULTS_DIR}}
       - go tool gotestsum --junitfile="{{.TEST_REPORT}}" -- {{.RACE}} -count=1 {{.ARGS}}
 
-  ci:diff:
+  ci:check:
     desc: Check no uncommitted diffs after generate/fmt/tidy
     cmds:
-      - task: generate
-      - task: fmt
+      - task: ci:lint
+      - task: license
+        vars:
+          CLI_ARGS: -check .
       - task: mod-tidy
+        vars:
+          CLI_ARGS: -diff
+      - task: generate
       - git diff --exit-code

--- a/licence.go
+++ b/licence.go
@@ -1,6 +1,0 @@
-// Copyright Circle Internet Services, Inc. 2026
-// SPDX-License-Identifier: MIT
-
-//go:generate go tool addlicense -c "Circle Internet Services, Inc." -l mit -s -ignore ".idea/**" -ignore ".circleci/**" -ignore ".claude/**" .
-
-package main


### PR DESCRIPTION
- Except for the results of generate, which we now don't have any configured.
