### PR TITLE
Make config read/write atomic

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -30,8 +30,10 @@ vars:
 tasks:
   build:
     desc: Build the circleci binary
+    vars:
+      DEST: '{{default "dist/circleci" .DEST}}'
     cmds:
-      - go build -o dist/circleci .
+      - go build -o "{{.DEST}}" .
 
   test:
     desc: Run unit tests
@@ -112,10 +114,13 @@ tasks:
 
   dev-install:
     desc: Build from source and install to ~/.local/bin
+    vars:
+      DEST: '${HOME}/.local/bin'
     cmds:
+      - mkdir -p "{{.DEST}}"
       - task: build
-      - mkdir -p ${HOME}/.local/bin
-      - cp dist/circleci ${HOME}/.local/bin
+        vars:
+          DEST: '{{.DEST}}/circleci'
 
   generate:
     desc: Run go generate

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/MakeNowJust/heredoc v1.0.0
 	github.com/go-chi/chi/v5 v5.2.5
 	github.com/go-chi/render v1.0.3
+	github.com/gofrs/flock v0.13.0
 	github.com/hashicorp/go-retryablehttp v0.7.8
 	github.com/njayp/ophis v1.1.4
 	github.com/spf13/cobra v1.10.2
@@ -108,7 +109,6 @@ require (
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/godbus/dbus/v5 v5.2.2 // indirect
 	github.com/godoc-lint/godoc-lint v0.11.2 // indirect
-	github.com/gofrs/flock v0.13.0 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/golangci/asciicheck v0.5.0 // indirect
 	github.com/golangci/dupl v0.0.0-20250308024227-f665c8d69b32 // indirect

--- a/internal/closer/closer.go
+++ b/internal/closer/closer.go
@@ -20,44 +20,16 @@
 //
 // SPDX-License-Identifier: MIT
 
-package cmdauth
+package closer
 
-import (
-	"context"
+import "io"
 
-	"github.com/spf13/cobra"
-
-	"github.com/CircleCI-Public/circleci-cli-v2/internal/cmdutil"
-	"github.com/CircleCI-Public/circleci-cli-v2/internal/config"
-	clierrors "github.com/CircleCI-Public/circleci-cli-v2/internal/errors"
-	"github.com/CircleCI-Public/circleci-cli-v2/internal/iostream"
-)
-
-func newLogoutCmd() *cobra.Command {
-	var jsonOut bool
-
-	cmd := &cobra.Command{
-		Use:   "logout",
-		Short: "Remove stored credentials",
-		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := iostream.FromCmd(cmd.Context(), cmd)
-			secureStorage := cmdutil.IsSecureStorage(cmd)
-			return runLogout(ctx, secureStorage)
-		},
+// ErrorHandler closes an io.Closer with error handling. If there's an
+// error during Close when `in` is `nil`, sets `in` to the value of
+// the Close error.
+func ErrorHandler(c io.Closer, in *error) {
+	cerr := c.Close()
+	if *in == nil {
+		*in = cerr
 	}
-
-	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output as JSON")
-	return cmd
-}
-
-func runLogout(ctx context.Context, secureStorage bool) error {
-	err := config.SetToken(ctx, "", secureStorage)
-	if err != nil {
-		return clierrors.New("settings.save_failed", "Failed to save settings", err.Error()).
-			WithExitCode(clierrors.ExitGeneralError)
-	}
-
-	iostream.ErrPrintf(ctx, "%s Removed %s from keyring\n", iostream.Symbol(ctx, "✓", "OK:"), "token")
-	return nil
 }

--- a/internal/closer/closer_test.go
+++ b/internal/closer/closer_test.go
@@ -20,44 +20,46 @@
 //
 // SPDX-License-Identifier: MIT
 
-package cmdauth
+package closer
 
 import (
-	"context"
+	"errors"
+	"testing"
 
-	"github.com/spf13/cobra"
-
-	"github.com/CircleCI-Public/circleci-cli-v2/internal/cmdutil"
-	"github.com/CircleCI-Public/circleci-cli-v2/internal/config"
-	clierrors "github.com/CircleCI-Public/circleci-cli-v2/internal/errors"
-	"github.com/CircleCI-Public/circleci-cli-v2/internal/iostream"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
 )
 
-func newLogoutCmd() *cobra.Command {
-	var jsonOut bool
+func TestErrorHandler(t *testing.T) {
+	t.Run("with error", func(t *testing.T) {
+		var errorSentinel = errors.New("error sentinel")
 
-	cmd := &cobra.Command{
-		Use:   "logout",
-		Short: "Remove stored credentials",
-		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := iostream.FromCmd(cmd.Context(), cmd)
-			secureStorage := cmdutil.IsSecureStorage(cmd)
-			return runLogout(ctx, secureStorage)
-		},
-	}
+		called := false
+		closer := func() error {
+			called = true
+			return errorSentinel
+		}
+		var err error
+		ErrorHandler(closerFunc(closer), &err)
+		assert.Check(t, called)
+		assert.Check(t, cmp.ErrorIs(err, errorSentinel))
+	})
 
-	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output as JSON")
-	return cmd
+	t.Run("no error", func(t *testing.T) {
+		called := false
+		closer := func() error {
+			called = true
+			return nil
+		}
+		var err error
+		ErrorHandler(closerFunc(closer), &err)
+		assert.Check(t, called)
+		assert.Check(t, err)
+	})
 }
 
-func runLogout(ctx context.Context, secureStorage bool) error {
-	err := config.SetToken(ctx, "", secureStorage)
-	if err != nil {
-		return clierrors.New("settings.save_failed", "Failed to save settings", err.Error()).
-			WithExitCode(clierrors.ExitGeneralError)
-	}
+type closerFunc func() error
 
-	iostream.ErrPrintf(ctx, "%s Removed %s from keyring\n", iostream.Symbol(ctx, "✓", "OK:"), "token")
-	return nil
+func (f closerFunc) Close() error {
+	return f()
 }

--- a/internal/cmd/cmdauth/token.go
+++ b/internal/cmd/cmdauth/token.go
@@ -55,12 +55,6 @@ func newTokenCmd() *cobra.Command {
 }
 
 func runToken(ctx context.Context, secureStorage bool) error {
-	cfg, err := config.Load(ctx, secureStorage)
-	if err != nil {
-		return clierrors.New("settings.load_failed", "Failed to load settings", err.Error()).
-			WithExitCode(clierrors.ExitGeneralError)
-	}
-
 	p := tea.NewProgram(ui.NewTokenModel(),
 		tea.WithContext(ctx),
 		tea.WithInput(iostream.In(ctx)),
@@ -76,8 +70,8 @@ func runToken(ctx context.Context, secureStorage bool) error {
 		return nil
 	}
 
-	cfg.Token = m.Token()
-	if err := config.Save(ctx, cfg, secureStorage); err != nil {
+	err = config.SetToken(ctx, m.Token(), secureStorage)
+	if err != nil {
 		return clierrors.New("settings.save_failed", "Failed to save settings", err.Error()).
 			WithExitCode(clierrors.ExitGeneralError)
 	}

--- a/internal/cmd/settings/list.go
+++ b/internal/cmd/settings/list.go
@@ -25,6 +25,7 @@ package settings
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
@@ -33,6 +34,7 @@ import (
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/config"
 	clierrors "github.com/CircleCI-Public/circleci-cli-v2/internal/errors"
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/iostream"
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/mdtable"
 )
 
 func newListCmd() *cobra.Command {
@@ -89,9 +91,15 @@ func runList(ctx context.Context, secureStorage bool, jsonOut bool) error {
 		return cmdutil.WriteJSON(iostream.Out(ctx), out)
 	}
 
-	iostream.Printf(ctx, "Config file: %s\n\n", path)
-	iostream.Printf(ctx, "%-10s  %s\n", "token", maskToken(cfg.EffectiveToken()))
-	iostream.Printf(ctx, "%-10s  %s\n", "host", cfg.EffectiveHost())
+	var md strings.Builder
+	_, _ = fmt.Fprintf(&md, "# Settings\n")
+	_, _ = fmt.Fprintf(&md, "- Path: %s\n", path)
+	_, _ = fmt.Fprintf(&md, "- Keyring: %t\n\n", secureStorage)
+	table := mdtable.New("Name", "Value")
+	table.Row("host", cfg.EffectiveHost())
+	table.Row("token", maskToken(cfg.EffectiveToken()))
+	md.WriteString(table.Render() + "\n")
+	iostream.PrintMarkdown(ctx, md.String())
 	return nil
 }
 

--- a/internal/cmd/settings/set.go
+++ b/internal/cmd/settings/set.go
@@ -79,25 +79,18 @@ func newSetCmd() *cobra.Command {
 	return cmd
 }
 
-func runSet(ctx context.Context, secureStorage bool, key, value string) error {
-	cfg, err := config.Load(ctx, secureStorage)
-	if err != nil {
-		return clierrors.New("settings.load_failed", "Failed to load settings", err.Error()).
-			WithExitCode(clierrors.ExitGeneralError)
-	}
-
+func runSet(ctx context.Context, secureStorage bool, key, value string) (err error) {
 	switch key {
 	case "token":
-		cfg.Token = value
+		err = config.SetToken(ctx, value, secureStorage)
 	case "host":
-		cfg.Host = value
+		err = config.SetHost(ctx, value, secureStorage)
 	default:
 		return clierrors.New("settings.unknown_key", "Unknown setting", "Unknown setting key: "+key).
 			WithSuggestions("Valid keys are: token, host").
 			WithExitCode(clierrors.ExitBadArguments)
 	}
-
-	if err := config.Save(ctx, cfg, secureStorage); err != nil {
+	if err != nil {
 		return clierrors.New("settings.save_failed", "Failed to save settings", err.Error()).
 			WithExitCode(clierrors.ExitGeneralError)
 	}

--- a/internal/cmdutil/client.go
+++ b/internal/cmdutil/client.go
@@ -59,7 +59,7 @@ func IsSecureStorage(cmd *cobra.Command) bool {
 // Honors a --config path set by the root PersistentPreRunE via WithConfigPath.
 func LoadClient(ctx context.Context, cmd *cobra.Command) (*apiclient.Client, error) {
 	configPath, _ := ctx.Value(configPathKey{}).(string)
-	cfg, err := config.LoadFrom(configPath, ctx, IsSecureStorage(cmd))
+	cfg, err := config.LoadFrom(ctx, configPath, IsSecureStorage(cmd))
 	if err != nil {
 		return nil, clierrors.New("config.load_failed", "Failed to load config", err.Error()).
 			WithExitCode(clierrors.ExitGeneralError)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,14 +34,21 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"time"
 
+	"github.com/gofrs/flock"
 	"gopkg.in/yaml.v3"
 
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/closer"
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/keyring"
 )
 
 // Config holds all persisted CLI settings.
 type Config struct {
+	state state
+}
+
+type state struct {
 	Token string `yaml:"token,omitempty"`
 	Host  string `yaml:"host,omitempty"`
 }
@@ -52,33 +59,50 @@ const DefaultHost = "https://circleci.com"
 // Load reads the config file from the default path, returning an empty Config
 // if the file does not exist.
 func Load(ctx context.Context, secureStorage bool) (*Config, error) {
-	return LoadFrom("", ctx, secureStorage)
+	return LoadFrom(ctx, "", secureStorage)
 }
 
 // LoadFrom reads the config file from the given path. If path is empty the
 // default XDG path is used. Returns an empty Config if the file does not exist.
-func LoadFrom(path string, ctx context.Context, secureStorage bool) (*Config, error) {
+func LoadFrom(ctx context.Context, path string, secureStorage bool) (*Config, error) {
 	resolved, err := resolvePath(path)
 	if err != nil {
 		return nil, err
 	}
 
+	err = mkConfigDir(resolved)
+	if err != nil {
+		return nil, err
+	}
+
+	fl := flock.New(lockPath(resolved))
+	rlock, err := fl.TryRLockContext(ctx, time.Second)
+	switch {
+	case err != nil:
+		return nil, fmt.Errorf("error opening lock file: %w", err)
+	default:
+		if !rlock {
+			return nil, fmt.Errorf("could not lock config file %s", resolved)
+		}
+		defer closer.ErrorHandler(fl, &err)
+	}
+
+	var cfg Config
+
 	data, err := os.ReadFile(resolved)
 	if os.IsNotExist(err) {
-		cfg := &Config{}
 		if secureStorage {
 			err = cfg.loadToken(ctx)
 			if err != nil {
 				return nil, err
 			}
 		}
-		return cfg, nil
+		return &cfg, nil
 	}
 	if err != nil {
 		return nil, fmt.Errorf("reading config file: %w", err)
 	}
 
-	var cfg Config
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
 		return nil, fmt.Errorf("parsing config file %s: %w", resolved, err)
 	}
@@ -93,25 +117,74 @@ func LoadFrom(path string, ctx context.Context, secureStorage bool) (*Config, er
 	return &cfg, nil
 }
 
-// Save writes cfg to the default config file path, creating parent directories
-// as needed.
-func Save(ctx context.Context, cfg *Config, secureStorage bool) error {
-	return SaveTo("", ctx, cfg, secureStorage)
+func mkConfigDir(resolved string) error {
+	err := os.MkdirAll(filepath.Dir(resolved), 0o700)
+	if err != nil {
+		return fmt.Errorf("creating config directory: %w", err)
+	}
+	return nil
 }
 
-// SaveTo writes cfg to the given path, creating parent directories as needed.
+func lockPath(path string) string {
+	return path + ".lock"
+}
+
+func SetToken(ctx context.Context, token string, secureStorage bool) error {
+	return saveTo(ctx, "", secureStorage, func(cfg *Config) error {
+		cfg.state.Token = token
+		return nil
+	})
+}
+
+func SetHost(ctx context.Context, host string, secureStorage bool) error {
+	return saveTo(ctx, "", secureStorage, func(cfg *Config) error {
+		cfg.state.Host = host
+		return nil
+	})
+}
+
+// saveTo writes cfg to the given path, creating parent directories as needed.
 // If path is empty the default XDG path is used.
-func SaveTo(path string, ctx context.Context, cfg *Config, secureStorage bool) error {
+func saveTo(ctx context.Context, path string, secureStorage bool, cb func(config *Config) error) error {
 	resolved, err := resolvePath(path)
 	if err != nil {
 		return err
 	}
 
-	if err := os.MkdirAll(filepath.Dir(resolved), 0o700); err != nil {
-		return fmt.Errorf("creating config directory: %w", err)
+	err = mkConfigDir(resolved)
+	if err != nil {
+		return err
 	}
 
-	cp := *cfg
+	fl := flock.New(lockPath(resolved))
+	lock, err := fl.TryLockContext(ctx, time.Second)
+	if err != nil {
+		return err
+	}
+	if !lock {
+		return fmt.Errorf("could not lock config file %s", resolved)
+	}
+	defer closer.ErrorHandler(fl, &err)
+
+	var cfg Config
+
+	data, err := os.ReadFile(resolved)
+	switch {
+	case os.IsNotExist(err):
+	case err != nil:
+		return fmt.Errorf("reading config file: %w", err)
+	}
+
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return fmt.Errorf("parsing config file %s: %w", resolved, err)
+	}
+
+	err = cb(&cfg)
+	if err != nil {
+		return err
+	}
+
+	cp := cfg.state
 	if secureStorage {
 		cp.Token = ""
 
@@ -121,7 +194,7 @@ func SaveTo(path string, ctx context.Context, cfg *Config, secureStorage bool) e
 		}
 	}
 
-	data, err := yaml.Marshal(cp)
+	data, err = yaml.Marshal(cp)
 	if err != nil {
 		return fmt.Errorf("serialising config: %w", err)
 	}
@@ -137,8 +210,8 @@ func Path() (string, error) {
 	return configPath()
 }
 
-// PathFrom returns the resolved path for the given override. If override is
-// empty, returns the default XDG path.
+// PathFrom returns the resolved path for the given override. If the override is
+// empty, it returns the default XDG path.
 func PathFrom(override string) (string, error) {
 	return resolvePath(override)
 }
@@ -149,8 +222,8 @@ func (c *Config) EffectiveHost() string {
 	if h := os.Getenv("CIRCLECI_HOST"); h != "" {
 		return h
 	}
-	if c.Host != "" {
-		return c.Host
+	if c.state.Host != "" {
+		return c.state.Host
 	}
 	return DefaultHost
 }
@@ -164,7 +237,7 @@ func (c *Config) EffectiveToken() string {
 	if t := os.Getenv("CIRCLECI_CLI_TOKEN"); t != "" {
 		return t
 	}
-	return c.Token
+	return c.state.Token
 }
 
 func (c *Config) loadToken(ctx context.Context) error {
@@ -185,7 +258,7 @@ func (c *Config) loadToken(ctx context.Context) error {
 		return nil
 	}
 
-	c.Token = password
+	c.state.Token = password
 	return nil
 }
 
@@ -195,7 +268,7 @@ func (c *Config) storeToken(ctx context.Context) error {
 		return err
 	}
 
-	return keyring.Set(ctx, c.EffectiveHost(), u.Username, c.Token)
+	return keyring.Set(ctx, c.EffectiveHost(), u.Username, c.state.Token)
 }
 
 // resolvePath returns override if non-empty, otherwise the default XDG path.

--- a/internal/iostream/streams.go
+++ b/internal/iostream/streams.go
@@ -29,14 +29,19 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"runtime"
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/glamour/v2"
+	"charm.land/glamour/v2/ansi"
+	"charm.land/glamour/v2/styles"
+	"charm.land/lipgloss/v2"
 	"charm.land/log/v2"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/closer"
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/ui"
 )
 
@@ -147,11 +152,12 @@ func Spinner(ctx context.Context, active bool, msg string) *Spin {
 // Streams bundles the I/O channels passed through every command.
 // All output must go through Streams — never write to os.Stdout directly.
 type Streams struct {
-	Out   io.Writer // structured output (data results)
-	Err   io.Writer // status messages, errors, progress
-	In    io.Reader // user input for interactive prompts
-	Quiet bool      // when true, ErrPrintf/ErrPrintln produce no output
-	slog  *slog.Logger
+	Out       io.Writer // structured output (data results)
+	Err       io.Writer // status messages, errors, progress
+	In        io.Reader // user input for interactive prompts
+	Quiet     bool      // when true, ErrPrintf/ErrPrintln produce no output
+	slog      *slog.Logger
+	hasDarkBg bool
 }
 
 // OS returns a Streams wired to the real os.Stdin / os.Stdout / os.Stderr.
@@ -169,15 +175,25 @@ func FromCmd(ctx context.Context, cmd *cobra.Command) context.Context {
 	}
 
 	quiet, _ := cmd.Flags().GetBool("quiet")
+
+	stdin := cmd.InOrStdin()
+	stdout := cmd.OutOrStdout()
+	stderr := cmd.ErrOrStderr()
 	return WithStreams(ctx, Streams{
-		Out:   cmd.OutOrStdout(),
-		Err:   cmd.ErrOrStderr(),
-		In:    cmd.InOrStdin(),
-		Quiet: quiet,
-		slog: slog.New(log.NewWithOptions(cmd.ErrOrStderr(), log.Options{
+		Out:       stdout,
+		Err:       stderr,
+		In:        stdin,
+		Quiet:     quiet,
+		hasDarkBg: hasDarkBackground(),
+		slog: slog.New(log.NewWithOptions(stderr, log.Options{
 			Level: lvl,
 		})),
 	})
+}
+
+func hasDarkBackground() bool {
+	// This lipgloss function doesn't work on Windows
+	return runtime.GOOS == "windows" || lipgloss.HasDarkBackground(os.Stdin, os.Stdout)
 }
 
 // Test returns a Streams backed by the provided writers with no-op stdin,
@@ -308,17 +324,21 @@ func (s Streams) DebugContext(ctx context.Context, msg string, args ...any) {
 // RenderMarkdown renders md as styled markdown when color is enabled, falling
 // back to the raw string when output is not a TTY or color is disabled.
 // The rendered string is returned; use PrintMarkdown to write it to Out.
-func (s Streams) RenderMarkdown(md string) (string, error) {
+func (s Streams) RenderMarkdown(md string) (_ string, err error) {
 	if !s.ColorEnabled() {
 		return md, nil
 	}
+
 	r, err := glamour.NewTermRenderer(
-		glamour.WithEnvironmentConfig(),
 		glamour.WithWordWrap(120),
+		glamour.WithStyles(s.styleConfig()),
+		glamour.WithInlineTableLinks(true),
 	)
 	if err != nil {
 		return md, err
 	}
+	defer closer.ErrorHandler(r, &err)
+
 	return r.Render(md)
 }
 
@@ -331,4 +351,12 @@ func (s Streams) PrintMarkdown(md string) {
 		return
 	}
 	_, _ = fmt.Fprint(s.Out, rendered)
+}
+
+func (s Streams) styleConfig() ansi.StyleConfig {
+	style := styles.DarkStyleConfig
+	if !s.hasDarkBg {
+		style = styles.LightStyleConfig
+	}
+	return style
 }


### PR DESCRIPTION
- Avoid concurrency issues reading/writing config.
- Markdown for `settings list` command.
- Configure light/dark modes for markdown rendering.

##
<img width="952" height="207" alt="Screenshot 2026-04-27 at 15 29 06" src="https://github.com/user-attachments/assets/c9e2a2d3-70a3-444d-9edf-1c4a4846a22a" />
