### PR TITLE
Add `project link` and prefer linked project ID for slug resolution

### DIFF
--- a/acceptance/link_test.go
+++ b/acceptance/link_test.go
@@ -1,0 +1,235 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package acceptance_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/testing/binary"
+	testenv "github.com/CircleCI-Public/circleci-cli-v2/internal/testing/env"
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/testing/fakes"
+)
+
+func TestProjectLink_WithFlag(t *testing.T) {
+	fake := fakes.NewCircleCI(t)
+	fake.AddProjectInfo("gh/myorg/alpha", map[string]any{
+		"id":                "proj-uuid-1234",
+		"slug":              "gh/myorg/alpha",
+		"name":              "alpha",
+		"organization_name": "myorg",
+		"organization_slug": "gh/myorg",
+		"organization_id":   "org-uuid-5678",
+	})
+
+	env := testenv.New(t)
+	env.Token = testToken
+	env.CircleCIURL = fake.URL()
+
+	workDir := t.TempDir()
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"project", "link", "--project", "gh/myorg/alpha"},
+		Env:     env.Environ(),
+		WorkDir: workDir,
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+
+	data, err := os.ReadFile(filepath.Join(workDir, ".circleci", "info.yml"))
+	assert.NilError(t, err)
+	body := string(data)
+
+	assert.Check(t, strings.Contains(body, "slug: gh/myorg/alpha"), "got: %s", body)
+	assert.Check(t, strings.Contains(body, "project_id: proj-uuid-1234"), "got: %s", body)
+	assert.Check(t, strings.Contains(body, "organization_id: org-uuid-5678"), "got: %s", body)
+}
+
+// Standalone-project slugs (circleci/<orgID>/<projectID>) should round-trip
+// through the same code path as VCS slugs.
+func TestProjectLink_StandaloneSlug(t *testing.T) {
+	fake := fakes.NewCircleCI(t)
+	fake.AddProjectInfo("circleci/E6i3yYZeWZhcf8UNqcKfjN/13c8F7nusayivoSxC6GMsw", map[string]any{
+		"id":              "13c8F7nusayivoSxC6GMsw",
+		"slug":            "circleci/E6i3yYZeWZhcf8UNqcKfjN/13c8F7nusayivoSxC6GMsw",
+		"name":            "standalone",
+		"organization_id": "E6i3yYZeWZhcf8UNqcKfjN",
+	})
+
+	env := testenv.New(t)
+	env.Token = testToken
+	env.CircleCIURL = fake.URL()
+
+	workDir := t.TempDir()
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"project", "link", "--project", "circleci/E6i3yYZeWZhcf8UNqcKfjN/13c8F7nusayivoSxC6GMsw"},
+		Env:     env.Environ(),
+		WorkDir: workDir,
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+
+	data, err := os.ReadFile(filepath.Join(workDir, ".circleci", "info.yml"))
+	assert.NilError(t, err)
+	body := string(data)
+	assert.Check(t, strings.Contains(body, "slug: circleci/E6i3yYZeWZhcf8UNqcKfjN/13c8F7nusayivoSxC6GMsw"), "got: %s", body)
+}
+
+// In a non-interactive environment with no git remote and no --project flag,
+// the command must fail rather than block on a prompt.
+func TestProjectLink_NonInteractive_NoSlug(t *testing.T) {
+	fake := fakes.NewCircleCI(t)
+	env := testenv.New(t)
+	env.Token = testToken
+	env.CircleCIURL = fake.URL()
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"project", "link"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(), // empty temp dir → no git remote
+	})
+
+	assert.Equal(t, result.ExitCode, 2, "stderr: %s", result.Stderr) // ExitBadArguments
+	assert.Check(t, strings.Contains(result.Stderr, "No project found via --project flag or git remote"), "stderr: %s", result.Stderr)
+}
+
+// Without a token configured, the command must short-circuit and tell the
+// user to authenticate, not write a placeholder file.
+func TestProjectLink_NoToken(t *testing.T) {
+	env := testenv.New(t) // no Token
+
+	workDir := t.TempDir()
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"project", "link", "--project", "gh/myorg/alpha"},
+		Env:     env.Environ(),
+		WorkDir: workDir,
+	})
+
+	assert.Equal(t, result.ExitCode, 3, "stderr: %s", result.Stderr) // ExitAuthError
+	_, statErr := os.Stat(filepath.Join(workDir, ".circleci", "info.yml"))
+	assert.Check(t, os.IsNotExist(statErr), "info.yml should not be written without a token")
+}
+
+// Once a checkout is linked, subsequent commands should resolve the project
+// from info.yml — using the canonical "circleci/<orgID>/<projectID>" slug
+// when info.yml carries the UUIDs, even though the git remote (if any)
+// would have produced a "gh/org/repo"-style slug.
+func TestProjectGet_UsesLinkedUUIDs(t *testing.T) {
+	const standaloneSlug = "circleci/E6i3yYZeWZhcf8UNqcKfjN/13c8F7nusayivoSxC6GMsw"
+
+	fake := fakes.NewCircleCI(t)
+	// Only register the standalone (UUID-form) slug. If `project get` falls
+	// back to a VCS-style slug for any reason, the API will return 404.
+	fake.AddProjectInfo(standaloneSlug, map[string]any{
+		"id":              "13c8F7nusayivoSxC6GMsw",
+		"slug":            standaloneSlug,
+		"name":            "linked",
+		"organization_id": "E6i3yYZeWZhcf8UNqcKfjN",
+	})
+	// Also register the VCS slug used during link, so the initial link call succeeds.
+	fake.AddProjectInfo("gh/myorg/alpha", map[string]any{
+		"id":              "13c8F7nusayivoSxC6GMsw",
+		"slug":            "gh/myorg/alpha",
+		"name":            "alpha",
+		"organization_id": "E6i3yYZeWZhcf8UNqcKfjN",
+	})
+
+	env := testenv.New(t)
+	env.Token = testToken
+	env.CircleCIURL = fake.URL()
+
+	workDir := t.TempDir()
+
+	link := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"project", "link", "--project", "gh/myorg/alpha"},
+		Env:     env.Environ(),
+		WorkDir: workDir,
+	})
+	assert.Equal(t, link.ExitCode, 0, "link stderr: %s", link.Stderr)
+
+	// Now run `project get` with no --project flag. It must resolve via
+	// info.yml and hit the standalone (UUID) endpoint, NOT the VCS slug.
+	get := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"project", "get", "--json"},
+		Env:     env.Environ(),
+		WorkDir: workDir,
+	})
+	assert.Equal(t, get.ExitCode, 0, "get stderr: %s", get.Stderr)
+	assert.Check(t, strings.Contains(get.Stdout, standaloneSlug), "stdout: %s", get.Stdout)
+}
+
+// Refuses to overwrite an existing info.yml without --force.
+func TestProjectLink_PreservesExisting(t *testing.T) {
+	fake := fakes.NewCircleCI(t)
+	fake.AddProjectInfo("gh/myorg/alpha", map[string]any{
+		"id":              "proj-uuid-1234",
+		"slug":            "gh/myorg/alpha",
+		"organization_id": "org-uuid-5678",
+	})
+
+	env := testenv.New(t)
+	env.Token = testToken
+	env.CircleCIURL = fake.URL()
+
+	workDir := t.TempDir()
+	circleciDir := filepath.Join(workDir, ".circleci")
+	assert.NilError(t, os.MkdirAll(circleciDir, 0o755))
+	existing := []byte("slug: pre-existing\n")
+	assert.NilError(t, os.WriteFile(filepath.Join(circleciDir, "info.yml"), existing, 0o644))
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"project", "link", "--project", "gh/myorg/alpha"},
+		Env:     env.Environ(),
+		WorkDir: workDir,
+	})
+
+	assert.Equal(t, result.ExitCode, 1, "stderr: %s", result.Stderr) // ExitGeneralError
+	body, err := os.ReadFile(filepath.Join(circleciDir, "info.yml"))
+	assert.NilError(t, err)
+	assert.Equal(t, string(body), "slug: pre-existing\n")
+
+	// With --force, the existing file is overwritten.
+	result = binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"project", "link", "--project", "gh/myorg/alpha", "--force"},
+		Env:     env.Environ(),
+		WorkDir: workDir,
+	})
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	body, err = os.ReadFile(filepath.Join(circleciDir, "info.yml"))
+	assert.NilError(t, err)
+	assert.Check(t, strings.Contains(string(body), "slug: gh/myorg/alpha"), "got: %s", string(body))
+}

--- a/acceptance/link_test.go
+++ b/acceptance/link_test.go
@@ -65,9 +65,14 @@ func TestProjectLink_WithFlag(t *testing.T) {
 	assert.NilError(t, err)
 	body := string(data)
 
-	assert.Check(t, strings.Contains(body, "slug: gh/myorg/alpha"), "got: %s", body)
-	assert.Check(t, strings.Contains(body, "project_id: proj-uuid-1234"), "got: %s", body)
-	assert.Check(t, strings.Contains(body, "organization_id: org-uuid-5678"), "got: %s", body)
+	// New schema: organization + project as top-level keys with nested fields.
+	assert.Check(t, strings.Contains(body, "organization:\n"), "got: %s", body)
+	assert.Check(t, strings.Contains(body, "    id: org-uuid-5678"), "got: %s", body)
+	assert.Check(t, strings.Contains(body, "    name: myorg"), "got: %s", body)
+	assert.Check(t, strings.Contains(body, "project:\n"), "got: %s", body)
+	assert.Check(t, strings.Contains(body, "    id: proj-uuid-1234"), "got: %s", body)
+	assert.Check(t, strings.Contains(body, "    slug: gh/myorg/alpha"), "got: %s", body)
+	assert.Check(t, strings.Contains(body, "    name: alpha"), "got: %s", body)
 }
 
 // Standalone-project slugs (circleci/<orgID>/<projectID>) should round-trip

--- a/acceptance/testdata/TestInfo_NotFound.stderr.txt
+++ b/acceptance/testdata/TestInfo_NotFound.stderr.txt
@@ -1,6 +1,6 @@
 error: No project found for "gh/myorg/nonexistent".
 
 Suggestions:
-  • Run 'circleci project link' to bind this checkout to a CircleCI project
+  • Run 'circleci project link' to bind this repository to a CircleCI project
   • Check the project slug and try again
   • Use 'circleci project list' to see followed projects

--- a/acceptance/testdata/TestInfo_NotFound.stderr.txt
+++ b/acceptance/testdata/TestInfo_NotFound.stderr.txt
@@ -1,5 +1,6 @@
 error: No project found for "gh/myorg/nonexistent".
 
 Suggestions:
+  • Run 'circleci project link' to bind this checkout to a CircleCI project
   • Check the project slug and try again
   • Use 'circleci project list' to see followed projects

--- a/acceptance/testdata/TestProjectGet_NotFound.stderr.txt
+++ b/acceptance/testdata/TestProjectGet_NotFound.stderr.txt
@@ -1,6 +1,6 @@
 error: No project found for "gh/myorg/nonexistent".
 
 Suggestions:
-  • Run 'circleci project link' to bind this checkout to a CircleCI project
+  • Run 'circleci project link' to bind this repository to a CircleCI project
   • Check the project slug and try again
   • Use 'circleci project list' to see followed projects

--- a/acceptance/testdata/TestProjectGet_NotFound.stderr.txt
+++ b/acceptance/testdata/TestProjectGet_NotFound.stderr.txt
@@ -1,5 +1,6 @@
 error: No project found for "gh/myorg/nonexistent".
 
 Suggestions:
+  • Run 'circleci project link' to bind this checkout to a CircleCI project
   • Check the project slug and try again
   • Use 'circleci project list' to see followed projects

--- a/internal/cmd/deploy/list.go
+++ b/internal/cmd/deploy/list.go
@@ -110,7 +110,7 @@ func runList(ctx context.Context, client *apiclient.Client, projectSlug string, 
 	if err != nil {
 		return cmdutil.APIErr(err, projectSlug,
 			"project.not_found", "No project found for %q.",
-			"Run 'circleci project link' to bind this checkout to a CircleCI project",
+			"Run 'circleci project link' to bind this repository to a CircleCI project",
 			"Check the project slug and try again",
 			"Use 'circleci project list' to see followed projects")
 	}

--- a/internal/cmd/deploy/list.go
+++ b/internal/cmd/deploy/list.go
@@ -110,6 +110,7 @@ func runList(ctx context.Context, client *apiclient.Client, projectSlug string, 
 	if err != nil {
 		return cmdutil.APIErr(err, projectSlug,
 			"project.not_found", "No project found for %q.",
+			"Run 'circleci project link' to bind this checkout to a CircleCI project",
 			"Check the project slug and try again",
 			"Use 'circleci project list' to see followed projects")
 	}

--- a/internal/cmd/project/get.go
+++ b/internal/cmd/project/get.go
@@ -106,7 +106,7 @@ func runProjectInfo(ctx context.Context, client *apiclient.Client, projectSlug s
 	proj, err := client.GetProjectInfo(ctx, projectSlug)
 	if err != nil {
 		return cmdutil.APIErr(err, projectSlug, "project.not_found", "No project found for %q.",
-			"Run 'circleci project link' to bind this checkout to a CircleCI project",
+			"Run 'circleci project link' to bind this repository to a CircleCI project",
 			"Check the project slug and try again",
 			"Use 'circleci project list' to see followed projects")
 	}

--- a/internal/cmd/project/get.go
+++ b/internal/cmd/project/get.go
@@ -106,6 +106,7 @@ func runProjectInfo(ctx context.Context, client *apiclient.Client, projectSlug s
 	proj, err := client.GetProjectInfo(ctx, projectSlug)
 	if err != nil {
 		return cmdutil.APIErr(err, projectSlug, "project.not_found", "No project found for %q.",
+			"Run 'circleci project link' to bind this checkout to a CircleCI project",
 			"Check the project slug and try again",
 			"Use 'circleci project list' to see followed projects")
 	}

--- a/internal/cmd/project/link.go
+++ b/internal/cmd/project/link.go
@@ -150,13 +150,17 @@ func runProjectLink(ctx context.Context, cmd *cobra.Command, projectSlug string,
 	}
 
 	// Step 4: if we still don't have project info, prompt for the slug.
+	// Interactive sessions get a bubbletea text-input; non-interactive callers
+	// (CI, agents driving the CLI without a TTY) get a structured error that
+	// tells them exactly which flag to pass instead.
 	if info == nil {
 		if !iostream.IsInteractive(ctx) {
 			return clierrors.New("project.link.cannot_resolve", "Could not resolve project",
 				"No project found via --project flag or git remote, and this session is not interactive.").
 				WithSuggestions(
-					"Pass --project <slug> (find it on the project's settings page in the CircleCI UI)",
-					"Or run from inside a git checkout with a CircleCI-connected origin",
+					"Re-run with --project <slug>, e.g. circleci project link --project gh/myorg/myrepo",
+					"For a standalone project, use the slug circleci/<orgID>/<projectID> from its CircleCI Project Settings page",
+					"Or run from inside a git checkout whose origin is connected to CircleCI",
 				).
 				WithExitCode(clierrors.ExitBadArguments)
 		}
@@ -169,10 +173,14 @@ func runProjectLink(ctx context.Context, cmd *cobra.Command, projectSlug string,
 	}
 
 	// Step 5: write .circleci/info.yml.
-	out := &projectref.Info{Slug: slug}
+	out := &projectref.Info{
+		Project: projectref.Project{Slug: slug},
+	}
 	if info != nil {
-		out.ProjectID = info.ID
-		out.OrganizationID = info.OrganizationID
+		out.Project.ID = info.ID
+		out.Project.Name = info.Name
+		out.Organization.ID = info.OrganizationID
+		out.Organization.Name = info.OrganizationName
 	}
 	if err := projectref.Write(cwd, out); err != nil {
 		return clierrors.New("project.link.write_failed", "Could not write .circleci/info.yml",
@@ -183,33 +191,41 @@ func runProjectLink(ctx context.Context, cmd *cobra.Command, projectSlug string,
 	return nil
 }
 
-// promptAndLookup asks the user for a project slug, validates it against the
-// API, and returns the slug + info. It loops until the user enters a slug the
-// API recognises, cancels (empty input), or an unrecoverable error occurs.
+// promptAndLookup asks the user for a project identifier — either a slug like
+// "circleci/<orgID>/<projectID>" or a bare project UUID — validates it against
+// the API, and returns the canonical slug + info. The /project/{slug} V2
+// endpoint accepts both forms, so a single prompt covers both cases. The
+// function loops on lookup failure until the user enters a value the API
+// recognises, cancels (esc / ctrl+c / empty input), or an unrecoverable
+// error occurs.
+//
+// Callers must guard this function with iostream.IsInteractive(ctx) — running
+// a bubbletea program without a TTY produces an unhelpful error and would
+// hang an agent that pipes the CLI's stdin.
 func promptAndLookup(ctx context.Context, client *apiclient.Client) (string, *apiclient.ProjectInfo, error) {
 	iostream.ErrPrintln(ctx,
 		"Could not resolve a CircleCI project for this directory.")
 	iostream.ErrPrintln(ctx,
-		"Find your project's slug on its Project Settings page in the CircleCI UI")
-	iostream.ErrPrintln(ctx,
-		"  (e.g. gh/myorg/myrepo, or circleci/<orgID>/<projectID> for standalone projects).")
+		"Enter a project slug (e.g. circleci/<orgID>/<projectID>) or project UUID (e.g. dcb570ed-b01e-4dd1-ac60-95fcc0f16872).")
 
 	for {
-		entered, err := iostream.PromptLine(ctx, "Project slug: ")
+		entered, err := iostream.PromptText(ctx,
+			"Project slug or UUID",
+			"circleci/<orgID>/<projectID> or dcb570ed-b01e-4dd1-ac60-95fcc0f16872")
 		if err != nil {
-			return "", nil, clierrors.New("project.link.prompt_failed", "Could not read project slug",
+			return "", nil, clierrors.New("project.link.prompt_failed", "Could not read project identifier",
 				err.Error()).WithExitCode(clierrors.ExitGeneralError)
 		}
 		entered = strings.TrimSpace(entered)
 		if entered == "" {
 			return "", nil, clierrors.New("project.link.cancelled", "Link cancelled",
-				"No project slug entered.").WithExitCode(clierrors.ExitCancelled)
+				"No project identifier entered.").WithExitCode(clierrors.ExitCancelled)
 		}
 
 		info, perr := client.GetProjectInfo(ctx, entered)
 		switch {
 		case perr == nil:
-			return entered, info, nil
+			return info.Slug, info, nil
 		case httpcl.HasStatusCode(perr, http.StatusUnauthorized):
 			return "", nil, clierrors.New("auth.token_invalid", "Authentication failed",
 				"The API token was rejected by CircleCI.").

--- a/internal/cmd/project/link.go
+++ b/internal/cmd/project/link.go
@@ -1,0 +1,225 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package project
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/apiclient"
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/cmdutil"
+	clierrors "github.com/CircleCI-Public/circleci-cli-v2/internal/errors"
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/gitremote"
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/httpcl"
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/iostream"
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/projectref"
+)
+
+func newLinkCmd() *cobra.Command {
+	var (
+		projectSlug string
+		force       bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "link",
+		Short: "Bind this checkout to a CircleCI project",
+		Long: heredoc.Doc(`
+			Record the CircleCI project for the current checkout in
+			.circleci/info.yml so other commands can resolve it without
+			re-detecting from the git remote each time.
+
+			Resolution order:
+			  1. --project <slug>, if given.
+			  2. The git remote (origin) of the current directory.
+			  3. An interactive prompt — used when neither of the above
+			     yields a project the API recognises.
+
+			If you are not authenticated, this command exits with an
+			authentication error rather than prompting blindly: the
+			lookup against the CircleCI API is what verifies the slug.
+
+			An existing .circleci/info.yml is preserved unless --force
+			is passed.
+		`),
+		Example: heredoc.Doc(`
+			# Auto-detect from the current git repository
+			$ circleci project link
+
+			# Bind to a specific project (skips lookup if it exists)
+			$ circleci project link --project gh/myorg/myrepo
+
+			# Bind to a standalone project by its CircleCI slug
+			$ circleci project link --project circleci/<orgID>/<projectID>
+
+			# Overwrite an existing .circleci/info.yml
+			$ circleci project link --force
+		`),
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := iostream.FromCmd(cmd.Context(), cmd)
+			return runProjectLink(ctx, cmd, projectSlug, force)
+		},
+	}
+
+	cmd.Flags().StringVar(&projectSlug, "project", "", "Project slug (e.g. gh/org/repo or circleci/<orgID>/<projectID>)")
+	cmd.Flags().BoolVarP(&force, "force", "f", false, "Overwrite an existing .circleci/info.yml")
+
+	return cmd
+}
+
+func runProjectLink(ctx context.Context, cmd *cobra.Command, projectSlug string, force bool) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return clierrors.New("project.link.cwd_failed", "Could not determine working directory", err.Error()).
+			WithExitCode(clierrors.ExitGeneralError)
+	}
+
+	if !force {
+		if _, err := os.Stat(projectref.Path(cwd)); err == nil {
+			return clierrors.New("project.link.exists", "Project already linked",
+				fmt.Sprintf("%s already exists.", projectref.FilePath)).
+				WithSuggestions("Re-run with --force to overwrite").
+				WithExitCode(clierrors.ExitGeneralError)
+		}
+	}
+
+	// Step 1: candidate slug from --project, then git remote.
+	// Note: we deliberately do NOT consult an existing .circleci/info.yml here
+	// — `project link` is what writes that file, so reading it first would
+	// turn re-running link into a no-op against the existing entry.
+	slug := strings.TrimSpace(projectSlug)
+	if slug == "" {
+		if info, gerr := gitremote.DetectFromRemote(); gerr == nil {
+			slug = info.Slug
+		}
+	}
+
+	// Step 2: load the API client. If the user has no token at all we cannot
+	// verify the slug — LoadClient returns a structured "log in" error in that
+	// case, which we propagate directly.
+	client, err := cmdutil.LoadClient(ctx, cmd)
+	if err != nil {
+		return err
+	}
+
+	// Step 3: try to fetch project info for the candidate slug.
+	var info *apiclient.ProjectInfo
+	if slug != "" {
+		pi, perr := client.GetProjectInfo(ctx, slug)
+		switch {
+		case perr == nil:
+			info = pi
+		case httpcl.HasStatusCode(perr, http.StatusUnauthorized):
+			return clierrors.New("auth.token_invalid", "Authentication failed",
+				"The API token was rejected by CircleCI.").
+				WithSuggestions("Run: circleci auth login").
+				WithRef("https://app.circleci.com/settings/user/tokens").
+				WithExitCode(clierrors.ExitAuthError)
+		case httpcl.HasStatusCode(perr, http.StatusNotFound):
+			// Fall through to manual prompt below.
+		default:
+			return cmdutil.APIErr(perr, slug, "project.not_found", "Could not look up project %q.")
+		}
+	}
+
+	// Step 4: if we still don't have project info, prompt for the slug.
+	if info == nil {
+		if !iostream.IsInteractive(ctx) {
+			return clierrors.New("project.link.cannot_resolve", "Could not resolve project",
+				"No project found via --project flag or git remote, and this session is not interactive.").
+				WithSuggestions(
+					"Pass --project <slug> (find it on the project's settings page in the CircleCI UI)",
+					"Or run from inside a git checkout with a CircleCI-connected origin",
+				).
+				WithExitCode(clierrors.ExitBadArguments)
+		}
+		entered, info2, perr := promptAndLookup(ctx, client)
+		if perr != nil {
+			return perr
+		}
+		slug = entered
+		info = info2
+	}
+
+	// Step 5: write .circleci/info.yml.
+	out := &projectref.Info{Slug: slug}
+	if info != nil {
+		out.ProjectID = info.ID
+		out.OrganizationID = info.OrganizationID
+	}
+	if err := projectref.Write(cwd, out); err != nil {
+		return clierrors.New("project.link.write_failed", "Could not write .circleci/info.yml",
+			err.Error()).WithExitCode(clierrors.ExitGeneralError)
+	}
+
+	iostream.Printf(ctx, "%s Linked %s → %s\n", iostream.SymbolOK(ctx), projectref.FilePath, slug)
+	return nil
+}
+
+// promptAndLookup asks the user for a project slug, validates it against the
+// API, and returns the slug + info. It loops until the user enters a slug the
+// API recognises, cancels (empty input), or an unrecoverable error occurs.
+func promptAndLookup(ctx context.Context, client *apiclient.Client) (string, *apiclient.ProjectInfo, error) {
+	iostream.ErrPrintln(ctx,
+		"Could not resolve a CircleCI project for this directory.")
+	iostream.ErrPrintln(ctx,
+		"Find your project's slug on its Project Settings page in the CircleCI UI")
+	iostream.ErrPrintln(ctx,
+		"  (e.g. gh/myorg/myrepo, or circleci/<orgID>/<projectID> for standalone projects).")
+
+	for {
+		entered, err := iostream.PromptLine(ctx, "Project slug: ")
+		if err != nil {
+			return "", nil, clierrors.New("project.link.prompt_failed", "Could not read project slug",
+				err.Error()).WithExitCode(clierrors.ExitGeneralError)
+		}
+		entered = strings.TrimSpace(entered)
+		if entered == "" {
+			return "", nil, clierrors.New("project.link.cancelled", "Link cancelled",
+				"No project slug entered.").WithExitCode(clierrors.ExitCancelled)
+		}
+
+		info, perr := client.GetProjectInfo(ctx, entered)
+		switch {
+		case perr == nil:
+			return entered, info, nil
+		case httpcl.HasStatusCode(perr, http.StatusUnauthorized):
+			return "", nil, clierrors.New("auth.token_invalid", "Authentication failed",
+				"The API token was rejected by CircleCI.").
+				WithSuggestions("Run: circleci auth login").
+				WithExitCode(clierrors.ExitAuthError)
+		case httpcl.HasStatusCode(perr, http.StatusNotFound):
+			iostream.ErrPrintf(ctx, "%s No project found for %q. Try again.\n", iostream.SymbolWarn(ctx), entered)
+			continue
+		default:
+			return "", nil, cmdutil.APIErr(perr, entered, "project.not_found", "Could not look up project %q.")
+		}
+	}
+}

--- a/internal/cmd/project/project.go
+++ b/internal/cmd/project/project.go
@@ -49,6 +49,7 @@ func NewProjectCmd() *cobra.Command {
 	cmd.AddCommand(newListCmd())
 	cmd.AddCommand(NewGetCmd("get"))
 	cmd.AddCommand(newFollowCmd())
+	cmd.AddCommand(newLinkCmd())
 	cmd.AddCommand(newEnvCmd())
 
 	return cmd

--- a/internal/cmd/root/testdata/usage/circleci/project.txt
+++ b/internal/cmd/root/testdata/usage/circleci/project.txt
@@ -5,6 +5,7 @@ Available Commands:
   envvar      Manage project environment variables
   follow      Follow a project
   get         Show project details
+  link        Bind this checkout to a CircleCI project
   list        List followed projects
 
 Global Flags:

--- a/internal/cmd/root/testdata/usage/circleci/project/link.txt
+++ b/internal/cmd/root/testdata/usage/circleci/project/link.txt
@@ -1,0 +1,25 @@
+Usage:
+  circleci project link [flags]
+
+Examples:
+# Auto-detect from the current git repository
+$ circleci project link
+
+# Bind to a specific project (skips lookup if it exists)
+$ circleci project link --project gh/myorg/myrepo
+
+# Bind to a standalone project by its CircleCI slug
+$ circleci project link --project circleci/<orgID>/<projectID>
+
+# Overwrite an existing .circleci/info.yml
+$ circleci project link --force
+
+
+Flags:
+  -f, --force            Overwrite an existing .circleci/info.yml
+      --project string   Project slug (e.g. gh/org/repo or circleci/<orgID>/<projectID>)
+
+Global Flags:
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected

--- a/internal/gitremote/detect.go
+++ b/internal/gitremote/detect.go
@@ -20,16 +20,21 @@
 //
 // SPDX-License-Identifier: MIT
 
-// Package gitremote detects the CircleCI project slug from a git repository's
-// remote URL and the current branch.
+// Package gitremote resolves the CircleCI project slug for the current
+// working directory. Resolution prefers the per-checkout .circleci/info.yml
+// recorded by `circleci project link` (so repository renames and standalone
+// projects stay addressable), falling back to parsing the git remote URL.
 package gitremote
 
 import (
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"regexp"
 	"strings"
+
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/projectref"
 )
 
 // ProjectInfo holds the information needed to identify a CircleCI project.
@@ -63,9 +68,32 @@ func DetectNamespace() (string, error) {
 	return parts[1], nil
 }
 
-// Detect reads the git remote "origin" and current branch from the working
-// directory and returns a ProjectInfo suitable for CircleCI API calls.
+// Detect resolves the CircleCI project for the current working directory.
+//
+// Resolution priority:
+//  1. .circleci/info.yml in the working directory (written by `circleci project link`).
+//     When this file carries both project_id and organization_id, the canonical
+//     "circleci/<orgID>/<projectID>" slug is returned so lookups survive VCS-side
+//     renames; otherwise the file's stored slug is returned verbatim.
+//  2. The git remote "origin" URL.
+//
+// The branch is always read from git (best-effort when info.yml supplied the slug,
+// since the branch is per-checkout and never persisted in info.yml).
 func Detect() (*ProjectInfo, error) {
+	if cwd, err := os.Getwd(); err == nil {
+		if ref, err := projectref.Read(cwd); err == nil {
+			branch, _ := gitOutput("rev-parse", "--abbrev-ref", "HEAD")
+			return &ProjectInfo{Slug: ref.EffectiveSlug(), Branch: branch}, nil
+		}
+	}
+	return DetectFromRemote()
+}
+
+// DetectFromRemote resolves the project from the git "origin" remote without
+// consulting .circleci/info.yml. Use this from the `project link` command itself
+// — reading info.yml there would short-circuit the very write that link is
+// about to perform.
+func DetectFromRemote() (*ProjectInfo, error) {
 	remoteURL, err := gitOutput("remote", "get-url", "origin")
 	if err != nil {
 		return nil, fmt.Errorf("could not read git remote: %w", err)

--- a/internal/gitremote/detect_test.go
+++ b/internal/gitremote/detect_test.go
@@ -162,15 +162,17 @@ func TestDetect_PrefersInfoYml(t *testing.T) {
 		{
 			name: "uuids present yields canonical slug",
 			info: projectref.Info{
-				Slug:           "gh/myorg/myrepo",
-				ProjectID:      "13c8F7nusayivoSxC6GMsw",
-				OrganizationID: "E6i3yYZeWZhcf8UNqcKfjN",
+				Organization: projectref.Organization{ID: "E6i3yYZeWZhcf8UNqcKfjN"},
+				Project: projectref.Project{
+					Slug: "gh/myorg/myrepo",
+					ID:   "13c8F7nusayivoSxC6GMsw",
+				},
 			},
 			wantSlug: "circleci/E6i3yYZeWZhcf8UNqcKfjN/13c8F7nusayivoSxC6GMsw",
 		},
 		{
 			name:     "slug-only falls through verbatim",
-			info:     projectref.Info{Slug: "gh/myorg/legacy"},
+			info:     projectref.Info{Project: projectref.Project{Slug: "gh/myorg/legacy"}},
 			wantSlug: "gh/myorg/legacy",
 		},
 	}
@@ -197,9 +199,11 @@ func TestDetect_PrefersInfoYml(t *testing.T) {
 func TestDetectFromRemote_IgnoresInfoYml(t *testing.T) {
 	dir := t.TempDir()
 	assert.NilError(t, projectref.Write(dir, &projectref.Info{
-		Slug:           "gh/myorg/myrepo",
-		ProjectID:      "PID",
-		OrganizationID: "OID",
+		Organization: projectref.Organization{ID: "OID"},
+		Project: projectref.Project{
+			Slug: "gh/myorg/myrepo",
+			ID:   "PID",
+		},
 	}))
 
 	cwd, err := os.Getwd()

--- a/internal/gitremote/detect_test.go
+++ b/internal/gitremote/detect_test.go
@@ -23,10 +23,14 @@
 package gitremote
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/assert/cmp"
+
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/projectref"
 )
 
 func TestSlugFromRemote(t *testing.T) {
@@ -144,4 +148,69 @@ func TestSlugFromRemote(t *testing.T) {
 			assert.Check(t, cmp.Equal(slug, tc.wantSlug))
 		})
 	}
+}
+
+// TestDetect_PrefersInfoYml verifies that an existing .circleci/info.yml takes
+// priority over the git remote, and that a UUID-bearing record is normalised
+// to the canonical "circleci/<orgID>/<projectID>" slug.
+func TestDetect_PrefersInfoYml(t *testing.T) {
+	tests := []struct {
+		name     string
+		info     projectref.Info
+		wantSlug string
+	}{
+		{
+			name: "uuids present yields canonical slug",
+			info: projectref.Info{
+				Slug:           "gh/myorg/myrepo",
+				ProjectID:      "13c8F7nusayivoSxC6GMsw",
+				OrganizationID: "E6i3yYZeWZhcf8UNqcKfjN",
+			},
+			wantSlug: "circleci/E6i3yYZeWZhcf8UNqcKfjN/13c8F7nusayivoSxC6GMsw",
+		},
+		{
+			name:     "slug-only falls through verbatim",
+			info:     projectref.Info{Slug: "gh/myorg/legacy"},
+			wantSlug: "gh/myorg/legacy",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			assert.NilError(t, projectref.Write(dir, &tc.info))
+
+			cwd, err := os.Getwd()
+			assert.NilError(t, err)
+			t.Cleanup(func() { _ = os.Chdir(cwd) })
+			assert.NilError(t, os.Chdir(dir))
+
+			info, err := Detect()
+			assert.NilError(t, err)
+			assert.Check(t, cmp.Equal(info.Slug, tc.wantSlug))
+		})
+	}
+}
+
+// Sanity check that DetectFromRemote does not consult info.yml — used by
+// `project link` to avoid short-circuiting against an existing entry.
+func TestDetectFromRemote_IgnoresInfoYml(t *testing.T) {
+	dir := t.TempDir()
+	assert.NilError(t, projectref.Write(dir, &projectref.Info{
+		Slug:           "gh/myorg/myrepo",
+		ProjectID:      "PID",
+		OrganizationID: "OID",
+	}))
+
+	cwd, err := os.Getwd()
+	assert.NilError(t, err)
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	assert.NilError(t, os.Chdir(dir))
+
+	_, err = DetectFromRemote()
+	assert.Check(t, err != nil, "expected git-remote detection to fail in a non-git temp dir")
+
+	// And info.yml is still present — DetectFromRemote did not consume it.
+	_, statErr := os.Stat(filepath.Join(dir, projectref.FilePath))
+	assert.NilError(t, statErr)
 }

--- a/internal/iostream/streams.go
+++ b/internal/iostream/streams.go
@@ -146,6 +146,29 @@ func PromptSecret(ctx context.Context, header string) (string, error) {
 	return fromContext(ctx).PromptSecret(ctx, header)
 }
 
+// PromptText presents a plain (non-secret) single-line text input via
+// bubbletea. header is the bold heading above the input; placeholder is
+// shown inside the empty field. Returns ("", nil) if the user cancels with
+// esc or ctrl+c.
+func PromptText(ctx context.Context, header, placeholder string) (string, error) {
+	s := fromContext(ctx)
+	p := tea.NewProgram(
+		ui.NewPromptModel(header, placeholder),
+		tea.WithContext(ctx),
+		tea.WithInput(s.In),
+		tea.WithOutput(s.Err),
+	)
+	anyModel, err := p.Run()
+	if err != nil {
+		return "", err
+	}
+	m := anyModel.(ui.PromptModel)
+	if m.Quitting() {
+		return "", nil
+	}
+	return m.Value(), nil
+}
+
 func DebugContext(ctx context.Context, msg string, args ...any) {
 	fromContext(ctx).DebugContext(ctx, msg, args...)
 }

--- a/internal/iostream/streams.go
+++ b/internal/iostream/streams.go
@@ -387,6 +387,26 @@ func ReadSecret(ctx context.Context, value string) (string, error) {
 	return fromContext(ctx).ReadSecret(value)
 }
 
+// PromptLine writes prompt to Err and reads a single line from In.
+// The returned value has surrounding whitespace trimmed. Used for plain
+// (non-secret) interactive input where bubbletea's terminal UI is overkill.
+func (s Streams) PromptLine(prompt string) (string, error) {
+	_, _ = fmt.Fprint(s.Err, prompt)
+	scanner := bufio.NewScanner(s.In)
+	if !scanner.Scan() {
+		if err := scanner.Err(); err != nil {
+			return "", err
+		}
+		return "", fmt.Errorf("expected input but got EOF")
+	}
+	return strings.TrimSpace(scanner.Text()), nil
+}
+
+// PromptLine reads a single line of plain text input from the streams in context.
+func PromptLine(ctx context.Context, prompt string) (string, error) {
+	return fromContext(ctx).PromptLine(prompt)
+}
+
 // Confirm presents a y/N confirmation prompt via bubbletea.
 // Returns true only if the user presses y/Y. Returns false on n/N, esc,
 // ctrl+c, enter, or any program error — the safe answer is always No.

--- a/internal/projectref/projectref.go
+++ b/internal/projectref/projectref.go
@@ -1,0 +1,112 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+// Package projectref reads and writes .circleci/info.yml — the per-checkout
+// file that records which CircleCI project this directory is bound to.
+//
+// It is consulted by slug-resolution code so that repository renames and
+// non-VCS-derived slugs (e.g. standalone projects) work without forcing
+// every caller to pass --project explicitly.
+package projectref
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// FilePath is the path to the info file relative to the checkout root.
+const FilePath = ".circleci/info.yml"
+
+// Info is the on-disk record written by `circleci project link`.
+//
+// Slug is always populated. ProjectID and OrganizationID are populated when
+// the slug was verified against the CircleCI API at link time; they let
+// callers reference the project by its stable UUID even after a repo rename.
+type Info struct {
+	Slug           string `yaml:"slug"`
+	ProjectID      string `yaml:"project_id,omitempty"`
+	OrganizationID string `yaml:"organization_id,omitempty"`
+}
+
+// EffectiveSlug returns the slug to use when calling the CircleCI API.
+// When both ProjectID and OrganizationID are known, the canonical
+// "circleci/<orgID>/<projectID>" form is returned so the lookup is stable
+// across VCS-side renames; otherwise the stored Slug is returned as-is.
+func (i *Info) EffectiveSlug() string {
+	if i == nil {
+		return ""
+	}
+	if i.ProjectID != "" && i.OrganizationID != "" {
+		return "circleci/" + i.OrganizationID + "/" + i.ProjectID
+	}
+	return i.Slug
+}
+
+// ErrNotFound is returned by Read when no info file exists.
+var ErrNotFound = errors.New("projectref: .circleci/info.yml not found")
+
+// Path returns the absolute path to the info file inside workDir.
+func Path(workDir string) string {
+	return filepath.Join(workDir, FilePath)
+}
+
+// Read parses .circleci/info.yml from workDir. Returns ErrNotFound if the
+// file does not exist; other errors signal a malformed file or I/O failure.
+func Read(workDir string) (*Info, error) {
+	target := Path(workDir)
+	data, err := os.ReadFile(target) //#nosec:G304 // workDir is the caller's chosen working directory; FilePath is constant
+	if os.IsNotExist(err) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", FilePath, err)
+	}
+	var info Info
+	if err := yaml.Unmarshal(data, &info); err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", FilePath, err)
+	}
+	if info.Slug == "" {
+		return nil, fmt.Errorf("%s is missing required 'slug' field", FilePath)
+	}
+	return &info, nil
+}
+
+// Write serialises info to .circleci/info.yml inside workDir, creating the
+// .circleci directory if needed.
+func Write(workDir string, info *Info) error {
+	target := Path(workDir)
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil { //#nosec:G301 // .circleci/ is a repo-shared directory, world-readable like the surrounding workspace
+		return fmt.Errorf("creating .circleci directory: %w", err)
+	}
+	data, err := yaml.Marshal(info)
+	if err != nil {
+		return fmt.Errorf("serialising info: %w", err)
+	}
+	if err := os.WriteFile(target, data, 0o644); err != nil { //#nosec:G306 // info.yml is intended to be committed alongside .circleci/config.yml
+		return fmt.Errorf("writing %s: %w", FilePath, err)
+	}
+	return nil
+}

--- a/internal/projectref/projectref.go
+++ b/internal/projectref/projectref.go
@@ -42,27 +42,51 @@ const FilePath = ".circleci/info.yml"
 
 // Info is the on-disk record written by `circleci project link`.
 //
-// Slug is always populated. ProjectID and OrganizationID are populated when
-// the slug was verified against the CircleCI API at link time; they let
-// callers reference the project by its stable UUID even after a repo rename.
+// Schema:
+//
+//	organization:
+//	  id: <uuid>          # required
+//	  name: <string>      # optional, populated from API when available
+//	project:
+//	  id: <uuid>          # required
+//	  slug: <string>      # required — VCS-style or canonical "circleci/<orgID>/<projectID>"
+//	  name: <string>      # optional, populated from API when available
+//
+// Project.Slug is always populated. Organization.ID and Project.ID are also
+// populated when the slug was verified against the CircleCI API at link time;
+// they let callers reference the project by its stable UUID even after a repo
+// rename.
 type Info struct {
-	Slug           string `yaml:"slug"`
-	ProjectID      string `yaml:"project_id,omitempty"`
-	OrganizationID string `yaml:"organization_id,omitempty"`
+	Organization Organization `yaml:"organization"`
+	Project      Project      `yaml:"project"`
+}
+
+// Organization is the CircleCI organization that owns the project.
+type Organization struct {
+	ID   string `yaml:"id,omitempty"`
+	Name string `yaml:"name,omitempty"`
+}
+
+// Project identifies a CircleCI project.
+type Project struct {
+	ID   string `yaml:"id,omitempty"`
+	Slug string `yaml:"slug"`
+	Name string `yaml:"name,omitempty"`
 }
 
 // EffectiveSlug returns the slug to use when calling the CircleCI API.
-// When both ProjectID and OrganizationID are known, the canonical
+// When both Project.ID and Organization.ID are known, the canonical
 // "circleci/<orgID>/<projectID>" form is returned so the lookup is stable
-// across VCS-side renames; otherwise the stored Slug is returned as-is.
+// across VCS-side renames; otherwise the stored Project.Slug is returned
+// as-is.
 func (i *Info) EffectiveSlug() string {
 	if i == nil {
 		return ""
 	}
-	if i.ProjectID != "" && i.OrganizationID != "" {
-		return "circleci/" + i.OrganizationID + "/" + i.ProjectID
+	if i.Project.ID != "" && i.Organization.ID != "" {
+		return "circleci/" + i.Organization.ID + "/" + i.Project.ID
 	}
-	return i.Slug
+	return i.Project.Slug
 }
 
 // ErrNotFound is returned by Read when no info file exists.
@@ -88,8 +112,8 @@ func Read(workDir string) (*Info, error) {
 	if err := yaml.Unmarshal(data, &info); err != nil {
 		return nil, fmt.Errorf("parsing %s: %w", FilePath, err)
 	}
-	if info.Slug == "" {
-		return nil, fmt.Errorf("%s is missing required 'slug' field", FilePath)
+	if info.Project.Slug == "" {
+		return nil, fmt.Errorf("%s is missing required 'project.slug' field", FilePath)
 	}
 	return &info, nil
 }

--- a/internal/ui/prompt.go
+++ b/internal/ui/prompt.go
@@ -1,0 +1,110 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package ui
+
+import (
+	"charm.land/bubbles/v2/textinput"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/ui/components"
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/ui/theme"
+)
+
+// PromptModel is a bubbletea model for prompting a single line of plain
+// (non-secret) text. Esc / Ctrl+C cancel. Enter confirms.
+type PromptModel struct {
+	textInput   textinput.Model
+	header      string
+	placeholder string
+	quitting    bool
+	value       string
+}
+
+// NewPromptModel creates a PromptModel with the given header and an optional
+// placeholder shown inside the empty input field.
+func NewPromptModel(header, placeholder string) PromptModel {
+	ti := textinput.New()
+	ti.SetVirtualCursor(false)
+	if placeholder != "" {
+		ti.Placeholder = placeholder
+		ti.SetWidth(len(placeholder))
+	}
+	ti.Focus()
+
+	return PromptModel{textInput: ti, header: header, placeholder: placeholder}
+}
+
+// Quitting reports whether the user pressed Esc or Ctrl+C without confirming.
+func (m PromptModel) Quitting() bool { return m.quitting }
+
+// Value returns the entered text.
+func (m PromptModel) Value() string { return m.value }
+
+func (m PromptModel) Init() tea.Cmd {
+	return textinput.Blink
+}
+
+func (m PromptModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+
+	if keyMsg, ok := msg.(tea.KeyPressMsg); ok {
+		switch keyMsg.String() {
+		case components.KeyCtrlC, components.KeyEsc:
+			m.quitting = true
+			return m, tea.Quit
+		case components.KeyEnter:
+			m.value = m.textInput.Value()
+			return m, tea.Quit
+		}
+	}
+
+	m.textInput, cmd = m.textInput.Update(msg)
+	return m, cmd
+}
+
+func (m PromptModel) View() tea.View {
+	if m.value != "" {
+		return tea.NewView("")
+	}
+
+	var c *tea.Cursor
+	if !m.textInput.VirtualCursor() {
+		c = m.textInput.Cursor()
+		c.Y += lipgloss.Height(m.headerView())
+	}
+
+	str := lipgloss.JoinVertical(lipgloss.Top, m.headerView(), m.textInput.View(), m.footerView())
+	if m.quitting {
+		str += "\n"
+	}
+
+	v := tea.NewView(str)
+	v.Cursor = c
+	return v
+}
+
+func (m PromptModel) headerView() string { return theme.TitleStyle.Render(m.header) }
+func (m PromptModel) footerView() string {
+	return theme.HelperStyle.Render("(enter to confirm, esc to cancel)")
+}


### PR DESCRIPTION
## Summary

- New `circleci project link` records the project for a checkout in `.circleci/info.yml` after verifying the slug against the API. When the lookup succeeds, the file also stores the project + organization UUIDs.
- `gitremote.Detect()` now consults `.circleci/info.yml` first and returns the canonical `circleci/<orgID>/<projectID>` slug when the UUIDs are recorded — every command that resolves a project from the working directory picks this up transparently.
- New `gitremote.DetectFromRemote()` exposes the prior git-only path, used by `project link` itself to avoid short-circuiting against the file it is about to write.
- Lookup failures in `project get` and `deploy list` now suggest `circleci project link` as the first remediation, since binding the repository fixes the most common cause (a stale or non-matching git remote).

## Behavior

`project link` resolution order:
1. `--project <slug>`
2. Git remote (origin)
3. Interactive prompt — only when stdin is a TTY. The user is shown a bubbletea picker to choose between entering a project **slug** (e.g. `circleci/<orgID>/<projectID>`) or a project **UUID** (e.g. `dcb570ed-…`); the chosen value is then verified against the `/project/{slug}` V2 endpoint, which accepts either form. Non-interactive callers (CI, agents) get a structured error with the exact `--project <slug>` invocation to use instead.

If no token is configured, the command exits 3 with a "log in" suggestion rather than writing a placeholder it can't trust. An existing `.circleci/info.yml` is preserved unless `--force` is passed.

## Test plan

- [x] `go test ./...`
- [x] `task check` (lint, license, mod-tidy)
- [x] Acceptance coverage:
  - [x] `--project gh/org/repo` writes slug + UUIDs to `.circleci/info.yml`
  - [x] Standalone slug (`circleci/<orgID>/<projectID>`) round-trips
  - [x] Non-interactive failure (no slug, no remote) exits 2
  - [x] Missing token exits 3 and writes nothing
  - [x] Existing `info.yml` is preserved without `--force`, overwritten with it
  - [x] `project get` (with no `--project`) hits the standalone-form endpoint after `project link`, proving info.yml's UUIDs are consumed
  - [x] `project get` / `info` / `deploy list` not-found stderr fixtures show the `project link` suggestion first
- [x] Unit coverage for `gitremote.Detect` priority and `DetectFromRemote` ignoring info.yml


```
❯ bat .circleci/info.yml
───────┬─────────────────────────────────────────────────────────────────────────────────────────
       │ File: .circleci/info.yml
───────┼─────────────────────────────────────────────────────────────────────────────────────────
   1   │ organization:
   2   │     id: 31cea8f6-4ec6-4c8f-a358-0a21256259e8
   3   │     name: TestingStandalone
   4   │ project:
   5   │     id: dcb570ed-b01e-4dd1-ac60-95fcc0f16872
   6   │     slug: circleci/79izUoowSQt7wijPns6hbD/UFjekVqDw8CkMZKq6Nqfms
   7   │     name: testingwhatever
───────┴─────────────────────────────────────────────────────────────────────────────────────────

```