### PR TITLE
chore(chunk): configure sidecar with snapshot, remote commands, and org ID

### DIFF
--- a/.chunk/config.json
+++ b/.chunk/config.json
@@ -6,7 +6,8 @@
       "role": "gate",
       "fileExt": ".go",
       "timeout": 300,
-      "limit": 3
+      "limit": 3,
+      "remote": true
     },
     {
       "name": "lint",
@@ -14,7 +15,8 @@
       "role": "gate",
       "fileExt": ".go",
       "timeout": 60,
-      "limit": 3
+      "limit": 3,
+      "remote": true
     },
     {
       "name": "format",
@@ -24,5 +26,27 @@
       "limit": 3,
       "always": true
     }
-  ]
+  ],
+  "validation": {
+    "sidecarImage": "3e440dfc-2708-466d-8572-fd64aa411950"
+  },
+  "environment": {
+    "stack": "go",
+    "setup": [
+      {
+        "name": "system",
+        "command": "sudo apt-get update \u0026\u0026 sudo apt-get install -y git --no-install-recommends \u0026\u0026 sudo rm -rf /var/lib/apt/lists/*"
+      },
+      {
+        "name": "install",
+        "command": "go mod download"
+      },
+      {
+        "name": "test",
+        "command": "go test -p 1 ./..."
+      }
+    ],
+    "image": "cimg/go",
+    "image_version": "1.26.3"
+  }
 }

--- a/.chunk/config.json
+++ b/.chunk/config.json
@@ -1,4 +1,5 @@
 {
+  "orgID": "f22b6566-597d-46d5-ba74-99ef5bb3d85c",
   "commands": [
     {
       "name": "test",

--- a/.chunk/config.json
+++ b/.chunk/config.json
@@ -16,8 +16,7 @@
       "role": "gate",
       "fileExt": ".go",
       "timeout": 60,
-      "limit": 3,
-      "remote": true
+      "limit": 3
     },
     {
       "name": "format",


### PR DESCRIPTION
## Summary

- Marks `test` as `remote: true` so it runs on the chunk sidecar (long-running, environment-sensitive)
- Leaves `lint` and `format` running locally — they're fast, self-contained, and don't benefit from the sidecar
- Adds `validation.sidecarImage` pointing to a pre-configured Go snapshot for fast sidecar boot
- Adds `environment` block describing the Go stack setup steps and base image
- Adds `orgID` so `chunk sidecar create` works without manual flag passing

## Test plan

- [x] Validated on a fresh sidecar booted from the snapshot — 489 tests pass, 0 lint issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)