### PR TITLE
See if not running mod-download is faster

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,6 @@ commands:
       - checkout
       - install-go
       - install-task
-      - run: task mod-download
 
   install-go:
     # TODO: Fix the Go orb install command, so it supports Windows.
@@ -195,6 +194,9 @@ jobs:
           steps:
             - run: task ci:release
 
+  ok-to-deploy:
+    type: no-op
+
 workflows:
   ci:
     jobs:
@@ -209,7 +211,7 @@ workflows:
                 - macos
                 - windows
 
-      - mark-release:
+      - ok-to-deploy:
           requires:
             - check
             - test
@@ -217,12 +219,12 @@ workflows:
             branches:
               only: next
 
+      - mark-release:
+          requires:
+            - ok-to-deploy
+
       - deploy:
           requires:
-            - check
-            - test
-          filters:
-            branches:
-              only: next
+            - ok-to-deploy
           context:
             - devex-release


### PR DESCRIPTION
Seems quite a bit faster:
<img width="316" height="205" alt="Screenshot 2026-05-06 at 09 23 57" src="https://github.com/user-attachments/assets/3cf1d079-16e6-4551-9977-8f67136144e8" />
vs:
<img width="316" height="205" alt="Screenshot 2026-05-06 at 09 24 08" src="https://github.com/user-attachments/assets/2b7776e7-98f2-4f01-a33b-b2ca0ecdb7c5" />
