### PR TITLE
feat(auth): add 'auth signup' command

### DIFF
--- a/acceptance/auth_signup_test.go
+++ b/acceptance/auth_signup_test.go
@@ -1,0 +1,206 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package acceptance_test
+
+import (
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/testing/binary"
+	testenv "github.com/CircleCI-Public/circleci-cli-v2/internal/testing/env"
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/testing/fakes"
+)
+
+func TestAuthSignup_AppearsInAuthHelp(t *testing.T) {
+	env := testenv.New(t)
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"auth", "--help"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Assert(t, strings.Contains(result.Stdout, "signup"),
+		"auth --help should list the signup subcommand:\n%s", result.Stdout)
+}
+
+func TestAuthSignup_OwnHelp(t *testing.T) {
+	env := testenv.New(t)
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"auth", "signup", "--help"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Assert(t, strings.Contains(result.Stdout, "Create a CircleCI account"),
+		"auth signup --help should describe the command:\n%s", result.Stdout)
+	// 3+ examples requirement → 3+ shell-prompt lines beginning with "$ ".
+	assert.Assert(t, strings.Count(result.Stdout, "\n$ ") >= 3,
+		"expected ≥3 examples in help output:\n%s", result.Stdout)
+}
+
+// TestAuthSignup_Timeout exercises the wait-for-callback path. The fake
+// server is started but never delivers a callback — the CLI should print
+// the signup URL (with signup=true and a loopback redirect_uri) and then
+// time out cleanly with ExitTimeout.
+func TestAuthSignup_Timeout(t *testing.T) {
+	fake := fakes.NewCircleCI(t)
+	env := testenv.New(t)
+	env.CircleCIURL = fake.URL()
+	env.Extra["CIRCLECI_LOGIN_TIMEOUT"] = "200ms"
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"auth", "signup", "--insecure-storage"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 8, "stderr: %s", result.Stderr) // ExitTimeout
+	assert.Assert(t, strings.Contains(result.Stderr, "Signup timed out"),
+		"stderr should contain timeout message:\n%s", result.Stderr)
+	// Verify the URL the CLI printed carries signup=true.
+	assert.Assert(t, strings.Contains(result.Stderr, "signup=true"),
+		"authorize URL must include signup=true:\n%s", result.Stderr)
+	// Verify it's a loopback redirect URI shape.
+	assert.Assert(t, strings.Contains(result.Stderr, "127.0.0.1%3A") ||
+		strings.Contains(result.Stderr, "127.0.0.1:"),
+		"authorize URL must include a loopback redirect_uri:\n%s", result.Stderr)
+}
+
+// TestAuthSignup_AlreadyAuthenticated asserts that running `circleci auth
+// signup` while a token is already configured refuses with a clear error
+// and helpful suggestions, rather than silently overwriting the token.
+func TestAuthSignup_AlreadyAuthenticated(t *testing.T) {
+	env := testenv.New(t)
+	env.Token = "preexisting-token"
+	// Intentionally unreachable — we want to confirm the guard short-circuits
+	// before any network or browser activity.
+	env.CircleCIURL = "https://example.invalid"
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"auth", "signup"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 3, "stderr: %s", result.Stderr) // ExitAuthError
+	assert.Assert(t, strings.Contains(result.Stderr, "Already authenticated"),
+		"stderr should mention the conflict:\n%s", result.Stderr)
+	assert.Assert(t, strings.Contains(result.Stderr, "circleci auth logout"),
+		"stderr should suggest auth logout:\n%s", result.Stderr)
+	assert.Assert(t, strings.Contains(result.Stderr, "circleci auth login"),
+		"stderr should suggest auth login as an alternative:\n%s", result.Stderr)
+}
+
+// TestAuthSignup_HappyPath drives the full signup flow against the fake
+// server, mirroring TestAuthLogin_Browser. The CLI prints the authorize
+// URL on a PTY; the test scrapes it, hits the loopback redirect_uri with a
+// fake code, and asserts the CLI exchanges the code, prints "Signed up as
+// …", and persists the token to YAML (--insecure-storage path).
+func TestAuthSignup_HappyPath(t *testing.T) {
+	ctx := t.Context()
+
+	fake := fakes.NewCircleCI(t)
+	fake.SetMe(map[string]any{
+		"id":    "user-uuid-1234",
+		"name":  "New User",
+		"login": "newuser",
+	})
+	fake.SetOAuthTokenResponse(map[string]any{
+		"access_token": "test-signup-token",
+		"token_type":   "Bearer",
+		"expires_in":   int64(7776000),
+	})
+
+	env := testenv.New(t)
+	env.CircleCIURL = fake.URL()
+	env.Extra["CIRCLECI_LOGIN_TIMEOUT"] = "20s"
+
+	console := binary.RunCLIInteractive(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"auth", "signup"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	var authURL string
+	assert.Assert(t, t.Run("read authorize url", func(t *testing.T) {
+		// "Waiting for signup to complete" is printed AFTER the URL,
+		// so the buffer at this point contains the URL.
+		out, err := console.ExpectString("Waiting for signup")
+		assert.NilError(t, err)
+
+		authURL = regexp.MustCompile(`https?://\S+`).FindString(out)
+		assert.Assert(t, authURL != "", "authorize URL not found in output: %q", out)
+		assert.Assert(t, strings.Contains(authURL, "signup=true"),
+			"authorize URL must include signup=true: %s", authURL)
+	}))
+
+	assert.Assert(t, t.Run("browser callback", func(t *testing.T) {
+		parsed, err := url.Parse(authURL)
+		assert.NilError(t, err)
+		q := parsed.Query()
+		state := q.Get("state")
+		redirectURI := q.Get("redirect_uri")
+		assert.Assert(t, state != "", "state param missing from authorize URL")
+		assert.Assert(t, redirectURI != "", "redirect_uri param missing from authorize URL")
+
+		callbackURL := redirectURI + "?code=fake-auth-code&state=" + url.QueryEscape(state)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, callbackURL, nil)
+		assert.NilError(t, err)
+
+		resp, err := http.DefaultClient.Do(req)
+		assert.NilError(t, err)
+		_ = resp.Body.Close()
+		assert.Equal(t, resp.StatusCode, http.StatusOK)
+	}))
+
+	assert.Assert(t, t.Run("signed up", func(t *testing.T) {
+		_, err := console.ExpectString("Signed up as newuser")
+		assert.NilError(t, err)
+		_, err = console.ExpectString("Saved host to")
+		assert.NilError(t, err)
+	}))
+
+	assert.Assert(t, t.Run("token persisted to YAML", func(t *testing.T) {
+		// --insecure-storage is injected by RunCLIInteractive; token lands in
+		// the YAML config under HOME/.config/circleci/config.yml.
+		cfgPath := filepath.Join(env.HomeDir, ".config", "circleci", "config.yml")
+		body, err := os.ReadFile(cfgPath)
+		assert.NilError(t, err)
+		assert.Assert(t, strings.Contains(string(body), "test-signup-token"),
+			"token not persisted in %s:\n%s", cfgPath, body)
+	}))
+}

--- a/acceptance/auth_signup_test.go
+++ b/acceptance/auth_signup_test.go
@@ -32,42 +32,13 @@ import (
 	"testing"
 
 	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+	"gotest.tools/v3/golden"
 
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/testing/binary"
 	testenv "github.com/CircleCI-Public/circleci-cli-v2/internal/testing/env"
 	"github.com/CircleCI-Public/circleci-cli-v2/internal/testing/fakes"
 )
-
-func TestAuthSignup_AppearsInAuthHelp(t *testing.T) {
-	env := testenv.New(t)
-	result := binary.RunCLI(t, binary.RunOpts{
-		Binary:  binaryPath,
-		Args:    []string{"auth", "--help"},
-		Env:     env.Environ(),
-		WorkDir: t.TempDir(),
-	})
-
-	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
-	assert.Assert(t, strings.Contains(result.Stdout, "signup"),
-		"auth --help should list the signup subcommand:\n%s", result.Stdout)
-}
-
-func TestAuthSignup_OwnHelp(t *testing.T) {
-	env := testenv.New(t)
-	result := binary.RunCLI(t, binary.RunOpts{
-		Binary:  binaryPath,
-		Args:    []string{"auth", "signup", "--help"},
-		Env:     env.Environ(),
-		WorkDir: t.TempDir(),
-	})
-
-	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
-	assert.Assert(t, strings.Contains(result.Stdout, "Create a CircleCI account"),
-		"auth signup --help should describe the command:\n%s", result.Stdout)
-	// 3+ examples requirement → 3+ shell-prompt lines beginning with "$ ".
-	assert.Assert(t, strings.Count(result.Stdout, "\n$ ") >= 3,
-		"expected ≥3 examples in help output:\n%s", result.Stdout)
-}
 
 // TestAuthSignup_Timeout exercises the wait-for-callback path. The fake
 // server is started but never delivers a callback — the CLI should print
@@ -87,13 +58,11 @@ func TestAuthSignup_Timeout(t *testing.T) {
 	})
 
 	assert.Equal(t, result.ExitCode, 8, "stderr: %s", result.Stderr) // ExitTimeout
-	assert.Assert(t, strings.Contains(result.Stderr, "Signup timed out"),
-		"stderr should contain timeout message:\n%s", result.Stderr)
+	assert.Check(t, cmp.Contains(result.Stderr, "Signup timed out"))
 	// Verify the URL the CLI printed carries signup=true.
-	assert.Assert(t, strings.Contains(result.Stderr, "signup=true"),
-		"authorize URL must include signup=true:\n%s", result.Stderr)
-	// Verify it's a loopback redirect URI shape.
-	assert.Assert(t, strings.Contains(result.Stderr, "127.0.0.1%3A") ||
+	assert.Check(t, cmp.Contains(result.Stderr, "signup=true"))
+	// Verify it's a loopback redirect URI shape (encoded or raw colon).
+	assert.Check(t, strings.Contains(result.Stderr, "127.0.0.1%3A") ||
 		strings.Contains(result.Stderr, "127.0.0.1:"),
 		"authorize URL must include a loopback redirect_uri:\n%s", result.Stderr)
 }
@@ -116,12 +85,7 @@ func TestAuthSignup_AlreadyAuthenticated(t *testing.T) {
 	})
 
 	assert.Equal(t, result.ExitCode, 3, "stderr: %s", result.Stderr) // ExitAuthError
-	assert.Assert(t, strings.Contains(result.Stderr, "Already authenticated"),
-		"stderr should mention the conflict:\n%s", result.Stderr)
-	assert.Assert(t, strings.Contains(result.Stderr, "circleci auth logout"),
-		"stderr should suggest auth logout:\n%s", result.Stderr)
-	assert.Assert(t, strings.Contains(result.Stderr, "circleci auth login"),
-		"stderr should suggest auth login as an alternative:\n%s", result.Stderr)
+	assert.Check(t, golden.String(result.Stderr, t.Name()+".stderr.txt"))
 }
 
 // TestAuthSignup_HappyPath drives the full signup flow against the fake
@@ -164,8 +128,7 @@ func TestAuthSignup_HappyPath(t *testing.T) {
 
 		authURL = regexp.MustCompile(`https?://\S+`).FindString(out)
 		assert.Assert(t, authURL != "", "authorize URL not found in output: %q", out)
-		assert.Assert(t, strings.Contains(authURL, "signup=true"),
-			"authorize URL must include signup=true: %s", authURL)
+		assert.Check(t, cmp.Contains(authURL, "signup=true"))
 	}))
 
 	assert.Assert(t, t.Run("browser callback", func(t *testing.T) {
@@ -200,7 +163,6 @@ func TestAuthSignup_HappyPath(t *testing.T) {
 		cfgPath := filepath.Join(env.HomeDir, ".config", "circleci", "config.yml")
 		body, err := os.ReadFile(cfgPath)
 		assert.NilError(t, err)
-		assert.Assert(t, strings.Contains(string(body), "test-signup-token"),
-			"token not persisted in %s:\n%s", cfgPath, body)
+		assert.Check(t, cmp.Contains(string(body), "test-signup-token"))
 	}))
 }

--- a/acceptance/auth_signup_test.go
+++ b/acceptance/auth_signup_test.go
@@ -58,13 +58,17 @@ func TestAuthSignup_Timeout(t *testing.T) {
 	})
 
 	assert.Equal(t, result.ExitCode, 8, "stderr: %s", result.Stderr) // ExitTimeout
-	assert.Check(t, cmp.Contains(result.Stderr, "Signup timed out"))
-	// Verify the URL the CLI printed carries signup=true.
+
+	// Targeted URL semantics: lock down the params we care about while the
+	// rest of the URL (host, ports, PKCE values, state, device_id) is random.
 	assert.Check(t, cmp.Contains(result.Stderr, "signup=true"))
-	// Verify it's a loopback redirect URI shape (encoded or raw colon).
 	assert.Check(t, strings.Contains(result.Stderr, "127.0.0.1%3A") ||
 		strings.Contains(result.Stderr, "127.0.0.1:"),
 		"authorize URL must include a loopback redirect_uri:\n%s", result.Stderr)
+
+	// Golden-compare the surrounding stderr after scrubbing the random URL.
+	scrubbed := regexp.MustCompile(`https?://\S+`).ReplaceAllString(result.Stderr, "<authorize-url>")
+	assert.Check(t, golden.String(scrubbed, t.Name()+".stderr.txt"))
 }
 
 // TestAuthSignup_AlreadyAuthenticated asserts that running `circleci auth

--- a/acceptance/testdata/TestAuthSignup_AlreadyAuthenticated.stderr.txt
+++ b/acceptance/testdata/TestAuthSignup_AlreadyAuthenticated.stderr.txt
@@ -1,0 +1,5 @@
+error: Already authenticated — a token is already configured and signup will not overwrite it.
+
+Suggestions:
+  • Run 'circleci auth logout' to clear it, then re-run 'circleci auth signup'
+  • If you already have a CircleCI account, use 'circleci auth login'

--- a/acceptance/testdata/TestAuthSignup_Timeout.stderr.txt
+++ b/acceptance/testdata/TestAuthSignup_Timeout.stderr.txt
@@ -1,0 +1,9 @@
+Open this URL in your browser to sign up:
+
+  <authorize-url>
+
+Waiting for signup to complete...
+error: Signup timed out — no browser callback received within 200ms.
+
+Suggestions:
+  • Re-run 'circleci auth signup' and complete the browser flow promptly

--- a/internal/cmd/cmdauth/auth.go
+++ b/internal/cmd/cmdauth/auth.go
@@ -41,6 +41,7 @@ func NewAuthCmd() *cobra.Command {
 		Long: heredoc.Doc(`
 			Manage authentication for the CLI.
 
+			Use 'circleci auth signup' to create a new CircleCI account via the browser.
 			Use 'circleci auth login' to authenticate via the browser-based OAuth flow.
 			Use 'circleci auth me' to get current user info.
 			Use 'circleci auth logout' to clear your stored credentials.
@@ -48,6 +49,7 @@ func NewAuthCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(newLoginCmd())
+	cmd.AddCommand(newSignupCmd())
 	cmd.AddCommand(newMeCmd())
 	cmd.AddCommand(newLogoutCmd())
 	cmd.AddCommand(newDeviceIDCmd())

--- a/internal/cmd/cmdauth/signup.go
+++ b/internal/cmd/cmdauth/signup.go
@@ -1,0 +1,146 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package cmdauth
+
+import (
+	"context"
+	"errors"
+	"runtime"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/pkg/browser"
+	"github.com/spf13/cobra"
+
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/apiclient"
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/cmdutil"
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/config"
+	clierrors "github.com/CircleCI-Public/circleci-cli-v2/internal/errors"
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/iostream"
+	"github.com/CircleCI-Public/circleci-cli-v2/internal/oauth"
+)
+
+func newSignupCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "signup",
+		Short: "Sign up for CircleCI via the browser",
+		Long: heredoc.Doc(`
+			Create a CircleCI account by opening the signup page in your browser.
+			After you complete signup and approve the CLI, an authorization code
+			is delivered back to a temporary loopback server on 127.0.0.1, then
+			exchanged for an access token via POST /oauth/token.
+
+			The token is saved to the system keyring (or to the YAML config when
+			--insecure-storage is set) and used automatically by all subsequent
+			CLI commands.
+
+			If a token is already configured, run 'circleci auth logout' first
+			(signup will not silently overwrite an existing token). If you
+			already have a CircleCI account, use 'circleci auth login' instead.
+		`),
+		Example: heredoc.Doc(`
+			# Open the signup page in your browser
+			$ circleci auth signup
+
+			# Sign up against a non-default host
+			$ CIRCLECI_HOST=https://example.circleci.com circleci auth signup
+
+			# Store the token in plain YAML instead of the system keyring
+			$ circleci auth signup --insecure-storage
+		`),
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := iostream.FromCmd(cmd.Context(), cmd)
+			configPath, _ := cmd.Flags().GetString("config")
+			secureStorage := cmdutil.IsSecureStorage(cmd)
+			return runSignup(ctx, configPath, secureStorage)
+		},
+	}
+}
+
+func runSignup(ctx context.Context, configPath string, secureStorage bool) error {
+	cfg, err := config.LoadFrom(ctx, configPath, secureStorage)
+	if err != nil {
+		return clierrors.New("config.load_failed",
+			"Failed to load config", err.Error()).
+			WithExitCode(clierrors.ExitGeneralError)
+	}
+
+	if cfg.EffectiveToken() != "" {
+		return clierrors.New("auth.signup.already_authenticated",
+			"Already authenticated",
+			"Already authenticated — a token is already configured and signup will not overwrite it.").
+			WithSuggestions(
+				"Run 'circleci auth logout' to clear it, then re-run 'circleci auth signup'",
+				"If you already have a CircleCI account, use 'circleci auth login'",
+			).
+			WithExitCode(clierrors.ExitAuthError)
+	}
+
+	host := cfg.EffectiveHost()
+	deviceID := config.EnsureDeviceID(ctx, configPath)
+
+	flow, err := oauth.StartSignup(ctx, host, deviceID, runtime.GOOS)
+	if err != nil {
+		return clierrors.New("auth.signup.listen_failed",
+			"Could not start local callback server", err.Error()).
+			WithSuggestions("Check that no other process is blocking loopback ports").
+			WithExitCode(clierrors.ExitGeneralError)
+	}
+	defer func() { _ = flow.Close() }()
+
+	iostream.ErrPrintf(ctx, "Open this URL in your browser to sign up:\n\n  %s\n\n", flow.AuthorizeURL)
+	_ = browser.OpenURL(flow.AuthorizeURL) // best-effort
+
+	waitCtx, cancel := context.WithTimeout(ctx, callbackTimeout())
+	defer cancel()
+
+	sp := iostream.Spinner(ctx, true, "Waiting for signup to complete")
+	res, err := flow.Wait(waitCtx)
+	sp.Stop()
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			return clierrors.New("auth.signup.timeout",
+				"Signup timed out",
+				"Signup timed out — no browser callback received within "+callbackTimeout().String()+".").
+				WithSuggestions("Re-run 'circleci auth signup' and complete the browser flow promptly").
+				WithExitCode(clierrors.ExitTimeout)
+		}
+		return clierrors.New("auth.signup.callback_error",
+			"Signup failed", err.Error()).
+			WithExitCode(clierrors.ExitAuthError)
+	}
+
+	token, err := flow.Exchange(ctx, res.Code)
+	if err != nil {
+		return clierrors.New("auth.signup.token_exchange_failed",
+			"Failed to exchange authorization code for token", err.Error()).
+			WithExitCode(clierrors.ExitAuthError)
+	}
+
+	c := apiclient.New(host, token.AccessToken, nil)
+	if me, err := c.GetMe(ctx); err == nil && me.Login != "" {
+		iostream.ErrPrintf(ctx, "%s Signed up as %s\n", iostream.SymbolOK(ctx), me.Login)
+	}
+
+	return persistToken(ctx, host, token.AccessToken, secureStorage)
+}

--- a/internal/cmd/cmdauth/signup.go
+++ b/internal/cmd/cmdauth/signup.go
@@ -40,18 +40,17 @@ import (
 )
 
 func newSignupCmd() *cobra.Command {
-	return &cobra.Command{
+	var noBrowser bool
+
+	cmd := &cobra.Command{
 		Use:   "signup",
 		Short: "Sign up for CircleCI via the browser",
 		Long: heredoc.Doc(`
 			Create a CircleCI account by opening the signup page in your browser.
 			After you complete signup and approve the CLI, an authorization code
 			is delivered back to a temporary loopback server on 127.0.0.1, then
-			exchanged for an access token via POST /oauth/token.
-
-			The token is saved to the system keyring (or to the YAML config when
-			--insecure-storage is set) and used automatically by all subsequent
-			CLI commands.
+			exchanged for an access token via POST /oauth/token. The resulting
+			token is used automatically by all subsequent CLI commands.
 
 			If a token is already configured, run 'circleci auth logout' first
 			(signup will not silently overwrite an existing token). If you
@@ -61,23 +60,26 @@ func newSignupCmd() *cobra.Command {
 			# Open the signup page in your browser
 			$ circleci auth signup
 
-			# Sign up against a non-default host
-			$ CIRCLECI_HOST=https://example.circleci.com circleci auth signup
+			# Print the authorize URL instead of opening a browser
+			$ circleci auth signup --no-browser
 
-			# Store the token in plain YAML instead of the system keyring
-			$ circleci auth signup --insecure-storage
+			# Authenticate against a non-default host
+			$ CIRCLECI_HOST=https://example.circleci.com circleci auth signup
 		`),
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := iostream.FromCmd(cmd.Context(), cmd)
 			configPath, _ := cmd.Flags().GetString("config")
 			secureStorage := cmdutil.IsSecureStorage(cmd)
-			return runSignup(ctx, configPath, secureStorage)
+			return runSignup(ctx, configPath, noBrowser, secureStorage)
 		},
 	}
+
+	cmd.Flags().BoolVar(&noBrowser, "no-browser", false, "Print the authorize URL instead of opening a browser")
+	return cmd
 }
 
-func runSignup(ctx context.Context, configPath string, secureStorage bool) error {
+func runSignup(ctx context.Context, configPath string, noBrowser, secureStorage bool) error {
 	cfg, err := config.LoadFrom(ctx, configPath, secureStorage)
 	if err != nil {
 		return clierrors.New("config.load_failed",
@@ -109,7 +111,9 @@ func runSignup(ctx context.Context, configPath string, secureStorage bool) error
 	defer func() { _ = flow.Close() }()
 
 	iostream.ErrPrintf(ctx, "Open this URL in your browser to sign up:\n\n  %s\n\n", flow.AuthorizeURL)
-	_ = browser.OpenURL(flow.AuthorizeURL) // best-effort
+	if !noBrowser {
+		_ = browser.OpenURL(flow.AuthorizeURL) // best-effort
+	}
 
 	waitCtx, cancel := context.WithTimeout(ctx, callbackTimeout())
 	defer cancel()

--- a/internal/cmd/cmdauth/signup_test.go
+++ b/internal/cmd/cmdauth/signup_test.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package cmdauth
+
+import (
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+func TestNewSignupCmd_Metadata(t *testing.T) {
+	cmd := newSignupCmd()
+
+	assert.Check(t, is.Equal(cmd.Use, "signup"))
+	assert.Check(t, cmd.Short != "", "Short must be set")
+	assert.Check(t, cmd.Long != "", "Long must be set")
+	assert.Check(t, cmd.Example != "", "Example must be set")
+	assert.Check(t, cmd.RunE != nil, "RunE must be wired")
+
+	// Per CLAUDE.md, every command needs at least 3 examples.
+	// Each example begins with a shell prompt ("$ ") on a fresh line.
+	exampleCount := strings.Count(cmd.Example, "\n$ ")
+	assert.Check(t, exampleCount >= 3,
+		"expected ≥3 examples, got %d in:\n%s", exampleCount, cmd.Example)
+
+	// Args == cobra.NoArgs — pass an unexpected positional arg and expect error.
+	err := cmd.Args(cmd, []string{"unexpected-positional"})
+	assert.Check(t, err != nil, "signup must reject positional args")
+}

--- a/internal/cmd/root/testdata/usage/circleci/auth.txt
+++ b/internal/cmd/root/testdata/usage/circleci/auth.txt
@@ -6,6 +6,7 @@ Available Commands:
   login       Authenticate via the CircleCI OAuth flow
   logout      Remove stored credentials
   me          Get info about the current user
+  signup      Sign up for CircleCI via the browser
 
 Global Flags:
   -c, --config string   path to config file (default: ~/.config/circleci/config.yml)

--- a/internal/cmd/root/testdata/usage/circleci/auth/signup.txt
+++ b/internal/cmd/root/testdata/usage/circleci/auth/signup.txt
@@ -5,12 +5,15 @@ Examples:
 # Open the signup page in your browser
 $ circleci auth signup
 
-# Sign up against a non-default host
+# Print the authorize URL instead of opening a browser
+$ circleci auth signup --no-browser
+
+# Authenticate against a non-default host
 $ CIRCLECI_HOST=https://example.circleci.com circleci auth signup
 
-# Store the token in plain YAML instead of the system keyring
-$ circleci auth signup --insecure-storage
 
+Flags:
+      --no-browser   Print the authorize URL instead of opening a browser
 
 Global Flags:
   -c, --config string   path to config file (default: ~/.config/circleci/config.yml)

--- a/internal/cmd/root/testdata/usage/circleci/auth/signup.txt
+++ b/internal/cmd/root/testdata/usage/circleci/auth/signup.txt
@@ -1,0 +1,18 @@
+Usage:
+  circleci auth signup [flags]
+
+Examples:
+# Open the signup page in your browser
+$ circleci auth signup
+
+# Sign up against a non-default host
+$ CIRCLECI_HOST=https://example.circleci.com circleci auth signup
+
+# Store the token in plain YAML instead of the system keyring
+$ circleci auth signup --insecure-storage
+
+
+Global Flags:
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected

--- a/internal/oauth/login.go
+++ b/internal/oauth/login.go
@@ -31,6 +31,11 @@
 //     ?code=...&state=... and validate the state.
 //  5. Return the captured code and PKCE verifier so the caller can exchange
 //     them for a token (once /oauth/token ships).
+//
+// Two entry points share the same underlying flow:
+//   - Start lands the user on the OAuth login page.
+//   - StartSignup appends signup=true so unauthenticated users land on the
+//     signup page instead. Everything past the authorize step is identical.
 package oauth
 
 import (
@@ -105,6 +110,18 @@ type callbackResult struct {
 // deviceID and osInfo are appended as query parameters on the authorize URL
 // so the server can correlate requests by CLI installation and platform.
 func Start(ctx context.Context, host, deviceID, osInfo string) (*Flow, error) {
+	return start(ctx, host, deviceID, osInfo, false)
+}
+
+// StartSignup is like Start, but appends signup=true to the authorize URL so
+// the OAuth provider routes unauthenticated users to the signup page rather
+// than the login page. The PKCE handshake, loopback callback, and token
+// exchange are otherwise identical.
+func StartSignup(ctx context.Context, host, deviceID, osInfo string) (*Flow, error) {
+	return start(ctx, host, deviceID, osInfo, true)
+}
+
+func start(ctx context.Context, host, deviceID, osInfo string, signup bool) (*Flow, error) {
 	verifier := oauth2.GenerateVerifier()
 
 	state, err := generateState()
@@ -134,6 +151,9 @@ func Start(ctx context.Context, host, deviceID, osInfo string) (*Flow, error) {
 	}
 	if osInfo != "" {
 		params = append(params, oauth2.SetAuthURLParam("os", osInfo))
+	}
+	if signup {
+		params = append(params, oauth2.SetAuthURLParam("signup", "true"))
 	}
 
 	f := &Flow{

--- a/internal/oauth/login_test.go
+++ b/internal/oauth/login_test.go
@@ -122,6 +122,34 @@ func TestStart_FlowsAreUnique(t *testing.T) {
 	assert.Check(t, a.state != b.state, "state must be per-flow")
 }
 
+func TestStart_DoesNotIncludeSignupParam(t *testing.T) {
+	flow := startFlow(t, "https://example.com")
+	u, err := url.Parse(flow.AuthorizeURL)
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(u.Query().Get("signup"), ""),
+		"Start must not send signup=true; that's reserved for StartSignup")
+}
+
+func TestStartSignup_IncludesSignupParam(t *testing.T) {
+	flow, err := StartSignup(context.Background(), "https://example.com", "test-device-id", "test-os")
+	assert.NilError(t, err)
+	t.Cleanup(func() { _ = flow.Close() })
+
+	u, err := url.Parse(flow.AuthorizeURL)
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(u.Query().Get("signup"), "true"))
+
+	// Everything else should be identical to a regular Start flow.
+	q := u.Query()
+	assert.Check(t, is.Equal(q.Get("client_id"), ClientID))
+	assert.Check(t, is.Equal(q.Get("response_type"), "code"))
+	assert.Check(t, is.Equal(q.Get("code_challenge_method"), "S256"))
+	assert.Check(t, q.Get("code_challenge") != "")
+	assert.Check(t, q.Get("state") != "")
+	assert.Check(t, is.Equal(q.Get("device_id"), "test-device-id"))
+	assert.Check(t, is.Equal(q.Get("os"), "test-os"))
+}
+
 func TestFlow_Wait_Success(t *testing.T) {
 	flow := startFlow(t, "https://example.com")
 	u, _ := url.Parse(flow.AuthorizeURL)


### PR DESCRIPTION
## Summary
- Adds `circleci auth signup`, a new subcommand that opens the browser-based PKCE OAuth flow against the signup page.
- Refactors `internal/oauth.Start` to share its core implementation with a new `StartSignup` variant that appends `signup=true` to the authorize URL. PKCE handshake, loopback callback, and token exchange are otherwise identical to `auth login`.
- Wires the new command into the `auth` group and regenerates help fixtures.

## Test plan
- [ ] `task test` (unit + acceptance) passes
- [ ] `./dist/circleci auth signup --help` renders correctly
- [ ] Manual: run `circleci auth signup` and confirm browser lands on the signup page (not login)
- [ ] Manual: confirm `circleci auth login` still routes to the login page (no regression)