### PR TITLE
Fix orb API client reference keys to match v3 spec

### DIFF
--- a/internal/apiclient/orb.go
+++ b/internal/apiclient/orb.go
@@ -54,7 +54,7 @@ type orbPackageAttributes struct {
 	Last30DaysOrgCount     int64  `json:"last_30_days_org_count"`
 }
 
-type orbNamespaceRef struct {
+type namespaceRef struct {
 	ID         string `json:"id"`
 	Attributes struct {
 		Name string `json:"name"`
@@ -77,9 +77,9 @@ type orbCategoryRef struct {
 }
 
 type orbPackageReferences struct {
-	Namespace     orbNamespaceRef  `json:"namespace"`
-	LatestVersion *orbVersionRef   `json:"latest_version"`
-	Categories    []orbCategoryRef `json:"categories"`
+	Namespace  namespaceRef     `json:"namespace"`
+	Versions   []orbVersionRef  `json:"orb/versions"`
+	Categories []orbCategoryRef `json:"orb/categories"`
 }
 
 // orbPackageWire is the detail response shape (GET /orb/packages/{id}).
@@ -91,7 +91,7 @@ type orbPackageWire struct {
 
 // orbPackageListWire is the shape returned by the list endpoint
 // (GET /orb/packages). The namespace reference contains only an id (no name);
-// latest_version is included; categories and usage stats are not.
+// usage stats are not included.
 type orbPackageListWire struct {
 	ID         string `json:"id"`
 	Attributes struct {
@@ -103,13 +103,14 @@ type orbPackageListWire struct {
 		Namespace struct {
 			ID string `json:"id"`
 		} `json:"namespace"`
-		LatestVersion *struct {
+		Versions []struct {
 			ID         string `json:"id"`
 			Attributes struct {
 				Version   string `json:"version"`
 				CreatedAt string `json:"created_at"`
 			} `json:"attributes"`
-		} `json:"latest_version"`
+		} `json:"orb/versions"`
+		Categories []orbCategoryRef `json:"orb/categories"`
 	} `json:"references"`
 }
 
@@ -121,9 +122,12 @@ func (w *orbPackageListWire) toOrbPackage() *OrbPackage {
 		IsPrivate:   w.Attributes.IsPrivate,
 		IsListed:    w.Attributes.IsListed,
 	}
-	if w.References.LatestVersion != nil {
-		pkg.LatestVersion = w.References.LatestVersion.Attributes.Version
-		pkg.LatestVersionAt = w.References.LatestVersion.Attributes.CreatedAt
+	if len(w.References.Versions) > 0 {
+		pkg.LatestVersion = w.References.Versions[0].Attributes.Version
+		pkg.LatestVersionAt = w.References.Versions[0].Attributes.CreatedAt
+	}
+	for _, c := range w.References.Categories {
+		pkg.Categories = append(pkg.Categories, OrbCategory{ID: c.ID, Name: c.Attributes.Name})
 	}
 	return pkg
 }
@@ -142,7 +146,7 @@ type orbVersionOrbRef struct {
 }
 
 type orbVersionReferences struct {
-	Orb orbVersionOrbRef `json:"orb"`
+	Package orbVersionOrbRef `json:"orb/package"`
 }
 
 type orbVersionWire struct {
@@ -224,9 +228,9 @@ func (w *orbPackageWire) toOrbPackage() *OrbPackage {
 		Last30DaysProjectCount: w.Attributes.Last30DaysProjectCount,
 		Last30DaysOrgCount:     w.Attributes.Last30DaysOrgCount,
 	}
-	if w.References.LatestVersion != nil {
-		pkg.LatestVersion = w.References.LatestVersion.Attributes.Version
-		pkg.LatestVersionAt = w.References.LatestVersion.Attributes.CreatedAt
+	if len(w.References.Versions) > 0 {
+		pkg.LatestVersion = w.References.Versions[0].Attributes.Version
+		pkg.LatestVersionAt = w.References.Versions[0].Attributes.CreatedAt
 	}
 	for _, c := range w.References.Categories {
 		pkg.Categories = append(pkg.Categories, OrbCategory{ID: c.ID, Name: c.Attributes.Name})
@@ -237,8 +241,8 @@ func (w *orbPackageWire) toOrbPackage() *OrbPackage {
 func (w *orbVersionWire) toOrbVersion() *OrbVersion {
 	return &OrbVersion{
 		ID:        w.ID,
-		OrbID:     w.References.Orb.ID,
-		OrbName:   w.References.Orb.Attributes.Name,
+		OrbID:     w.References.Package.ID,
+		OrbName:   w.References.Package.Attributes.Name,
 		Version:   w.Attributes.Version,
 		Source:    w.Attributes.Source,
 		CreatedAt: w.Attributes.CreatedAt,

--- a/internal/testing/fakes/circleci.go
+++ b/internal/testing/fakes/circleci.go
@@ -1941,7 +1941,7 @@ func (f *CircleCI) AddOrbPackage(id, nsID, nsName, orbName string, isPrivate, is
 				"id":         nsID,
 				"attributes": map[string]any{"name": nsName},
 			},
-			"categories": []any{},
+			"orb/categories": []any{},
 		},
 	}
 	f.orbPackages[id] = pkg
@@ -1964,7 +1964,7 @@ func (f *CircleCI) AddOrbVersion(id, orbID, orbName, version, source, createdAt 
 			"created_at": createdAt,
 		},
 		"references": map[string]any{
-			"orb": map[string]any{
+			"orb/package": map[string]any{
 				"id":         orbID,
 				"attributes": map[string]any{"name": orbName},
 			},
@@ -1979,16 +1979,16 @@ func (f *CircleCI) AddOrbVersion(id, orbID, orbName, version, source, createdAt 
 	// Add to orb's version list (for list by orb_id)
 	f.orbVersionsByOrbID[orbID] = append([]string{id}, f.orbVersionsByOrbID[orbID]...)
 
-	// Update the package's latest_version reference
+	// Update the package's orb/versions reference
 	if pkg, ok := f.orbPackages[orbID]; ok {
 		if refs, ok := pkg["references"].(map[string]any); ok {
-			refs["latest_version"] = map[string]any{
+			refs["orb/versions"] = []any{map[string]any{
 				"id": id,
 				"attributes": map[string]any{
 					"version":    version,
 					"created_at": createdAt,
 				},
-			}
+			}}
 		}
 	}
 }
@@ -2067,7 +2067,7 @@ func (f *CircleCI) handleOrbListPackages(w http.ResponseWriter, r *http.Request)
 			attrsCopy["is_listed"] = !unlisted[id]
 		}
 		if refsCopy, ok := pkgCopy["references"].(map[string]any); ok {
-			refsCopy["categories"] = catList
+			refsCopy["orb/categories"] = catList
 		}
 		items = append(items, pkgCopy)
 	}
@@ -2120,7 +2120,7 @@ func (f *CircleCI) handleOrbCreatePackage(w http.ResponseWriter, r *http.Request
 				"id":         body.NamespaceID,
 				"attributes": map[string]any{"name": nsName},
 			},
-			"categories": []any{},
+			"orb/categories": []any{},
 		},
 	}
 	f.mu.Lock()
@@ -2159,7 +2159,7 @@ func (f *CircleCI) handleOrbGetPackage(w http.ResponseWriter, r *http.Request) {
 		attrsCopy["is_listed"] = !unlisted
 	}
 	if refsCopy, ok := pkgCopy["references"].(map[string]any); ok {
-		refsCopy["categories"] = catList
+		refsCopy["orb/categories"] = catList
 	}
 	render.JSON(w, r, orbPackageResponse(pkgCopy))
 }
@@ -2398,7 +2398,7 @@ func (f *CircleCI) handleOrbCreateVersion(w http.ResponseWriter, r *http.Request
 			"created_at": "2026-01-15T10:30:00.000Z",
 		},
 		"references": map[string]any{
-			"orb": map[string]any{
+			"orb/package": map[string]any{
 				"id":         body.OrbID,
 				"attributes": map[string]any{"name": orbName},
 			},
@@ -2411,15 +2411,15 @@ func (f *CircleCI) handleOrbCreateVersion(w http.ResponseWriter, r *http.Request
 	f.orbVersionsByRef[ref] = id
 	f.orbVersionsByRef[orbName+"@volatile"] = id
 	f.orbVersionsByOrbID[body.OrbID] = append([]string{id}, f.orbVersionsByOrbID[body.OrbID]...)
-	// Update package latest_version
+	// Update package orb/versions reference
 	if refs, ok := pkg["references"].(map[string]any); ok {
-		refs["latest_version"] = map[string]any{
+		refs["orb/versions"] = []any{map[string]any{
 			"id": id,
 			"attributes": map[string]any{
 				"version":    body.Version,
 				"created_at": "2026-01-15T10:30:00.000Z",
 			},
-		}
+		}}
 	}
 	f.orbCreatedVersions = append(f.orbCreatedVersions, ver)
 	f.mu.Unlock()
@@ -2464,7 +2464,7 @@ func (f *CircleCI) handleOrbPromoteVersion(w http.ResponseWriter, r *http.Reques
 	}
 
 	refs, _ := ver["references"].(map[string]any)
-	orb, _ := refs["orb"].(map[string]any)
+	orb, _ := refs["orb/package"].(map[string]any)
 	orbID, _ := orb["id"].(string)
 	orbName, _ := orb["attributes"].(map[string]any)["name"].(string)
 
@@ -2502,7 +2502,7 @@ func (f *CircleCI) handleOrbPromoteVersion(w http.ResponseWriter, r *http.Reques
 			"created_at": "2026-01-15T10:30:00.000Z",
 		},
 		"references": map[string]any{
-			"orb": map[string]any{
+			"orb/package": map[string]any{
 				"id":         orbID,
 				"attributes": map[string]any{"name": orbName},
 			},


### PR DESCRIPTION
## Summary
- Fix JSON reference keys in orb API client wire types: `"latest_version"` → `"orb/versions"` (array), `"categories"` → `"orb/categories"`, `"orb"` → `"orb/package"`
- Update converters to index into versions array instead of dereferencing a single pointer
- Align fake server response builders with the same key changes