### PR TITLE
feat(pipeline watch): suggest log commands when pipeline fails

### DIFF
--- a/acceptance/watch_test.go
+++ b/acceptance/watch_test.go
@@ -137,6 +137,42 @@ func TestPipelineWatch_Failed(t *testing.T) {
 	assert.Check(t, cmp.Contains(result.Stderr, "circleci logs --last-failed"), "stderr: %s", result.Stderr)
 }
 
+// --- failed pipeline with a failed job → suggests `circleci logs <num>` ---
+
+func TestPipelineWatch_Failed_SuggestsJobLogs(t *testing.T) {
+	pipelineID := "watch-pid-failedjob"
+	wfID := "watch-wf-failedjob"
+	p := fakePipeline(pipelineID, 75, "created", watchSlug, "main")
+
+	failedJob := fakeJob("job-1", "integration-test", 156057, watchSlug)
+	failedJob["status"] = "failed"
+
+	fake := fakes.NewCircleCI(t)
+	fake.AddPipeline(pipelineID, p)
+	fake.AddProjectPipelines(watchSlug, p)
+	fake.AddPipelineWorkflows(pipelineID, map[string]any{"id": wfID, "name": "build", "status": "failed"})
+	fake.AddWorkflowJobs(wfID,
+		failedJob,
+		fakeJob("job-2", "lint", 156058, watchSlug),
+	)
+
+	env := testenv.New(t)
+	env.Token = testToken
+	env.CircleCIURL = fake.URL()
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"pipeline", "watch", "75", "--project", watchSlug},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 1, "stderr: %s", result.Stderr)
+	assert.Check(t, cmp.Contains(result.Stderr, `"integration-test"`), "stderr: %s", result.Stderr)
+	assert.Check(t, cmp.Contains(result.Stderr, "circleci logs 156057"), "stderr: %s", result.Stderr)
+	assert.Check(t, cmp.Contains(result.Stderr, "circleci logs --last-failed"), "stderr: %s", result.Stderr)
+}
+
 // --- cancelled pipeline → exit 6 ---
 
 func TestPipelineWatch_Cancelled(t *testing.T) {

--- a/acceptance/watch_test.go
+++ b/acceptance/watch_test.go
@@ -134,6 +134,7 @@ func TestPipelineWatch_Failed(t *testing.T) {
 
 	assert.Equal(t, result.ExitCode, 1, "stderr: %s", result.Stderr)
 	assert.Check(t, cmp.Contains(result.Stderr, "failed"), "stderr: %s", result.Stderr)
+	assert.Check(t, cmp.Contains(result.Stderr, "circleci logs --last-failed"), "stderr: %s", result.Stderr)
 }
 
 // --- cancelled pipeline → exit 6 ---

--- a/internal/cmd/pipeline/watch.go
+++ b/internal/cmd/pipeline/watch.go
@@ -395,8 +395,35 @@ func watchFinalResult(ctx context.Context, state pipelineGetOutput, number int64
 			iostream.SymbolFail(ctx), number, formatElapsed(elapsed))
 		return clierrors.New("pipeline.failed", "Pipeline failed",
 			fmt.Sprintf("Pipeline #%d failed.", number)).
+			WithSuggestions(failedJobLogSuggestions(state)...).
 			WithExitCode(clierrors.ExitGeneralError)
 	}
+}
+
+// failedJobLogSuggestions returns commands the user can run to view logs for
+// the failed jobs in the pipeline. Caps individual job suggestions so the
+// suggestion list stays readable when many jobs fail.
+func failedJobLogSuggestions(state pipelineGetOutput) []string {
+	const maxJobs = 3
+	var suggestions []string
+	for _, wf := range state.Workflows {
+		for _, j := range wf.Jobs {
+			if j.Status != "failed" || j.Number <= 0 {
+				continue
+			}
+			if len(suggestions) >= maxJobs {
+				suggestions = append(suggestions,
+					"More jobs failed; see all with: circleci pipeline get")
+				return append(suggestions,
+					"Or fetch logs for the latest failed job: circleci logs --last-failed")
+			}
+			suggestions = append(suggestions,
+				fmt.Sprintf("View logs for failed job %q: circleci logs %d", j.Name, j.Number))
+		}
+	}
+	suggestions = append(suggestions,
+		"Or fetch logs for the latest failed job: circleci logs --last-failed")
+	return suggestions
 }
 
 func formatElapsed(d time.Duration) string {


### PR DESCRIPTION
## Summary
- When a watched pipeline ends in failure, attach actionable suggestions to the existing structured error so the user knows exactly which command to run next.
- Per failed job (capped at 3): \`circleci logs <job-number>\`. If more than 3 jobs failed, point at \`circleci pipeline get\` for the full list. Always include \`circleci logs --last-failed\` as a generic fallback.
- Suggestions are emitted via \`CLIError.WithSuggestions\`, so they render under the existing \`Suggestions:\` block on stderr and are included in the JSON error payload when \`--json\` is active.

## Test plan
- [x] Updated \`TestPipelineWatch_Failed\` to assert the new suggestion text appears on stderr.
- [x] \`go test ./acceptance/ -run TestPipelineWatch -count=1\` passes.
- [x] \`go test ./internal/cmd/pipeline/ -count=1\` passes.
- [x] \`task lint\` reports 0 issues.