### PR TITLE
docs: fill gaps in CLAUDE.md — mcp package and dev-install task

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,7 @@ internal/
 │   ├── runner/           circleci runner resource-class/token/instance
 │   ├── policy/           circleci policy push/diff/fetch/...
 │   ├── settings/         circleci settings list/get/set
+│   ├── mcp/              circleci mcp start/stream/tools + editor integrations (claude/cursor/vscode)
 │   └── api/              circleci api <endpoint> (raw API escape hatch)
 │
 ├── artifacts/            Business logic for artifact listing and downloading.
@@ -152,6 +153,7 @@ Defined in `internal/errors/exitcodes.go`. Document new codes there before using
 
 ```sh
 task build                             # build binary → dist/circleci
+task dev-install                       # build and copy to ~/.local/bin
 task test                              # all tests including acceptance, with -race
 task lint                              # golangci-lint
 task fmt                               # gosimports formatting


### PR DESCRIPTION
## Summary

- Add `mcp/` to the package structure table — it was the only registered top-level command group missing from the list
- Add `task dev-install` to the Common commands section — it's the primary way to test the built binary locally but wasn't documented

## Why

Both omissions were only discoverable by reading `Taskfile.yml` or `root.go` directly. This makes them findable in the place a developer reads first.