### PR TITLE
feat(init): scaffold onboarding command

### DIFF
--- a/acceptance/init_test.go
+++ b/acceptance/init_test.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package acceptance_test
+
+import (
+	"os/exec"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/testing/binary"
+	testenv "github.com/CircleCI-Public/circleci-cli-v2/internal/testing/env"
+)
+
+func TestInit_InGitRepo(t *testing.T) {
+	dir := t.TempDir()
+	out, err := exec.Command("git", "init", dir).CombinedOutput()
+	assert.NilError(t, err, "git init failed: %s", out)
+
+	env := testenv.New(t)
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"init"},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	for _, step := range []string{
+		"Git repository detected",
+		"[1/3] Scanning repository",
+		"[2/3] Running tests in Docker",
+		"[3/3] Generating config",
+		"sign up for CircleCI",
+		"https://circleci.com/signup",
+	} {
+		assert.Check(t, cmp.Contains(result.Stderr, step),
+			"expected %q in stderr, got: %s", step, result.Stderr)
+	}
+}
+
+func TestInit_Help(t *testing.T) {
+	env := testenv.New(t)
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"init", "--help"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	for _, phase := range []string{
+		"Scan your repo",
+		"Docker container",
+		"Generate a config",
+		"Sign up for CircleCI",
+	} {
+		assert.Check(t, cmp.Contains(result.Stdout, phase),
+			"--help is missing onboarding phase %q; stdout: %s", phase, result.Stdout)
+	}
+}
+
+func TestInit_NotInGitRepo(t *testing.T) {
+	env := testenv.New(t)
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"init"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 2, "expected ExitBadArguments=2, stderr: %s", result.Stderr)
+	assert.Check(t, cmp.Contains(result.Stderr, "valid git repository"),
+		"expected 'valid git repository' guidance in stderr, got: %s", result.Stderr)
+	assert.Check(t, cmp.Contains(result.Stderr, "cd <path>"),
+		"expected cd suggestion in stderr, got: %s", result.Stderr)
+}

--- a/acceptance/init_test.go
+++ b/acceptance/init_test.go
@@ -23,7 +23,10 @@
 package acceptance_test
 
 import (
+	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -49,15 +52,44 @@ func TestInit_InGitRepo(t *testing.T) {
 	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
 	for _, step := range []string{
 		"Git repository detected",
+		"This will run in your selected repo: " + filepath.Base(dir),
 		"[1/3] Scanning repository",
 		"[2/3] Running tests in Docker",
 		"[3/3] Generating config",
 		"sign up for CircleCI",
 		"https://circleci.com/signup",
+		"Runs on git events and webhooks",
+		"Pass/fail checks on PRs",
+		"Optimize speed with test parallelism",
+		"Deploy to staging or prod",
 	} {
 		assert.Check(t, cmp.Contains(result.Stderr, step),
 			"expected %q in stderr, got: %s", step, result.Stderr)
 	}
+	assert.Check(t, cmp.Equal(result.Stdout, ""), "expected init progress on stderr only")
+}
+
+func TestInit_InNestedGitDirectoryUsesRepoRootName(t *testing.T) {
+	dir := t.TempDir()
+	out, err := exec.Command("git", "init", dir).CombinedOutput()
+	assert.NilError(t, err, "git init failed: %s", out)
+
+	nested := filepath.Join(dir, "src", "app")
+	assert.NilError(t, os.MkdirAll(nested, 0o755))
+
+	env := testenv.New(t)
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"init"},
+		Env:     env.Environ(),
+		WorkDir: nested,
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Check(t, cmp.Contains(result.Stderr, "This will run in your selected repo: "+filepath.Base(dir)),
+		"expected root repo name in stderr, got: %s", result.Stderr)
+	assert.Check(t, !strings.Contains(result.Stderr, "This will run in your selected repo: app"),
+		"expected nested directory name not to be used as repo name, got: %s", result.Stderr)
 }
 
 func TestInit_Help(t *testing.T) {
@@ -95,4 +127,22 @@ func TestInit_NotInGitRepo(t *testing.T) {
 		"expected 'valid git repository' guidance in stderr, got: %s", result.Stderr)
 	assert.Check(t, cmp.Contains(result.Stderr, "cd <path>"),
 		"expected cd suggestion in stderr, got: %s", result.Stderr)
+}
+
+func TestInit_RejectsExtraArgs(t *testing.T) {
+	dir := t.TempDir()
+	out, err := exec.Command("git", "init", dir).CombinedOutput()
+	assert.NilError(t, err, "git init failed: %s", out)
+
+	env := testenv.New(t)
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"init", "extra"},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	assert.Check(t, result.ExitCode != 0, "expected extra args to fail")
+	assert.Check(t, cmp.Contains(result.Stderr, `unknown command "extra"`),
+		"expected extra arg error in stderr, got: %s", result.Stderr)
 }

--- a/internal/cmd/cmdinit/init.go
+++ b/internal/cmd/cmdinit/init.go
@@ -24,7 +24,6 @@
 package cmdinit
 
 import (
-	"os"
 	"path/filepath"
 
 	"github.com/MakeNowJust/heredoc"
@@ -70,7 +69,8 @@ func NewInitCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := iostream.FromCmd(cmd.Context(), cmd)
 
-			if !gitremote.InsideWorkTree() {
+			root, err := gitremote.WorkTreeRoot()
+			if err != nil {
 				return clierrors.New("init.not_in_git_repo",
 					"Not in a git repository",
 					"You must be in a valid git repository directory to run this command.").
@@ -81,8 +81,7 @@ func NewInitCmd() *cobra.Command {
 			}
 
 			ok := iostream.SymbolOK(ctx)
-			cwd, _ := os.Getwd()
-			repoName := filepath.Base(cwd)
+			repoName := filepath.Base(root)
 
 			iostream.ErrPrintf(ctx, "%s Git repository detected.\n\n", ok)
 			iostream.ErrPrintf(ctx, "circleci init will:\n")
@@ -97,6 +96,10 @@ func NewInitCmd() *cobra.Command {
 
 			iostream.ErrPrintf(ctx, "Next: sign up for CircleCI to run your generated config file.\n")
 			iostream.ErrPrintf(ctx, "  %s\n", signupURL)
+			iostream.ErrPrintf(ctx, "  • Runs on git events and webhooks\n")
+			iostream.ErrPrintf(ctx, "  • Pass/fail checks on PRs with shared dashboards and Slack alerts\n")
+			iostream.ErrPrintf(ctx, "  • Optimize speed with test parallelism and larger resource classes\n")
+			iostream.ErrPrintf(ctx, "  • Deploy to staging or prod after tests pass, gated on branch\n")
 			return nil
 		},
 	}

--- a/internal/cmd/cmdinit/init.go
+++ b/internal/cmd/cmdinit/init.go
@@ -1,0 +1,103 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+// Package cmdinit implements the "circleci init" onboarding command.
+package cmdinit
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+
+	clierrors "github.com/CircleCI-Public/circleci-cli-v2/internal/errors"
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/gitremote"
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/iostream"
+)
+
+const signupURL = "https://circleci.com/signup"
+
+// NewInitCmd returns the "circleci init" command.
+//
+// This is the shell for the CLI onboarding flow (WEBXP-987). Each of the four
+// phases (Scan, Test, Generate, Sign up) is a stub here and will be filled in
+// by follow-up tickets.
+func NewInitCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "init",
+		Short: "Set up CircleCI for the current project",
+		Long: heredoc.Doc(`
+			Walk through onboarding for the current project. circleci init will:
+
+			  1. Scan your repo for tests
+			  2. Run the tests in a Docker container using CircleCI's test framework
+			  3. Generate a config file that can run your tests with CircleCI
+			  4. Sign up for CircleCI to run your generated config
+
+			Run from inside a git repository.
+		`),
+		Example: heredoc.Doc(`
+			# Start onboarding from the current repo
+			$ circleci init
+
+			# Inspect what each step will do
+			$ circleci init --help
+
+			# Re-run onboarding to regenerate config
+			$ cd path/to/repo && circleci init
+		`),
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			ctx := iostream.FromCmd(cmd.Context(), cmd)
+
+			if !gitremote.InsideWorkTree() {
+				return clierrors.New("init.not_in_git_repo",
+					"Not in a git repository",
+					"You must be in a valid git repository directory to run this command.").
+					WithSuggestions(
+						"Use `cd <path>` to navigate to your project, then try again.",
+					).
+					WithExitCode(clierrors.ExitBadArguments)
+			}
+
+			ok := iostream.SymbolOK(ctx)
+			cwd, _ := os.Getwd()
+			repoName := filepath.Base(cwd)
+
+			iostream.ErrPrintf(ctx, "%s Git repository detected.\n\n", ok)
+			iostream.ErrPrintf(ctx, "circleci init will:\n")
+			iostream.ErrPrintf(ctx, "  • Scan your repo for tests\n")
+			iostream.ErrPrintf(ctx, "  • Run the tests in a Docker container using CircleCI's test framework\n")
+			iostream.ErrPrintf(ctx, "  • Generate a config file that can run your tests with CircleCI\n\n")
+			iostream.ErrPrintf(ctx, "This will run in your selected repo: %s\n\n", repoName)
+
+			iostream.ErrPrintf(ctx, "[1/3] Scanning repository (stub)\n")
+			iostream.ErrPrintf(ctx, "[2/3] Running tests in Docker (stub)\n")
+			iostream.ErrPrintf(ctx, "[3/3] Generating config (stub)\n\n")
+
+			iostream.ErrPrintf(ctx, "Next: sign up for CircleCI to run your generated config file.\n")
+			iostream.ErrPrintf(ctx, "  %s\n", signupURL)
+			return nil
+		},
+	}
+}

--- a/internal/cmd/cmdinit/init_test.go
+++ b/internal/cmd/cmdinit/init_test.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package cmdinit
+
+import (
+	"bytes"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+)
+
+func TestNewInitCmd_Registration(t *testing.T) {
+	cmd := NewInitCmd()
+	assert.Equal(t, cmd.Use, "init")
+	assert.Check(t, cmd.RunE != nil, "init command must have a RunE")
+	assert.Check(t, cmd.Short != "", "init command must have a Short description")
+	assert.Check(t, cmd.Long != "", "init command must have a Long description")
+	assert.Check(t, cmd.Example != "", "init command must have examples")
+}
+
+func TestNewInitCmd_HelpNamesAllFourSteps(t *testing.T) {
+	cmd := NewInitCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"--help"})
+	assert.NilError(t, cmd.Execute())
+
+	help := buf.String()
+	for _, phase := range []string{
+		"Scan your repo",
+		"Docker container",
+		"Generate a config",
+		"Sign up for CircleCI",
+	} {
+		assert.Check(t, cmp.Contains(help, phase),
+			"--help output is missing onboarding phase %q", phase)
+	}
+}

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -31,6 +31,7 @@ import (
 	cmdapi "github.com/CircleCI-Public/circleci-cli-v2/internal/cmd/api"
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/cmd/artifacts"
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/cmd/cmdauth"
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/cmd/cmdinit"
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/cmd/completion"
 	cmdcontext "github.com/CircleCI-Public/circleci-cli-v2/internal/cmd/context"
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/cmd/deploy"
@@ -103,6 +104,7 @@ func NewRootCmd(version string) *cobra.Command {
 	cmd.AddCommand(cmdversion.NewVersionCmd(version))
 	cmd.AddCommand(completion.NewCompletionCmd())
 	cmd.AddCommand(envvar.NewEnvVarCmd())
+	cmd.AddCommand(cmdinit.NewInitCmd())
 	cmd.AddCommand(project.NewGetCmd("info")) // Alias to project get
 	cmd.AddCommand(job.NewJobCmd())
 	cmd.AddCommand(cmdrun.NewRunCmd())

--- a/internal/cmd/root/testdata/usage/circleci.txt
+++ b/internal/cmd/root/testdata/usage/circleci.txt
@@ -10,6 +10,7 @@ Available Commands:
   deploy      Manage deploys
   envvar      Manage project environment variables
   info        Show project details
+  init        Set up CircleCI for the current project
   job         Manage jobs
   logs        Fetch job logs
   mcp         MCP server management

--- a/internal/cmd/root/testdata/usage/circleci/init.txt
+++ b/internal/cmd/root/testdata/usage/circleci/init.txt
@@ -1,0 +1,18 @@
+Usage:
+  circleci init [flags]
+
+Examples:
+# Start onboarding from the current repo
+$ circleci init
+
+# Inspect what each step will do
+$ circleci init --help
+
+# Re-run onboarding to regenerate config
+$ cd path/to/repo && circleci init
+
+
+Global Flags:
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected

--- a/internal/gitremote/detect.go
+++ b/internal/gitremote/detect.go
@@ -72,8 +72,19 @@ func DetectNamespace() (string, error) {
 // git working tree. Used by commands that only need to confirm "is this a
 // repo" without requiring a parseable CircleCI remote.
 func InsideWorkTree() bool {
-	out, err := gitOutput("rev-parse", "--is-inside-work-tree")
-	return err == nil && out == "true"
+	_, err := WorkTreeRoot()
+	return err == nil
+}
+
+// WorkTreeRoot returns the absolute path to the current git working tree root.
+// It is intentionally looser than Detect: fresh init targets may not have a
+// CircleCI-compatible remote yet.
+func WorkTreeRoot() (string, error) {
+	out, err := gitOutput("rev-parse", "--show-toplevel")
+	if err != nil {
+		return "", err
+	}
+	return out, nil
 }
 
 // Detect resolves the CircleCI project for the current working directory.

--- a/internal/gitremote/detect.go
+++ b/internal/gitremote/detect.go
@@ -68,6 +68,14 @@ func DetectNamespace() (string, error) {
 	return parts[1], nil
 }
 
+// InsideWorkTree reports whether the current working directory is inside a
+// git working tree. Used by commands that only need to confirm "is this a
+// repo" without requiring a parseable CircleCI remote.
+func InsideWorkTree() bool {
+	out, err := gitOutput("rev-parse", "--is-inside-work-tree")
+	return err == nil && out == "true"
+}
+
 // Detect resolves the CircleCI project for the current working directory.
 //
 // Resolution priority:

--- a/internal/gitremote/detect_test.go
+++ b/internal/gitremote/detect_test.go
@@ -24,6 +24,7 @@ package gitremote
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 
@@ -217,4 +218,27 @@ func TestDetectFromRemote_IgnoresInfoYml(t *testing.T) {
 	// And info.yml is still present — DetectFromRemote did not consume it.
 	_, statErr := os.Stat(filepath.Join(dir, projectref.FilePath))
 	assert.NilError(t, statErr)
+}
+
+func TestWorkTreeRoot_FromNestedDirectory(t *testing.T) {
+	dir := t.TempDir()
+	out, err := exec.Command("git", "init", dir).CombinedOutput()
+	assert.NilError(t, err, "git init failed: %s", out)
+
+	nested := filepath.Join(dir, "one", "two")
+	assert.NilError(t, os.MkdirAll(nested, 0o755))
+
+	cwd, err := os.Getwd()
+	assert.NilError(t, err)
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	assert.NilError(t, os.Chdir(nested))
+
+	root, err := WorkTreeRoot()
+	assert.NilError(t, err)
+	realRoot, err := filepath.EvalSymlinks(root)
+	assert.NilError(t, err)
+	realDir, err := filepath.EvalSymlinks(dir)
+	assert.NilError(t, err)
+	assert.Check(t, cmp.Equal(realRoot, realDir))
+	assert.Check(t, InsideWorkTree(), "expected nested directory to be inside work tree")
 }


### PR DESCRIPTION
## Summary

This PR combines Keaton's initial `circleci init` scaffold with a small follow-up polish pass for the first onboarding steps.

- Registers a top-level `circleci init` command on `next`.
- Keeps scan, Docker test, config generation, and signup as scaffolded/stubbed steps.
- Adds git worktree-root detection so nested directories display the selected repo correctly.
- Adds signup CTA benefit bullets from the prototype without wiring signup/login/OAuth behavior.
- Adds acceptance coverage for nested git directories, stderr-only progress output, CTA copy, and extra args failing.

## Out of scope

- Real repository scanning
- Real Docker test execution
- Real config generation
- Signup/login/OAuth wiring, including Enter-to-signup behavior
- Telemetry
- JSON output

## Testing

- `go test ./internal/gitremote ./internal/cmd/cmdinit`
- `go test ./acceptance -run TestInit`

## Notes

This branch is based on current `origin/next` and includes Keaton's scaffold commit plus the follow-up polish commit.