### PR TITLE
Set User-Agent header to circleci-cli (os; id)

### DIFF
--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -26,6 +26,7 @@ package apiclient
 import (
 	"context"
 	"net/http"
+	"runtime"
 	"strings"
 	"time"
 
@@ -43,6 +44,14 @@ type Client struct {
 	raw *http.Client
 }
 
+// DeviceID is set once at startup (in PersistentPreRunE, after --config is
+// parsed) and embedded in the User-Agent header as:
+//
+//	circleci-cli (<os>; <device-id>)
+//
+// The device ID is a stable per-machine UUID persisted in the config file.
+var DeviceID string
+
 // New creates a Client. baseURL should be the CircleCI host, e.g. "https://circleci.com".
 // An http.RoundTripper can be injected for testing. Set CIRCLECI_DEBUG=1 to log
 // all HTTP requests and response status codes to stderr.
@@ -54,6 +63,7 @@ func New(baseURL, token string, transport http.RoundTripper) *Client {
 	cfg := httpcl.Config{
 		AuthToken:  token,
 		AuthHeader: "Circle-Token",
+		UserAgent:  "circleci-cli (" + runtime.GOOS + "; " + DeviceID + ")",
 		Transport:  transport,
 	}
 

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -27,6 +27,7 @@ import (
 	"github.com/njayp/ophis"
 	"github.com/spf13/cobra"
 
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/apiclient"
 	cmdapi "github.com/CircleCI-Public/circleci-cli-v2/internal/cmd/api"
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/cmd/artifacts"
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/cmd/cmdauth"
@@ -41,6 +42,7 @@ import (
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/cmd/settings"
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/cmd/workflow"
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/cmdutil"
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/config"
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/iostream"
 )
 
@@ -64,6 +66,7 @@ func NewRootCmd(version string) *cobra.Command {
 
 			configPath, _ := cmd.Flags().GetString("config")
 			ctx = cmdutil.WithConfigPath(ctx, configPath)
+			apiclient.DeviceID = config.EnsureDeviceID(ctx, configPath)
 
 			jqFilter, _ := cmd.Flags().GetString("jq")
 			ctx = iostream.WithJQFilter(ctx, jqFilter)


### PR DESCRIPTION
## Rationale
API requests from the CLI had no User-Agent header, making them
indistinguishable from raw Go HTTP clients in server-side logs and
analytics. A stable, structured agent string lets the CircleCI backend
identify CLI traffic and correlate it by platform and device.

## Changes
- Wired `UserAgent: "circleci-cli (os; device-id)"` into `httpcl.Config`
  in `apiclient.New`, so every outbound API request carries the header
- Added `apiclient.DeviceID` package-level var, set in `PersistentPreRunE`
  after the `--config` flag is parsed so custom config paths are honoured

Can add version later when we decide on the numbering

## Monitoring
- No observable behaviour change for users
