### PR TITLE
Prevent auth acceptance tests from opening browser tabs

### DIFF
--- a/internal/cmd/cmdauth/browser.go
+++ b/internal/cmd/cmdauth/browser.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package cmdauth
+
+import (
+	"os"
+
+	"github.com/pkg/browser"
+)
+
+func browserOpener() func(string) error {
+	// Test seam for acceptance tests, which exercise browser auth flows by
+	// calling the loopback callback directly and must not open real tabs.
+	if os.Getenv("CIRCLECI_NO_BROWSER_OPEN") != "" {
+		return func(string) error { return nil }
+	}
+	return browser.OpenURL
+}

--- a/internal/cmd/cmdauth/browser_test.go
+++ b/internal/cmd/cmdauth/browser_test.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package cmdauth
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestBrowserOpenerDisabledByEnv(t *testing.T) {
+	t.Setenv("CIRCLECI_NO_BROWSER_OPEN", "true")
+
+	openURL := browserOpener()
+
+	assert.NilError(t, openURL("https://example.com"))
+}
+
+func TestBrowserOpenerDefaultReturnsOpener(t *testing.T) {
+	t.Setenv("CIRCLECI_NO_BROWSER_OPEN", "")
+
+	openURL := browserOpener()
+
+	assert.Assert(t, openURL != nil)
+}

--- a/internal/cmd/cmdauth/login.go
+++ b/internal/cmd/cmdauth/login.go
@@ -178,6 +178,7 @@ func runLoginInteractive(ctx context.Context, configPath string, secureStorage b
 		DeviceID: deviceID,
 		OSInfo:   runtime.GOOS,
 		Color:    iostream.ColorEnabled(ctx),
+		OpenURL:  browserOpener(),
 		GetUsername: func(ctx context.Context, host, token string) (string, error) {
 			me, err := apiclient.New(host, token, nil).GetMe(ctx)
 			if err != nil {

--- a/internal/cmd/cmdauth/signup.go
+++ b/internal/cmd/cmdauth/signup.go
@@ -133,6 +133,7 @@ func runSignupInteractive(ctx context.Context, host, deviceID string, noBrowser,
 		OSInfo:                runtime.GOOS,
 		NoBrowser:             noBrowser,
 		Color:                 iostream.ColorEnabled(ctx),
+		OpenURL:               browserOpener(),
 		SignupCallbackTimeout: time.Second,
 		LoginCallbackTimeout:  callbackTimeout(),
 		GetUsername: func(ctx context.Context, host, token string) (string, error) {

--- a/internal/testing/env/env.go
+++ b/internal/testing/env/env.go
@@ -59,6 +59,7 @@ func (e *TestEnv) Environ() []string {
 		"HOME=" + e.HomeDir,
 		"XDG_CONFIG_HOME=" + filepath.Join(e.HomeDir, ".config"),
 		"PATH=" + os.Getenv("PATH"),
+		"CIRCLECI_NO_BROWSER_OPEN=true",
 		"CIRCLECI_SPINNER_DISABLED=true",
 	}
 	if e.Token != "" {

--- a/internal/ui/login_flow.go
+++ b/internal/ui/login_flow.go
@@ -76,6 +76,7 @@ type LoginFlowOptions struct {
 	// GetUsername, if non-nil, is called after token exchange to display
 	// the authenticated user's login name.
 	GetUsername func(ctx context.Context, host, token string) (string, error)
+	OpenURL     func(string) error
 	Color       bool
 }
 
@@ -127,6 +128,10 @@ var loginMethodOptions = []string{"Login with a web browser", "Paste an authenti
 
 // NewLoginFlow returns a LoginFlowModel ready to pass to tea.NewProgram.
 func NewLoginFlow(ctx context.Context, opts LoginFlowOptions) LoginFlowModel {
+	if opts.OpenURL == nil {
+		opts.OpenURL = browser.OpenURL
+	}
+
 	ti := textinput.New()
 	ti.Placeholder = "https://example.circleci.com"
 	ti.SetWidth(50)
@@ -359,7 +364,7 @@ func (m LoginFlowModel) keyEnterPrompt(msg tea.KeyPressMsg) (tea.Model, tea.Cmd)
 		m.result.Cancelled = true
 		return m, tea.Quit
 	case components.KeyEnter:
-		_ = browser.OpenURL(m.flow.AuthorizeURL)
+		_ = m.opts.OpenURL(m.flow.AuthorizeURL)
 		m.stage = stageWaiting
 		return m, m.spin.Tick
 	}

--- a/internal/ui/signup_flow.go
+++ b/internal/ui/signup_flow.go
@@ -83,6 +83,7 @@ type SignupFlowOptions struct {
 	OSInfo                string
 	NoBrowser             bool
 	Color                 bool
+	OpenURL               func(string) error
 	SignupCallbackTimeout time.Duration
 	LoginCallbackTimeout  time.Duration
 	GetUsername           func(ctx context.Context, host, token string) (string, error)
@@ -136,6 +137,9 @@ type signupUsernameFetchedMsg struct {
 }
 
 func NewSignupFlow(ctx context.Context, opts SignupFlowOptions) SignupFlowModel {
+	if opts.OpenURL == nil {
+		opts.OpenURL = browser.OpenURL
+	}
 	if opts.SignupCallbackTimeout <= 0 {
 		opts.SignupCallbackTimeout = time.Second
 	}
@@ -388,7 +392,7 @@ func (m SignupFlowModel) cmdGetUsername(token string) tea.Cmd {
 
 func (m SignupFlowModel) cmdOpenURL(url string) tea.Cmd {
 	return func() tea.Msg {
-		_ = browser.OpenURL(url)
+		_ = m.opts.OpenURL(url)
 		return nil
 	}
 }

--- a/internal/ui/signup_flow_test.go
+++ b/internal/ui/signup_flow_test.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package ui
+
+import (
+	"context"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/CircleCI-Public/circleci-cli/internal/oauth"
+)
+
+func TestSignupFlowOpensSignupURL(t *testing.T) {
+	var opened []string
+	model := NewSignupFlow(context.Background(), SignupFlowOptions{
+		Host:     "https://circleci.com",
+		OpenURL:  func(url string) error { opened = append(opened, url); return nil },
+		DeviceID: "test-device",
+		OSInfo:   "test-os",
+	})
+
+	updated, cmd := model.onSignupStarted(signupOAuthStartedMsg{
+		flow: &oauth.Flow{AuthorizeURL: "https://circleci.com/oauth/authorize?signup=true"},
+	})
+	assert.Assert(t, cmd != nil)
+	cmd()
+
+	assert.DeepEqual(t, opened, []string{"https://circleci.com/oauth/authorize?signup=true"})
+	assert.Equal(t, updated.(SignupFlowModel).stage, signupStagePrompt)
+}
+
+func TestSignupFlowNoBrowserSkipsSignupURL(t *testing.T) {
+	var opened []string
+	model := NewSignupFlow(context.Background(), SignupFlowOptions{
+		Host:      "https://circleci.com",
+		NoBrowser: true,
+		OpenURL:   func(url string) error { opened = append(opened, url); return nil },
+		DeviceID:  "test-device",
+		OSInfo:    "test-os",
+	})
+
+	updated, cmd := model.onSignupStarted(signupOAuthStartedMsg{
+		flow: &oauth.Flow{AuthorizeURL: "https://circleci.com/oauth/authorize?signup=true"},
+	})
+
+	assert.Assert(t, cmd == nil)
+	assert.DeepEqual(t, opened, []string(nil))
+	assert.Equal(t, updated.(SignupFlowModel).stage, signupStagePrompt)
+}


### PR DESCRIPTION
## Summary

Acceptance tests were launching real browser tabs because the interactive auth UI models called `browser.OpenURL` directly.

This adds an injectable browser opener to the login and signup flow models. In normal usage, the opener still defaults to `browser.OpenURL`, so production behavior is unchanged. In acceptance tests, `TestEnv` now sets `CIRCLECI_NO_BROWSER_OPEN=true`, which makes the command layer pass a no-op opener instead.

`CIRCLECI_NO_BROWSER_OPEN` is intentionally undocumented; it is a test seam, not a supported user-facing configuration flag.

## Context

`auth login` already opened a browser tab during the interactive browser-login path. PR #1310 added signup coverage that exercises browser auth more often, so running acceptance tests became noisy and disruptive locally.

Before this change, the login interactive path, signup start, and signup-to-login fallback could all open browser tabs during acceptance tests.

With this change:
- Normal `circleci auth login` and `circleci auth signup` still open the browser.
- Acceptance tests still exercise the full interactive login/signup flows.
- Acceptance tests no longer open real browser tabs.

## Testing

Unit tests cover the `browserOpener()` env-var switch and the signup model's use of the injected opener with and without `NoBrowser`.

\`\`\`sh
go test ./internal/ui ./internal/cmd/cmdauth
go test ./acceptance -run 'TestAuthSignup|TestAuthLogin' -count=1
go test ./acceptance -count=1
go test ./...
task ci:check
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)