### PR TITLE
Make Ctrl-C exit 'run watch' immediately

### DIFF
--- a/acceptance/watch_test.go
+++ b/acceptance/watch_test.go
@@ -23,10 +23,18 @@
 package acceptance_test
 
 import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"runtime"
 	"testing"
+	"time"
 
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/assert/cmp"
+	"gotest.tools/v3/skip"
 
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/testing/binary"
 	testenv "github.com/CircleCI-Public/circleci-cli-v2/internal/testing/env"
@@ -256,6 +264,71 @@ func TestRunWatch_Timeout(t *testing.T) {
 	})
 
 	assert.Equal(t, result.ExitCode, 8, "stderr: %s", result.Stderr) // ExitTimeout
+}
+
+// --- Ctrl-C during polling exits within a poll interval (regression: was stuck for 5–30s) ---
+
+func TestRunWatch_InterruptDuringPolling(t *testing.T) {
+	skip.If(t, runtime.GOOS == "windows", "os.Interrupt is not supported on Windows")
+
+	runID := "watch-pid-interrupt"
+	wfID := "watch-wf-interrupt"
+	r := fakeRun(runID, 78, "created", watchSlug, "main")
+
+	fake := fakes.NewCircleCI(t)
+	fake.AddRun(runID, r)
+	fake.AddProjectRuns(watchSlug, r)
+	// Workflow stays "running" forever, so the watch loop is in its
+	// time-based poll wait when the signal arrives.
+	fake.AddRunWorkflows(runID, map[string]any{"id": wfID, "name": "build", "status": "running"})
+	fake.AddWorkflowJobs(wfID, fakeJob("job-1", "test", 100, watchSlug))
+
+	env := testenv.New(t)
+	env.Token = testToken
+	env.CircleCIURL = fake.URL()
+
+	// Start the CLI directly (not via RunCLI) so we can deliver SIGINT.
+	args := []string{
+		"--insecure-storage", "--theme=dark",
+		"run", "watch", "78", "--project", watchSlug,
+	}
+	var stdout, stderr bytes.Buffer
+	cmd := exec.Command(binaryPath, args...)
+	cmd.Dir = t.TempDir()
+	cmd.Env = env.Environ()
+	cmd.Stdout = io.MultiWriter(os.Stdout, &stdout)
+	cmd.Stderr = io.MultiWriter(os.Stderr, &stderr)
+
+	assert.NilError(t, cmd.Start())
+
+	// Let the watch loop enter its first sleep.
+	time.Sleep(1 * time.Second)
+	assert.NilError(t, cmd.Process.Signal(os.Interrupt))
+
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+
+	// With ctx-aware sleep, the process should exit within a fraction of a
+	// second. Allow a generous 3s budget — but well below the 5s minimum
+	// poll interval that would prove the bug is back.
+	select {
+	case err := <-done:
+		var exitCode int
+		var exitErr *exec.ExitError
+		switch {
+		case err == nil:
+			exitCode = 0
+		case errors.As(err, &exitErr):
+			exitCode = exitErr.ExitCode()
+		default:
+			t.Fatalf("unexpected wait error: %v", err)
+		}
+		assert.Equal(t, exitCode, 6, "expected ExitCancelled (6); stderr: %s", stderr.String())
+	case <-time.After(3 * time.Second):
+		_ = cmd.Process.Kill()
+		<-done
+		t.Fatalf("watch did not exit within 3s of SIGINT — stuck in time.Sleep?")
+	}
 }
 
 // --- no token → exit 3 ---

--- a/internal/cmd/run/watch.go
+++ b/internal/cmd/run/watch.go
@@ -24,6 +24,7 @@ package run
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -190,6 +191,9 @@ func waitForRunBySHA(ctx context.Context, client *apiclient.Client, projectSlug,
 	for {
 		runs, err := client.ListPipelines(ctx, projectSlug, branch, 10)
 		if err != nil {
+			if errors.Is(err, context.Canceled) {
+				return nil, watchInterrupted()
+			}
 			return nil, apiErr(err, projectSlug)
 		}
 		for i := range runs {
@@ -213,7 +217,9 @@ func waitForRunBySHA(ctx context.Context, client *apiclient.Client, projectSlug,
 			iostream.ErrPrintf(ctx, "Waiting for run for commit %s...\n", sha)
 			printed = true
 		}
-		time.Sleep(interval)
+		if err := sleepOrCancel(ctx, interval); err != nil {
+			return nil, watchInterrupted()
+		}
 	}
 }
 
@@ -231,6 +237,12 @@ func watchUntilDone(ctx context.Context, client *apiclient.Client, runID string,
 	for {
 		state, err := fetchWatchState(ctx, client, runID)
 		if err != nil {
+			if errors.Is(err, context.Canceled) {
+				if tty {
+					iostream.ErrPrintf(ctx, "\n")
+				}
+				return watchInterrupted()
+			}
 			return clierrors.New("api.error", "API error while watching run", err.Error()).
 				WithExitCode(clierrors.ExitAPIError)
 		}
@@ -267,12 +279,38 @@ func watchUntilDone(ctx context.Context, client *apiclient.Client, runID string,
 				WithExitCode(clierrors.ExitTimeout)
 		}
 
-		time.Sleep(pollInterval)
+		if err := sleepOrCancel(ctx, pollInterval); err != nil {
+			if tty {
+				iostream.ErrPrintf(ctx, "\n")
+			}
+			return watchInterrupted()
+		}
 		// Ramp from 5s to 30s over the first few polls.
 		if pollInterval < 30*time.Second {
 			pollInterval += 5 * time.Second
 		}
 	}
+}
+
+// sleepOrCancel waits for d to elapse, returning nil. If ctx is cancelled
+// first (e.g. user pressed Ctrl-C), it returns ctx.Err() immediately.
+func sleepOrCancel(ctx context.Context, d time.Duration) error {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
+}
+
+// watchInterrupted is the structured error returned when the user cancels
+// the watch (Ctrl-C) before the run reaches a terminal state.
+func watchInterrupted() *clierrors.CLIError {
+	return clierrors.New("run.interrupted", "Watch interrupted",
+		"Stopped watching before the run completed. The run is still active in CircleCI.").
+		WithExitCode(clierrors.ExitCancelled)
 }
 
 // fetchWatchState retrieves the current run state including all workflows


### PR DESCRIPTION
## Summary
- \`circleci run watch\` was unresponsive to Ctrl-C: the polling loop used bare \`time.Sleep\` (5s ramping to 30s), so signal-cancelled context wasn't observed until the sleep ended naturally.
- Replaced both \`time.Sleep\` calls in \`watchUntilDone\` and \`waitForRunBySHA\` with a \`sleepOrCancel\` helper that selects on \`ctx.Done()\`. On cancellation, return a structured \`run.interrupted\` error with \`ExitCancelled\` (6) instead of letting it surface as a generic API error.

## Test plan
- [x] \`task test\` — full suite (488 tests) passes
- [x] \`task check\` — lint, license, mod-tidy clean
- [x] New regression test \`TestRunWatch_InterruptDuringPolling\` sends \`os.Interrupt\` to the running binary and asserts exit code 6 within 3s (well under the 5s minimum poll interval that would prove the bug returned)


```
❯ cci run watch
Watching run #5128 (gh/CircleCI-Public/circleci-cli @ escape-not-wokring)

^C
error: Stopped watching before the run completed. The run is still active in CircleCI.

```