### PR TITLE
perf(logs): fetch job steps concurrently

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/zalando/go-keyring v0.2.8
 	golang.org/x/oauth2 v0.36.0
+	golang.org/x/sync v0.20.0
 	golang.org/x/sys v0.43.0
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/v3 v3.5.2
@@ -69,6 +70,5 @@ require (
 	github.com/yuin/goldmark-emoji v1.0.6 // indirect
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
 	golang.org/x/net v0.53.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
 )

--- a/internal/bulkhead/work.go
+++ b/internal/bulkhead/work.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+// Package bulkhead runs a slice of work with bounded parallelism.
+package bulkhead
+
+import (
+	"context"
+
+	"golang.org/x/sync/errgroup"
+)
+
+// Do calls f for each element of input, running at most maxParallelism
+// goroutines concurrently. f receives the element and its original index.
+// The first error returned by any f cancels remaining work and is returned.
+func Do[T any](ctx context.Context, maxParallelism int, input []T, f func(e T, i int) error) error {
+	count := len(input)
+
+	type elem struct {
+		v T
+		i int
+	}
+
+	ch := make(chan elem, count)
+	defer close(ch)
+	for i, v := range input {
+		ch <- elem{v: v, i: i}
+	}
+
+	g, ctx := errgroup.WithContext(ctx)
+
+	parallelism := min(maxParallelism, count)
+	for range parallelism {
+		g.Go(func() error {
+			ctxDone := ctx.Done()
+			for {
+				select {
+				case e := <-ch:
+					if err := f(e.v, e.i); err != nil {
+						return err
+					}
+				case <-ctxDone:
+					return ctx.Err()
+				default:
+					return nil
+				}
+			}
+		})
+	}
+	return g.Wait()
+}

--- a/internal/logs/logs.go
+++ b/internal/logs/logs.go
@@ -26,9 +26,9 @@ package logs
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/apiclient"
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/bulkhead"
 )
 
 const statusFailed = "failed"
@@ -41,50 +41,39 @@ type StepLog struct {
 	Output   string `json:"output"`
 }
 
+// maxStepParallelism caps concurrent step-output fetches to avoid hammering
+// the API or exhausting file descriptors on jobs with many steps.
+const maxStepParallelism = 8
+
 // ForJob fetches the log output for every step in a job, returning one StepLog
 // per step. If stepFilter is non-empty, only steps whose name matches are included.
-// Steps are fetched concurrently; output order matches the original step order.
+// Steps are fetched concurrently (up to maxStepParallelism at a time); output
+// order matches the original step order.
 func ForJob(ctx context.Context, client *apiclient.Client, projectSlug string, jobNumber int64, stepFilter string) ([]StepLog, error) {
 	job, err := client.GetJob(ctx, projectSlug, jobNumber)
 	if err != nil {
 		return nil, err
 	}
 
-	// Collect the steps we actually need to fetch.
-	type indexedStep struct {
-		idx  int
-		step apiclient.JobStep
-	}
-	var toFetch []indexedStep
-	for i, step := range job.Steps {
+	var toFetch []apiclient.JobStep
+	for _, step := range job.Steps {
 		if stepFilter != "" && step.Name != stepFilter {
 			continue
 		}
-		toFetch = append(toFetch, indexedStep{i, step})
+		toFetch = append(toFetch, step)
 	}
 
 	results := make([]StepLog, len(toFetch))
-	errs := make([]error, len(toFetch))
-
-	var wg sync.WaitGroup
-	for i, item := range toFetch {
-		wg.Add(1)
-		go func(resultIdx int, s apiclient.JobStep) {
-			defer wg.Done()
-			sl, ferr := fetchStep(ctx, client, s)
-			if ferr != nil {
-				errs[resultIdx] = fmt.Errorf("fetching output for step %q: %w", s.Name, ferr)
-				return
-			}
-			results[resultIdx] = sl
-		}(i, item.step)
-	}
-	wg.Wait()
-
-	for _, ferr := range errs {
-		if ferr != nil {
-			return nil, ferr
+	err = bulkhead.Do(ctx, maxStepParallelism, toFetch, func(step apiclient.JobStep, i int) error {
+		sl, err := fetchStep(ctx, client, step)
+		if err != nil {
+			return fmt.Errorf("fetching output for step %q: %w", step.Name, err)
 		}
+		results[i] = sl
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 	return results, nil
 }

--- a/internal/logs/logs.go
+++ b/internal/logs/logs.go
@@ -26,6 +26,7 @@ package logs
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/apiclient"
 )
@@ -42,22 +43,48 @@ type StepLog struct {
 
 // ForJob fetches the log output for every step in a job, returning one StepLog
 // per step. If stepFilter is non-empty, only steps whose name matches are included.
+// Steps are fetched concurrently; output order matches the original step order.
 func ForJob(ctx context.Context, client *apiclient.Client, projectSlug string, jobNumber int64, stepFilter string) ([]StepLog, error) {
 	job, err := client.GetJob(ctx, projectSlug, jobNumber)
 	if err != nil {
 		return nil, err
 	}
 
-	var results []StepLog
-	for _, step := range job.Steps {
+	// Collect the steps we actually need to fetch.
+	type indexedStep struct {
+		idx  int
+		step apiclient.JobStep
+	}
+	var toFetch []indexedStep
+	for i, step := range job.Steps {
 		if stepFilter != "" && step.Name != stepFilter {
 			continue
 		}
-		sl, err := fetchStep(ctx, client, step)
-		if err != nil {
-			return nil, fmt.Errorf("fetching output for step %q: %w", step.Name, err)
+		toFetch = append(toFetch, indexedStep{i, step})
+	}
+
+	results := make([]StepLog, len(toFetch))
+	errs := make([]error, len(toFetch))
+
+	var wg sync.WaitGroup
+	for i, item := range toFetch {
+		wg.Add(1)
+		go func(resultIdx int, s apiclient.JobStep) {
+			defer wg.Done()
+			sl, ferr := fetchStep(ctx, client, s)
+			if ferr != nil {
+				errs[resultIdx] = fmt.Errorf("fetching output for step %q: %w", s.Name, ferr)
+				return
+			}
+			results[resultIdx] = sl
+		}(i, item.step)
+	}
+	wg.Wait()
+
+	for _, ferr := range errs {
+		if ferr != nil {
+			return nil, ferr
 		}
-		results = append(results, sl)
 	}
 	return results, nil
 }


### PR DESCRIPTION
## Problem

`circleci logs` fetched each job step sequentially in `ForJob`. With per-step latency averaging ~1.6 s and underlying API calls taking ~350–470 ms, the overhead compounded with every step — a 10-step job took ~16 s of wall time, most of it just waiting.

## Fix

Introduce `internal/bulkhead` — a small generic helper (ported from `circleci/ciam-gateway`) that distributes a slice of work across a bounded worker pool using `errgroup`:

```go
func Do[T any](ctx context.Context, maxParallelism int, input []T, f func(e T, i int) error) error
```

`ForJob` now fetches steps with up to 8 concurrent workers. Results are written into a pre-indexed slice so output order is preserved. `errgroup` cancels remaining work on the first error and propagates context cancellation, which is cleaner than the manual `errs[]` slice approach.

```
Before: total latency ≈ Σ(per-step latency)   — O(N)
After:  total latency ≈ Σ(per-step latency) / 8 — O(N/8)
```

The parallelism cap avoids hammering the API or exhausting file descriptors on jobs with many steps.

## Changes

- `internal/bulkhead/work.go`: new generic bounded worker pool
- `internal/logs/logs.go`: wire `ForJob` through `bulkhead.Do`
- `go.mod`: promote `golang.org/x/sync` from indirect to direct dependency