### PR TITLE
fix(spinner): drain TTY line discipline buffer on stop

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/zalando/go-keyring v0.2.8
 	golang.org/x/oauth2 v0.35.0
+	golang.org/x/sys v0.43.0
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/v3 v3.5.2
 )
@@ -253,7 +254,6 @@ require (
 	golang.org/x/mod v0.34.0 // indirect
 	golang.org/x/net v0.52.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
-	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/term v0.42.0 // indirect
 	golang.org/x/text v0.35.0 // indirect
 	golang.org/x/tools v0.43.0 // indirect

--- a/internal/iostream/drain_bsd.go
+++ b/internal/iostream/drain_bsd.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+//go:build darwin || dragonfly || freebsd || netbsd || openbsd
+
+package iostream
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// drainStdin discards bytes pending in stdin's line discipline buffer.
+//
+// Bubbletea v2 writes capability queries (mode 2026 synchronized output, mode
+// 2027 unicode core) to the output at startup. The terminal responds on stdin.
+// Because the spinner uses WithInput(nil) the input loop never runs, so those
+// responses accumulate in the TTY line discipline buffer. A plain read() cannot
+// drain them in canonical mode (no newline, so the line discipline won't
+// deliver the data). TIOCFLUSH with FREAD=1 discards the buffer directly.
+// Without this, the responses appear as garbage in the shell prompt after exit.
+// See: charmbracelet/bubbletea#1590.
+func drainStdin() {
+	_ = unix.IoctlSetPointerInt(int(os.Stdin.Fd()), unix.TIOCFLUSH, 1)
+}

--- a/internal/iostream/drain_linux.go
+++ b/internal/iostream/drain_linux.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+//go:build linux
+
+package iostream
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// drainStdin discards bytes pending in stdin's line discipline buffer.
+//
+// Bubbletea v2 writes capability queries (mode 2026 synchronized output, mode
+// 2027 unicode core) to the output at startup. The terminal responds on stdin.
+// Because the spinner uses WithInput(nil) the input loop never runs, so those
+// responses accumulate in the TTY line discipline buffer. A plain read() cannot
+// drain them in canonical mode (no newline, so the line discipline won't
+// deliver the data). TCFLSH/TCIFLUSH discards the buffer directly.
+//
+// We loop — flush then poll — to handle SSH round-trip latency where responses
+// may arrive after the first flush. On local terminals the poll returns
+// immediately with no data. See: charmbracelet/bubbletea#1590.
+func drainStdin() {
+	fd := int(os.Stdin.Fd())
+	fds := []unix.PollFd{{Fd: int32(fd), Events: unix.POLLIN}}
+	for {
+		_ = unix.IoctlSetInt(fd, unix.TCFLSH, 0) // 0 = TCIFLUSH: discard received, unread data
+		n, _ := unix.Poll(fds, 200)
+		if n <= 0 {
+			return
+		}
+	}
+}

--- a/internal/iostream/drain_linux.go
+++ b/internal/iostream/drain_linux.go
@@ -24,11 +24,7 @@
 
 package iostream
 
-import (
-	"os"
-
-	"golang.org/x/sys/unix"
-)
+import "golang.org/x/sys/unix"
 
 // drainStdin discards bytes pending in stdin's line discipline buffer.
 //
@@ -43,10 +39,9 @@ import (
 // may arrive after the first flush. On local terminals the poll returns
 // immediately with no data. See: charmbracelet/bubbletea#1590.
 func drainStdin() {
-	fd := int(os.Stdin.Fd())
-	fds := []unix.PollFd{{Fd: int32(fd), Events: unix.POLLIN}}
+	fds := []unix.PollFd{{Fd: 0, Events: unix.POLLIN}} // stdin is always fd 0
 	for {
-		_ = unix.IoctlSetInt(fd, unix.TCFLSH, 0) // 0 = TCIFLUSH: discard received, unread data
+		_ = unix.IoctlSetInt(0, unix.TCFLSH, 0) // 0 = TCIFLUSH: discard received, unread data
 		n, _ := unix.Poll(fds, 200)
 		if n <= 0 {
 			return

--- a/internal/iostream/drain_other.go
+++ b/internal/iostream/drain_other.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+//go:build !darwin && !dragonfly && !freebsd && !netbsd && !openbsd && !linux
+
+package iostream
+
+func drainStdin() {}

--- a/internal/iostream/spinner.go
+++ b/internal/iostream/spinner.go
@@ -82,6 +82,7 @@ func (sp *Spin) Stop() {
 	sp.once.Do(func() {
 		sp.program.Quit()
 		sp.program.Wait()
+		drainStdin()
 	})
 }
 


### PR DESCRIPTION
## Summary

- Bubbletea v2 sends terminal capability queries (mode 2026/2027) to output at startup; the terminal responds on stdin
- The spinner uses `WithInput(nil)` so the input loop never runs, leaving those responses in the TTY line discipline buffer
- After exit, the shell reads the buffered bytes and prints them as garbage at the prompt (e.g. `2026;2$y2027;1$y`)
- A plain `read()` cannot drain them in canonical mode (no newline = line discipline never delivers the data); the fix uses `TIOCFLUSH` (BSD/Darwin) or `TCFLSH` (Linux) to discard the buffer directly after `Wait()` returns

Upstream issue: charmbracelet/bubbletea#1590 (open as of this writing).

Before:


<img width="525" height="536" alt="Screenshot 2026-05-01 at 4 56 11 PM" src="https://github.com/user-attachments/assets/133ecec9-2dcc-4a27-a093-87dd301886d0" />

After:
<img width="525" height="519" alt="Screenshot 2026-05-01 at 4 55 45 PM" src="https://github.com/user-attachments/assets/a565ef02-40fb-4d50-a649-c4c74652957b" />


## Test plan

- [x] `task dev-install && circleci pipeline get` — no garbage chars after spinner clears
- [x] `CIRCLECI_SPINNER_DISABLED=1 circleci pipeline get` — static fallback path unchanged
- [x] `CI=true circleci pipeline get` — non-interactive path unchanged
- [x] `task test` — all unit + acceptance tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)