### PR TITLE
Add deploy markers to CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,6 +137,28 @@ jobs:
             - run: task ci:test
             - store_results
 
+  mark-release:
+    executor: linux
+    steps:
+      - run:
+          name: Plan deployment
+          command: |
+            circleci run release plan "${CIRCLE_JOB}" \
+              --environment-name="default" \
+              --component-name="${CIRCLE_PROJECT_REPONAME}" \
+              --target-version="1.0.${CIRCLE_BUILD_NUM}-${CIRCLE_SHA1:0:7}"
+      - run:
+          name: Update deployment status to running
+          command: circleci run release update "${CIRCLE_JOB}" --status=RUNNING
+      - run:
+          name: Update deployment status to success
+          command: circleci run release update "${CIRCLE_JOB}" --status=SUCCESS
+          when: on_success
+      - run:
+          name: Update deployment status to failed
+          command: circleci run release update "${CIRCLE_JOB}" --status=FAILED
+          when: on_fail
+
 workflows:
   ci:
     jobs:
@@ -148,3 +170,7 @@ workflows:
                 - linux
                 - macos
                 - windows
+      - mark-release:
+          requires:
+            - check
+            - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,3 +174,6 @@ workflows:
           requires:
             - check
             - test
+          filters:
+            branches:
+              only: next


### PR DESCRIPTION
## Summary

- Adds a `mark-release` job to `.circleci/config.yml` that uses [deploy markers](https://circleci.com/docs/deploy-markers/) to track release status
- The job runs after `check` and `test` pass, and reports plan/running/success/failed status via `circleci run release` commands
- See also: [CLI release commands](https://circleci.com/docs/cli-release-commands/)

## Test plan

- [ ] Verify the config is valid (`circleci config validate`)
- [ ] Confirm the `mark-release` job runs after check and test in the workflow
- [ ] Verify deploy marker status updates appear in the CircleCI UI