### PR TITLE
Add circleci pipeline run command

### DIFF
--- a/acceptance/pipeline_test.go
+++ b/acceptance/pipeline_test.go
@@ -472,7 +472,7 @@ func TestPipelineRun_WithDefinitionID(t *testing.T) {
 	_, env := setupPipelineRunFake(t)
 
 	result := binary.RunCLI(t, binary.RunOpts{
-		Binary:  binaryPath,
+		Binary: binaryPath,
 		Args: []string{
 			"pipeline", "run",
 			"--project", "gh/myorg/myrepo",

--- a/acceptance/pipeline_test.go
+++ b/acceptance/pipeline_test.go
@@ -36,6 +36,8 @@ import (
 	"github.com/CircleCI-Public/circleci-cli/internal/testing/fakes"
 )
 
+// keyDown is defined in login_test.go (same package).
+
 const (
 	pipelineProjectID = "proj-uuid-pipeline"
 	pipelineDefID     = "pdef-uuid-0001"
@@ -393,4 +395,316 @@ func TestPipelineList_ProjectNotFound(t *testing.T) {
 	})
 
 	assert.Equal(t, result.ExitCode, 5, "stderr: %s", result.Stderr)
+}
+
+// --- pipeline run ---
+
+const (
+	pipelineRunID     = "run-uuid-0001"
+	pipelineRunNumber = 42
+)
+
+func setupPipelineRunFake(t *testing.T) (*fakes.CircleCI, *testenv.TestEnv) {
+	t.Helper()
+	fake := fakes.NewCircleCI(t)
+	fake.SetTriggerPipelineRunResponse("gh/myorg/myrepo", map[string]any{
+		"id":         pipelineRunID,
+		"state":      "created",
+		"number":     pipelineRunNumber,
+		"created_at": "2024-06-01T00:00:00Z",
+	})
+	env := testenv.New(t)
+	env.Token = testToken
+	env.CircleCIURL = fake.URL()
+	return fake, env
+}
+
+func TestPipelineRun(t *testing.T) {
+	_, env := setupPipelineRunFake(t)
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"pipeline", "run", "--project", "gh/myorg/myrepo"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Check(t, strings.Contains(result.Stdout, pipelineRunID))
+	assert.Check(t, strings.Contains(result.Stdout, "42"))
+}
+
+func TestPipelineRun_JSON(t *testing.T) {
+	_, env := setupPipelineRunFake(t)
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"pipeline", "run", "--project", "gh/myorg/myrepo", "--json"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+
+	var out map[string]any
+	err := json.Unmarshal([]byte(result.Stdout), &out)
+	assert.NilError(t, err)
+	assert.Check(t, cmp.Equal(out["id"], pipelineRunID))
+	assert.Check(t, cmp.Equal(out["state"], "created"))
+	assert.Check(t, cmp.Equal(out["triggered"], true))
+}
+
+func TestPipelineRun_WithBranch(t *testing.T) {
+	_, env := setupPipelineRunFake(t)
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"pipeline", "run", "--project", "gh/myorg/myrepo", "--branch", "feature/my-branch"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Check(t, strings.Contains(result.Stdout, pipelineRunID))
+}
+
+func TestPipelineRun_WithDefinitionID(t *testing.T) {
+	_, env := setupPipelineRunFake(t)
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args: []string{
+			"pipeline", "run",
+			"--project", "gh/myorg/myrepo",
+			"--definition-id", pipelineDefID,
+		},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Check(t, strings.Contains(result.Stdout, pipelineRunID))
+}
+
+func TestPipelineRun_WithParams(t *testing.T) {
+	_, env := setupPipelineRunFake(t)
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary: binaryPath,
+		Args: []string{
+			"pipeline", "run",
+			"--project", "gh/myorg/myrepo",
+			"--param", "deploy_env=staging",
+			"--param", "run_tests=true",
+		},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Check(t, strings.Contains(result.Stdout, pipelineRunID))
+}
+
+func TestPipelineRun_MutuallyExclusiveBranchAndTag(t *testing.T) {
+	_, env := setupPipelineRunFake(t)
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary: binaryPath,
+		Args: []string{
+			"pipeline", "run",
+			"--project", "gh/myorg/myrepo",
+			"--branch", "main",
+			"--tag", "v1.0",
+		},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 2, "stderr: %s", result.Stderr)
+	assert.Check(t, strings.Contains(result.Stderr, "--branch"))
+	assert.Check(t, strings.Contains(result.Stderr, "--tag"))
+}
+
+func TestPipelineRun_Skipped(t *testing.T) {
+	fake := fakes.NewCircleCI(t)
+	fake.SetTriggerPipelineRunSkipped("gh/myorg/myrepo", "Ignoring pipeline due to CI skip in the commit")
+	env := testenv.New(t)
+	env.Token = testToken
+	env.CircleCIURL = fake.URL()
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"pipeline", "run", "--project", "gh/myorg/myrepo"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Check(t, strings.Contains(result.Stdout, "not triggered"))
+	assert.Check(t, strings.Contains(result.Stdout, "CI skip"))
+}
+
+func TestPipelineRun_Skipped_JSON(t *testing.T) {
+	fake := fakes.NewCircleCI(t)
+	fake.SetTriggerPipelineRunSkipped("gh/myorg/myrepo", "Ignoring pipeline due to CI skip in the commit")
+	env := testenv.New(t)
+	env.Token = testToken
+	env.CircleCIURL = fake.URL()
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"pipeline", "run", "--project", "gh/myorg/myrepo", "--json"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+
+	var out map[string]any
+	err := json.Unmarshal([]byte(result.Stdout), &out)
+	assert.NilError(t, err)
+	assert.Check(t, cmp.Equal(out["triggered"], false))
+	assert.Check(t, strings.Contains(out["message"].(string), "CI skip"))
+}
+
+func TestPipelineRun_ProjectNotFound(t *testing.T) {
+	_, env := setupPipelineRunFake(t)
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"pipeline", "run", "--project", "gh/myorg/nonexistent"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 5, "stderr: %s", result.Stderr)
+}
+
+func TestPipelineRun_InvalidParam(t *testing.T) {
+	_, env := setupPipelineRunFake(t)
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"pipeline", "run", "--project", "gh/myorg/myrepo", "--param", "notakeyvalue"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 2, "stderr: %s", result.Stderr)
+}
+
+// --- pipeline run interactive ---
+
+// setupPipelineRunInteractiveFake builds a fake with project info, pipeline
+// definitions, and a trigger run response — everything needed for the
+// interactive definition-selection prompt.
+func setupPipelineRunInteractiveFake(t *testing.T) (*fakes.CircleCI, *testenv.TestEnv) {
+	t.Helper()
+	fake := fakes.NewCircleCI(t)
+	fake.AddProjectInfo("gh/myorg/myrepo", map[string]any{
+		"id":   pipelineProjectID,
+		"slug": "gh/myorg/myrepo",
+		"name": "myrepo",
+		"vcs_info": map[string]any{
+			"provider":       "GitHub",
+			"default_branch": "main",
+			"vcs_url":        "https://github.com/myorg/myrepo",
+		},
+	})
+	for _, d := range pipelineListFixtures {
+		fake.AddPipelineDefinition(pipelineProjectID, d)
+	}
+	fake.SetTriggerPipelineRunResponse("gh/myorg/myrepo", map[string]any{
+		"id":         pipelineRunID,
+		"state":      "created",
+		"number":     pipelineRunNumber,
+		"created_at": "2024-06-01T00:00:00Z",
+	})
+	env := testenv.New(t)
+	env.Token = testToken
+	env.CircleCIURL = fake.URL()
+	return fake, env
+}
+
+func TestPipelineRun_Interactive_SelectFirst(t *testing.T) {
+	_, env := setupPipelineRunInteractiveFake(t)
+
+	console := binary.RunCLIInteractive(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"pipeline", "run", "--project", "gh/myorg/myrepo"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	// Step 1: select the first pipeline definition (main-pipeline).
+	_, err := console.ExpectString("Select a pipeline definition")
+	assert.NilError(t, err)
+	_, err = console.Send("\r")
+	assert.NilError(t, err)
+
+	// Step 2: accept the default branch (main).
+	_, err = console.ExpectString("Branch to run on")
+	assert.NilError(t, err)
+	_, err = console.Send("\r")
+	assert.NilError(t, err)
+
+	_, err = console.ExpectString("Pipeline #42 triggered")
+	assert.NilError(t, err)
+}
+
+func TestPipelineRun_Interactive_SkipDefinition(t *testing.T) {
+	_, env := setupPipelineRunInteractiveFake(t)
+
+	console := binary.RunCLIInteractive(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"pipeline", "run", "--project", "gh/myorg/myrepo"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	// Step 1: navigate past both definitions to "None" (2 × down, Enter).
+	_, err := console.ExpectString("Select a pipeline definition")
+	assert.NilError(t, err)
+	_, err = console.Send(keyDown + keyDown + "\r")
+	assert.NilError(t, err)
+
+	// Step 2: accept the default branch (main).
+	_, err = console.ExpectString("Branch to run on")
+	assert.NilError(t, err)
+	_, err = console.Send("\r")
+	assert.NilError(t, err)
+
+	_, err = console.ExpectString("Pipeline #42 triggered")
+	assert.NilError(t, err)
+}
+
+func TestPipelineRun_Interactive_CustomBranch(t *testing.T) {
+	_, env := setupPipelineRunInteractiveFake(t)
+
+	console := binary.RunCLIInteractive(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"pipeline", "run", "--project", "gh/myorg/myrepo"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	// Step 1: select the first pipeline definition.
+	_, err := console.ExpectString("Select a pipeline definition")
+	assert.NilError(t, err)
+	_, err = console.Send("\r")
+	assert.NilError(t, err)
+
+	// Step 2: navigate to "Other..." and type a custom branch.
+	_, err = console.ExpectString("Branch to run on")
+	assert.NilError(t, err)
+	_, err = console.Send(keyDown + "\r") // move to "Other..."
+	assert.NilError(t, err)
+
+	_, err = console.ExpectString("Branch name")
+	assert.NilError(t, err)
+	_, err = console.Send("feature/my-branch\r")
+	assert.NilError(t, err)
+
+	_, err = console.ExpectString("Pipeline #42 triggered")
+	assert.NilError(t, err)
 }

--- a/acceptance/testdata/TestCertificateDelete_NotFound.stderr.txt
+++ b/acceptance/testdata/TestCertificateDelete_NotFound.stderr.txt
@@ -1,4 +1,6 @@
 error: No iOS certificate found for "cert-missing".
+API: {"message":"not found"}
+
 
 Suggestions:
   • Check the certificate ID and try again

--- a/acceptance/testdata/TestContextDelete_NotFound.stderr.txt
+++ b/acceptance/testdata/TestContextDelete_NotFound.stderr.txt
@@ -1,4 +1,6 @@
 error: No context found for "00000000-0000-0000-0000-000000000000".
+API: {"message":"not found"}
+
 
 Suggestions:
   • Check the context name or ID and try again

--- a/acceptance/testdata/TestContextGet_NotFound.stderr.txt
+++ b/acceptance/testdata/TestContextGet_NotFound.stderr.txt
@@ -1,4 +1,6 @@
 error: No context found for "00000000-0000-0000-0000-000000000000".
+API: {"message":"not found"}
+
 
 Suggestions:
   • Check the context name or ID and try again

--- a/acceptance/testdata/TestContextRestrictionDelete_NotFound.stderr.txt
+++ b/acceptance/testdata/TestContextRestrictionDelete_NotFound.stderr.txt
@@ -1,4 +1,6 @@
 error: No restriction found for "e0000001-0000-4000-8000-000000000001".
+API: {"message":"not found"}
+
 
 Suggestions:
   • Check the context ID and try again

--- a/acceptance/testdata/TestContextSecretDelete_NotFound.stderr.txt
+++ b/acceptance/testdata/TestContextSecretDelete_NotFound.stderr.txt
@@ -1,4 +1,6 @@
 error: No environment variable found for "NONEXISTENT".
+API: {"message":"not found"}
+
 
 Suggestions:
   • Check the context ID and variable name and try again

--- a/acceptance/testdata/TestInfo_NotFound.stderr.txt
+++ b/acceptance/testdata/TestInfo_NotFound.stderr.txt
@@ -1,4 +1,6 @@
 error: No project found for "gh/myorg/nonexistent".
+API: {"message":"not found"}
+
 
 Suggestions:
   • Run 'circleci project link' to bind this repository to a CircleCI project

--- a/acceptance/testdata/TestProjectGet_NotFound.stderr.txt
+++ b/acceptance/testdata/TestProjectGet_NotFound.stderr.txt
@@ -1,4 +1,6 @@
 error: No project found for "gh/myorg/nonexistent".
+API: {"message":"not found"}
+
 
 Suggestions:
   • Run 'circleci project link' to bind this repository to a CircleCI project

--- a/acceptance/testdata/TestRunCancel_NotFound.stderr.txt
+++ b/acceptance/testdata/TestRunCancel_NotFound.stderr.txt
@@ -1,4 +1,6 @@
 error: No run found for "00000000-0000-0000-0000-000000000000".
+API: {"message":"not found"}
+
 
 Suggestions:
   • Check the run UUID or branch name and try again

--- a/acceptance/testdata/TestRunGet_NotFound.stderr.txt
+++ b/acceptance/testdata/TestRunGet_NotFound.stderr.txt
@@ -1,4 +1,6 @@
 error: No run found for "00000000-0000-0000-0000-000000000000".
+API: {"message":"not found"}
+
 
 Suggestions:
   • Check the run UUID or branch name and try again

--- a/acceptance/testdata/TestSigningConfigDelete_NotFound.stderr.txt
+++ b/acceptance/testdata/TestSigningConfigDelete_NotFound.stderr.txt
@@ -1,4 +1,6 @@
 error: No iOS signing config found for "cfg-missing".
+API: {"message":"not found"}
+
 
 Suggestions:
   • Check the signing config ID and try again

--- a/acceptance/testdata/TestWorkflowGet_NotFound.stderr.txt
+++ b/acceptance/testdata/TestWorkflowGet_NotFound.stderr.txt
@@ -1,4 +1,6 @@
 error: No workflow found for "00000000-0000-0000-0000-000000000000".
+API: {"message":"not found"}
+
 
 Suggestions:
   • Check the workflow ID with: circleci run get

--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -131,6 +131,13 @@ func (c *Client) post(ctx context.Context, route string, body, dst any, opts ...
 	return err
 }
 
+func (c *Client) postStatus(ctx context.Context, route string, body, dst any, opts ...func(*httpcl.Request)) (int, error) {
+	return c.main.Call(ctx, httpcl.NewRequest(http.MethodPost, "/api/v2"+route, baseOpts(
+		httpcl.Body(body),
+		httpcl.JSONDecoder(dst),
+	).With(opts)...))
+}
+
 func (c *Client) postV1(ctx context.Context, route string, body, dst any, opts ...func(*httpcl.Request)) error {
 	_, err := c.main.Call(ctx, httpcl.NewRequest(http.MethodPost, "/api/v1.1"+route, baseOpts(
 		httpcl.Body(body),

--- a/internal/apiclient/pipeline_definition.go
+++ b/internal/apiclient/pipeline_definition.go
@@ -24,6 +24,9 @@ package apiclient
 
 import (
 	"context"
+	"fmt"
+	"net/http"
+	"strings"
 	"time"
 )
 
@@ -73,6 +76,93 @@ type CreatePipelineDefinitionInput struct {
 	ConfigFilePath   string
 	CheckoutProvider string
 	CheckoutRepoID   string
+}
+
+// TriggerPipelineRunInput contains the options for triggering a pipeline run.
+type TriggerPipelineRunInput struct {
+	DefinitionID   string
+	ConfigBranch   string
+	ConfigTag      string
+	CheckoutBranch string
+	CheckoutTag    string
+	Parameters     map[string]any
+}
+
+// TriggerPipelineRunResult holds the response from triggering a pipeline run.
+// When Triggered is false the pipeline was skipped (e.g. due to a CI skip
+// commit message) and Message describes why.
+type TriggerPipelineRunResult struct {
+	Triggered bool
+	ID        string
+	State     string
+	Number    int
+	CreatedAt time.Time
+	Message   string
+}
+
+// TriggerPipelineRun triggers a pipeline run via the recommended v2 endpoint.
+// projectSlug must be in "vcs/org/repo" form (e.g. "gh/myorg/myrepo").
+func (c *Client) TriggerPipelineRun(ctx context.Context, projectSlug string, input TriggerPipelineRunInput) (*TriggerPipelineRunResult, error) {
+	// The endpoint path is /project/{provider}/{organization}/{project}/pipeline/run.
+	// We split the slug into three separate route params so each segment is
+	// individually percent-encoded. Passing the full slug as one param would
+	// encode the slashes as %2F, producing a single path segment that the server
+	// cannot route — resulting in a 404.
+	parts := strings.SplitN(projectSlug, "/", 3)
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("invalid project slug %q: expected provider/organization/project", projectSlug)
+	}
+
+	body := map[string]any{}
+	if input.DefinitionID != "" {
+		body["definition_id"] = input.DefinitionID
+	}
+
+	cfg := map[string]any{}
+	if input.ConfigBranch != "" {
+		cfg["branch"] = input.ConfigBranch
+	} else if input.ConfigTag != "" {
+		cfg["tag"] = input.ConfigTag
+	}
+	if len(cfg) > 0 {
+		body["config"] = cfg
+	}
+
+	checkout := map[string]any{}
+	if input.CheckoutBranch != "" {
+		checkout["branch"] = input.CheckoutBranch
+	} else if input.CheckoutTag != "" {
+		checkout["tag"] = input.CheckoutTag
+	}
+	if len(checkout) > 0 {
+		body["checkout"] = checkout
+	}
+
+	if len(input.Parameters) > 0 {
+		body["parameters"] = input.Parameters
+	}
+
+	var raw struct {
+		ID        string    `json:"id"`
+		State     string    `json:"state"`
+		Number    int       `json:"number"`
+		CreatedAt time.Time `json:"created_at"`
+		Message   string    `json:"message"`
+	}
+	status, err := c.postStatus(ctx, "/project/%s/%s/%s/pipeline/run", body, &raw,
+		routeParams(parts[0], parts[1], parts[2]),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &TriggerPipelineRunResult{
+		Triggered: status == http.StatusCreated,
+		ID:        raw.ID,
+		State:     raw.State,
+		Number:    raw.Number,
+		CreatedAt: raw.CreatedAt,
+		Message:   raw.Message,
+	}, nil
 }
 
 // CreatePipelineDefinition creates a new pipeline definition for a project.

--- a/internal/cmd/pipeline/pipeline.go
+++ b/internal/cmd/pipeline/pipeline.go
@@ -48,6 +48,7 @@ func NewPipelineCmd() *cobra.Command {
 
 	cmd.AddCommand(newCreateCmd())
 	cmd.AddCommand(newListCmd())
+	cmd.AddCommand(newRunCmd())
 
 	return cmd
 }

--- a/internal/cmd/pipeline/run.go
+++ b/internal/cmd/pipeline/run.go
@@ -1,0 +1,297 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package pipeline
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+
+	"github.com/CircleCI-Public/circleci-cli/internal/apiclient"
+	"github.com/CircleCI-Public/circleci-cli/internal/cmdutil"
+	clierrors "github.com/CircleCI-Public/circleci-cli/internal/errors"
+	"github.com/CircleCI-Public/circleci-cli/internal/iostream"
+)
+
+func newRunCmd() *cobra.Command {
+	var (
+		projectSlug  string
+		definitionID string
+		branch       string
+		tag          string
+		params       []string
+		jsonOut      bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "run",
+		Short: "Trigger a new pipeline run",
+		Long: heredoc.Doc(`
+			Trigger a new pipeline run using the recommended CircleCI v2 API.
+
+			The project is resolved from --project if provided; otherwise the
+			project slug is detected from the git remote.
+
+			In a terminal, missing --definition-id prompts you to pick from the
+			project's pipeline definitions, and missing --branch/--tag prompts you
+			to choose the project's default branch or enter a custom one.
+			In non-interactive mode (CI, agents, scripts) both are optional and
+			the trigger proceeds without them.
+
+			Use --branch or --tag to specify which revision to run on. They are
+			mutually exclusive. --branch sets both the config fetch branch and the
+			checkout branch; --tag sets both the config fetch tag and the checkout tag.
+
+			Pass pipeline parameters with --param key=value (repeatable). Values
+			are sent as strings.
+
+			When the pipeline is skipped (e.g. due to a [ci skip] commit message)
+			the command exits 0 and prints the reason to stdout.
+
+			JSON fields (triggered): id, state, number, created_at, triggered
+			JSON fields (skipped):   triggered, message
+		`),
+		Example: heredoc.Doc(`
+			# Trigger a pipeline interactively — pick definition and branch from menus
+			$ circleci pipeline run --project gh/myorg/myrepo
+
+			# Trigger a specific definition on a branch non-interactively
+			$ circleci pipeline run --project gh/myorg/myrepo \
+			    --definition-id 2338d0ae-5541-4bbf-88a2-55e9f7281f80 \
+			    --branch main
+
+			# Trigger on a tag with parameters
+			$ circleci pipeline run --project gh/myorg/myrepo \
+			    --definition-id 2338d0ae-5541-4bbf-88a2-55e9f7281f80 \
+			    --tag v1.2.3 \
+			    --param deploy_env=staging
+
+			# Output as JSON for scripting
+			$ circleci pipeline run --project gh/myorg/myrepo \
+			    --definition-id 2338d0ae-5541-4bbf-88a2-55e9f7281f80 \
+			    --branch main --json
+		`),
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := iostream.FromCmd(cmd.Context(), cmd)
+			client, err := cmdutil.LoadClient(ctx, cmd)
+			if err != nil {
+				return err
+			}
+			return runRun(ctx, client, projectSlug, definitionID, branch, tag, params, jsonOut)
+		},
+	}
+
+	cmd.Flags().StringVar(&projectSlug, "project", "", "Project slug (e.g. gh/org/repo); defaults to git remote")
+	cmd.Flags().StringVar(&definitionID, "definition-id", "", "Pipeline definition UUID to run (prompted interactively if omitted)")
+	cmd.Flags().StringVarP(&branch, "branch", "b", "", "Branch for config fetch and checkout (mutually exclusive with --tag)")
+	cmd.Flags().StringVarP(&tag, "tag", "t", "", "Tag for config fetch and checkout (mutually exclusive with --branch)")
+	cmd.Flags().StringArrayVar(&params, "param", nil, "Pipeline parameter as key=value (repeatable)")
+	cmdutil.AddJSONFlag(cmd, &jsonOut)
+	cmdutil.AddJQFlag(cmd)
+
+	return cmd
+}
+
+type runOutput struct {
+	Triggered bool   `json:"triggered"`
+	ID        string `json:"id,omitempty"`
+	State     string `json:"state,omitempty"`
+	Number    int    `json:"number,omitempty"`
+	CreatedAt string `json:"created_at,omitempty"`
+	Message   string `json:"message,omitempty"`
+}
+
+func runRun(ctx context.Context, client *apiclient.Client, projectSlug, definitionID, branch, tag string, rawParams []string, jsonOut bool) error {
+	if branch != "" && tag != "" {
+		return clierrors.New("pipeline.run.invalid_args", "Invalid arguments",
+			"--branch and --tag are mutually exclusive").
+			WithExitCode(clierrors.ExitBadArguments)
+	}
+
+	slug, err := cmdutil.ResolveProjectSlug(projectSlug)
+	if err != nil {
+		return err
+	}
+
+	// Fetch project info once; reused for both definition and branch prompts.
+	var projInfo *apiclient.ProjectInfo
+	if iostream.IsInteractive(ctx) {
+		projInfo, _ = client.GetProjectInfo(ctx, slug) // best-effort; nil skips prompts
+	}
+
+	definitionID, err = resolveDefinitionID(ctx, client, projInfo, definitionID)
+	if err != nil {
+		return err
+	}
+
+	branch, err = resolveBranch(ctx, projInfo, branch, tag)
+	if err != nil {
+		return err
+	}
+
+	parameters, err := parseParams(rawParams)
+	if err != nil {
+		return err
+	}
+
+	input := apiclient.TriggerPipelineRunInput{
+		DefinitionID:   definitionID,
+		ConfigBranch:   branch,
+		ConfigTag:      tag,
+		CheckoutBranch: branch,
+		CheckoutTag:    tag,
+		Parameters:     parameters,
+	}
+
+	result, err := client.TriggerPipelineRun(ctx, slug, input)
+	if err != nil {
+		return cmdutil.APIErr(err, slug,
+			"pipeline.run_failed",
+			"Failed to trigger pipeline run for project %q.",
+			"Check that the project slug is correct and you have permission to trigger pipelines",
+			"Visit: https://app.circleci.com/settings/project")
+	}
+
+	out := runOutput{
+		Triggered: result.Triggered,
+		Message:   result.Message,
+	}
+	if result.Triggered {
+		out.ID = result.ID
+		out.State = result.State
+		out.Number = result.Number
+		out.CreatedAt = result.CreatedAt.Format(time.RFC3339)
+	}
+
+	if jsonOut {
+		return iostream.PrintJSON(ctx, out)
+	}
+
+	if !result.Triggered {
+		iostream.Println(ctx, fmt.Sprintf("Pipeline not triggered: %s", result.Message))
+		return nil
+	}
+
+	iostream.Println(ctx, fmt.Sprintf("Pipeline #%d triggered  (id: %s, state: %s)", result.Number, result.ID, result.State))
+	return nil
+}
+
+// resolveDefinitionID returns definitionID as-is if provided. In interactive
+// mode it lists the project's pipeline definitions and prompts for a selection.
+// In non-interactive mode it returns "" so the trigger proceeds without one.
+func resolveDefinitionID(ctx context.Context, client *apiclient.Client, projInfo *apiclient.ProjectInfo, definitionID string) (string, error) {
+	if definitionID != "" {
+		return definitionID, nil
+	}
+	if !iostream.IsInteractive(ctx) || projInfo == nil {
+		return "", nil
+	}
+
+	defs, err := client.ListPipelineDefinitions(ctx, projInfo.ID)
+	if err != nil || len(defs) == 0 {
+		return "", nil
+	}
+
+	const skipOption = "None (trigger without a specific definition)"
+	labels := make([]string, len(defs)+1)
+	for i, d := range defs {
+		label := d.Name
+		if d.ID != "" {
+			label += "  (" + d.ID + ")"
+		}
+		labels[i] = label
+	}
+	labels[len(defs)] = skipOption
+
+	idx, err := iostream.PromptSelect(ctx, "Select a pipeline definition", labels)
+	if err != nil {
+		return "", err
+	}
+	if idx < 0 || labels[idx] == skipOption {
+		return "", nil
+	}
+	return defs[idx].ID, nil
+}
+
+// resolveBranch returns branch as-is if either branch or tag is already set.
+// In interactive mode it prompts the user to choose the project's default branch
+// or enter a custom one. In non-interactive mode it returns "" unchanged.
+func resolveBranch(ctx context.Context, projInfo *apiclient.ProjectInfo, branch, tag string) (string, error) {
+	if branch != "" || tag != "" {
+		return branch, nil
+	}
+	if !iostream.IsInteractive(ctx) || projInfo == nil {
+		return "", nil
+	}
+
+	defaultBranch := "main"
+	if projInfo.VCSInfo != nil && projInfo.VCSInfo.DefaultBranch != "" {
+		defaultBranch = projInfo.VCSInfo.DefaultBranch
+	}
+
+	const otherOption = "Other..."
+	options := []string{defaultBranch, otherOption}
+
+	idx, err := iostream.PromptSelect(ctx, "Branch to run on", options)
+	if err != nil {
+		return "", err
+	}
+	if idx < 0 {
+		return "", clierrors.New("run.cancelled", "Aborted", "No branch selected.").
+			WithExitCode(clierrors.ExitCancelled)
+	}
+	if options[idx] == otherOption {
+		v, err := iostream.PromptText(ctx, "Branch name", "e.g. my-feature-branch")
+		if err != nil {
+			return "", err
+		}
+		if v == "" {
+			return "", clierrors.New("run.cancelled", "Aborted", "No branch entered.").
+				WithExitCode(clierrors.ExitCancelled)
+		}
+		return v, nil
+	}
+	return options[idx], nil
+}
+
+func parseParams(raw []string) (map[string]any, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	out := make(map[string]any, len(raw))
+	for _, p := range raw {
+		k, v, ok := strings.Cut(p, "=")
+		if !ok || k == "" {
+			return nil, clierrors.New("pipeline.run.invalid_param", "Invalid parameter",
+				fmt.Sprintf("%q is not in key=value format", p)).
+				WithExitCode(clierrors.ExitBadArguments)
+		}
+		out[k] = v
+	}
+	return out, nil
+}

--- a/internal/cmd/root/testdata/usage/circleci/pipeline.txt
+++ b/internal/cmd/root/testdata/usage/circleci/pipeline.txt
@@ -5,6 +5,7 @@ Usage:
 Available Commands:
   create      Create a pipeline definition
   list        List pipeline definitions for a project
+  run         Trigger a new pipeline run
 
 Global Flags:
   -c, --config string   path to config file (default: ~/.config/circleci/config.yml)

--- a/internal/cmd/root/testdata/usage/circleci/pipeline/run.txt
+++ b/internal/cmd/root/testdata/usage/circleci/pipeline/run.txt
@@ -1,0 +1,37 @@
+Usage:
+  circleci pipeline run [flags]
+
+Examples:
+# Trigger a pipeline interactively — pick definition and branch from menus
+$ circleci pipeline run --project gh/myorg/myrepo
+
+# Trigger a specific definition on a branch non-interactively
+$ circleci pipeline run --project gh/myorg/myrepo \
+    --definition-id 2338d0ae-5541-4bbf-88a2-55e9f7281f80 \
+    --branch main
+
+# Trigger on a tag with parameters
+$ circleci pipeline run --project gh/myorg/myrepo \
+    --definition-id 2338d0ae-5541-4bbf-88a2-55e9f7281f80 \
+    --tag v1.2.3 \
+    --param deploy_env=staging
+
+# Output as JSON for scripting
+$ circleci pipeline run --project gh/myorg/myrepo \
+    --definition-id 2338d0ae-5541-4bbf-88a2-55e9f7281f80 \
+    --branch main --json
+
+
+Flags:
+  -b, --branch string          Branch for config fetch and checkout (mutually exclusive with --tag)
+      --definition-id string   Pipeline definition UUID to run (prompted interactively if omitted)
+      --jq string              Process values from the response using jq syntax
+      --json                   Output as JSON
+      --param stringArray      Pipeline parameter as key=value (repeatable)
+      --project string         Project slug (e.g. gh/org/repo); defaults to git remote
+  -t, --tag string             Tag for config fetch and checkout (mutually exclusive with --branch)
+
+Global Flags:
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected

--- a/internal/cmdutil/client.go
+++ b/internal/cmdutil/client.go
@@ -113,8 +113,11 @@ func APIErr(err error, subject, notFoundCode, notFoundMsg string, notFoundSugges
 			WithExitCode(clierrors.ExitAuthError)
 	}
 	if httpcl.HasStatusCode(err, http.StatusNotFound) {
-		nf := clierrors.New(notFoundCode, "Not found",
-			fmt.Sprintf(notFoundMsg, subject)).
+		msg := fmt.Sprintf(notFoundMsg, subject)
+		if he, ok := errors.AsType[*httpcl.HTTPError](err); ok && len(he.Body) > 0 {
+			msg += "\nAPI: " + string(he.Body)
+		}
+		nf := clierrors.New(notFoundCode, "Not found", msg).
 			WithExitCode(clierrors.ExitNotFound)
 		if len(notFoundSuggestions) > 0 {
 			nf = nf.WithSuggestions(notFoundSuggestions...)

--- a/internal/cmdutil/project.go
+++ b/internal/cmdutil/project.go
@@ -29,6 +29,21 @@ import (
 	"github.com/CircleCI-Public/circleci-cli/internal/gitremote"
 )
 
+// ResolveProjectSlug returns projectSlug as-is when non-empty. Otherwise it
+// detects the slug from the git remote. Unlike ResolveProjectID this does not
+// make an API call and does not return a UUID — use it for endpoints that
+// require a slug in the path (e.g. POST /project/{vcs}/{org}/{repo}/pipeline/run).
+func ResolveProjectSlug(projectSlug string) (string, error) {
+	if projectSlug != "" {
+		return projectSlug, nil
+	}
+	info, err := gitremote.Detect()
+	if err != nil {
+		return "", GitDetectErr(err, "Or specify the project with --project gh/org/repo")
+	}
+	return info.Slug, nil
+}
+
 // ResolveProjectID returns projectID as-is when non-empty. Otherwise it resolves
 // the project from the slug (--project flag or git remote) to recover its UUID.
 func ResolveProjectID(ctx context.Context, client *apiclient.Client, projectSlug, projectID string) (string, error) {

--- a/internal/testing/fakes/circleci.go
+++ b/internal/testing/fakes/circleci.go
@@ -55,6 +55,8 @@ type CircleCI struct {
 	jobsV1                            map[string]any    // "vcs/org/repo/jobNumber" → job detail response (v1.1)
 	stepOutputs                       map[string]string // path → JSON log lines content
 	triggerResponses                  map[string]any    // project slug → trigger response body
+	triggerPipelineRunResponses       map[string]any    // project slug → trigger run response body
+	triggerPipelineRunStatuses        map[string]int    // project slug → HTTP status (default 201)
 	pipelineDefinitions               map[string][]any  // projectID → list of pipeline definition objects
 	createPipelineDefinitionResponses map[string]any    // projectID → response body
 	createTriggerResponses            map[string]any    // "projectID/pipelineDefinitionID" → response body
@@ -145,6 +147,8 @@ func NewCircleCI(t *testing.T) *CircleCI {
 		jobsV1:                            map[string]any{},
 		stepOutputs:                       map[string]string{},
 		triggerResponses:                  map[string]any{},
+		triggerPipelineRunResponses:       map[string]any{},
+		triggerPipelineRunStatuses:        map[string]int{},
 		pipelineDefinitions:               map[string][]any{},
 		createPipelineDefinitionResponses: map[string]any{},
 		createTriggerResponses:            map[string]any{},
@@ -201,6 +205,7 @@ func NewCircleCI(t *testing.T) *CircleCI {
 	r.Get("/api/v2/project/{vcs}/{org}/{repo}/{jobNumber}/artifacts", f.handleGetJobArtifacts)
 	r.Get("/api/v2/project/{vcs}/{org}/{repo}/job/{jobNumber}", f.handleGetJob)
 	r.Post("/api/v2/project/{vcs}/{org}/{repo}/pipeline", f.handleTriggerPipeline)
+	r.Post("/api/v2/project/{vcs}/{org}/{repo}/pipeline/run", f.handleTriggerPipelineRun)
 	r.Get("/api/v1.1/project/{vcs}/{org}/{repo}/{jobNumber}", f.handleGetJobV1)
 	// Project / env-var routes. These API calls do not URL-encode slashes in the
 	// project slug, so we match three separate path segments rather than {slug}.
@@ -364,6 +369,25 @@ func (f *CircleCI) SetTriggerResponse(slug string, resp any) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.triggerResponses[slug] = resp
+}
+
+// SetTriggerPipelineRunResponse registers the response body returned when POST
+// /api/v2/project/<slug>/pipeline/run is called with a 201 status.
+// slug should be in "vcs/org/repo" form.
+func (f *CircleCI) SetTriggerPipelineRunResponse(slug string, resp any) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.triggerPipelineRunResponses[slug] = resp
+	f.triggerPipelineRunStatuses[slug] = http.StatusCreated
+}
+
+// SetTriggerPipelineRunSkipped registers a "not triggered" response (200) for
+// POST /api/v2/project/<slug>/pipeline/run.
+func (f *CircleCI) SetTriggerPipelineRunSkipped(slug, message string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.triggerPipelineRunResponses[slug] = map[string]any{"message": message}
+	f.triggerPipelineRunStatuses[slug] = http.StatusOK
 }
 
 // AddJob registers a job detail response for GET /api/v2/project/<slug>/job/<number>.
@@ -552,6 +576,22 @@ func (f *CircleCI) handleTriggerPipeline(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	render.Status(r, http.StatusCreated)
+	render.JSON(w, r, resp)
+}
+
+func (f *CircleCI) handleTriggerPipelineRun(w http.ResponseWriter, r *http.Request) {
+	slug := chi.URLParam(r, "vcs") + "/" + chi.URLParam(r, "org") + "/" + chi.URLParam(r, "repo")
+	f.mu.RLock()
+	resp, ok := f.triggerPipelineRunResponses[slug]
+	status := f.triggerPipelineRunStatuses[slug]
+	f.mu.RUnlock()
+
+	if !ok {
+		render.Status(r, http.StatusNotFound)
+		render.JSON(w, r, map[string]any{"message": "project not found"})
+		return
+	}
+	render.Status(r, status)
 	render.JSON(w, r, resp)
 }
 


### PR DESCRIPTION
## Summary

- Adds `circleci pipeline run` backed by the recommended `POST /project/{provider}/{org}/{project}/pipeline/run` v2 endpoint
- In interactive mode: prompts to select a pipeline definition from the project's list, then prompts for a branch (project default or custom "Other...")
- Flags: `--definition-id`, `--branch`/`-b`, `--tag`/`-t`, `--param key=value` (repeatable), `--json`

## Bug fixes

- **URL encoding**: `TriggerPipelineRun` was encoding the project slug as a single `%2F`-encoded path segment; the endpoint expects three separate path segments (`{provider}/{org}/{project}`), so the server was returning 404. Fixed by splitting the slug and passing three separate route params.
- **Silent 404 body**: `APIErr` discarded the API response body for 404 errors, showing only the generic message. The body is now appended so callers see what the API actually said.

## Test plan

- [ ] `go test -count=1 -run TestPipelineRun ./acceptance/...` — 13 acceptance tests covering non-interactive (all flag combos, skipped pipeline, project not found, invalid param) and interactive (select definition + default branch, skip definition, custom branch via "Other...")
- [ ] Manual: `circleci pipeline run --project gh/<org>/<repo>` shows definition + branch prompts, triggers successfully