### PR TITLE
docs: add branch context and MCP developer workflow to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,10 @@ A new CircleCI CLI built from scratch in Go + Cobra, targeting exemplary CLI des
 
 Full architecture, command surface, and phased roadmap: `docs/build-plan.md`
 
+> **Branch context:** `next` is the active v2 rewrite. `main` is the legacy CLI that ships
+> today. These are independent codebases — `next` does not import from `main`. All new feature
+> work happens on `next`; `main` receives only critical fixes.
+
 ---
 
 ## Critical rules — read before writing any command
@@ -160,6 +164,15 @@ goreleaser build --snapshot --clean    # test multi-platform release builds
 ./dist/circleci --help                 # smoke test
 NO_COLOR=1 ./dist/circleci --help      # verify color is disabled
 CI=true ./dist/circleci --help         # verify CI mode
+```
+
+To test the CLI as an MCP server in Claude Desktop:
+
+```sh
+task dev-install                       # build and install to ~/.local/bin
+circleci mcp claude enable             # register with Claude Desktop
+circleci mcp claude list               # verify registration
+circleci mcp start --log-level debug   # run server manually for inspection
 ```
 
 `task test` runs unit tests (cached) then acceptance tests with `-count=1` (never cached).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,13 +166,15 @@ NO_COLOR=1 ./dist/circleci --help      # verify color is disabled
 CI=true ./dist/circleci --help         # verify CI mode
 ```
 
-To test the CLI as an MCP server in Claude Desktop:
+To wire up the CLI as an MCP server:
 
 ```sh
-task dev-install                       # build and install to ~/.local/bin
-circleci mcp claude enable             # register with Claude Desktop
-circleci mcp claude list               # verify registration
-circleci mcp start --log-level debug   # run server manually for inspection
+# Once — build, install, and register with Claude Desktop
+task dev-install
+circleci mcp claude enable
+
+# Per project — import from Claude Desktop into Claude Code
+claude mcp add-from-claude-desktop
 ```
 
 `task test` runs unit tests (cached) then acceptance tests with `-count=1` (never cached).


### PR DESCRIPTION
## Summary

- Add a branch context callout at the top explaining the `next`/`main` split — without this, it's not obvious this is a rewrite or what the relationship to `main` is
- Add an MCP developer workflow block showing how to install, enable, and test the MCP server with Claude Desktop — the commands existed but were only findable by exploring `root.go`

## Why

Both gaps came up during a first-run experience on the `next` branch: the branch purpose wasn't stated anywhere, and enabling the MCP Claude interface required codebase exploration rather than reading the docs.