### PR TITLE
reject extra positional args on info/get

### DIFF
--- a/internal/cmd/project/get.go
+++ b/internal/cmd/project/get.go
@@ -66,6 +66,7 @@ func NewGetCmd(use string) *cobra.Command {
 			# Output as JSON for scripting
 			$ circleci project get --json
 		`),
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := iostream.FromCmd(cmd.Context(), cmd)
 			client, err := cmdutil.LoadClient(ctx, cmd)


### PR DESCRIPTION
Adds missing no args for the project commands.

`circleci info foo bar` (and `circleci project get foo`) silently ignored extra positional args because Cobra's default arg policy is `ArbitraryArgs`. The handler only reads `--project`, so the extras went straight into the void.

Setting `Args: cobra.NoArgs` makes both surfaces fail loudly with `unknown command "foo" for "circleci info"`.

Affects `circleci project get` and `circleci info` since both flow through `project.NewGetCmd(...)`.
