### PR TITLE
Add OAuth login command with PKCE flow

### DIFF
--- a/acceptance/login_test.go
+++ b/acceptance/login_test.go
@@ -112,7 +112,9 @@ func runLoginCLI(t *testing.T, baseURL string, extraEnv ...string) (cmd *exec.Cm
 }
 
 // extractAuthorizeURL returns the authorize URL on a line if present, else "".
-// Matches any http(s) URL that contains "/oauth/authorize?".
+// Matches any http(s) URL that contains "/oauth/authorize?". Stops at the
+// first whitespace or ANSI escape (\x1b) so styled output doesn't bleed into
+// the captured URL.
 func extractAuthorizeURL(line string) string {
 	for _, scheme := range []string{"https://", "http://"} {
 		i := strings.Index(line, scheme)
@@ -123,7 +125,7 @@ func extractAuthorizeURL(line string) string {
 		if !strings.Contains(rest, "/oauth/authorize?") {
 			continue
 		}
-		if end := strings.IndexAny(rest, " \t\r\n"); end > 0 {
+		if end := strings.IndexAny(rest, " \t\r\n\x1b"); end > 0 {
 			return rest[:end]
 		}
 		return rest
@@ -176,6 +178,11 @@ func TestAuthLogin(t *testing.T) {
 		"expires_in":    int64(3600),
 		"refresh_token": "test-refresh-token",
 	})
+	fake.SetMe(map[string]any{
+		"id":    "user-id",
+		"login": "test-user",
+		"name":  "Test User",
+	})
 
 	cmd, authorizeURL, stdout, stderr, stderrPipe := runLoginCLI(t, fake.URL())
 
@@ -188,6 +195,7 @@ func TestAuthLogin(t *testing.T) {
 	exit := finishLoginCLI(t, cmd, stderr, stderrPipe)
 	assert.Equal(t, exit, 0, "stderr: %s", stderr.String())
 	assert.Equal(t, stdout.String(), "")
+	assert.Check(t, cmp.Contains(stderr.String(), "OK: Logged in as test-user"))
 	assert.Check(t, cmp.Contains(stderr.String(), "OK: Saved token to"))
 	assert.Check(t, !strings.Contains(stderr.String(), "Received authorization code"),
 		"stderr should not leak internal protocol step; got: %s", stderr.String())
@@ -259,6 +267,10 @@ func runLoginCLIPTY(t *testing.T, baseURL, browserCmd string) (cmd *pty.Cmd, p p
 
 	p, err = pty.New()
 	assert.NilError(t, err)
+	// Bubble Tea v2's renderer draws into a buffer sized by the PTY's window
+	// size. Without an explicit Resize, the slave reports 0×0 and rendered
+	// content is silently dropped (only init escapes appear on the master).
+	assert.NilError(t, p.Resize(80, 24))
 
 	cmd = p.CommandContext(ctx, binPath,
 		"--insecure-storage",
@@ -270,6 +282,7 @@ func runLoginCLIPTY(t *testing.T, baseURL, browserCmd string) (cmd *pty.Cmd, p p
 
 	output := &bytes.Buffer{}
 	urlCh := make(chan string, 1)
+	selectCh := make(chan struct{}, 1)
 	drained := make(chan struct{})
 	go func() {
 		defer close(drained)
@@ -278,6 +291,12 @@ func runLoginCLIPTY(t *testing.T, baseURL, browserCmd string) (cmd *pty.Cmd, p p
 			n, err := p.Read(buf)
 			if n > 0 {
 				output.Write(buf[:n])
+				if strings.Contains(output.String(), "How would you like to authenticate") {
+					select {
+					case selectCh <- struct{}{}:
+					default:
+					}
+				}
 				if u := extractAuthorizeURL(output.String()); u != "" {
 					select {
 					case urlCh <- u:
@@ -290,6 +309,17 @@ func runLoginCLIPTY(t *testing.T, baseURL, browserCmd string) (cmd *pty.Cmd, p p
 			}
 		}
 	}()
+
+	// Dismiss the method-select prompt by accepting the default (browser).
+	select {
+	case <-selectCh:
+	case <-time.After(10 * time.Second):
+		_ = cmd.Process.Kill()
+		t.Fatalf("timed out waiting for method-select prompt on PTY output\noutput: %q", output.String())
+	}
+	// In raw mode (bubbletea) Enter arrives as \r, not \n.
+	_, err = p.Write([]byte("\r"))
+	assert.NilError(t, err)
 
 	select {
 	case authorizeURL = <-urlCh:
@@ -344,8 +374,9 @@ func TestAuthLogin_InteractivePrompt(t *testing.T) {
 	out, exit := finish()
 	assert.Equal(t, exit, 0, "output: %s", out)
 
-	assert.Check(t, cmp.Contains(out, "The following URL will be opened in your browser to authorize the CLI:"))
-	assert.Check(t, cmp.Contains(out, "Press Enter to continue (Ctrl+C to abort)"))
+	assert.Check(t, cmp.Contains(out, "How would you like to authenticate"))
+	assert.Check(t, cmp.Contains(out, "Press Enter to open"))
+	assert.Check(t, cmp.Contains(out, "in your browser"))
 	assert.Check(t, cmp.Contains(out, "Saved token to"))
 	assert.Check(t, !strings.Contains(out, "Received authorization code"),
 		"PTY output should not leak internal protocol step; got: %s", out)
@@ -394,7 +425,8 @@ func TestAuthLogin_Timeout(t *testing.T) {
 
 	exit := finishLoginCLI(t, cmd, stderr, stderrPipe)
 	assert.Equal(t, exit, 8, "expected ExitTimeout; stderr: %s", stderr.String())
-	assert.Check(t, cmp.Contains(stderr.String(), "error: No callback received within the timeout window."))
+	assert.Check(t, cmp.Contains(stderr.String(), "Login timed out"))
+	assert.Check(t, cmp.Contains(stderr.String(), "no browser callback received within"))
 	assert.Check(t, cmp.Contains(stderr.String(), "Re-run 'circleci auth login'"))
 }
 

--- a/acceptance/login_test.go
+++ b/acceptance/login_test.go
@@ -1,0 +1,478 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package acceptance_test
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/aymanbagabas/go-pty"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+	"gotest.tools/v3/skip"
+
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/testing/binary"
+	testenv "github.com/CircleCI-Public/circleci-cli-v2/internal/testing/env"
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/testing/fakes"
+)
+
+// runLoginCLI starts `circleci auth login --no-browser` with CIRCLECI_HOST
+// set to baseURL, streams stderr until it sees the authorize URL printed by
+// the command, then returns the URL alongside the running command. The caller
+// is responsible for delivering a callback to redirect_uri (or cancelling the
+// context) and then calling finishLoginCLI to collect output and the exit code.
+func runLoginCLI(t *testing.T, baseURL string, extraEnv ...string) (cmd *exec.Cmd, authorizeURL string, stdout, stderr *bytes.Buffer, stderrPipe io.ReadCloser) {
+	t.Helper()
+
+	binPath, cleanup, err := binary.BuildBinary()
+	assert.NilError(t, err)
+	t.Cleanup(cleanup)
+
+	env := testenv.New(t)
+	env.CircleCIURL = baseURL
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	cmd = exec.CommandContext(ctx, binPath, //nolint:gosec // test binary path
+		"--insecure-storage",
+		"auth", "login", "--no-browser",
+	)
+	cmd.Env = append(env.Environ(), extraEnv...)
+	cmd.Dir = t.TempDir()
+
+	stdout = &bytes.Buffer{}
+	stderr = &bytes.Buffer{}
+	cmd.Stdout = stdout
+
+	stderrPipe, err = cmd.StderrPipe()
+	assert.NilError(t, err)
+
+	assert.NilError(t, cmd.Start())
+
+	// Tee stderr into a buffer for assertions while we scan it for the URL.
+	tee := io.TeeReader(stderrPipe, stderr)
+	scanner := bufio.NewScanner(tee)
+
+	deadline := time.After(10 * time.Second)
+	urlCh := make(chan string, 1)
+	go func() {
+		for scanner.Scan() {
+			line := scanner.Text()
+			if u := extractAuthorizeURL(line); u != "" {
+				urlCh <- u
+				return
+			}
+		}
+		urlCh <- ""
+	}()
+
+	select {
+	case authorizeURL = <-urlCh:
+	case <-deadline:
+		_ = cmd.Process.Kill()
+		t.Fatal("timed out waiting for authorize URL on stderr")
+	}
+	assert.Assert(t, authorizeURL != "", "expected authorize URL on stderr; got: %s", stderr.String())
+
+	return cmd, authorizeURL, stdout, stderr, stderrPipe
+}
+
+// extractAuthorizeURL returns the authorize URL on a line if present, else "".
+// Matches any http(s) URL that contains "/oauth/authorize?".
+func extractAuthorizeURL(line string) string {
+	for _, scheme := range []string{"https://", "http://"} {
+		i := strings.Index(line, scheme)
+		if i < 0 {
+			continue
+		}
+		rest := line[i:]
+		if !strings.Contains(rest, "/oauth/authorize?") {
+			continue
+		}
+		if end := strings.IndexAny(rest, " \t\r\n"); end > 0 {
+			return rest[:end]
+		}
+		return rest
+	}
+	return ""
+}
+
+// finishLoginCLI drains remaining stderr and waits for the command to exit.
+func finishLoginCLI(t *testing.T, cmd *exec.Cmd, stderr *bytes.Buffer, stderrPipe io.ReadCloser) int {
+	t.Helper()
+	_, _ = io.Copy(stderr, stderrPipe)
+	err := cmd.Wait()
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitCode()
+	}
+	assert.NilError(t, err)
+	return 0
+}
+
+// deliverCallback issues the OAuth provider's redirect to the CLI's loopback
+// server with the given code/state.
+func deliverCallback(t *testing.T, authorizeURL, code, state string) {
+	t.Helper()
+	u, err := url.Parse(authorizeURL)
+	assert.NilError(t, err)
+
+	cb, err := url.Parse(u.Query().Get("redirect_uri"))
+	assert.NilError(t, err)
+	q := cb.Query()
+	if code != "" {
+		q.Set("code", code)
+	}
+	if state != "" {
+		q.Set("state", state)
+	}
+	cb.RawQuery = q.Encode()
+
+	resp, err := http.Get(cb.String()) //nolint:gosec,noctx // test loopback URL
+	assert.NilError(t, err)
+	_ = resp.Body.Close()
+	assert.Check(t, cmp.Equal(resp.StatusCode, http.StatusOK))
+}
+
+func TestAuthLogin(t *testing.T) {
+	fake := fakes.NewCircleCI(t)
+	fake.SetOAuthTokenResponse(map[string]any{
+		"access_token":  "test-access-token",
+		"token_type":    "Bearer",
+		"expires_in":    int64(3600),
+		"refresh_token": "test-refresh-token",
+	})
+
+	cmd, authorizeURL, stdout, stderr, stderrPipe := runLoginCLI(t, fake.URL())
+
+	u, err := url.Parse(authorizeURL)
+	assert.NilError(t, err)
+	state := u.Query().Get("state")
+
+	deliverCallback(t, authorizeURL, "test-auth-code", state)
+
+	exit := finishLoginCLI(t, cmd, stderr, stderrPipe)
+	assert.Equal(t, exit, 0, "stderr: %s", stderr.String())
+	assert.Equal(t, stdout.String(), "")
+	assert.Check(t, cmp.Contains(stderr.String(), "OK: Saved token to"))
+	assert.Check(t, !strings.Contains(stderr.String(), "Received authorization code"),
+		"stderr should not leak internal protocol step; got: %s", stderr.String())
+}
+
+func TestAuthLogin_StateMismatch(t *testing.T) {
+	cmd, authorizeURL, _, stderr, stderrPipe := runLoginCLI(t, "https://example.com")
+
+	u, err := url.Parse(authorizeURL)
+	assert.NilError(t, err)
+	wrongState := u.Query().Get("state") + "tampered"
+
+	// We can't use deliverCallback here because the loopback server returns
+	// 400 on state mismatch and we want to assert that without failing.
+	cb, _ := url.Parse(u.Query().Get("redirect_uri"))
+	q := cb.Query()
+	q.Set("code", "test-auth-code")
+	q.Set("state", wrongState)
+	cb.RawQuery = q.Encode()
+	resp, err := http.Get(cb.String()) //nolint:gosec,noctx // test loopback URL
+	assert.NilError(t, err)
+	_ = resp.Body.Close()
+	assert.Check(t, cmp.Equal(resp.StatusCode, http.StatusBadRequest))
+
+	exit := finishLoginCLI(t, cmd, stderr, stderrPipe)
+	assert.Equal(t, exit, 3, "expected ExitAuthError; stderr: %s", stderr.String())
+	assert.Check(t, cmp.Contains(stderr.String(), "error: state parameter does not match the CLI's expected value"))
+}
+
+func TestAuthLogin_OAuthError(t *testing.T) {
+	cmd, authorizeURL, _, stderr, stderrPipe := runLoginCLI(t, "https://example.com")
+
+	u, err := url.Parse(authorizeURL)
+	assert.NilError(t, err)
+	cb, _ := url.Parse(u.Query().Get("redirect_uri"))
+	q := cb.Query()
+	q.Set("error", "access_denied")
+	q.Set("error_description", "User denied authorization")
+	cb.RawQuery = q.Encode()
+	resp, err := http.Get(cb.String()) //nolint:gosec,noctx // test loopback URL
+	assert.NilError(t, err)
+	_ = resp.Body.Close()
+
+	exit := finishLoginCLI(t, cmd, stderr, stderrPipe)
+	assert.Equal(t, exit, 3, "expected ExitAuthError; stderr: %s", stderr.String())
+	assert.Check(t, cmp.Contains(stderr.String(), "error: authorization failed: access_denied: User denied authorization"))
+}
+
+// runLoginCLIPTY starts `circleci auth login` (no --no-browser) under a PTY so
+// the binary's IsInteractive check returns true and the new prompt-before-browser
+// flow is exercised. BROWSER is set to /bin/true so OpenBrowser is a no-op.
+// Returns the running command, the captured authorize URL, the PTY (for writing
+// the Enter keystroke), and a function that blocks until the binary exits and
+// returns the combined PTY output plus the exit code.
+func runLoginCLIPTY(t *testing.T, baseURL, browserCmd string) (cmd *pty.Cmd, p pty.Pty, authorizeURL string, finish func() (string, int)) {
+	t.Helper()
+	skip.If(t, runtime.GOOS == "windows", "PTY-based interactive prompt test not supported on Windows")
+
+	binPath, cleanup, err := binary.BuildBinary()
+	assert.NilError(t, err)
+	t.Cleanup(cleanup)
+
+	env := testenv.New(t)
+	env.CircleCIURL = baseURL
+	envSlice := append(env.Environ(), "BROWSER="+browserCmd)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	p, err = pty.New()
+	assert.NilError(t, err)
+
+	cmd = p.CommandContext(ctx, binPath,
+		"--insecure-storage",
+		"auth", "login",
+	)
+	cmd.Env = envSlice
+	cmd.Dir = t.TempDir()
+	assert.NilError(t, cmd.Start())
+
+	output := &bytes.Buffer{}
+	urlCh := make(chan string, 1)
+	drained := make(chan struct{})
+	go func() {
+		defer close(drained)
+		buf := make([]byte, 4096)
+		for {
+			n, err := p.Read(buf)
+			if n > 0 {
+				output.Write(buf[:n])
+				if u := extractAuthorizeURL(output.String()); u != "" {
+					select {
+					case urlCh <- u:
+					default:
+					}
+				}
+			}
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	select {
+	case authorizeURL = <-urlCh:
+	case <-time.After(10 * time.Second):
+		_ = cmd.Process.Kill()
+		t.Fatalf("timed out waiting for authorize URL on PTY output\noutput: %s", output.String())
+	}
+	assert.Assert(t, authorizeURL != "")
+
+	finish = func() (string, int) {
+		err := cmd.Wait()
+		_ = p.Close()
+		<-drained
+		exit := 0
+		if exitErr, ok := errAs[*exec.ExitError](err); ok {
+			exit = exitErr.ExitCode()
+		} else if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, syscall.EIO) && !errors.Is(err, os.ErrClosed) {
+			t.Fatalf("cmd.Wait failed: %v\noutput: %s", err, output.String())
+		}
+		return output.String(), exit
+	}
+	return cmd, p, authorizeURL, finish
+}
+
+// errAs is a small helper around errors.As for use with type-asserted unwrapping.
+func errAs[T error](err error) (T, bool) {
+	var t T
+	if errors.As(err, &t) {
+		return t, true
+	}
+	return t, false
+}
+
+func TestAuthLogin_InteractivePrompt(t *testing.T) {
+	fake := fakes.NewCircleCI(t)
+	fake.SetOAuthTokenResponse(map[string]any{
+		"access_token": "interactive-access-token",
+		"token_type":   "Bearer",
+		"expires_in":   int64(3600),
+	})
+
+	_, p, authorizeURL, finish := runLoginCLIPTY(t, fake.URL(), "/bin/true")
+
+	// Send Enter to dismiss the "Press Enter to continue..." prompt.
+	_, err := p.Write([]byte("\n"))
+	assert.NilError(t, err)
+
+	u, err := url.Parse(authorizeURL)
+	assert.NilError(t, err)
+	deliverCallback(t, authorizeURL, "test-auth-code", u.Query().Get("state"))
+
+	out, exit := finish()
+	assert.Equal(t, exit, 0, "output: %s", out)
+
+	assert.Check(t, cmp.Contains(out, "The following URL will be opened in your browser to authorize the CLI:"))
+	assert.Check(t, cmp.Contains(out, "Press Enter to continue (Ctrl+C to abort)"))
+	assert.Check(t, cmp.Contains(out, "Saved token to"))
+	assert.Check(t, !strings.Contains(out, "Received authorization code"),
+		"PTY output should not leak internal protocol step; got: %s", out)
+}
+
+// TestAuthLogin_InteractivePromptCancel verifies that Ctrl+C at the
+// "Press Enter to continue..." prompt aborts promptly. The previous
+// implementation called bufio.ReadString on stdin without selecting on the
+// context, so SIGINT only cancelled ctx — the read kept blocking until the
+// user actually pressed Enter, making the CLI appear hung.
+func TestAuthLogin_InteractivePromptCancel(t *testing.T) {
+	cmd, _, _, finish := runLoginCLIPTY(t, "https://example.com", "/bin/true")
+
+	// We're parked at the "Press Enter to continue..." prompt. Send SIGINT
+	// instead of a newline.
+	assert.NilError(t, cmd.Process.Signal(os.Interrupt))
+
+	// Bound the wait so a regression (read that ignores ctx) fails this test
+	// instead of hanging until the 30s context timeout.
+	done := make(chan struct{})
+	var out string
+	var exit int
+	go func() {
+		out, exit = finish()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		_ = cmd.Process.Kill()
+		<-done
+		t.Fatalf("CLI did not exit within 5s of SIGINT at prompt; output: %s", out)
+	}
+
+	assert.Equal(t, exit, 6, "expected ExitCancelled; output: %s", out)
+	assert.Check(t, cmp.Contains(out, "Interrupted before authorization started."))
+}
+
+// TestAuthLogin_Timeout covers the auth.login.timeout branch by setting
+// CIRCLECI_LOGIN_TIMEOUT to a very short duration and never delivering the
+// OAuth callback. The CLI should give up with ExitTimeout and surface the
+// re-run suggestion.
+func TestAuthLogin_Timeout(t *testing.T) {
+	cmd, _, _, stderr, stderrPipe := runLoginCLI(t, "https://example.com", "CIRCLECI_LOGIN_TIMEOUT=100ms")
+
+	exit := finishLoginCLI(t, cmd, stderr, stderrPipe)
+	assert.Equal(t, exit, 8, "expected ExitTimeout; stderr: %s", stderr.String())
+	assert.Check(t, cmp.Contains(stderr.String(), "error: No callback received within the timeout window."))
+	assert.Check(t, cmp.Contains(stderr.String(), "Re-run 'circleci auth login'"))
+}
+
+// TestAuthLogin_BrowserOpenFails covers the fallback message shown when
+// OpenBrowser returns an error. We force failure by pointing BROWSER at a
+// non-existent binary so cmd.Start() returns ENOENT. The flow should not
+// abort — the user is told to open the URL manually and the OAuth callback
+// still completes the login.
+//
+// Linux-only: pkg/browser dispatches via xdg-open on Linux (which honors the
+// BROWSER env var), but uses `open` on macOS and `rundll32` on Windows —
+// neither returns an error for a missing handler, so the failure path can't
+// be exercised there.
+func TestAuthLogin_BrowserOpenFails(t *testing.T) {
+	skip.If(t, runtime.GOOS != "linux", "browser-open failure can only be forced on Linux via BROWSER env var")
+	fake := fakes.NewCircleCI(t)
+	fake.SetOAuthTokenResponse(map[string]any{
+		"access_token": "fallback-access-token",
+		"token_type":   "Bearer",
+	})
+
+	_, p, authorizeURL, finish := runLoginCLIPTY(t, fake.URL(), "circleci-test-nonexistent-browser-xyz")
+
+	_, err := p.Write([]byte("\n"))
+	assert.NilError(t, err)
+
+	u, err := url.Parse(authorizeURL)
+	assert.NilError(t, err)
+	deliverCallback(t, authorizeURL, "test-auth-code", u.Query().Get("state"))
+
+	out, exit := finish()
+	assert.Equal(t, exit, 0, "output: %s", out)
+
+	assert.Check(t, cmp.Contains(out, "Could not open browser automatically. Open this URL manually:"))
+	assert.Check(t, cmp.Contains(out, "Saved token to"))
+}
+
+// TestAuthLogin_TokenExchangeFails covers the auth.login.token_exchange_failed
+// branch: callback succeeds, but POST /oauth/token returns a 4xx error. The
+// CLI should exit with ExitAuthError and surface the OAuth error.
+func TestAuthLogin_TokenExchangeFails(t *testing.T) {
+	fake := fakes.NewCircleCI(t)
+	fake.SetOAuthTokenError(http.StatusBadRequest, map[string]any{
+		"error":             "invalid_grant",
+		"error_description": "code already redeemed",
+	})
+
+	cmd, authorizeURL, _, stderr, stderrPipe := runLoginCLI(t, fake.URL())
+
+	u, err := url.Parse(authorizeURL)
+	assert.NilError(t, err)
+	deliverCallback(t, authorizeURL, "test-auth-code", u.Query().Get("state"))
+
+	exit := finishLoginCLI(t, cmd, stderr, stderrPipe)
+	assert.Equal(t, exit, 3, "expected ExitAuthError; stderr: %s", stderr.String())
+	assert.Check(t, cmp.Contains(stderr.String(), "error: "))
+	assert.Check(t, cmp.Contains(stderr.String(), "invalid_grant"))
+}
+
+// TestAuthLogin_ConfigLoadFailure covers the config.load_failed branch by
+// pointing --config at a file containing malformed YAML. The CLI should exit
+// with ExitGeneralError and surface the parse error in the structured format.
+func TestAuthLogin_ConfigLoadFailure(t *testing.T) {
+	badConfig := filepath.Join(t.TempDir(), "config.yml")
+	err := os.WriteFile(badConfig, []byte("token: [unclosed\n"), 0o600)
+	assert.NilError(t, err)
+
+	env := testenv.New(t)
+	env.CircleCIURL = "https://example.com"
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"--config", badConfig, "auth", "login", "--no-browser"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 1, "expected ExitGeneralError; stderr: %s", result.Stderr)
+	assert.Check(t, cmp.Contains(result.Stderr, "error: parsing config file"))
+	assert.Check(t, cmp.Contains(result.Stderr, badConfig))
+}

--- a/go.mod
+++ b/go.mod
@@ -18,8 +18,10 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.8
 	github.com/itchyny/gojq v0.12.19
 	github.com/njayp/ophis v1.1.4
+	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/spf13/cobra v1.10.2
 	github.com/zalando/go-keyring v0.2.8
+	golang.org/x/oauth2 v0.35.0
 	golang.org/x/sync v0.20.0
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/v3 v3.5.2
@@ -253,7 +255,6 @@ require (
 	golang.org/x/exp/typeparams v0.0.0-20260209203927-2842357ff358 // indirect
 	golang.org/x/mod v0.34.0 // indirect
 	golang.org/x/net v0.52.0 // indirect
-	golang.org/x/oauth2 v0.35.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/term v0.42.0 // indirect
 	golang.org/x/text v0.35.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -548,6 +548,8 @@ github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3v
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
 github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
+github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
+github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -898,6 +900,7 @@ golang.org/x/sys v0.0.0-20211105183446-c75c47738b0c/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/cmd/cmdauth/auth.go
+++ b/internal/cmd/cmdauth/auth.go
@@ -28,6 +28,7 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
 
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/apiclient"
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/config"
 	clierrors "github.com/CircleCI-Public/circleci-cli-v2/internal/errors"
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/iostream"
@@ -57,11 +58,20 @@ func NewAuthCmd() *cobra.Command {
 	return cmd
 }
 
-// persistToken saves token to the configured backend (keyring by default,
+// persistToken probes the new token via /me, prints "Logged in as <login>" on
+// success, then saves the token to the configured backend (keyring by default,
 // or the YAML config when --insecure-storage is set) and prints a
 // "Saved token to <path>" status line on stderr. Shared by `auth login`
 // (after OAuth token exchange) and `auth token` (after the TUI prompt).
-func persistToken(ctx context.Context, token string, secureStorage bool) error {
+//
+// A failed /me call (network blip, 401, etc.) is non-fatal: we skip the
+// identity line and still save the token. The user explicitly authenticated;
+// a transient probe failure shouldn't drop the credential on the floor.
+func persistToken(ctx context.Context, host, token string, secureStorage bool) error {
+	if me, err := apiclient.New(host, token, nil).GetMe(ctx); err == nil && me.Login != "" {
+		iostream.ErrPrintf(ctx, "%s Logged in as %s\n", iostream.Symbol(ctx, "✓", "OK:"), me.Login)
+	}
+
 	if err := config.SetToken(ctx, token, secureStorage); err != nil {
 		return clierrors.New("auth.save_failed", "Failed to save token", err.Error()).
 			WithExitCode(clierrors.ExitGeneralError)

--- a/internal/cmd/cmdauth/id.go
+++ b/internal/cmd/cmdauth/id.go
@@ -23,53 +23,58 @@
 package cmdauth
 
 import (
-	"context"
+	"runtime"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
 
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/cmdutil"
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/config"
-	clierrors "github.com/CircleCI-Public/circleci-cli-v2/internal/errors"
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/iostream"
 )
 
-// NewAuthCmd returns the "circleci auth" command group.
-func NewAuthCmd() *cobra.Command {
+func newDeviceIDCmd() *cobra.Command {
+	var jsonOut bool
+
 	cmd := &cobra.Command{
-		Use:   "auth <command>",
-		Short: "Manage CLI auth",
+		Use:   "id",
+		Short: "Show the device ID for this CLI installation",
 		Long: heredoc.Doc(`
-			Manage authentication for the CLI.
+			Print the device ID for this CLI installation as "<os>:<uuid>".
 
-			Use 'circleci auth login' to authenticate via the browser-based OAuth flow.
-			Use 'circleci auth token' to configure your personal API token.
-			Use 'circleci auth me' to get current user info.
-			Use 'circleci auth logout' to clear your stored credentials.
+			The UUID is generated on first use and stored in the config file.
+			The OS prefix (e.g. darwin, linux) is added at print time so you
+			can identify the machine and platform at a glance. The same UUID
+			is sent with every OAuth authorization request, so you can match
+			a token in the CircleCI UI back to this installation.
+
+			JSON fields:
+			  device_id  string  Stable identifier in the form <os>:<uuid>
 		`),
+		Example: heredoc.Doc(`
+			# Print the device ID
+			$ circleci auth id
+
+			# Output as JSON
+			$ circleci auth id --json
+
+			# Use in a script
+			$ DEVICE=$(circleci auth id)
+		`),
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := iostream.FromCmd(cmd.Context(), cmd)
+			configPath, _ := cmd.Flags().GetString("config")
+			id := runtime.GOOS + ":" + config.EnsureDeviceID(ctx, configPath)
+
+			if jsonOut {
+				return iostream.PrintJSON(ctx, map[string]string{"device_id": id})
+			}
+			iostream.Println(ctx, id)
+			return nil
+		},
 	}
 
-	cmd.AddCommand(newLoginCmd())
-	cmd.AddCommand(newTokenCmd())
-	cmd.AddCommand(newMeCmd())
-	cmd.AddCommand(newLogoutCmd())
-	cmd.AddCommand(newDeviceIDCmd())
-
+	cmdutil.AddJSONFlag(cmd, &jsonOut)
 	return cmd
-}
-
-// persistToken saves token to the configured backend (keyring by default,
-// or the YAML config when --insecure-storage is set) and prints a
-// "Saved token to <path>" status line on stderr. Shared by `auth login`
-// (after OAuth token exchange) and `auth token` (after the TUI prompt).
-func persistToken(ctx context.Context, token string, secureStorage bool) error {
-	if err := config.SetToken(ctx, token, secureStorage); err != nil {
-		return clierrors.New("auth.save_failed", "Failed to save token", err.Error()).
-			WithExitCode(clierrors.ExitGeneralError)
-	}
-	path, _ := config.Path()
-	if secureStorage {
-		path = "keyring"
-	}
-	iostream.ErrPrintf(ctx, "%s Saved token to %s\n", iostream.Symbol(ctx, "✓", "OK:"), path)
-	return nil
 }

--- a/internal/cmd/cmdauth/login.go
+++ b/internal/cmd/cmdauth/login.go
@@ -1,0 +1,187 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package cmdauth
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"runtime"
+	"time"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/pkg/browser"
+	"github.com/spf13/cobra"
+
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/cmdutil"
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/config"
+	clierrors "github.com/CircleCI-Public/circleci-cli-v2/internal/errors"
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/iostream"
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/oauth"
+)
+
+// defaultCallbackTimeout caps how long we'll wait for the user to complete the
+// browser-based authorization. Long enough to log in and approve consent;
+// short enough that an abandoned terminal eventually gives up.
+const defaultCallbackTimeout = 5 * time.Minute
+
+// callbackTimeout returns the timeout for the OAuth callback wait. Tests may
+// override the default by setting CIRCLECI_LOGIN_TIMEOUT to a duration string
+// parseable by time.ParseDuration (e.g. "100ms", "30s").
+func callbackTimeout() time.Duration {
+	if v := os.Getenv("CIRCLECI_LOGIN_TIMEOUT"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			return d
+		}
+	}
+	return defaultCallbackTimeout
+}
+
+func newLoginCmd() *cobra.Command {
+	var noBrowser bool
+
+	cmd := &cobra.Command{
+		Use:   "login",
+		Short: "Authenticate via the CircleCI OAuth flow",
+		Long: heredoc.Doc(`
+			Log in to CircleCI by opening the OAuth authorization page in your
+			browser. After you approve the request, an authorization code is
+			delivered back to a temporary loopback server on 127.0.0.1, then
+			exchanged for an access token via POST /oauth/token.
+
+			The token is saved to the system keyring (or to the YAML config
+			when --insecure-storage is set) and used automatically by all
+			subsequent CLI commands.
+		`),
+		Example: heredoc.Doc(`
+			# Open the browser and authorize the CLI
+			$ circleci auth login
+
+			# Print the authorize URL instead of opening a browser
+			$ circleci auth login --no-browser
+
+			# Authenticate against a non-default host
+			$ CIRCLECI_HOST=https://example.circleci.com circleci auth login
+		`),
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := iostream.FromCmd(cmd.Context(), cmd)
+			configPath, _ := cmd.Flags().GetString("config")
+			secureStorage := cmdutil.IsSecureStorage(cmd)
+			return runLogin(ctx, configPath, noBrowser, secureStorage)
+		},
+	}
+
+	cmd.Flags().BoolVar(&noBrowser, "no-browser", false, "Print the authorize URL instead of opening a browser")
+	return cmd
+}
+
+func runLogin(ctx context.Context, configPath string, noBrowser, secureStorage bool) error {
+	cfg, err := config.LoadFrom(ctx, configPath, false)
+	if err != nil {
+		return clierrors.New("config.load_failed", "Failed to load config", err.Error()).
+			WithExitCode(clierrors.ExitGeneralError)
+	}
+	host := cfg.EffectiveHost()
+	deviceID := config.EnsureDeviceID(ctx, configPath)
+
+	flow, err := oauth.Start(ctx, host, deviceID, runtime.GOOS)
+	if err != nil {
+		return clierrors.New("auth.login.listen_failed",
+			"Could not start local callback server", err.Error()).
+			WithSuggestions("Check that no other process is blocking loopback ports").
+			WithExitCode(clierrors.ExitGeneralError)
+	}
+	defer func() { _ = flow.Close() }()
+
+	if noBrowser || !iostream.IsInteractive(ctx) {
+		iostream.ErrPrintf(ctx, "Open this URL in your browser to continue:\n\n  %s\n\n", flow.AuthorizeURL)
+	} else {
+		iostream.ErrPrintf(ctx, "The following URL will be opened in your browser to authorize the CLI:\n\n  %s\n\n", flow.AuthorizeURL)
+		iostream.ErrPrintf(ctx, "Press Enter to continue (Ctrl+C to abort)...")
+		if err := waitForEnter(ctx); err != nil {
+			return err
+		}
+		iostream.ErrPrintln(ctx)
+		if err := browser.OpenURL(flow.AuthorizeURL); err != nil {
+			iostream.ErrPrintf(ctx, "Could not open browser automatically. Open this URL manually:\n\n  %s\n\n", flow.AuthorizeURL)
+		}
+	}
+
+	waitCtx, cancel := context.WithTimeout(ctx, callbackTimeout())
+	defer cancel()
+
+	sp := iostream.Spinner(ctx, true, "Waiting for authorization")
+	res, err := flow.Wait(waitCtx)
+	sp.Stop()
+	if err != nil {
+		if waitCtx.Err() == context.DeadlineExceeded {
+			return clierrors.New("auth.login.timeout",
+				"Timed out waiting for authorization",
+				"No callback received within the timeout window.").
+				WithSuggestions("Re-run 'circleci auth login' and complete the browser flow promptly").
+				WithExitCode(clierrors.ExitTimeout)
+		}
+		return clierrors.New("auth.login.callback_error",
+			"Authorization failed", err.Error()).
+			WithExitCode(clierrors.ExitAuthError)
+	}
+
+	token, err := flow.Exchange(ctx, res.Code)
+	if err != nil {
+		return clierrors.New("auth.login.token_exchange_failed",
+			"Failed to exchange authorization code for token", err.Error()).
+			WithExitCode(clierrors.ExitAuthError)
+	}
+
+	return persistToken(ctx, token.AccessToken, secureStorage)
+}
+
+// waitForEnter blocks until the user presses Enter on stdin or ctx is cancelled.
+// A bare bufio.ReadString call would ignore ctx because the underlying read
+// syscall doesn't return on signal — so Ctrl+C at the prompt would appear to
+// hang. The read goroutine leaks if ctx fires first, but that's fine: the
+// process is exiting anyway.
+func waitForEnter(ctx context.Context) error {
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := bufio.NewReader(iostream.In(ctx)).ReadString('\n')
+		errCh <- err
+	}()
+	select {
+	case err := <-errCh:
+		if err != nil && !errors.Is(err, io.EOF) {
+			return clierrors.New("auth.login.prompt_failed",
+				"Failed to read from stdin", err.Error()).
+				WithExitCode(clierrors.ExitGeneralError)
+		}
+		return nil
+	case <-ctx.Done():
+		return clierrors.New("auth.login.cancelled",
+			"Login cancelled",
+			"Interrupted before authorization started.").
+			WithExitCode(clierrors.ExitCancelled)
+	}
+}

--- a/internal/cmd/cmdauth/login.go
+++ b/internal/cmd/cmdauth/login.go
@@ -27,10 +27,12 @@ import (
 	"context"
 	"errors"
 	"io"
+	"net/url"
 	"os"
 	"runtime"
 	"time"
 
+	tea "charm.land/bubbletea/v2"
 	"github.com/MakeNowJust/heredoc"
 	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
@@ -40,6 +42,7 @@ import (
 	clierrors "github.com/CircleCI-Public/circleci-cli-v2/internal/errors"
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/iostream"
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/oauth"
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/ui"
 )
 
 // defaultCallbackTimeout caps how long we'll wait for the user to complete the
@@ -105,6 +108,21 @@ func runLogin(ctx context.Context, configPath string, noBrowser, secureStorage b
 			WithExitCode(clierrors.ExitGeneralError)
 	}
 	host := cfg.EffectiveHost()
+
+	// In an interactive session (and unless --no-browser forces the URL-only
+	// path), let the user pick between OAuth and pasting a token. --no-browser
+	// and non-interactive sessions skip the prompt and fall through to the
+	// browser flow, which prints the authorize URL when it can't open one.
+	if !noBrowser && iostream.IsInteractive(ctx) {
+		method, err := promptAuthMethod(ctx, host)
+		if err != nil {
+			return err
+		}
+		if method == authMethodToken {
+			return runToken(ctx, configPath, secureStorage)
+		}
+	}
+
 	deviceID := config.EnsureDeviceID(ctx, configPath)
 
 	flow, err := oauth.Start(ctx, host, deviceID, runtime.GOOS)
@@ -119,8 +137,10 @@ func runLogin(ctx context.Context, configPath string, noBrowser, secureStorage b
 	if noBrowser || !iostream.IsInteractive(ctx) {
 		iostream.ErrPrintf(ctx, "Open this URL in your browser to continue:\n\n  %s\n\n", flow.AuthorizeURL)
 	} else {
-		iostream.ErrPrintf(ctx, "The following URL will be opened in your browser to authorize the CLI:\n\n  %s\n\n", flow.AuthorizeURL)
-		iostream.ErrPrintf(ctx, "Press Enter to continue (Ctrl+C to abort)...")
+		// Show the destination URL muted so the user can verify where they're
+		// being sent (and so they have a fallback if the browser doesn't open).
+		iostream.ErrPrintf(ctx, "%s\n", ui.HelperStyle.Render(flow.AuthorizeURL))
+		iostream.ErrPrintf(ctx, "Press Enter to open %s in your browser...", hostDisplay(host))
 		if err := waitForEnter(ctx); err != nil {
 			return err
 		}
@@ -133,14 +153,14 @@ func runLogin(ctx context.Context, configPath string, noBrowser, secureStorage b
 	waitCtx, cancel := context.WithTimeout(ctx, callbackTimeout())
 	defer cancel()
 
-	sp := iostream.Spinner(ctx, true, "Waiting for authorization")
+	sp := iostream.Spinner(ctx, true, "Waiting for browser authentication")
 	res, err := flow.Wait(waitCtx)
 	sp.Stop()
 	if err != nil {
 		if waitCtx.Err() == context.DeadlineExceeded {
 			return clierrors.New("auth.login.timeout",
-				"Timed out waiting for authorization",
-				"No callback received within the timeout window.").
+				"Login timed out",
+				"Login timed out — no browser callback received within "+callbackTimeout().String()+".").
 				WithSuggestions("Re-run 'circleci auth login' and complete the browser flow promptly").
 				WithExitCode(clierrors.ExitTimeout)
 		}
@@ -156,7 +176,55 @@ func runLogin(ctx context.Context, configPath string, noBrowser, secureStorage b
 			WithExitCode(clierrors.ExitAuthError)
 	}
 
-	return persistToken(ctx, token.AccessToken, secureStorage)
+	return persistToken(ctx, host, token.AccessToken, secureStorage)
+}
+
+type authMethod int
+
+const (
+	authMethodBrowser authMethod = iota
+	authMethodToken
+)
+
+// promptAuthMethod presents the login method picker. The default selection is
+// browser-based OAuth; users can arrow down to "paste a token" instead.
+func promptAuthMethod(ctx context.Context, host string) (authMethod, error) {
+	model := ui.NewSelectModel(
+		"How would you like to authenticate "+hostDisplay(host)+"?",
+		[]string{"Login with a web browser", "Paste an authentication token"},
+	)
+	p := tea.NewProgram(model,
+		tea.WithContext(ctx),
+		tea.WithInput(iostream.In(ctx)),
+		tea.WithOutput(iostream.Err(ctx)),
+	)
+	finalModel, err := p.Run()
+	if err != nil {
+		return 0, clierrors.New("auth.login.prompt_failed",
+			"Failed to read authentication method", err.Error()).
+			WithExitCode(clierrors.ExitGeneralError)
+	}
+	m := finalModel.(ui.SelectModel)
+	if m.Cancelled() {
+		return 0, clierrors.New("auth.login.cancelled",
+			"Login cancelled",
+			"Interrupted before authorization started.").
+			WithExitCode(clierrors.ExitCancelled)
+	}
+	if m.Selected() == 1 {
+		return authMethodToken, nil
+	}
+	return authMethodBrowser, nil
+}
+
+// hostDisplay returns the bare hostname of a configured host URL (e.g.
+// "circleci.com" for "https://circleci.com"). Falls back to the input string
+// if it doesn't parse as a URL with a host component.
+func hostDisplay(host string) string {
+	if u, err := url.Parse(host); err == nil && u.Host != "" {
+		return u.Host
+	}
+	return host
 }
 
 // waitForEnter blocks until the user presses Enter on stdin or ctx is cancelled.

--- a/internal/cmd/cmdauth/token.go
+++ b/internal/cmd/cmdauth/token.go
@@ -29,6 +29,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/cmdutil"
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/config"
 	clierrors "github.com/CircleCI-Public/circleci-cli-v2/internal/errors"
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/iostream"
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/ui"
@@ -46,14 +47,20 @@ func newTokenCmd() *cobra.Command {
 					"Login requires an interactive session.").
 					WithExitCode(clierrors.ExitCancelled)
 			}
+			configPath, _ := cmd.Flags().GetString("config")
 			secureStorage := cmdutil.IsSecureStorage(cmd)
-			return runToken(ctx, secureStorage)
+			return runToken(ctx, configPath, secureStorage)
 		},
 	}
 	return cmd
 }
 
-func runToken(ctx context.Context, secureStorage bool) error {
+func runToken(ctx context.Context, configPath string, secureStorage bool) error {
+	cfg, err := config.LoadFrom(ctx, configPath, false)
+	if err != nil {
+		return clierrors.New("config.load_failed", "Failed to load config", err.Error()).
+			WithExitCode(clierrors.ExitGeneralError)
+	}
 	p := tea.NewProgram(ui.NewTokenModel(),
 		tea.WithContext(ctx),
 		tea.WithInput(iostream.In(ctx)),
@@ -69,5 +76,5 @@ func runToken(ctx context.Context, secureStorage bool) error {
 		return nil
 	}
 
-	return persistToken(ctx, m.Token(), secureStorage)
+	return persistToken(ctx, cfg.EffectiveHost(), m.Token(), secureStorage)
 }

--- a/internal/cmd/cmdauth/token.go
+++ b/internal/cmd/cmdauth/token.go
@@ -29,7 +29,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/cmdutil"
-	"github.com/CircleCI-Public/circleci-cli-v2/internal/config"
 	clierrors "github.com/CircleCI-Public/circleci-cli-v2/internal/errors"
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/iostream"
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/ui"
@@ -70,16 +69,5 @@ func runToken(ctx context.Context, secureStorage bool) error {
 		return nil
 	}
 
-	err = config.SetToken(ctx, m.Token(), secureStorage)
-	if err != nil {
-		return clierrors.New("settings.save_failed", "Failed to save settings", err.Error()).
-			WithExitCode(clierrors.ExitGeneralError)
-	}
-
-	path, _ := config.Path()
-	if secureStorage {
-		path = "keyring"
-	}
-	iostream.ErrPrintf(ctx, "%s Saved %s to %s\n", iostream.Symbol(ctx, "✓", "OK:"), "token", path)
-	return nil
+	return persistToken(ctx, m.Token(), secureStorage)
 }

--- a/internal/cmd/root/testdata/usage/circleci/auth.txt
+++ b/internal/cmd/root/testdata/usage/circleci/auth.txt
@@ -2,6 +2,8 @@ Usage:
   circleci auth [command]
 
 Available Commands:
+  id          Show the device ID for this CLI installation
+  login       Authenticate via the CircleCI OAuth flow
   logout      Remove stored credentials
   me          Get info about the current user
   token       Set personal access token for authenticating to CircleCI

--- a/internal/cmd/root/testdata/usage/circleci/auth/id.txt
+++ b/internal/cmd/root/testdata/usage/circleci/auth/id.txt
@@ -1,0 +1,21 @@
+Usage:
+  circleci auth id [flags]
+
+Examples:
+# Print the device ID
+$ circleci auth id
+
+# Output as JSON
+$ circleci auth id --json
+
+# Use in a script
+$ DEVICE=$(circleci auth id)
+
+
+Flags:
+      --json   Output as JSON
+
+Global Flags:
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/auth/login.txt
+++ b/internal/cmd/root/testdata/usage/circleci/auth/login.txt
@@ -1,0 +1,21 @@
+Usage:
+  circleci auth login [flags]
+
+Examples:
+# Open the browser and authorize the CLI
+$ circleci auth login
+
+# Print the authorize URL instead of opening a browser
+$ circleci auth login --no-browser
+
+# Authenticate against a non-default host
+$ CIRCLECI_HOST=https://example.circleci.com circleci auth login
+
+
+Flags:
+      --no-browser   Print the authorize URL instead of opening a browser
+
+Global Flags:
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,6 +37,7 @@ import (
 	"time"
 
 	"github.com/gofrs/flock"
+	"github.com/google/uuid"
 	"gopkg.in/yaml.v3"
 
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/closer"
@@ -49,8 +50,9 @@ type Config struct {
 }
 
 type state struct {
-	Token string `yaml:"token,omitempty"`
-	Host  string `yaml:"host,omitempty"`
+	Token    string `yaml:"token,omitempty"`
+	Host     string `yaml:"host,omitempty"`
+	DeviceID string `yaml:"device_id,omitempty"`
 }
 
 // DefaultHost is the CircleCI API host used when none is configured.
@@ -104,7 +106,7 @@ func LoadFrom(ctx context.Context, path string, secureStorage bool) (*Config, er
 		return nil, fmt.Errorf("reading config file: %w", err)
 	}
 
-	if err := yaml.Unmarshal(data, &cfg); err != nil {
+	if err := yaml.Unmarshal(data, &cfg.state); err != nil {
 		return nil, fmt.Errorf("parsing config file %s: %w", resolved, err)
 	}
 
@@ -144,6 +146,26 @@ func SetHost(ctx context.Context, host string, secureStorage bool) error {
 	})
 }
 
+// EnsureDeviceID returns the device_id stored in the config file at path,
+// generating and persisting a new UUID if none exists yet. path follows the
+// same convention as LoadFrom (empty → XDG default). If the config file
+// cannot be written, an ephemeral UUID is returned so the caller always gets
+// a non-empty value.
+func EnsureDeviceID(ctx context.Context, path string) string {
+	var id string
+	err := saveTo(ctx, path, false, func(cfg *Config) error {
+		if cfg.state.DeviceID == "" {
+			cfg.state.DeviceID = uuid.New().String()
+		}
+		id = cfg.state.DeviceID
+		return nil
+	})
+	if err != nil || id == "" {
+		return uuid.New().String()
+	}
+	return id
+}
+
 // saveTo writes cfg to the given path, creating parent directories as needed.
 // If path is empty the default XDG path is used.
 func saveTo(ctx context.Context, path string, secureStorage bool, cb func(config *Config) error) error {
@@ -177,7 +199,7 @@ func saveTo(ctx context.Context, path string, secureStorage bool, cb func(config
 		return fmt.Errorf("reading config file: %w", err)
 	}
 
-	if err := yaml.Unmarshal(data, &cfg); err != nil {
+	if err := yaml.Unmarshal(data, &cfg.state); err != nil {
 		return fmt.Errorf("parsing config file %s: %w", resolved, err)
 	}
 

--- a/internal/iostream/spinner.go
+++ b/internal/iostream/spinner.go
@@ -63,6 +63,7 @@ func (s Streams) Spinner(active bool, msg string) *Spin {
 	p := tea.NewProgram(
 		ui.NewSpinnerModel(msg, s.ColorEnabled()),
 		tea.WithOutput(s.Err),
+		tea.WithInput(nil), // keep stdin out of raw mode so Ctrl+C still generates SIGINT
 	)
 
 	sp := &Spin{program: p, active: true}

--- a/internal/oauth/login.go
+++ b/internal/oauth/login.go
@@ -1,0 +1,276 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+// Package oauth implements the client side of the CircleCI OAuth 2.0
+// Authorization Code + PKCE flow (RFC 6749 + RFC 7636 + RFC 8252).
+//
+// The flow:
+//  1. Start a localhost listener on 127.0.0.1:0.
+//  2. Build an authorize URL with a PKCE code challenge and random state.
+//  3. The caller opens the URL in the user's browser.
+//  4. Wait for the OAuth provider to redirect to the loopback server with
+//     ?code=...&state=... and validate the state.
+//  5. Return the captured code and PKCE verifier so the caller can exchange
+//     them for a token (once /oauth/token ships).
+package oauth
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"html/template"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+// ClientID is the CircleCI-registered OAuth client identifier for the CLI.
+const ClientID = "circleci-cli"
+
+// Flow is an in-progress authorization-code+PKCE exchange.
+//
+// Typical usage:
+//
+//	flow, err := oauth.Start(ctx, host)
+//	if err != nil { ... }
+//	defer flow.Close()
+//	// open flow.AuthorizeURL in the user's browser
+//	res, err := flow.Wait(ctx)
+type Flow struct {
+	// AuthorizeURL is the URL the user's browser must visit to start the flow.
+	AuthorizeURL string
+
+	cfg      *oauth2.Config
+	verifier string
+	state    string
+	server   *http.Server
+	listener net.Listener
+	result   chan callbackResult
+}
+
+// Result is the outcome of a successful authorization. The Verifier must be
+// presented when exchanging Code for an access token.
+type Result struct {
+	Code     string
+	Verifier string
+}
+
+// TokenResponse is the parsed response from POST /oauth/token. It mirrors the
+// OAuth 2.0 wire format; we expose this rather than oauth2.Token directly so
+// the JSON output is deterministic (oauth2.Token.Expiry is computed from
+// time.Now() at parse time, which makes it non-reproducible across runs).
+type TokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	TokenType    string `json:"token_type,omitempty"`
+	ExpiresIn    int64  `json:"expires_in,omitempty"`
+	RefreshToken string `json:"refresh_token,omitempty"`
+}
+
+type callbackResult struct {
+	code string
+	err  error
+}
+
+// Start binds a loopback listener, generates PKCE + state, and returns a Flow
+// whose AuthorizeURL the caller should open in the user's browser. The
+// returned Flow owns the listener and HTTP server until Close is called.
+//
+// host is the CircleCI base URL (e.g. https://circleci.com). The OAuth
+// endpoints are derived as host + /oauth/authorize and host + /oauth/token.
+// deviceID and osInfo are appended as query parameters on the authorize URL
+// so the server can correlate requests by CLI installation and platform.
+func Start(ctx context.Context, host, deviceID, osInfo string) (*Flow, error) {
+	verifier := oauth2.GenerateVerifier()
+
+	state, err := generateState()
+	if err != nil {
+		return nil, fmt.Errorf("generating state: %w", err)
+	}
+
+	listener, err := (&net.ListenConfig{}).Listen(ctx, "tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, fmt.Errorf("starting callback server: %w", err)
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+
+	host = strings.TrimRight(host, "/")
+	cfg := &oauth2.Config{
+		ClientID: ClientID,
+		Endpoint: oauth2.Endpoint{
+			AuthURL:  host + "/oauth/authorize",
+			TokenURL: host + "/oauth/token",
+		},
+		RedirectURL: fmt.Sprintf("http://127.0.0.1:%d/callback", port),
+	}
+
+	params := []oauth2.AuthCodeOption{oauth2.S256ChallengeOption(verifier)}
+	if deviceID != "" {
+		params = append(params, oauth2.SetAuthURLParam("device_id", deviceID))
+	}
+	if osInfo != "" {
+		params = append(params, oauth2.SetAuthURLParam("os", osInfo))
+	}
+
+	f := &Flow{
+		AuthorizeURL: cfg.AuthCodeURL(state, params...),
+		cfg:          cfg,
+		verifier:     verifier,
+		state:        state,
+		listener:     listener,
+		result:       make(chan callbackResult, 1),
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/callback", f.handleCallback)
+	f.server = &http.Server{Handler: mux, ReadHeaderTimeout: 5 * time.Second}
+
+	go func() {
+		_ = f.server.Serve(listener)
+	}()
+
+	return f, nil
+}
+
+// Wait blocks until the loopback server receives a callback from the OAuth
+// provider, ctx is cancelled, or the result is otherwise resolved.
+func (f *Flow) Wait(ctx context.Context) (*Result, error) {
+	select {
+	case res := <-f.result:
+		if res.err != nil {
+			return nil, res.err
+		}
+		return &Result{Code: res.code, Verifier: f.verifier}, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+// Exchange swaps an authorization code for an access token by POSTing to the
+// configured /oauth/token endpoint with PKCE verifier. The verifier captured
+// during Start is reused.
+func (f *Flow) Exchange(ctx context.Context, code string) (*TokenResponse, error) {
+	tok, err := f.cfg.Exchange(ctx, code, oauth2.VerifierOption(f.verifier))
+	if err != nil {
+		return nil, err
+	}
+	return &TokenResponse{
+		AccessToken:  tok.AccessToken,
+		TokenType:    tok.TokenType,
+		ExpiresIn:    tok.ExpiresIn,
+		RefreshToken: tok.RefreshToken,
+	}, nil
+}
+
+// Close shuts down the loopback server. Safe to call multiple times.
+func (f *Flow) Close() error {
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	return f.server.Shutdown(shutdownCtx)
+}
+
+func (f *Flow) handleCallback(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/callback" {
+		http.NotFound(w, r)
+		return
+	}
+
+	q := r.URL.Query()
+
+	if errParam := q.Get("error"); errParam != "" {
+		msg := errParam
+		if desc := q.Get("error_description"); desc != "" {
+			msg = errParam + ": " + desc
+		}
+		writeBrowserResponse(w, http.StatusBadRequest, "Authorization failed", msg)
+		f.deliver(callbackResult{err: fmt.Errorf("authorization failed: %s", msg)})
+		return
+	}
+
+	if got := q.Get("state"); got != f.state {
+		writeBrowserResponse(w, http.StatusBadRequest, "Authorization failed",
+			"The state parameter did not match. This may indicate a CSRF attempt.")
+		f.deliver(callbackResult{err: errors.New("state parameter does not match the CLI's expected value")})
+		return
+	}
+
+	code := q.Get("code")
+	if code == "" {
+		writeBrowserResponse(w, http.StatusBadRequest, "Authorization failed",
+			"The authorization response did not include a code.")
+		f.deliver(callbackResult{err: errors.New("authorization response missing code")})
+		return
+	}
+
+	writeBrowserResponse(w, http.StatusOK, "Authorization successful",
+		"You can close this window and return to your terminal.")
+	f.deliver(callbackResult{code: code})
+}
+
+// deliver sends res on the result channel non-blockingly. The channel is
+// buffered to size 1, so duplicate callbacks (which shouldn't happen but
+// might from misbehaving clients) are dropped rather than blocking the
+// HTTP handler.
+func (f *Flow) deliver(res callbackResult) {
+	select {
+	case f.result <- res:
+	default:
+	}
+}
+
+var browserResponseTmpl = template.Must(template.New("browser").Parse(`<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>{{.Title}} — CircleCI CLI</title>
+<style>
+body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; padding: 3rem; max-width: 36rem; margin: 0 auto; color: #1a1a1a; }
+h1 { font-size: 1.5rem; margin-bottom: 0.5rem; }
+p { color: #555; line-height: 1.5; }
+</style>
+</head>
+<body>
+<h1>{{.Title}}</h1>
+<p>{{.Body}}</p>
+</body>
+</html>
+`))
+
+func writeBrowserResponse(w http.ResponseWriter, status int, title, body string) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(status)
+	_ = browserResponseTmpl.Execute(w, struct{ Title, Body string }{title, body})
+}
+
+// generateState returns a 32-character hex string suitable for the OAuth
+// `state` parameter (16 bytes of CSPRNG output).
+func generateState() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}

--- a/internal/oauth/login_test.go
+++ b/internal/oauth/login_test.go
@@ -1,0 +1,271 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package oauth
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+// startFlow returns a Flow against the given host with a Cleanup that closes it.
+func startFlow(t *testing.T, host string) *Flow {
+	t.Helper()
+	flow, err := Start(context.Background(), host, "test-device-id", "test-os")
+	assert.NilError(t, err)
+	t.Cleanup(func() { _ = flow.Close() })
+	return flow
+}
+
+// callback issues a GET to the loopback redirect_uri with the given query params.
+func callback(t *testing.T, redirectURI string, params map[string]string) {
+	t.Helper()
+	cb, err := url.Parse(redirectURI)
+	assert.NilError(t, err)
+	q := cb.Query()
+	for k, v := range params {
+		q.Set(k, v)
+	}
+	cb.RawQuery = q.Encode()
+
+	resp, err := http.Get(cb.String())
+	assert.NilError(t, err)
+	_ = resp.Body.Close()
+}
+
+func TestStart_AuthorizeURL(t *testing.T) {
+	flow := startFlow(t, "https://example.com")
+
+	u, err := url.Parse(flow.AuthorizeURL)
+	assert.NilError(t, err)
+
+	t.Run("base URL", func(t *testing.T) {
+		assert.Check(t, is.Equal(u.Scheme, "https"))
+		assert.Check(t, is.Equal(u.Host, "example.com"))
+		assert.Check(t, is.Equal(u.Path, "/oauth/authorize"))
+	})
+
+	t.Run("required PKCE and OAuth params", func(t *testing.T) {
+		q := u.Query()
+		assert.Check(t, is.Equal(q.Get("client_id"), ClientID))
+		assert.Check(t, is.Equal(q.Get("response_type"), "code"))
+		assert.Check(t, is.Equal(q.Get("code_challenge_method"), "S256"))
+		assert.Check(t, q.Get("code_challenge") != "")
+		assert.Check(t, q.Get("state") != "")
+	})
+
+	t.Run("device_id and os params", func(t *testing.T) {
+		q := u.Query()
+		assert.Check(t, is.Equal(q.Get("device_id"), "test-device-id"))
+		assert.Check(t, is.Equal(q.Get("os"), "test-os"))
+	})
+
+	t.Run("code_challenge is SHA256(verifier)", func(t *testing.T) {
+		h := sha256.Sum256([]byte(flow.verifier))
+		want := base64.RawURLEncoding.EncodeToString(h[:])
+		assert.Check(t, is.Equal(u.Query().Get("code_challenge"), want))
+	})
+
+	t.Run("state is 32 hex chars", func(t *testing.T) {
+		s := u.Query().Get("state")
+		assert.Check(t, is.Len(s, 32))
+	})
+
+	t.Run("redirect_uri is loopback", func(t *testing.T) {
+		r := u.Query().Get("redirect_uri")
+		assert.Check(t, strings.HasPrefix(r, "http://127.0.0.1:"))
+		assert.Check(t, strings.HasSuffix(r, "/callback"))
+	})
+}
+
+func TestStart_TrimsTrailingSlashFromHost(t *testing.T) {
+	flow := startFlow(t, "https://example.com/")
+	assert.Check(t, strings.HasPrefix(flow.AuthorizeURL, "https://example.com/oauth/authorize?"))
+}
+
+func TestStart_FlowsAreUnique(t *testing.T) {
+	a := startFlow(t, "https://example.com")
+	b := startFlow(t, "https://example.com")
+
+	assert.Check(t, a.verifier != b.verifier, "verifier must be per-flow")
+	assert.Check(t, a.state != b.state, "state must be per-flow")
+}
+
+func TestFlow_Wait_Success(t *testing.T) {
+	flow := startFlow(t, "https://example.com")
+	u, _ := url.Parse(flow.AuthorizeURL)
+
+	go callback(t, u.Query().Get("redirect_uri"), map[string]string{
+		"code":  "test-code",
+		"state": u.Query().Get("state"),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	res, err := flow.Wait(ctx)
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(res.Code, "test-code"))
+	assert.Check(t, is.Equal(res.Verifier, flow.verifier))
+}
+
+func TestFlow_Wait_StateMismatch(t *testing.T) {
+	flow := startFlow(t, "https://example.com")
+	u, _ := url.Parse(flow.AuthorizeURL)
+
+	go callback(t, u.Query().Get("redirect_uri"), map[string]string{
+		"code":  "test-code",
+		"state": "wrong-state",
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := flow.Wait(ctx)
+	assert.ErrorContains(t, err, "state")
+}
+
+func TestFlow_Wait_OAuthError(t *testing.T) {
+	flow := startFlow(t, "https://example.com")
+	u, _ := url.Parse(flow.AuthorizeURL)
+
+	go callback(t, u.Query().Get("redirect_uri"), map[string]string{
+		"error":             "access_denied",
+		"error_description": "User declined the request",
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := flow.Wait(ctx)
+	assert.ErrorContains(t, err, "access_denied")
+	assert.ErrorContains(t, err, "User declined the request")
+}
+
+func TestFlow_Wait_MissingCode(t *testing.T) {
+	flow := startFlow(t, "https://example.com")
+	u, _ := url.Parse(flow.AuthorizeURL)
+
+	go callback(t, u.Query().Get("redirect_uri"), map[string]string{
+		"state": u.Query().Get("state"),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := flow.Wait(ctx)
+	assert.ErrorContains(t, err, "code")
+}
+
+func TestFlow_Wait_ContextCancelled(t *testing.T) {
+	flow := startFlow(t, "https://example.com")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := flow.Wait(ctx)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestFlow_Wait_ContextDeadline(t *testing.T) {
+	flow := startFlow(t, "https://example.com")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	_, err := flow.Wait(ctx)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestFlow_Callback_RejectsUnknownPath(t *testing.T) {
+	flow := startFlow(t, "https://example.com")
+	u, _ := url.Parse(flow.AuthorizeURL)
+
+	r, _ := url.Parse(u.Query().Get("redirect_uri"))
+	r.Path = "/not-callback"
+
+	resp, err := http.Get(r.String())
+	assert.NilError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Check(t, is.Equal(resp.StatusCode, http.StatusNotFound))
+}
+
+func TestFlow_Exchange_Success(t *testing.T) {
+	var gotForm url.Values
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		body, _ := io.ReadAll(r.Body)
+		gotForm, _ = url.ParseQuery(string(body))
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token":  "exchanged-token",
+			"token_type":    "Bearer",
+			"expires_in":    int64(7200),
+			"refresh_token": "exchanged-refresh",
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	flow := startFlow(t, srv.URL)
+	tok, err := flow.Exchange(context.Background(), "test-code")
+	assert.NilError(t, err)
+
+	assert.Check(t, is.Equal(tok.AccessToken, "exchanged-token"))
+	assert.Check(t, is.Equal(tok.TokenType, "Bearer"))
+	assert.Check(t, is.Equal(tok.ExpiresIn, int64(7200)))
+	assert.Check(t, is.Equal(tok.RefreshToken, "exchanged-refresh"))
+
+	assert.Check(t, is.Equal(gotPath, "/oauth/token"))
+	assert.Check(t, is.Equal(gotForm.Get("grant_type"), "authorization_code"))
+	assert.Check(t, is.Equal(gotForm.Get("code"), "test-code"))
+	assert.Check(t, is.Equal(gotForm.Get("code_verifier"), flow.verifier))
+}
+
+func TestFlow_Exchange_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"error":             "invalid_grant",
+			"error_description": "code already redeemed",
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	flow := startFlow(t, srv.URL)
+	_, err := flow.Exchange(context.Background(), "bad-code")
+	assert.ErrorContains(t, err, "invalid_grant")
+}

--- a/internal/testing/fakes/circleci.go
+++ b/internal/testing/fakes/circleci.go
@@ -82,7 +82,9 @@ type CircleCI struct {
 	deletedContextRestrictions map[string]bool  // "contextID/restrictionID" → deleted
 
 	// Auth state.
-	me any // response for GET /api/v2/me
+	me                 any // response for GET /api/v2/me
+	oauthTokenResponse any // response body for POST /oauth/token
+	oauthTokenStatus   int // HTTP status for POST /oauth/token (0 → 200 OK)
 }
 
 // NewCircleCI starts a fake CircleCI API server and registers t.Cleanup to close it.
@@ -141,6 +143,7 @@ func NewCircleCI(t *testing.T) *CircleCI {
 	r.Get("/api/v1.1/projects", f.handleListProjects)
 	r.Post("/api/v1.1/project/{vcs}/{org}/{repo}/follow", f.handleFollowProject)
 	r.Get("/api/v2/me", f.handleGetMe)
+	r.Post("/oauth/token", f.handleOAuthToken)
 	// Context routes.
 	r.Get("/api/v2/context", f.handleListContexts)
 	r.Post("/api/v2/context", f.handleCreateContext)
@@ -772,6 +775,42 @@ func (f *CircleCI) handleGetMe(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	render.JSON(w, r, me)
+}
+
+// SetOAuthTokenResponse sets the response body for POST /oauth/token.
+func (f *CircleCI) SetOAuthTokenResponse(resp any) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.oauthTokenResponse = resp
+}
+
+// SetOAuthTokenError configures POST /oauth/token to return the given status
+// and JSON body. Use for testing token-exchange failure paths.
+func (f *CircleCI) SetOAuthTokenError(status int, resp any) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.oauthTokenStatus = status
+	f.oauthTokenResponse = resp
+}
+
+func (f *CircleCI) handleOAuthToken(w http.ResponseWriter, r *http.Request) {
+	f.mu.RLock()
+	resp := f.oauthTokenResponse
+	status := f.oauthTokenStatus
+	f.mu.RUnlock()
+
+	if resp == nil {
+		resp = map[string]any{
+			"access_token":  "fake-access-token",
+			"token_type":    "Bearer",
+			"expires_in":    int64(3600),
+			"refresh_token": "fake-refresh-token",
+		}
+	}
+	if status != 0 {
+		render.Status(r, status)
+	}
+	render.JSON(w, r, resp)
 }
 
 // --- Project / env-var helpers ---

--- a/internal/ui/select.go
+++ b/internal/ui/select.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package ui
+
+import (
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// SelectModel is a single-choice picker rendered as a vertical list with a
+// cursor (›) marking the focused option. ↑/↓ or k/j move; Enter confirms;
+// Esc/Ctrl+C cancels.
+type SelectModel struct {
+	prompt   string
+	options  []string
+	cursor   int
+	chosen   bool
+	quitting bool
+}
+
+func NewSelectModel(prompt string, options []string) SelectModel {
+	return SelectModel{prompt: prompt, options: options}
+}
+
+// Selected returns the index chosen by the user. Only valid when Done() and
+// !Cancelled().
+func (m SelectModel) Selected() int { return m.cursor }
+
+// Cancelled reports whether the user dismissed the prompt with Esc/Ctrl+C.
+func (m SelectModel) Cancelled() bool { return m.quitting }
+
+// Done reports whether the model has finished (either chosen or cancelled).
+func (m SelectModel) Done() bool { return m.chosen || m.quitting }
+
+func (m SelectModel) Init() tea.Cmd { return nil }
+
+func (m SelectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if keyMsg, ok := msg.(tea.KeyPressMsg); ok {
+		switch keyMsg.String() {
+		case keyCtrlC, keyEsc:
+			m.quitting = true
+			return m, tea.Quit
+		case keyEnter:
+			m.chosen = true
+			return m, tea.Quit
+		case "up", "k":
+			if m.cursor > 0 {
+				m.cursor--
+			}
+		case "down", "j":
+			if m.cursor < len(m.options)-1 {
+				m.cursor++
+			}
+		}
+	}
+	return m, nil
+}
+
+func (m SelectModel) View() tea.View {
+	var b strings.Builder
+	b.WriteString(TitleStyle.Render("? "+m.prompt) + "\n")
+
+	if m.chosen {
+		b.WriteString("  " + SuccessStyle.Render(m.options[m.cursor]) + "\n")
+		return tea.NewView(b.String())
+	}
+
+	for i, opt := range m.options {
+		if i == m.cursor {
+			b.WriteString(AccentStyle.Render("› "+opt) + "\n")
+		} else {
+			b.WriteString("  " + opt + "\n")
+		}
+	}
+	b.WriteString(HelperStyle.Render("(↑/↓ to move, enter to select, esc to quit)"))
+	return tea.NewView(b.String())
+}

--- a/internal/ui/theme.go
+++ b/internal/ui/theme.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package ui
+
+import "charm.land/lipgloss/v2"
+
+// Semantic color tokens. Use these instead of raw lipgloss.Color values so
+// every widget speaks the same visual language, and a future palette swap
+// only has to touch this file.
+//
+// 256-color codes are used (not hex) so terminals with reduced color depth
+// degrade gracefully instead of falling back to white.
+var (
+	ColorAccent  = lipgloss.Color("205") // pink — in-progress state, focused input
+	ColorSuccess = lipgloss.Color("42")  // green — completed actions
+	ColorError   = lipgloss.Color("196") // red — failures
+	ColorWarning = lipgloss.Color("220") // yellow — warnings, "press Y to confirm"
+	ColorMuted   = lipgloss.Color("244") // gray — footer hints, less important text
+)
+
+// Style presets that combine the colors above with shared layout choices
+// (bold/margins/etc). Widgets should reach for these before declaring a
+// local style; only fork into a one-off style when the preset genuinely
+// doesn't fit.
+var (
+	// TitleStyle is for prompt headings and emphasized labels. Bold, no color
+	// so it works across light and dark terminals.
+	TitleStyle = lipgloss.NewStyle().Bold(true)
+
+	// AccentStyle is for active or in-progress UI: the spinner glyph, the
+	// focused-input cursor accent, anything the user's eye should track.
+	AccentStyle = lipgloss.NewStyle().Foreground(ColorAccent)
+
+	// HelperStyle is for de-emphasized hint text — footers like
+	// "(esc to quit)", inline shortcuts, secondary instructions.
+	HelperStyle = lipgloss.NewStyle().Foreground(ColorMuted)
+
+	// SuccessStyle / ErrorStyle / WarningStyle are for status glyphs and
+	// short status words. Pair them with the icons below.
+	SuccessStyle = lipgloss.NewStyle().Foreground(ColorSuccess)
+	ErrorStyle   = lipgloss.NewStyle().Foreground(ColorError)
+	WarningStyle = lipgloss.NewStyle().Foreground(ColorWarning)
+)
+
+// Status icons. Keep these in one place so prompts, results, and JSON-text
+// fallbacks all reach for the same glyph.
+const (
+	IconOK   = "✓"
+	IconWarn = "⚠"
+	IconFail = "✗"
+)


### PR DESCRIPTION
## Rationale

Adds a browser-based OAuth login as the primary path, while keeping `auth token` as the fallback for headless environments.

## Changes
- New `circleci auth login` command — PKCE OAuth flow, opens browser, waits for the redirect on a local loopback listener
- New `circleci auth id` command — prints cli device id
- Persist OAuth access token via the existing keyring/config layer - Send device ID + OS in the `/authorize` request so the server can label the session



