### PR TITLE
ci: run chocolatey release steps in Git Bash on Windows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -327,6 +327,7 @@ jobs:
       - checkout
       - run:
           name: Plan deployment
+          shell: bash.exe
           command: |
             circleci run release plan "${CIRCLE_JOB}" \
               --environment-name="default" \
@@ -344,6 +345,7 @@ jobs:
           working_directory: chocolatey
       - run:
           name: Update deployment status to running
+          shell: bash.exe
           command: circleci run release update "${CIRCLE_JOB}" --status=RUNNING
       - run:
           name: Push to Chocolatey package repository
@@ -351,10 +353,12 @@ jobs:
           working_directory: chocolatey
       - run:
           name: Update deployment status to success
+          shell: bash.exe
           command: circleci run release update "${CIRCLE_JOB}" --status=SUCCESS
           when: on_success
       - run:
           name: Update deployment status to failed
+          shell: bash.exe
           command: circleci run release update "${CIRCLE_JOB}" --status=FAILED
           when: on_fail
 


### PR DESCRIPTION
## Checklist

- [x] I have performed a self-review of my own code
- [x] I have checked for similar issues and haven't found anything relevant.
- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/main/CONTRIBUTING.md).

## Changes

- Set `shell: bash.exe` for all `circleci run release …` steps in the `chocolatey-deploy` job.

## Rationale

The `chocolatey-deploy` job runs on `windows/default`, where run steps default to **PowerShell**. The **Plan deployment** step used the same multiline script as Linux jobs (backslash continuations and `"${CIRCLE_JOB}"` / `${CIRCLE_SHA1:0:7}`), which PowerShell parses incorrectly. That caused the job to fail before deployment; the subsequent **Update deployment status to failed** step then hit a 404 from the releases API.

## Considerations

Git Bash ships with the CircleCI Windows image. Using `bash.exe` for only the `circleci run release …` steps keeps Chocolatey and PowerShell script steps on the default shell.

## Screenshots

N/A (CI configuration only).