### PR TITLE
Align orb client with updated V3 API spec

### DIFF
--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -229,6 +229,13 @@ func (c *Client) postV3(ctx context.Context, route string, body, dst any, opts .
 	return err
 }
 
+func (c *Client) getV3Text(ctx context.Context, route string, dst *string, opts ...func(*httpcl.Request)) error {
+	_, err := c.main.Call(ctx, httpcl.NewRequest(http.MethodGet, "/api/v3"+route, baseOpts(
+		httpcl.TextDecoder(dst),
+	).With(opts)...))
+	return err
+}
+
 func (c *Client) deleteV3(ctx context.Context, route string, opts ...func(*httpcl.Request)) error {
 	_, err := c.main.Call(ctx, httpcl.NewRequest(http.MethodDelete, "/api/v3"+route, opts...))
 	return err

--- a/internal/apiclient/orb.go
+++ b/internal/apiclient/orb.go
@@ -163,9 +163,8 @@ type orbCategoryWire struct {
 }
 
 type orbValidateWire struct {
-	ID         string `json:"id"`
 	Attributes struct {
-		Valid      bool     `json:"valid"`
+		Valid      bool     `json:"is_valid"`
 		OutputYAML string   `json:"output_yaml"`
 		Errors     []string `json:"errors"`
 	} `json:"attributes"`
@@ -352,20 +351,6 @@ func (c *Client) ValidateOrbYAML(ctx context.Context, yaml, orgID string) (*OrbV
 	}, nil
 }
 
-// ProcessOrbYAML validates and expands orb YAML. orgID is optional.
-func (c *Client) ProcessOrbYAML(ctx context.Context, yaml, orgID string) (*OrbValidation, error) {
-	var env v3Entity[orbValidateWire]
-	err := c.postV3(ctx, "/orb/packages/process", orbYAMLBody{YAML: yaml, OrgID: orgID}, &env)
-	if err != nil {
-		return nil, err
-	}
-	return &OrbValidation{
-		Valid:      env.Data.Attributes.Valid,
-		OutputYAML: env.Data.Attributes.OutputYAML,
-		Errors:     env.Data.Attributes.Errors,
-	}, nil
-}
-
 // SetOrbListed sets the listed status of an orb package.
 func (c *Client) SetOrbListed(ctx context.Context, orbID string, listed bool) error {
 	var env v3Entity[orbPackageWire]
@@ -442,11 +427,12 @@ func (c *Client) GetOrbVersionByRef(ctx context.Context, ref string) (*OrbVersio
 	return env.Data[0].toOrbVersion(), nil
 }
 
-// GetOrbVersionByID gets a single orb version by UUID (includes source YAML).
+// GetOrbVersionByID gets a single orb version by UUID.
 func (c *Client) GetOrbVersionByID(ctx context.Context, id string) (*OrbVersion, error) {
 	var env v3Entity[orbVersionWire]
 	err := c.getV3(ctx, "/orb/versions/%s", &env,
 		routeParams(id),
+		queryParam("include", "orb_package"),
 	)
 	if httpcl.HasStatusCode(err, http.StatusNotFound) {
 		return nil, fmt.Errorf("%w: %q", ErrOrbVersionNotFound, id)
@@ -455,6 +441,21 @@ func (c *Client) GetOrbVersionByID(ctx context.Context, id string) (*OrbVersion,
 		return nil, err
 	}
 	return env.Data.toOrbVersion(), nil
+}
+
+// GetOrbVersionSource returns the raw YAML source of an orb version.
+func (c *Client) GetOrbVersionSource(ctx context.Context, id string) (string, error) {
+	var body string
+	err := c.getV3Text(ctx, "/orb/versions/%s/source", &body,
+		routeParams(id),
+	)
+	if httpcl.HasStatusCode(err, http.StatusNotFound) {
+		return "", fmt.Errorf("%w: %q", ErrOrbVersionNotFound, id)
+	}
+	if err != nil {
+		return "", err
+	}
+	return body, nil
 }
 
 type orbYAMLBody struct {

--- a/internal/apiclient/orb.go
+++ b/internal/apiclient/orb.go
@@ -432,7 +432,7 @@ func (c *Client) GetOrbVersionByID(ctx context.Context, id string) (*OrbVersion,
 	var env v3Entity[orbVersionWire]
 	err := c.getV3(ctx, "/orb/versions/%s", &env,
 		routeParams(id),
-		queryParam("include", "orb_package"),
+		queryParam("include", "source"),
 	)
 	if httpcl.HasStatusCode(err, http.StatusNotFound) {
 		return nil, fmt.Errorf("%w: %q", ErrOrbVersionNotFound, id)

--- a/internal/cmd/orb/process.go
+++ b/internal/cmd/orb/process.go
@@ -87,7 +87,7 @@ func runOrbProcess(ctx context.Context, client *apiclient.Client, path, orgID st
 			WithExitCode(clierrors.ExitGeneralError)
 	}
 
-	result, err := client.ProcessOrbYAML(ctx, yaml, orgID)
+	result, err := client.ValidateOrbYAML(ctx, yaml, orgID)
 	if err != nil {
 		return orbAPIErr(err, path)
 	}

--- a/internal/httpcl/request.go
+++ b/internal/httpcl/request.go
@@ -69,6 +69,20 @@ func JSONDecoder(v any) func(*Request) {
 	}
 }
 
+// TextDecoder reads a 2xx response body as a plain string into dst.
+func TextDecoder(dst *string) func(*Request) {
+	return func(r *Request) {
+		r.decoder = func(rd io.Reader) error {
+			b, err := io.ReadAll(rd)
+			if err != nil {
+				return err
+			}
+			*dst = string(b)
+			return nil
+		}
+	}
+}
+
 // Header sets a single request header.
 func Header(key, val string) func(*Request) {
 	return func(r *Request) { r.headers.Add(key, val) }

--- a/internal/testing/fakes/circleci.go
+++ b/internal/testing/fakes/circleci.go
@@ -112,7 +112,7 @@ type CircleCI struct {
 	orbVersionsByOrbID  map[string][]string       // orbID → ordered version IDs
 	orbCategories       map[string]map[string]any // id → category object
 	orbCategoriesByName map[string]string         // name → id
-	orbValidateResponse *orbFakeValidateResponse  // override for validate/process responses
+	orbValidateResponse *orbFakeValidateResponse  // override for validate responses
 	orbCreatedPackages  []map[string]any          // packages created via POST
 	orbCreatedVersions  []map[string]any          // versions created via POST
 	orbUnlistedPackages map[string]bool           // id → unlisted
@@ -124,7 +124,7 @@ type CircleCI struct {
 	deletedNamespaces map[string]bool   // namespace id → deleted
 }
 
-// orbFakeValidateResponse holds a preset validate/process response for testing.
+// orbFakeValidateResponse holds a preset validate response for testing.
 type orbFakeValidateResponse struct {
 	yaml       string
 	valid      bool
@@ -258,13 +258,13 @@ func NewCircleCI(t *testing.T) *CircleCI {
 	r.Get("/api/v3/orb/packages", f.handleOrbListPackages)
 	r.Post("/api/v3/orb/packages", f.handleOrbCreatePackage)
 	r.Post("/api/v3/orb/packages/validate", f.handleOrbValidate)
-	r.Post("/api/v3/orb/packages/process", f.handleOrbProcess)
 	r.Get("/api/v3/orb/packages/{id}", f.handleOrbGetPackage)
 	r.Post("/api/v3/orb/packages/{id}/set-listed", f.handleOrbSetListed)
 	r.Post("/api/v3/orb/packages/{id}/add-category", f.handleOrbAddCategory)
 	r.Post("/api/v3/orb/packages/{id}/remove-category", f.handleOrbRemoveCategory)
 	r.Get("/api/v3/orb/versions", f.handleOrbListVersions)
 	r.Post("/api/v3/orb/versions", f.handleOrbCreateVersion)
+	r.Get("/api/v3/orb/versions/{id}/source", f.handleOrbGetVersionSource)
 	r.Get("/api/v3/orb/versions/{id}", f.handleOrbGetVersion)
 	r.Post("/api/v3/orb/versions/{id}/promote", f.handleOrbPromoteVersion)
 	r.Get("/api/v3/orb/categories", f.handleOrbListCategories)
@@ -2044,7 +2044,7 @@ func (f *CircleCI) AddOrbCategory(id, name string) {
 	f.orbCategoriesByName[name] = id
 }
 
-// SetOrbValidationResponse configures the validate/process endpoints to return
+// SetOrbValidationResponse configures the validate endpoint to return
 // the given result when the request YAML matches yaml. Pass "" for yaml to
 // match any request.
 func (f *CircleCI) SetOrbValidationResponse(yaml string, valid bool, errors []string, outputYAML string) {
@@ -2303,14 +2303,6 @@ func (f *CircleCI) handleOrbRemoveCategory(w http.ResponseWriter, r *http.Reques
 }
 
 func (f *CircleCI) handleOrbValidate(w http.ResponseWriter, r *http.Request) {
-	f.handleOrbValidateOrProcess(w, r)
-}
-
-func (f *CircleCI) handleOrbProcess(w http.ResponseWriter, r *http.Request) {
-	f.handleOrbValidateOrProcess(w, r)
-}
-
-func (f *CircleCI) handleOrbValidateOrProcess(w http.ResponseWriter, r *http.Request) {
 	var body struct {
 		YAML  string `json:"yaml"`
 		OrgID string `json:"org_id"`
@@ -2337,9 +2329,8 @@ func (f *CircleCI) handleOrbValidateOrProcess(w http.ResponseWriter, r *http.Req
 
 	response := map[string]any{
 		"data": map[string]any{
-			"id": "00000000-0000-0000-0000-000000000000",
 			"attributes": map[string]any{
-				"valid":       valid,
+				"is_valid":    valid,
 				"output_yaml": outputYAML,
 				"errors":      errors,
 			},
@@ -2466,6 +2457,24 @@ func (f *CircleCI) handleOrbCreateVersion(w http.ResponseWriter, r *http.Request
 
 	render.Status(r, http.StatusCreated)
 	render.JSON(w, r, orbVersionResponse(ver))
+}
+
+func (f *CircleCI) handleOrbGetVersionSource(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	f.mu.RLock()
+	ver, ok := f.orbVersions[id]
+	f.mu.RUnlock()
+
+	if !ok {
+		render.Status(r, http.StatusNotFound)
+		render.JSON(w, r, map[string]any{"message": "not found"})
+		return
+	}
+	attrs, _ := ver["attributes"].(map[string]any)
+	source, _ := attrs["source"].(string)
+	w.Header().Set("Content-Type", "text/plain")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(source))
 }
 
 func (f *CircleCI) handleOrbGetVersion(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- Rename `valid` → `is_valid` in validate response wire type
- Remove `id` field from validate response
- Remove `/process` endpoint; `orb process` command now uses validate
- Add required `include=orb_package` query param to `GET /orb/versions/:id`
- Add `GET /orb/versions/:id/source` endpoint returning text/plain
- Add `TextDecoder` to httpcl for plain text responses