### PR TITLE
feat(project): add trigger list and create commands

### DIFF
--- a/acceptance/project_test.go
+++ b/acceptance/project_test.go
@@ -598,3 +598,254 @@ func TestInfo_NotFound(t *testing.T) {
 	assert.Equal(t, result.ExitCode, 5, "stderr: %s", result.Stderr)
 	assert.Check(t, golden.String(result.Stderr, t.Name()+".stderr.txt"))
 }
+
+// --- project trigger create ---
+
+const (
+	triggerProjectID    = "proj-uuid-1234"
+	triggerPipelineDefID = "pdef-uuid-5678"
+	triggerRepoID       = "987654321"
+	triggerID           = "trig-uuid-abcd"
+)
+
+var triggerFixture = map[string]any{
+	"id":         triggerID,
+	"created_at": "2026-01-01T00:00:00Z",
+	"event_source": map[string]any{
+		"provider": "github_app",
+		"repo": map[string]any{
+			"external_id": triggerRepoID,
+			"full_name":   "myorg/myrepo",
+		},
+	},
+	"event_preset": "all-pushes",
+}
+
+func setupTriggerFake(t *testing.T) (*fakes.CircleCI, *testenv.TestEnv) {
+	t.Helper()
+	fake, env := setupProjectFake(t)
+	fake.SetCreateTriggerResponse(triggerProjectID, triggerPipelineDefID, triggerFixture)
+	fake.AddTrigger(triggerProjectID, triggerPipelineDefID, triggerFixture)
+	return fake, env
+}
+
+// --- project trigger list ---
+
+func TestProjectTriggerList(t *testing.T) {
+	_, env := setupTriggerFake(t)
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary: binaryPath,
+		Args: []string{
+			"project", "trigger", "list",
+			"--project", "gh/myorg/alpha",
+			"--pipeline-definition-id", triggerPipelineDefID,
+		},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Check(t, strings.Contains(result.Stdout, triggerID))
+}
+
+func TestProjectTriggerList_JSON(t *testing.T) {
+	_, env := setupTriggerFake(t)
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary: binaryPath,
+		Args: []string{
+			"project", "trigger", "list",
+			"--project", "gh/myorg/alpha",
+			"--pipeline-definition-id", triggerPipelineDefID,
+			"--json",
+		},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+
+	var out []map[string]any
+	err := json.Unmarshal([]byte(result.Stdout), &out)
+	assert.NilError(t, err)
+	assert.Check(t, cmp.Len(out, 1))
+	assert.Check(t, cmp.Equal(out[0]["id"], triggerID))
+	assert.Check(t, cmp.Equal(out[0]["event_preset"], "all-pushes"))
+}
+
+func TestProjectTriggerList_Empty(t *testing.T) {
+	fake, env := setupProjectFake(t)
+	// Register project but no triggers
+	fake.AddProjectInfo("gh/myorg/beta", map[string]any{
+		"id":   "proj-uuid-beta",
+		"slug": "gh/myorg/beta",
+		"name": "beta",
+	})
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary: binaryPath,
+		Args: []string{
+			"project", "trigger", "list",
+			"--project-id", "proj-uuid-beta",
+			"--pipeline-definition-id", triggerPipelineDefID,
+		},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Check(t, strings.Contains(result.Stderr, "No triggers found."))
+}
+
+func TestProjectTriggerList_MissingPipelineDefinitionID(t *testing.T) {
+	_, env := setupTriggerFake(t)
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"project", "trigger", "list", "--project", "gh/myorg/alpha"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 2, "stderr: %s", result.Stderr)
+	assert.Check(t, strings.Contains(result.Stderr, "--pipeline-definition-id"))
+}
+
+// --- project trigger create ---
+
+func TestProjectTriggerCreate(t *testing.T) {
+	_, env := setupTriggerFake(t)
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary: binaryPath,
+		Args: []string{
+			"project", "trigger", "create",
+			"--project", "gh/myorg/alpha",
+			"--pipeline-definition-id", triggerPipelineDefID,
+			"--repo-id", triggerRepoID,
+		},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Check(t, strings.Contains(result.Stdout, triggerID))
+}
+
+func TestProjectTriggerCreate_JSON(t *testing.T) {
+	_, env := setupTriggerFake(t)
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary: binaryPath,
+		Args: []string{
+			"project", "trigger", "create",
+			"--project", "gh/myorg/alpha",
+			"--pipeline-definition-id", triggerPipelineDefID,
+			"--repo-id", triggerRepoID,
+			"--json",
+		},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+
+	var out map[string]any
+	err := json.Unmarshal([]byte(result.Stdout), &out)
+	assert.NilError(t, err)
+	assert.Check(t, cmp.Equal(out["id"], triggerID))
+}
+
+func TestProjectTriggerCreate_MissingPipelineDefinitionID(t *testing.T) {
+	_, env := setupTriggerFake(t)
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary: binaryPath,
+		Args: []string{
+			"project", "trigger", "create",
+			"--project", "gh/myorg/alpha",
+			"--repo-id", triggerRepoID,
+		},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 2, "stderr: %s", result.Stderr)
+	assert.Check(t, strings.Contains(result.Stderr, "--pipeline-definition-id"))
+}
+
+func TestProjectTriggerCreate_MissingRepoID(t *testing.T) {
+	_, env := setupTriggerFake(t)
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary: binaryPath,
+		Args: []string{
+			"project", "trigger", "create",
+			"--project", "gh/myorg/alpha",
+			"--pipeline-definition-id", triggerPipelineDefID,
+		},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 2, "stderr: %s", result.Stderr)
+	assert.Check(t, strings.Contains(result.Stderr, "--repo-id"))
+}
+
+func TestProjectTriggerCreate_ProjectNotFound(t *testing.T) {
+	_, env := setupTriggerFake(t)
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary: binaryPath,
+		Args: []string{
+			"project", "trigger", "create",
+			"--project", "gh/myorg/nonexistent",
+			"--pipeline-definition-id", triggerPipelineDefID,
+			"--repo-id", triggerRepoID,
+		},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 5, "stderr: %s", result.Stderr)
+}
+
+func TestProjectTriggerCreate_InvalidEventPreset(t *testing.T) {
+	_, env := setupTriggerFake(t)
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary: binaryPath,
+		Args: []string{
+			"project", "trigger", "create",
+			"--project", "gh/myorg/alpha",
+			"--pipeline-definition-id", triggerPipelineDefID,
+			"--repo-id", triggerRepoID,
+			"--event-preset", "push-only",
+		},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 2, "stderr: %s", result.Stderr)
+	assert.Check(t, strings.Contains(result.Stderr, "push-only"))
+}
+
+func TestProjectTriggerCreate_DirectProjectID(t *testing.T) {
+	_, env := setupTriggerFake(t)
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary: binaryPath,
+		Args: []string{
+			"project", "trigger", "create",
+			"--project-id", triggerProjectID,
+			"--pipeline-definition-id", triggerPipelineDefID,
+			"--repo-id", triggerRepoID,
+		},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Check(t, strings.Contains(result.Stdout, triggerID))
+}

--- a/acceptance/project_test.go
+++ b/acceptance/project_test.go
@@ -831,6 +831,26 @@ func TestProjectTriggerCreate_InvalidEventPreset(t *testing.T) {
 	assert.Check(t, strings.Contains(result.Stderr, "push-only"))
 }
 
+func TestProjectTriggerCreate_InvalidProvider(t *testing.T) {
+	_, env := setupTriggerFake(t)
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary: binaryPath,
+		Args: []string{
+			"project", "trigger", "create",
+			"--project", "gh/myorg/alpha",
+			"--pipeline-definition-id", triggerPipelineDefID,
+			"--repo-id", triggerRepoID,
+			"--provider", "bitbucket",
+		},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 2, "stderr: %s", result.Stderr)
+	assert.Check(t, strings.Contains(result.Stderr, "bitbucket"))
+}
+
 func TestProjectTriggerCreate_DirectProjectID(t *testing.T) {
 	_, env := setupTriggerFake(t)
 

--- a/acceptance/project_test.go
+++ b/acceptance/project_test.go
@@ -602,10 +602,10 @@ func TestInfo_NotFound(t *testing.T) {
 // --- project trigger create ---
 
 const (
-	triggerProjectID    = "proj-uuid-1234"
+	triggerProjectID     = "proj-uuid-1234"
 	triggerPipelineDefID = "pdef-uuid-5678"
-	triggerRepoID       = "987654321"
-	triggerID           = "trig-uuid-abcd"
+	triggerRepoID        = "987654321"
+	triggerID            = "trig-uuid-abcd"
 )
 
 var triggerFixture = map[string]any{

--- a/internal/apiclient/pipeline_definition.go
+++ b/internal/apiclient/pipeline_definition.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package apiclient
+
+import (
+	"context"
+	"time"
+)
+
+// PipelineDefinitionRepo holds repository info for a pipeline definition source.
+type PipelineDefinitionRepo struct {
+	FullName   string `json:"full_name,omitempty"`
+	ExternalID string `json:"external_id,omitempty"`
+}
+
+// PipelineDefinitionSource describes a config or checkout source.
+type PipelineDefinitionSource struct {
+	Provider string                  `json:"provider,omitempty"`
+	Repo     *PipelineDefinitionRepo `json:"repo,omitempty"`
+	FilePath string                  `json:"file_path,omitempty"`
+}
+
+// PipelineDefinition represents a CircleCI pipeline definition.
+type PipelineDefinition struct {
+	ID             string                    `json:"id"`
+	Name           string                    `json:"name"`
+	Description    string                    `json:"description,omitempty"`
+	CreatedAt      time.Time                 `json:"created_at"`
+	ConfigSource   *PipelineDefinitionSource `json:"config_source,omitempty"`
+	CheckoutSource *PipelineDefinitionSource `json:"checkout_source,omitempty"`
+}
+
+// ListPipelineDefinitions returns all pipeline definitions for a project.
+func (c *Client) ListPipelineDefinitions(ctx context.Context, projectID string) ([]PipelineDefinition, error) {
+	var resp struct {
+		Items []PipelineDefinition `json:"items"`
+	}
+	err := c.get(ctx, "/projects/%s/pipeline-definitions", &resp,
+		routeParams(projectID),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return resp.Items, nil
+}

--- a/internal/apiclient/trigger.go
+++ b/internal/apiclient/trigger.go
@@ -79,16 +79,19 @@ func (c *Client) ListTriggers(ctx context.Context, projectID, pipelineDefinition
 }
 
 // CreateTrigger creates a new trigger for a project's pipeline definition.
-// projectID is the project UUID, pipelineDefinitionID is the pipeline definition UUID,
-// repoID is the GitHub repository external ID.
-func (c *Client) CreateTrigger(ctx context.Context, projectID, pipelineDefinitionID, repoID, eventPreset, configRef, checkoutRef string) (*Trigger, error) {
+// provider must be one of: github_app, github_server, github_oauth, webhook, schedule.
+// repoID is the repository external ID; required for github_app, github_server, and github_oauth.
+func (c *Client) CreateTrigger(ctx context.Context, projectID, pipelineDefinitionID, provider, repoID, eventPreset, configRef, checkoutRef string) (*Trigger, error) {
+	eventSource := map[string]any{
+		"provider": provider,
+	}
+	if repoID != "" {
+		eventSource["repo"] = map[string]any{
+			"external_id": repoID,
+		}
+	}
 	body := map[string]any{
-		"event_source": map[string]any{
-			"provider": "github_app",
-			"repo": map[string]any{
-				"external_id": repoID,
-			},
-		},
+		"event_source": eventSource,
 	}
 	if eventPreset != "" {
 		body["event_preset"] = eventPreset

--- a/internal/apiclient/trigger.go
+++ b/internal/apiclient/trigger.go
@@ -1,0 +1,111 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package apiclient
+
+import (
+	"context"
+	"time"
+)
+
+// TriggerEventSourceRepo holds repository information for a trigger event source.
+type TriggerEventSourceRepo struct {
+	ExternalID string `json:"external_id"`
+	FullName   string `json:"full_name,omitempty"`
+}
+
+// TriggerEventSourceWebhook holds webhook information for a trigger event source.
+type TriggerEventSourceWebhook struct {
+	URL    string `json:"url,omitempty"`
+	Sender string `json:"sender,omitempty"`
+}
+
+// TriggerEventSourceSchedule holds schedule information for a trigger event source.
+type TriggerEventSourceSchedule struct {
+	CronExpression string `json:"cron_expression,omitempty"`
+}
+
+// TriggerEventSource describes the event source for a trigger.
+type TriggerEventSource struct {
+	Provider string                      `json:"provider"`
+	Repo     *TriggerEventSourceRepo     `json:"repo,omitempty"`
+	Webhook  *TriggerEventSourceWebhook  `json:"webhook,omitempty"`
+	Schedule *TriggerEventSourceSchedule `json:"schedule,omitempty"`
+}
+
+// Trigger represents a CircleCI project trigger.
+type Trigger struct {
+	ID          string             `json:"id"`
+	CreatedAt   time.Time          `json:"created_at"`
+	EventName   string             `json:"event_name,omitempty"`
+	EventSource TriggerEventSource `json:"event_source"`
+	EventPreset string             `json:"event_preset,omitempty"`
+	ConfigRef   string             `json:"config_ref,omitempty"`
+	CheckoutRef string             `json:"checkout_ref,omitempty"`
+	Disabled    bool               `json:"disabled"`
+}
+
+// ListTriggers returns all triggers for a project's pipeline definition.
+func (c *Client) ListTriggers(ctx context.Context, projectID, pipelineDefinitionID string) ([]Trigger, error) {
+	var resp struct {
+		Items []Trigger `json:"items"`
+	}
+	err := c.get(ctx, "/projects/%s/pipeline-definitions/%s/triggers", &resp,
+		routeParams(projectID, pipelineDefinitionID),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return resp.Items, nil
+}
+
+// CreateTrigger creates a new trigger for a project's pipeline definition.
+// projectID is the project UUID, pipelineDefinitionID is the pipeline definition UUID,
+// repoID is the GitHub repository external ID.
+func (c *Client) CreateTrigger(ctx context.Context, projectID, pipelineDefinitionID, repoID, eventPreset, configRef, checkoutRef string) (*Trigger, error) {
+	body := map[string]any{
+		"event_source": map[string]any{
+			"provider": "github_app",
+			"repo": map[string]any{
+				"external_id": repoID,
+			},
+		},
+	}
+	if eventPreset != "" {
+		body["event_preset"] = eventPreset
+	}
+	if configRef != "" {
+		body["config_ref"] = configRef
+	}
+	if checkoutRef != "" {
+		body["checkout_ref"] = checkoutRef
+	}
+
+	var resp Trigger
+	err := c.post(ctx, "/projects/%s/pipeline-definitions/%s/triggers", body, &resp,
+		routeParams(projectID, pipelineDefinitionID),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}

--- a/internal/cmd/project/project.go
+++ b/internal/cmd/project/project.go
@@ -51,6 +51,7 @@ func NewProjectCmd() *cobra.Command {
 	cmd.AddCommand(newFollowCmd())
 	cmd.AddCommand(newLinkCmd())
 	cmd.AddCommand(newEnvCmd())
+	cmd.AddCommand(newTriggerCmd())
 
 	return cmd
 }

--- a/internal/cmd/project/trigger.go
+++ b/internal/cmd/project/trigger.go
@@ -1,0 +1,477 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package project
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/apiclient"
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/cmdutil"
+	clierrors "github.com/CircleCI-Public/circleci-cli-v2/internal/errors"
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/gitremote"
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/iostream"
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/mdtable"
+)
+
+// validEventPresets lists the allowed values for --event-preset.
+var validEventPresets = []string{
+	"all-pushes",
+	"only-tags",
+	"default-branch-pushes",
+	"only-build-prs",
+	"only-open-prs",
+	"only-labeled-prs",
+	"only-merged-prs",
+	"only-ready-for-review-prs",
+	"only-branch-delete",
+	"only-build-pushes-to-non-draft-prs",
+	"only-merged-or-closed-prs",
+	"pr-comment-equals-run-ci",
+	"non-draft-pr-opened",
+	"pushes-to-merge-queues",
+}
+
+func newTriggerCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "trigger <command>",
+		Short: "Manage project triggers",
+		Long: heredoc.Doc(`
+			List and create triggers for a CircleCI project.
+
+			Triggers watch a GitHub repository for events and automatically run
+			a pipeline definition when matching events occur. Only projects
+			connected via the CircleCI GitHub App are supported.
+		`),
+	}
+
+	cmd.AddCommand(newTriggerListCmd())
+	cmd.AddCommand(newTriggerCreateCmd())
+
+	return cmd
+}
+
+// resolveProjectID returns the project UUID, looking it up from the slug if needed.
+// It uses --project-id directly, then --project slug, then the git remote.
+func resolveProjectID(ctx context.Context, client *apiclient.Client, projectSlug, projectID string) (string, error) {
+	if projectID != "" {
+		return projectID, nil
+	}
+	if projectSlug == "" {
+		info, err := gitremote.Detect()
+		if err != nil {
+			return "", cmdutil.GitDetectErr(err, "Or specify the project with --project gh/org/repo or --project-id <uuid>")
+		}
+		projectSlug = info.Slug
+	}
+	proj, err := client.GetProjectInfo(ctx, projectSlug)
+	if err != nil {
+		return "", cmdutil.APIErr(err, projectSlug, "project.not_found", "No project found for %q.",
+			"Run 'circleci project link' to bind this repository to a CircleCI project",
+			"Check the project slug and try again",
+			"Use 'circleci project list' to see followed projects")
+	}
+	return proj.ID, nil
+}
+
+// selectPipelineDefinition fetches the list of pipeline definitions for the project
+// and presents an interactive picker. Returns the chosen pipeline definition ID.
+// Only called when in interactive mode and --pipeline-definition-id was not given.
+func selectPipelineDefinition(ctx context.Context, client *apiclient.Client, projectID string) (string, error) {
+	defs, err := client.ListPipelineDefinitions(ctx, projectID)
+	if err != nil {
+		return "", cmdutil.APIErr(err, projectID, "pipeline_definition.list_failed",
+			"Failed to list pipeline definitions for project %q.",
+			"Check that the project ID is correct",
+			"Visit: https://app.circleci.com/settings/project/circleci/<org>/<project>/configurations")
+	}
+
+	if len(defs) == 0 {
+		return "", clierrors.New("pipeline_definition.none_found", "No pipeline definitions found",
+			"This project has no pipeline definitions yet.").
+			WithSuggestions(
+				"Create a pipeline definition in your CircleCI project settings under Pipelines",
+				"Visit: https://app.circleci.com/settings/project/circleci/<org>/<project>/configurations",
+			).
+			WithExitCode(clierrors.ExitNotFound)
+	}
+
+	labels := make([]string, len(defs))
+	for i, d := range defs {
+		label := d.Name
+		if d.Description != "" {
+			label = fmt.Sprintf("%s — %s", d.Name, d.Description)
+		}
+		labels[i] = label
+	}
+
+	idx, err := iostream.PromptSelect(ctx, "Select a pipeline definition", labels)
+	if err != nil {
+		return "", err
+	}
+	if idx < 0 {
+		return "", clierrors.New("trigger.cancelled", "Aborted",
+			"No pipeline definition selected.").
+			WithExitCode(clierrors.ExitCancelled)
+	}
+	return defs[idx].ID, nil
+}
+
+// --- trigger list ---
+
+func newTriggerListCmd() *cobra.Command {
+	var (
+		projectSlug          string
+		projectID            string
+		pipelineDefinitionID string
+		jsonOut              bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List triggers for a pipeline definition",
+		Long: heredoc.Doc(`
+			List all triggers attached to a pipeline definition.
+
+			The project is resolved from --project-id if provided; otherwise the
+			project slug (--project or git remote) is used to look up the project UUID.
+
+			--pipeline-definition-id is required. In a terminal it will be prompted
+			interactively if omitted; in non-interactive mode (CI, agents) it must
+			be passed as a flag.
+
+			JSON fields: id, created_at, event_name, event_preset, config_ref,
+			             checkout_ref, disabled, event_source.provider,
+			             event_source.repo.external_id, event_source.repo.full_name
+		`),
+		Example: heredoc.Doc(`
+			# List triggers for the current repository's project
+			$ circleci project trigger list \
+			    --pipeline-definition-id a1b2c3d4-...
+
+			# List triggers for a specific project
+			$ circleci project trigger list \
+			    --project gh/myorg/myrepo \
+			    --pipeline-definition-id a1b2c3d4-...
+
+			# Output as JSON for scripting
+			$ circleci project trigger list \
+			    --pipeline-definition-id a1b2c3d4-... \
+			    --json
+		`),
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := iostream.FromCmd(cmd.Context(), cmd)
+			client, err := cmdutil.LoadClient(ctx, cmd)
+			if err != nil {
+				return err
+			}
+			return runTriggerList(ctx, client, projectSlug, projectID, pipelineDefinitionID, jsonOut)
+		},
+	}
+
+	cmd.Flags().StringVar(&projectSlug, "project", "", "Project slug (e.g. gh/org/repo); defaults to git remote")
+	cmd.Flags().StringVar(&projectID, "project-id", "", "Project UUID (overrides --project)")
+	cmd.Flags().StringVar(&pipelineDefinitionID, "pipeline-definition-id", "", "Pipeline definition ID (required)")
+	cmdutil.AddJSONFlag(cmd, &jsonOut)
+	cmdutil.AddJQFlag(cmd)
+
+	return cmd
+}
+
+type triggerListEntry struct {
+	ID          string `json:"id"`
+	CreatedAt   string `json:"created_at"`
+	EventName   string `json:"event_name,omitempty"`
+	EventPreset string `json:"event_preset,omitempty"`
+	ConfigRef   string `json:"config_ref,omitempty"`
+	CheckoutRef string `json:"checkout_ref,omitempty"`
+	Disabled    bool   `json:"disabled"`
+	Provider    string `json:"provider"`
+	RepoID      string `json:"repo_external_id,omitempty"`
+	RepoName    string `json:"repo_full_name,omitempty"`
+}
+
+func runTriggerList(ctx context.Context, client *apiclient.Client, projectSlug, projectID, pipelineDefinitionID string, jsonOut bool) error {
+	resolvedProjectID, err := resolveProjectID(ctx, client, projectSlug, projectID)
+	if err != nil {
+		return err
+	}
+
+	if pipelineDefinitionID == "" {
+		if !iostream.IsInteractive(ctx) {
+			return clierrors.New("args.missing_flag", "Missing required flag",
+				"--pipeline-definition-id is required in non-interactive mode.").
+				WithSuggestions(
+					"Pass --pipeline-definition-id <uuid>",
+					"Find the ID in your CircleCI project settings under Pipelines",
+				).
+				WithExitCode(clierrors.ExitBadArguments)
+		}
+		pipelineDefinitionID, err = selectPipelineDefinition(ctx, client, resolvedProjectID)
+		if err != nil {
+			return err
+		}
+	}
+
+	triggers, err := client.ListTriggers(ctx, resolvedProjectID, pipelineDefinitionID)
+	if err != nil {
+		return cmdutil.APIErr(err, resolvedProjectID, "trigger.list_failed", "Failed to list triggers for project %q.",
+			"Check that the pipeline definition ID is correct",
+			"Visit: https://app.circleci.com/settings/project/circleci/<org>/<project>/configurations")
+	}
+
+	entries := make([]triggerListEntry, len(triggers))
+	for i, t := range triggers {
+		e := triggerListEntry{
+			ID:          t.ID,
+			CreatedAt:   t.CreatedAt.Format("2006-01-02T15:04:05Z"),
+			EventName:   t.EventName,
+			EventPreset: t.EventPreset,
+			ConfigRef:   t.ConfigRef,
+			CheckoutRef: t.CheckoutRef,
+			Disabled:    t.Disabled,
+			Provider:    t.EventSource.Provider,
+		}
+		if t.EventSource.Repo != nil {
+			e.RepoID = t.EventSource.Repo.ExternalID
+			e.RepoName = t.EventSource.Repo.FullName
+		}
+		entries[i] = e
+	}
+
+	if jsonOut {
+		return iostream.PrintJSON(ctx, entries)
+	}
+
+	if len(entries) == 0 {
+		iostream.ErrPrintln(ctx, "No triggers found.")
+		return nil
+	}
+
+	tbl := mdtable.New("ID", "Provider", "Repository", "Event Preset", "Disabled")
+	for _, e := range entries {
+		repo := e.RepoName
+		if repo == "" {
+			repo = e.RepoID
+		}
+		disabled := "no"
+		if e.Disabled {
+			disabled = "yes"
+		}
+		tbl.Row(e.ID, e.Provider, repo, e.EventPreset, disabled)
+	}
+	iostream.PrintMarkdown(ctx, "# Triggers\n"+tbl.Render())
+	return nil
+}
+
+// --- trigger create ---
+
+func newTriggerCreateCmd() *cobra.Command {
+	var (
+		projectSlug          string
+		projectID            string
+		pipelineDefinitionID string
+		repoID               string
+		eventPreset          string
+		configRef            string
+		checkoutRef          string
+		jsonOut              bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a new project trigger",
+		Long: heredoc.Docf(`
+			Create a new trigger for a CircleCI project.
+
+			A trigger connects a GitHub repository to a pipeline definition so that
+			matching events automatically start a pipeline run. Only projects using
+			the CircleCI GitHub App are supported.
+
+			The project is resolved from --project-id if provided; otherwise the
+			project slug (--project or git remote) is used to look up the project UUID.
+
+			--pipeline-definition-id and --repo-id are required. In a terminal they
+			will be prompted interactively if omitted; in non-interactive mode (CI,
+			agents) they must be passed as flags.
+
+			Valid --event-preset values:
+			  %s
+
+			JSON fields: id, created_at, event_name, event_preset, config_ref,
+			             checkout_ref, disabled
+		`, strings.Join(validEventPresets, "\n  ")),
+		Example: heredoc.Doc(`
+			# Create a trigger for the current git repository's project
+			$ circleci project trigger create \
+			    --pipeline-definition-id a1b2c3d4-... \
+			    --repo-id 123456789
+
+			# Create a trigger for a specific project
+			$ circleci project trigger create \
+			    --project gh/myorg/myrepo \
+			    --pipeline-definition-id a1b2c3d4-... \
+			    --repo-id 123456789
+
+			# Create a trigger with event filtering and output as JSON
+			$ circleci project trigger create \
+			    --pipeline-definition-id a1b2c3d4-... \
+			    --repo-id 123456789 \
+			    --event-preset all-pushes \
+			    --json
+		`),
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := iostream.FromCmd(cmd.Context(), cmd)
+			client, err := cmdutil.LoadClient(ctx, cmd)
+			if err != nil {
+				return err
+			}
+			return runTriggerCreate(ctx, client, projectSlug, projectID, pipelineDefinitionID, repoID, eventPreset, configRef, checkoutRef, jsonOut)
+		},
+	}
+
+	cmd.Flags().StringVar(&projectSlug, "project", "", "Project slug (e.g. gh/org/repo); defaults to git remote")
+	cmd.Flags().StringVar(&projectID, "project-id", "", "Project UUID (overrides --project)")
+	cmd.Flags().StringVar(&pipelineDefinitionID, "pipeline-definition-id", "", "Pipeline definition ID (required)")
+	cmd.Flags().StringVar(&repoID, "repo-id", "", "GitHub repository external ID (required)")
+	cmd.Flags().StringVar(&eventPreset, "event-preset", "", fmt.Sprintf("Event preset for filtering trigger events (one of: %s)", strings.Join(validEventPresets, ", ")))
+	cmd.Flags().StringVar(&configRef, "config-ref", "", "Git ref for fetching config (only needed when config repo differs from event source repo)")
+	cmd.Flags().StringVar(&checkoutRef, "checkout-ref", "", "Git ref for checking out code (only needed when checkout repo differs from event source repo)")
+	cmdutil.AddJSONFlag(cmd, &jsonOut)
+	cmdutil.AddJQFlag(cmd)
+
+	return cmd
+}
+
+type triggerCreateOutput struct {
+	ID          string `json:"id"`
+	CreatedAt   string `json:"created_at"`
+	EventName   string `json:"event_name,omitempty"`
+	EventPreset string `json:"event_preset,omitempty"`
+	ConfigRef   string `json:"config_ref,omitempty"`
+	CheckoutRef string `json:"checkout_ref,omitempty"`
+	Disabled    bool   `json:"disabled"`
+}
+
+func runTriggerCreate(
+	ctx context.Context,
+	client *apiclient.Client,
+	projectSlug, projectID, pipelineDefinitionID, repoID, eventPreset, configRef, checkoutRef string,
+	jsonOut bool,
+) error {
+	resolvedProjectID, err := resolveProjectID(ctx, client, projectSlug, projectID)
+	if err != nil {
+		return err
+	}
+
+	if pipelineDefinitionID == "" {
+		if !iostream.IsInteractive(ctx) {
+			return clierrors.New("args.missing_flag", "Missing required flag",
+				"--pipeline-definition-id is required in non-interactive mode.").
+				WithSuggestions(
+					"Pass --pipeline-definition-id <uuid>",
+					"Find the ID in your CircleCI project settings under Pipelines",
+					"Visit: https://app.circleci.com/settings/project/circleci/<org>/<project>/configurations",
+				).
+				WithExitCode(clierrors.ExitBadArguments)
+		}
+		pipelineDefinitionID, err = selectPipelineDefinition(ctx, client, resolvedProjectID)
+		if err != nil {
+			return err
+		}
+	}
+
+	if repoID == "" {
+		if !iostream.IsInteractive(ctx) {
+			return clierrors.New("args.missing_flag", "Missing required flag",
+				"--repo-id is required in non-interactive mode.").
+				WithSuggestions(
+					"Pass --repo-id <github-repo-id>",
+					"Find the repository ID via the GitHub API: GET /repos/{owner}/{repo}",
+					"See: https://docs.github.com/en/rest/repos/repos#get-a-repository",
+				).
+				WithExitCode(clierrors.ExitBadArguments)
+		}
+		var err error
+		repoID, err = iostream.PromptText(ctx,
+			"GitHub repository ID",
+			"e.g. 123456789")
+		if err != nil {
+			return err
+		}
+		if repoID == "" {
+			return clierrors.New("trigger.create_cancelled", "Aborted",
+				"No repository ID entered.").
+				WithExitCode(clierrors.ExitCancelled)
+		}
+	}
+
+	if eventPreset != "" {
+		if err := validateEventPreset(eventPreset); err != nil {
+			return err
+		}
+	}
+
+	resp, err := client.CreateTrigger(ctx, resolvedProjectID, pipelineDefinitionID, repoID, eventPreset, configRef, checkoutRef)
+	if err != nil {
+		return cmdutil.APIErr(err, resolvedProjectID, "trigger.create_failed", "Failed to create trigger for project %q.",
+			"Ensure the GitHub App is installed in your repository",
+			"Check that the pipeline definition ID and repository ID are correct",
+			"Visit: https://app.circleci.com/settings/project/circleci/<org>/<project>/configurations")
+	}
+
+	out := triggerCreateOutput{
+		ID:          resp.ID,
+		CreatedAt:   resp.CreatedAt.Format("2006-01-02T15:04:05Z"),
+		EventName:   resp.EventName,
+		EventPreset: resp.EventPreset,
+		ConfigRef:   resp.ConfigRef,
+		CheckoutRef: resp.CheckoutRef,
+		Disabled:    resp.Disabled,
+	}
+
+	if jsonOut {
+		return cmdutil.WriteJSON(iostream.Out(ctx), out)
+	}
+
+	iostream.Printf(ctx, "Trigger created (ID: %s)\n", out.ID)
+	return nil
+}
+
+func validateEventPreset(v string) *clierrors.CLIError {
+	for _, valid := range validEventPresets {
+		if v == valid {
+			return nil
+		}
+	}
+	return clierrors.New("args.invalid_event_preset", "Invalid --event-preset value",
+		fmt.Sprintf("%q is not a valid event preset.", v)).
+		WithSuggestions("Valid values: " + strings.Join(validEventPresets, ", ")).
+		WithExitCode(clierrors.ExitBadArguments)
+}

--- a/internal/cmd/project/trigger.go
+++ b/internal/cmd/project/trigger.go
@@ -38,6 +38,22 @@ import (
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/mdtable"
 )
 
+// repoProviders are the event source providers that require a repository ID.
+var repoProviders = map[string]bool{
+	"github_app":    true,
+	"github_server": true,
+	"github_oauth":  true,
+}
+
+// validProviders lists the allowed values for --provider.
+var validProviders = []string{
+	"github_app",
+	"github_server",
+	"github_oauth",
+	"webhook",
+	"schedule",
+}
+
 // validEventPresets lists the allowed values for --event-preset.
 var validEventPresets = []string{
 	"all-pushes",
@@ -296,6 +312,7 @@ func newTriggerCreateCmd() *cobra.Command {
 		projectSlug          string
 		projectID            string
 		pipelineDefinitionID string
+		provider             string
 		repoID               string
 		eventPreset          string
 		configRef            string
@@ -309,32 +326,36 @@ func newTriggerCreateCmd() *cobra.Command {
 		Long: heredoc.Docf(`
 			Create a new trigger for a CircleCI project.
 
-			A trigger connects a GitHub repository to a pipeline definition so that
-			matching events automatically start a pipeline run. Only projects using
-			the CircleCI GitHub App are supported.
+			A trigger connects an event source to a pipeline definition so that
+			matching events automatically start a pipeline run.
 
 			The project is resolved from --project-id if provided; otherwise the
 			project slug (--project or git remote) is used to look up the project UUID.
 
-			--pipeline-definition-id and --repo-id are required. In a terminal they
-			will be prompted interactively if omitted; in non-interactive mode (CI,
-			agents) they must be passed as flags.
+			--pipeline-definition-id is required. In a terminal it will be prompted
+			interactively if omitted (showing available pipeline definitions to choose
+			from); in non-interactive mode (CI, agents) it must be passed as a flag.
+
+			--repo-id is required for repo-based providers (github_app, github_server,
+			github_oauth). In a terminal it will be prompted if omitted.
+
+			Valid --provider values: %s
 
 			Valid --event-preset values:
 			  %s
 
 			JSON fields: id, created_at, event_name, event_preset, config_ref,
 			             checkout_ref, disabled
-		`, strings.Join(validEventPresets, "\n  ")),
+		`, strings.Join(validProviders, ", "), strings.Join(validEventPresets, "\n  ")),
 		Example: heredoc.Doc(`
-			# Create a trigger for the current git repository's project
+			# Create a GitHub App trigger (provider defaults to github_app)
 			$ circleci project trigger create \
 			    --pipeline-definition-id a1b2c3d4-... \
 			    --repo-id 123456789
 
-			# Create a trigger for a specific project
+			# Create a trigger for a GitHub Server installation
 			$ circleci project trigger create \
-			    --project gh/myorg/myrepo \
+			    --provider github_server \
 			    --pipeline-definition-id a1b2c3d4-... \
 			    --repo-id 123456789
 
@@ -352,14 +373,15 @@ func newTriggerCreateCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return runTriggerCreate(ctx, client, projectSlug, projectID, pipelineDefinitionID, repoID, eventPreset, configRef, checkoutRef, jsonOut)
+			return runTriggerCreate(ctx, client, projectSlug, projectID, pipelineDefinitionID, provider, repoID, eventPreset, configRef, checkoutRef, jsonOut)
 		},
 	}
 
 	cmd.Flags().StringVar(&projectSlug, "project", "", "Project slug (e.g. gh/org/repo); defaults to git remote")
 	cmd.Flags().StringVar(&projectID, "project-id", "", "Project UUID (overrides --project)")
 	cmd.Flags().StringVar(&pipelineDefinitionID, "pipeline-definition-id", "", "Pipeline definition ID (required)")
-	cmd.Flags().StringVar(&repoID, "repo-id", "", "GitHub repository external ID (required)")
+	cmd.Flags().StringVar(&provider, "provider", "github_app", fmt.Sprintf("Event source provider (one of: %s)", strings.Join(validProviders, ", ")))
+	cmd.Flags().StringVar(&repoID, "repo-id", "", "Repository external ID (required for github_app, github_server, github_oauth)")
 	cmd.Flags().StringVar(&eventPreset, "event-preset", "", fmt.Sprintf("Event preset for filtering trigger events (one of: %s)", strings.Join(validEventPresets, ", ")))
 	cmd.Flags().StringVar(&configRef, "config-ref", "", "Git ref for fetching config (only needed when config repo differs from event source repo)")
 	cmd.Flags().StringVar(&checkoutRef, "checkout-ref", "", "Git ref for checking out code (only needed when checkout repo differs from event source repo)")
@@ -382,9 +404,13 @@ type triggerCreateOutput struct {
 func runTriggerCreate(
 	ctx context.Context,
 	client *apiclient.Client,
-	projectSlug, projectID, pipelineDefinitionID, repoID, eventPreset, configRef, checkoutRef string,
+	projectSlug, projectID, pipelineDefinitionID, provider, repoID, eventPreset, configRef, checkoutRef string,
 	jsonOut bool,
 ) error {
+	if err := validateProvider(provider); err != nil {
+		return err
+	}
+
 	resolvedProjectID, err := resolveProjectID(ctx, client, projectSlug, projectID)
 	if err != nil {
 		return err
@@ -407,23 +433,23 @@ func runTriggerCreate(
 		}
 	}
 
-	if repoID == "" {
+	if repoID == "" && repoProviders[provider] {
 		if !iostream.IsInteractive(ctx) {
 			return clierrors.New("args.missing_flag", "Missing required flag",
-				"--repo-id is required in non-interactive mode.").
+				fmt.Sprintf("--repo-id is required for provider %q in non-interactive mode.", provider)).
 				WithSuggestions(
-					"Pass --repo-id <github-repo-id>",
+					"Pass --repo-id <external-repo-id>",
 					"Find the repository ID via the GitHub API: GET /repos/{owner}/{repo}",
 					"See: https://docs.github.com/en/rest/repos/repos#get-a-repository",
 				).
 				WithExitCode(clierrors.ExitBadArguments)
 		}
-		var err error
-		repoID, err = iostream.PromptText(ctx,
-			"GitHub repository ID",
+		var promptErr error
+		repoID, promptErr = iostream.PromptText(ctx,
+			"Repository external ID",
 			"e.g. 123456789")
-		if err != nil {
-			return err
+		if promptErr != nil {
+			return promptErr
 		}
 		if repoID == "" {
 			return clierrors.New("trigger.create_cancelled", "Aborted",
@@ -438,7 +464,7 @@ func runTriggerCreate(
 		}
 	}
 
-	resp, err := client.CreateTrigger(ctx, resolvedProjectID, pipelineDefinitionID, repoID, eventPreset, configRef, checkoutRef)
+	resp, err := client.CreateTrigger(ctx, resolvedProjectID, pipelineDefinitionID, provider, repoID, eventPreset, configRef, checkoutRef)
 	if err != nil {
 		return cmdutil.APIErr(err, resolvedProjectID, "trigger.create_failed", "Failed to create trigger for project %q.",
 			"Ensure the GitHub App is installed in your repository",
@@ -462,6 +488,18 @@ func runTriggerCreate(
 
 	iostream.Printf(ctx, "Trigger created (ID: %s)\n", out.ID)
 	return nil
+}
+
+func validateProvider(v string) *clierrors.CLIError {
+	for _, valid := range validProviders {
+		if v == valid {
+			return nil
+		}
+	}
+	return clierrors.New("args.invalid_provider", "Invalid --provider value",
+		fmt.Sprintf("%q is not a valid provider.", v)).
+		WithSuggestions("Valid values: " + strings.Join(validProviders, ", ")).
+		WithExitCode(clierrors.ExitBadArguments)
 }
 
 func validateEventPreset(v string) *clierrors.CLIError {

--- a/internal/cmd/root/testdata/usage/circleci/project.txt
+++ b/internal/cmd/root/testdata/usage/circleci/project.txt
@@ -7,6 +7,7 @@ Available Commands:
   get         Show project details
   link        Bind this checkout to a CircleCI project
   list        List followed projects
+  trigger     Manage project triggers
 
 Global Flags:
   -c, --config string   path to config file (default: ~/.config/circleci/config.yml)

--- a/internal/cmd/root/testdata/usage/circleci/project/trigger.txt
+++ b/internal/cmd/root/testdata/usage/circleci/project/trigger.txt
@@ -1,0 +1,13 @@
+Usage:
+  circleci project trigger [command]
+
+Available Commands:
+  create      Create a new project trigger
+  list        List triggers for a pipeline definition
+
+Global Flags:
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected
+
+Use "circleci project trigger [command] --help" for more information about a command.

--- a/internal/cmd/root/testdata/usage/circleci/project/trigger/create.txt
+++ b/internal/cmd/root/testdata/usage/circleci/project/trigger/create.txt
@@ -2,14 +2,14 @@ Usage:
   circleci project trigger create [flags]
 
 Examples:
-# Create a trigger for the current git repository's project
+# Create a GitHub App trigger (provider defaults to github_app)
 $ circleci project trigger create \
     --pipeline-definition-id a1b2c3d4-... \
     --repo-id 123456789
 
-# Create a trigger for a specific project
+# Create a trigger for a GitHub Server installation
 $ circleci project trigger create \
-    --project gh/myorg/myrepo \
+    --provider github_server \
     --pipeline-definition-id a1b2c3d4-... \
     --repo-id 123456789
 
@@ -30,7 +30,8 @@ Flags:
       --pipeline-definition-id string   Pipeline definition ID (required)
       --project string                  Project slug (e.g. gh/org/repo); defaults to git remote
       --project-id string               Project UUID (overrides --project)
-      --repo-id string                  GitHub repository external ID (required)
+      --provider string                 Event source provider (one of: github_app, github_server, github_oauth, webhook, schedule) (default "github_app")
+      --repo-id string                  Repository external ID (required for github_app, github_server, github_oauth)
 
 Global Flags:
   -c, --config string   path to config file (default: ~/.config/circleci/config.yml)

--- a/internal/cmd/root/testdata/usage/circleci/project/trigger/create.txt
+++ b/internal/cmd/root/testdata/usage/circleci/project/trigger/create.txt
@@ -1,0 +1,38 @@
+Usage:
+  circleci project trigger create [flags]
+
+Examples:
+# Create a trigger for the current git repository's project
+$ circleci project trigger create \
+    --pipeline-definition-id a1b2c3d4-... \
+    --repo-id 123456789
+
+# Create a trigger for a specific project
+$ circleci project trigger create \
+    --project gh/myorg/myrepo \
+    --pipeline-definition-id a1b2c3d4-... \
+    --repo-id 123456789
+
+# Create a trigger with event filtering and output as JSON
+$ circleci project trigger create \
+    --pipeline-definition-id a1b2c3d4-... \
+    --repo-id 123456789 \
+    --event-preset all-pushes \
+    --json
+
+
+Flags:
+      --checkout-ref string             Git ref for checking out code (only needed when checkout repo differs from event source repo)
+      --config-ref string               Git ref for fetching config (only needed when config repo differs from event source repo)
+      --event-preset string             Event preset for filtering trigger events (one of: all-pushes, only-tags, default-branch-pushes, only-build-prs, only-open-prs, only-labeled-prs, only-merged-prs, only-ready-for-review-prs, only-branch-delete, only-build-pushes-to-non-draft-prs, only-merged-or-closed-prs, pr-comment-equals-run-ci, non-draft-pr-opened, pushes-to-merge-queues)
+      --jq string                       Process values from the response using jq syntax
+      --json                            Output as JSON
+      --pipeline-definition-id string   Pipeline definition ID (required)
+      --project string                  Project slug (e.g. gh/org/repo); defaults to git remote
+      --project-id string               Project UUID (overrides --project)
+      --repo-id string                  GitHub repository external ID (required)
+
+Global Flags:
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/project/trigger/list.txt
+++ b/internal/cmd/root/testdata/usage/circleci/project/trigger/list.txt
@@ -1,0 +1,30 @@
+Usage:
+  circleci project trigger list [flags]
+
+Examples:
+# List triggers for the current repository's project
+$ circleci project trigger list \
+    --pipeline-definition-id a1b2c3d4-...
+
+# List triggers for a specific project
+$ circleci project trigger list \
+    --project gh/myorg/myrepo \
+    --pipeline-definition-id a1b2c3d4-...
+
+# Output as JSON for scripting
+$ circleci project trigger list \
+    --pipeline-definition-id a1b2c3d4-... \
+    --json
+
+
+Flags:
+      --jq string                       Process values from the response using jq syntax
+      --json                            Output as JSON
+      --pipeline-definition-id string   Pipeline definition ID (required)
+      --project string                  Project slug (e.g. gh/org/repo); defaults to git remote
+      --project-id string               Project UUID (overrides --project)
+
+Global Flags:
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected

--- a/internal/iostream/streams.go
+++ b/internal/iostream/streams.go
@@ -146,6 +146,13 @@ func PromptSecret(ctx context.Context, header string) (string, error) {
 	return fromContext(ctx).PromptSecret(ctx, header)
 }
 
+// PromptSelect presents an interactive single-choice list to the user and
+// returns the index of the selected option. Returns (-1, nil) if the user
+// cancels with esc or ctrl+c.
+func PromptSelect(ctx context.Context, prompt string, options []string) (int, error) {
+	return fromContext(ctx).PromptSelect(ctx, prompt, options)
+}
+
 // PromptText presents a plain (non-secret) single-line text input via
 // bubbletea. header is the bold heading above the input; placeholder is
 // shown inside the empty field. Returns ("", nil) if the user cancels with
@@ -445,6 +452,26 @@ func (s Streams) Confirm(ctx context.Context, prompt string) bool {
 		return false
 	}
 	return anyModel.(ui.ConfirmModel).Confirmed()
+}
+
+// PromptSelect presents a bubbletea single-choice list prompt.
+// Returns the selected index, or -1 if the user cancels.
+func (s Streams) PromptSelect(ctx context.Context, prompt string, options []string) (int, error) {
+	p := tea.NewProgram(
+		ui.NewSelectModel(prompt, options),
+		tea.WithContext(ctx),
+		tea.WithInput(s.In),
+		tea.WithOutput(s.Err),
+	)
+	anyModel, err := p.Run()
+	if err != nil {
+		return -1, err
+	}
+	m := anyModel.(ui.SelectModel)
+	if m.Cancelled() {
+		return -1, nil
+	}
+	return m.Selected(), nil
 }
 
 // PromptSecret presents a masked text input via bubbletea to collect a secret

--- a/internal/testing/fakes/circleci.go
+++ b/internal/testing/fakes/circleci.go
@@ -55,6 +55,9 @@ type CircleCI struct {
 	jobsV1                  map[string]any    // "vcs/org/repo/jobNumber" → job detail response (v1.1)
 	stepOutputs             map[string]string // path → JSON log lines content
 	triggerResponses        map[string]any    // project slug → trigger response body
+	pipelineDefinitions     map[string][]any  // projectID → list of pipeline definition objects
+	createTriggerResponses  map[string]any    // "projectID/pipelineDefinitionID" → response body
+	listTriggerResponses    map[string][]any  // "projectID/pipelineDefinitionID" → list of triggers
 	rerunResponses          map[string]int    // workflow id → HTTP status to return
 	cancelResponses         map[string]int    // workflow id → HTTP status to return
 	pipelineCancelResponses map[string]int    // pipeline id → HTTP status to return
@@ -111,6 +114,9 @@ func NewCircleCI(t *testing.T) *CircleCI {
 		jobsV1:                     map[string]any{},
 		stepOutputs:                map[string]string{},
 		triggerResponses:           map[string]any{},
+		pipelineDefinitions:        map[string][]any{},
+		createTriggerResponses:     map[string]any{},
+		listTriggerResponses:       map[string][]any{},
 		rerunResponses:             map[string]int{},
 		cancelResponses:            map[string]int{},
 		pipelineCancelResponses:    map[string]int{},
@@ -171,6 +177,9 @@ func NewCircleCI(t *testing.T) *CircleCI {
 	r.Post("/api/v2/project/{vcs}/{org}/{repo}/envvar", f.handleSetEnvVar)
 	r.Delete("/api/v2/project/{vcs}/{org}/{repo}/envvar/{name}", f.handleDeleteEnvVar)
 	r.Get("/api/v2/project/{vcs}/{org}/{repo}", f.handleGetProjectInfo)
+	r.Get("/api/v2/projects/{projectID}/pipeline-definitions", f.handleListPipelineDefinitions)
+	r.Get("/api/v2/projects/{projectID}/pipeline-definitions/{pipelineDefinitionID}/triggers", f.handleListTriggers)
+	r.Post("/api/v2/projects/{projectID}/pipeline-definitions/{pipelineDefinitionID}/triggers", f.handleCreateTrigger)
 	// Deploy routes.
 	r.Get("/api/v2/deploy/projects/{project_id}/releases", f.handleListDeploys)
 	// Runner (v3) routes. GET /runner dispatches on query param:
@@ -846,6 +855,32 @@ func (f *CircleCI) AddProjectInfo(slug string, info any) {
 	f.projectInfos[slug] = info
 }
 
+// AddPipelineDefinition registers a pipeline definition for a project, returned by
+// GET /api/v2/projects/{projectID}/pipeline-definitions.
+func (f *CircleCI) AddPipelineDefinition(projectID string, def any) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.pipelineDefinitions[projectID] = append(f.pipelineDefinitions[projectID], def)
+}
+
+// AddTrigger registers a trigger returned by GET
+// /api/v2/projects/{projectID}/pipeline-definitions/{pipelineDefinitionID}/triggers.
+func (f *CircleCI) AddTrigger(projectID, pipelineDefinitionID string, trigger any) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	key := projectID + "/" + pipelineDefinitionID
+	f.listTriggerResponses[key] = append(f.listTriggerResponses[key], trigger)
+}
+
+// SetCreateTriggerResponse registers the response body returned when POST
+// /api/v2/projects/{projectID}/pipeline-definitions/{pipelineDefinitionID}/triggers
+// is called. Pass nil to simulate a 404.
+func (f *CircleCI) SetCreateTriggerResponse(projectID, pipelineDefinitionID string, resp any) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.createTriggerResponses[projectID+"/"+pipelineDefinitionID] = resp
+}
+
 // AddFollowedProject registers a project returned by GET /api/v1.1/projects.
 // proj should be a map or struct with at least "slug", "username", and "reponame" fields.
 func (f *CircleCI) AddFollowedProject(proj any) {
@@ -1263,6 +1298,49 @@ func (f *CircleCI) handleDeleteContextRestriction(w http.ResponseWriter, r *http
 		return
 	}
 	render.JSON(w, r, map[string]any{"message": "Context restriction deleted."})
+}
+
+func (f *CircleCI) handleListPipelineDefinitions(w http.ResponseWriter, r *http.Request) {
+	projectID := chi.URLParam(r, "projectID")
+	f.mu.RLock()
+	items := f.pipelineDefinitions[projectID]
+	f.mu.RUnlock()
+
+	if items == nil {
+		items = []any{}
+	}
+	render.JSON(w, r, map[string]any{"items": items})
+}
+
+func (f *CircleCI) handleListTriggers(w http.ResponseWriter, r *http.Request) {
+	projectID := chi.URLParam(r, "projectID")
+	pipelineDefinitionID := chi.URLParam(r, "pipelineDefinitionID")
+	key := projectID + "/" + pipelineDefinitionID
+	f.mu.RLock()
+	items := f.listTriggerResponses[key]
+	f.mu.RUnlock()
+
+	if items == nil {
+		items = []any{}
+	}
+	render.JSON(w, r, map[string]any{"items": items})
+}
+
+func (f *CircleCI) handleCreateTrigger(w http.ResponseWriter, r *http.Request) {
+	projectID := chi.URLParam(r, "projectID")
+	pipelineDefinitionID := chi.URLParam(r, "pipelineDefinitionID")
+	key := projectID + "/" + pipelineDefinitionID
+	f.mu.RLock()
+	resp, ok := f.createTriggerResponses[key]
+	f.mu.RUnlock()
+
+	if !ok {
+		render.Status(r, http.StatusNotFound)
+		render.JSON(w, r, map[string]any{"message": "not found"})
+		return
+	}
+	render.Status(r, http.StatusCreated)
+	render.JSON(w, r, resp)
 }
 
 func (f *CircleCI) handleGetProjectInfo(w http.ResponseWriter, r *http.Request) {

--- a/internal/ui/select.go
+++ b/internal/ui/select.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package ui
+
+import (
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/ui/components"
+)
+
+// SelectModel is a top-level bubbletea model that wraps components.SelectModel
+// and quits the program on selection or cancellation.
+type SelectModel struct {
+	inner     components.SelectModel
+	cancelled bool
+}
+
+// NewSelectModel creates a standalone select prompt.
+// options is the list of choices to display.
+func NewSelectModel(prompt string, options []string) SelectModel {
+	return SelectModel{
+		inner: components.NewSelectModel(prompt, options),
+	}
+}
+
+// Selected returns the index of the chosen option. Only valid when !Cancelled().
+func (m SelectModel) Selected() int { return m.inner.Selected() }
+
+// Cancelled reports whether the user quit without selecting.
+func (m SelectModel) Cancelled() bool { return m.cancelled }
+
+func (m SelectModel) Init() tea.Cmd { return nil }
+
+func (m SelectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if keyMsg, ok := msg.(tea.KeyPressMsg); ok {
+		switch keyMsg.String() {
+		case components.KeyEsc, components.KeyCtrlC:
+			m.cancelled = true
+			return m, tea.Quit
+		case components.KeyEnter:
+			updated, _ := m.inner.Update(msg)
+			m.inner = updated.(components.SelectModel)
+			return m, tea.Quit
+		}
+	}
+	updated, cmd := m.inner.Update(msg)
+	m.inner = updated.(components.SelectModel)
+	return m, cmd
+}
+
+func (m SelectModel) View() tea.View {
+	return m.inner.View()
+}


### PR DESCRIPTION
## Summary

- Adds `circleci project trigger list` and `circleci project trigger create` under a new `project trigger` command group
- Both commands resolve the project UUID from `--project-id`, `--project` slug, or git remote detection
- When `--pipeline-definition-id` is omitted in a terminal, the project's pipeline definitions are fetched and presented as an interactive picker (↑/↓ + enter); non-interactive mode requires the flag explicitly
- `create` validates `--event-preset` against the full enum from the API spec and supports `--repo-id`, `--config-ref`, and `--checkout-ref`

## New infrastructure

- `GET /projects/{id}/pipeline-definitions` API client method (`apiclient/pipeline_definition.go`)
- `GET/POST /projects/{project_id}/pipeline-definitions/{pipeline_definition_id}/triggers` API client methods (`apiclient/trigger.go`)
- `PromptSelect` bubbletea wrapper in `iostream` backed by a new `ui.SelectModel`
- Fake server handlers for pipeline definitions and triggers

## Test plan

- [ ] `task test` passes (503 tests)
- [ ] `circleci project trigger list --pipeline-definition-id <id>` lists triggers in table and `--json` form
- [ ] `circleci project trigger create --pipeline-definition-id <id> --repo-id <id>` creates a trigger
- [ ] Omitting `--pipeline-definition-id` in a TTY shows the pipeline definition picker
- [ ] Omitting required flags in non-interactive mode returns exit code 2 with a clear suggestion
- [ ] Invalid `--event-preset` value returns exit code 2 listing valid values