### PR TITLE
Add circleci deploy init

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,4 @@
 **/testdata/**/*.html text eol=lf
 **/testdata/**/*.json text eol=lf
 **/testdata/**/*.yml text eol=lf
+**/testdata/**/*.yaml text eol=lf

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -97,7 +97,7 @@ tasks:
           -ignore ".claude/**" \
           -ignore "test-reports/**" \
           -ignore "**/*.html" \
-          -ignore "**/testdata/**/*.yml" \
+          -ignore "acceptance/testdata/**" \
           {{.ARGS}}
 
   mod-tidy:

--- a/acceptance/deploy_init_test.go
+++ b/acceptance/deploy_init_test.go
@@ -1,0 +1,196 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package acceptance_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/golden"
+
+	"github.com/CircleCI-Public/circleci-cli/internal/testing/binary"
+	testenv "github.com/CircleCI-Public/circleci-cli/internal/testing/env"
+)
+
+// rawConfig is a minimal config with two deploy-like jobs and branch filters.
+const rawConfig = `version: 2.1
+
+jobs:
+  build:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - checkout
+      - run: make build
+
+  deploy-staging:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - checkout
+      - run: make deploy-staging
+
+  deploy-prod:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - checkout
+      - run: make deploy
+
+workflows:
+  main:
+    jobs:
+      - build
+      - deploy-staging:
+          requires:
+            - build
+          filters:
+            branches:
+              only: develop
+      - deploy-prod:
+          requires:
+            - build
+          filters:
+            branches:
+              only: main
+`
+
+func writeConfig(t *testing.T, dir, content string) string {
+	t.Helper()
+	ciDir := filepath.Join(dir, ".circleci")
+	if err := os.MkdirAll(ciDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(ciDir, "config.yml")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestDeployInit(t *testing.T) {
+	dir := t.TempDir()
+	writeConfig(t, dir, rawConfig)
+
+	env := testenv.New(t)
+	env.Token = testToken
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"deploy", "init", "--component", "api", "--environment", "production"},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Check(t, golden.String(result.Stdout, t.Name()+".txt"))
+
+	patched, err := os.ReadFile(filepath.Join(dir, ".circleci", "config.yml"))
+	assert.NilError(t, err)
+	assert.Check(t, golden.Bytes(patched, t.Name()+".config.yml"))
+}
+
+func TestDeployInit_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	writeConfig(t, dir, rawConfig)
+
+	env := testenv.New(t)
+	env.Token = testToken
+
+	args := []string{"deploy", "init", "--component", "api", "--environment", "production"}
+	opts := binary.RunOpts{Binary: binaryPath, Args: args, Env: env.Environ(), WorkDir: dir}
+
+	r1 := binary.RunCLI(t, opts)
+	assert.Equal(t, r1.ExitCode, 0, "first run stderr: %s", r1.Stderr)
+
+	r2 := binary.RunCLI(t, opts)
+	assert.Equal(t, r2.ExitCode, 0, "second run stderr: %s", r2.Stderr)
+	assert.Check(t, golden.String(r2.Stdout, t.Name()+".txt"))
+}
+
+func TestDeployInit_NoJobs(t *testing.T) {
+	dir := t.TempDir()
+	writeConfig(t, dir, `version: 2.1
+jobs:
+  build:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - checkout
+`)
+
+	env := testenv.New(t)
+	env.Token = testToken
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"deploy", "init", "--component", "api"},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	assert.Check(t, result.ExitCode != 0)
+	assert.Check(t, golden.String(result.Stderr, t.Name()+".stderr.txt"))
+}
+
+func TestDeployInit_InferEnvironments(t *testing.T) {
+	dir := t.TempDir()
+	writeConfig(t, dir, `version: 2.1
+jobs:
+  deploy-staging:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - checkout
+      - run: make deploy-staging
+  deploy-production:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - checkout
+      - run: make deploy-prod
+workflows:
+  main:
+    jobs:
+      - deploy-staging
+      - deploy-production
+`)
+
+	env := testenv.New(t)
+	env.Token = testToken
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"deploy", "init", "--component", "myapp"},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+
+	patched, err := os.ReadFile(filepath.Join(dir, ".circleci", "config.yml"))
+	assert.NilError(t, err)
+	assert.Check(t, golden.Bytes(patched, t.Name()+".config.yml"))
+}

--- a/acceptance/testdata/TestDeployInit.config.yml
+++ b/acceptance/testdata/TestDeployInit.config.yml
@@ -1,25 +1,3 @@
-# Copyright (c) 2026 Circle Internet Services, Inc.
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in
-# all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
-#
-# SPDX-License-Identifier: MIT
-
 version: 2.1
 jobs:
   build:

--- a/acceptance/testdata/TestDeployInit.config.yml
+++ b/acceptance/testdata/TestDeployInit.config.yml
@@ -1,3 +1,25 @@
+# Copyright (c) 2026 Circle Internet Services, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+
 version: 2.1
 jobs:
   build:

--- a/acceptance/testdata/TestDeployInit.config.yml
+++ b/acceptance/testdata/TestDeployInit.config.yml
@@ -1,0 +1,42 @@
+version: 2.1
+jobs:
+  build:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - checkout
+      - run: make build
+  deploy-staging:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - checkout
+      - run: make deploy-staging
+      - run:
+          name: Log deploy marker
+          command: circleci run release log --component "api" --environment "staging"
+  deploy-prod:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - checkout
+      - run: make deploy
+      - run:
+          name: Log deploy marker
+          command: circleci run release log --component "api" --environment "production"
+workflows:
+  main:
+    jobs:
+      - build
+      - deploy-staging:
+          requires:
+            - build
+          filters:
+            branches:
+              only: develop
+      - deploy-prod:
+          requires:
+            - build
+          filters:
+            branches:
+              only: main

--- a/acceptance/testdata/TestDeployInit.txt
+++ b/acceptance/testdata/TestDeployInit.txt
@@ -1,0 +1,12 @@
+Scanning .circleci/config.yml...
+
+Found 2 deploy job(s):
+  deploy-staging                 runs on: develop
+  deploy-prod                    runs on: main
+
+Updating .circleci/config.yml...
+
+Done. Your next deploy will appear at:
+→ https://app.circleci.com/deploys
+
+Commit and push config.yml to activate.

--- a/acceptance/testdata/TestDeployInit_Idempotent.txt
+++ b/acceptance/testdata/TestDeployInit_Idempotent.txt
@@ -1,0 +1,9 @@
+Scanning .circleci/config.yml...
+
+Found 2 deploy job(s):
+  deploy-staging                 runs on: develop
+  deploy-prod                    runs on: main
+
+Updating .circleci/config.yml...
+
+Already configured — no changes needed.

--- a/acceptance/testdata/TestDeployInit_InferEnvironments.config.yml
+++ b/acceptance/testdata/TestDeployInit_InferEnvironments.config.yml
@@ -1,0 +1,25 @@
+version: 2.1
+jobs:
+  deploy-staging:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - checkout
+      - run: make deploy-staging
+      - run:
+          name: Log deploy marker
+          command: circleci run release log --component "myapp" --environment "staging"
+  deploy-production:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - checkout
+      - run: make deploy-prod
+      - run:
+          name: Log deploy marker
+          command: circleci run release log --component "myapp" --environment "production"
+workflows:
+  main:
+    jobs:
+      - deploy-staging
+      - deploy-production

--- a/acceptance/testdata/TestDeployInit_InferEnvironments.config.yml
+++ b/acceptance/testdata/TestDeployInit_InferEnvironments.config.yml
@@ -1,25 +1,3 @@
-# Copyright (c) 2026 Circle Internet Services, Inc.
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in
-# all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
-#
-# SPDX-License-Identifier: MIT
-
 version: 2.1
 jobs:
   deploy-staging:

--- a/acceptance/testdata/TestDeployInit_InferEnvironments.config.yml
+++ b/acceptance/testdata/TestDeployInit_InferEnvironments.config.yml
@@ -1,3 +1,25 @@
+# Copyright (c) 2026 Circle Internet Services, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+
 version: 2.1
 jobs:
   deploy-staging:

--- a/acceptance/testdata/TestDeployInit_NoJobs.stderr.txt
+++ b/acceptance/testdata/TestDeployInit_NoJobs.stderr.txt
@@ -1,0 +1,5 @@
+No deploy jobs found in .circleci/config.yml.
+
+Add a job with a name like deploy, release, publish, or ship,
+then run this command again.
+error: No jobs with deploy-like names were detected in the config.

--- a/internal/cmd/deploy/deploy.go
+++ b/internal/cmd/deploy/deploy.go
@@ -44,6 +44,7 @@ func NewDeployCmd() *cobra.Command {
 
 	cmd.AddCommand(newListCmd())
 	cmd.AddCommand(newOpenCmd())
+	cmd.AddCommand(newInitCmd())
 
 	return cmd
 }

--- a/internal/cmd/deploy/init.go
+++ b/internal/cmd/deploy/init.go
@@ -1,0 +1,238 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package deploy
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+
+	"github.com/CircleCI-Public/circleci-cli/internal/deployinit"
+	clierrors "github.com/CircleCI-Public/circleci-cli/internal/errors"
+	"github.com/CircleCI-Public/circleci-cli/internal/gitremote"
+	"github.com/CircleCI-Public/circleci-cli/internal/iostream"
+)
+
+func newInitCmd() *cobra.Command {
+	var (
+		configPath string
+		component  string
+		defEnv     string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "init",
+		Short: "Instrument your config for deploy tracking",
+		Long: heredoc.Doc(`
+			Set up deploy markers in .circleci/config.yml.
+
+			Scans the config for deploy-like jobs (names containing deploy,
+			release, publish, or ship), prompts for your service name and
+			target environment, then adds a log step to each deploy job.
+
+			The command is idempotent: running it twice on the same config
+			makes no duplicate changes.
+
+			Works offline — no API calls required.
+		`),
+		Example: heredoc.Doc(`
+			# Interactive setup in the current repo
+			$ circleci deploy init
+
+			# Skip the service-name prompt
+			$ circleci deploy init --component api
+
+			# Fully non-interactive (supply both answers as flags)
+			$ circleci deploy init --component api --environment production
+
+			# Use a non-default config location
+			$ circleci deploy init --pipeline-config path/to/config.yml
+		`),
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := iostream.FromCmd(cmd.Context(), cmd)
+			return runInit(ctx, configPath, component, defEnv)
+		},
+	}
+
+	cmd.Flags().StringVar(&configPath, "pipeline-config", ".circleci/config.yml", "Path to CircleCI pipeline config file")
+	cmd.Flags().StringVar(&component, "component", "", "Service/component name (skips prompt)")
+	cmd.Flags().StringVar(&defEnv, "environment", "", "Default environment for jobs whose target can't be inferred (skips prompt)")
+
+	return cmd
+}
+
+func runInit(ctx context.Context, configPath, component, defEnv string) error {
+	iostream.Printf(ctx, "Scanning %s...\n\n", configPath)
+
+	result, err := deployinit.Detect(configPath)
+	if err != nil {
+		return clierrors.New("deploy.init_scan_failed", "Could not scan config",
+			err.Error()).
+			WithSuggestions(
+				"Check that the file exists and is valid YAML",
+				"Run: circleci config validate",
+			).
+			WithExitCode(clierrors.ExitGeneralError)
+	}
+
+	if len(result.Jobs) == 0 {
+		iostream.ErrPrintln(ctx, "No deploy jobs found in "+configPath+".")
+		iostream.ErrPrintln(ctx, "")
+		iostream.ErrPrintln(ctx, "Add a job with a name like deploy, release, publish, or ship,")
+		iostream.ErrPrintln(ctx, "then run this command again.")
+		return clierrors.New("deploy.init_no_jobs", "No deploy jobs found",
+			"No jobs with deploy-like names were detected in the config.").
+			WithExitCode(clierrors.ExitNotFound)
+	}
+
+	iostream.Printf(ctx, "Found %d deploy job(s):\n", len(result.Jobs))
+	for _, j := range result.Jobs {
+		branch := j.Branch
+		if branch == "" {
+			branch = "any"
+		}
+		iostream.Printf(ctx, "  %-30s runs on: %s\n", j.Name, branch)
+	}
+	iostream.Printf(ctx, "\n")
+
+	// Determine component name.
+	if component == "" {
+		defaultComponent := repoName()
+		if iostream.IsInteractive(ctx) {
+			val, err := iostream.PromptText(ctx, "What's this service called?", defaultComponent)
+			if err != nil {
+				return clierrors.New("deploy.init_cancelled", "Cancelled", "Prompt was cancelled.").
+					WithExitCode(clierrors.ExitCancelled)
+			}
+			if val == "" {
+				val = defaultComponent
+			}
+			component = val
+		} else {
+			component = defaultComponent
+		}
+	}
+
+	// Determine environment for each job — infer where possible, ask once for the rest.
+	needsPrompt := false
+	for _, j := range result.Jobs {
+		if j.InferredEnv == "" {
+			needsPrompt = true
+			break
+		}
+	}
+	if needsPrompt && defEnv == "" {
+		if iostream.IsInteractive(ctx) {
+			val, err := iostream.PromptText(ctx, "What environment do your deploy jobs target?", "production")
+			if err != nil {
+				return clierrors.New("deploy.init_cancelled", "Cancelled", "Prompt was cancelled.").
+					WithExitCode(clierrors.ExitCancelled)
+			}
+			if val == "" {
+				val = "production"
+			}
+			defEnv = val
+		} else {
+			defEnv = "production"
+		}
+	}
+
+	// Build patch jobs list.
+	patchJobs := make([]deployinit.PatchJob, len(result.Jobs))
+	for i, j := range result.Jobs {
+		env := j.InferredEnv
+		if env == "" {
+			env = defEnv
+		}
+		patchJobs[i] = deployinit.PatchJob{Name: j.Name, Environment: env}
+	}
+
+	iostream.Printf(ctx, "Updating %s...\n\n", configPath)
+
+	changed, err := deployinit.Patch(configPath, deployinit.PatchInput{
+		Component: component,
+		Jobs:      patchJobs,
+	}, result.HasDeploys)
+	if err != nil {
+		return clierrors.New("deploy.init_patch_failed", "Could not patch config",
+			err.Error()).
+			WithSuggestions("Check that the file is writable and is valid YAML").
+			WithExitCode(clierrors.ExitGeneralError)
+	}
+
+	if !changed {
+		iostream.Printf(ctx, "Already configured — no changes needed.\n")
+		return nil
+	}
+
+	iostream.Printf(ctx, "Done. Your next deploy will appear at:\n")
+	iostream.Printf(ctx, "→ %s\n\n", deploysURL())
+	iostream.Printf(ctx, "Commit and push %s to activate.\n", filepath.Base(configPath))
+	return nil
+}
+
+// repoName returns the current directory's base name as a default component name.
+func repoName() string {
+	info, err := gitremote.Detect()
+	if err != nil {
+		return "my-service"
+	}
+	parts := strings.Split(info.Slug, "/")
+	if len(parts) == 3 {
+		return parts[2]
+	}
+	return "my-service"
+}
+
+// deploysURL returns the org deploys dashboard URL.
+func deploysURL() string {
+	info, err := gitremote.Detect()
+	if err != nil {
+		return "https://app.circleci.com/deploys"
+	}
+	parts := strings.Split(info.Slug, "/")
+	if len(parts) != 3 {
+		return "https://app.circleci.com/deploys"
+	}
+	provider := providerName(parts[0])
+	org := parts[1]
+	return fmt.Sprintf("https://app.circleci.com/deploys/%s/%s", provider, org)
+}
+
+func providerName(slug string) string {
+	switch slug {
+	case "gh":
+		return "github"
+	case "bb":
+		return "bitbucket"
+	case "gl":
+		return "gitlab"
+	default:
+		return slug
+	}
+}

--- a/internal/cmd/root/testdata/usage/circleci/deploy.txt
+++ b/internal/cmd/root/testdata/usage/circleci/deploy.txt
@@ -2,6 +2,7 @@ Usage:
   circleci deploy [command]
 
 Available Commands:
+  init        Instrument your config for deploy tracking
   list        List recent deploys
   open        Open the deploys page in the browser
 

--- a/internal/cmd/root/testdata/usage/circleci/deploy/init.txt
+++ b/internal/cmd/root/testdata/usage/circleci/deploy/init.txt
@@ -1,0 +1,26 @@
+Usage:
+  circleci deploy init [flags]
+
+Examples:
+# Interactive setup in the current repo
+$ circleci deploy init
+
+# Skip the service-name prompt
+$ circleci deploy init --component api
+
+# Fully non-interactive (supply both answers as flags)
+$ circleci deploy init --component api --environment production
+
+# Use a non-default config location
+$ circleci deploy init --pipeline-config path/to/config.yml
+
+
+Flags:
+      --component string         Service/component name (skips prompt)
+      --environment string       Default environment for jobs whose target can't be inferred (skips prompt)
+      --pipeline-config string   Path to CircleCI pipeline config file (default ".circleci/config.yml")
+
+Global Flags:
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected

--- a/internal/deployinit/deployinit.go
+++ b/internal/deployinit/deployinit.go
@@ -1,0 +1,357 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+// Package deployinit implements scanning and patching of .circleci/config.yml
+// to add deploy marker steps for circleci deploy init.
+package deployinit
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// JobInfo describes a deploy-like job detected in the config.
+type JobInfo struct {
+	Name        string
+	Branch      string // from workflow branch filter; "" means all/unknown
+	InferredEnv string // environment guessed from job name; "" if unknown
+}
+
+// DetectResult holds the jobs found in the config.
+type DetectResult struct {
+	Jobs       []JobInfo
+	HasDeploys bool // config already uses circleci/deploys orb
+}
+
+var deployPattern = regexp.MustCompile(`(?i)(^|[-_])(deploy|release|publish|ship)([-_]|$)`)
+
+var envPatterns = []struct {
+	re  *regexp.Regexp
+	env string
+}{
+	{regexp.MustCompile(`(?i)(^|[-_])(prod|production)([-_]|$)`), "production"},
+	{regexp.MustCompile(`(?i)(^|[-_])(staging|stage)([-_]|$)`), "staging"},
+	{regexp.MustCompile(`(?i)(^|[-_])(dev|development)([-_]|$)`), "development"},
+	{regexp.MustCompile(`(?i)(^|[-_])(qa|test|testing)([-_]|$)`), "testing"},
+	{regexp.MustCompile(`(?i)(^|[-_])(demo)([-_]|$)`), "demo"},
+}
+
+// InferEnvironment returns an environment name from a job name, or "".
+func InferEnvironment(jobName string) string {
+	for _, p := range envPatterns {
+		if p.re.MatchString(jobName) {
+			return p.env
+		}
+	}
+	return ""
+}
+
+// IsDeployJob returns true if jobName looks like a deploy job.
+func IsDeployJob(name string) bool {
+	return deployPattern.MatchString(name)
+}
+
+// Detect reads configPath and returns detected deploy jobs.
+func Detect(configPath string) (*DetectResult, error) {
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var root yaml.Node
+	if err := yaml.Unmarshal(data, &root); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", configPath, err)
+	}
+	if len(root.Content) == 0 {
+		return &DetectResult{}, nil
+	}
+	doc := root.Content[0]
+
+	jobNames := extractJobNames(doc)
+	branchForJob := extractBranchFilters(doc)
+
+	result := &DetectResult{
+		HasDeploys: hasDeploysOrb(doc),
+	}
+	for _, name := range jobNames {
+		if !IsDeployJob(name) {
+			continue
+		}
+		result.Jobs = append(result.Jobs, JobInfo{
+			Name:        name,
+			Branch:      branchForJob[name],
+			InferredEnv: InferEnvironment(name),
+		})
+	}
+	return result, nil
+}
+
+// hasDeploysOrb returns true if the config already uses circleci/deploys.
+func hasDeploysOrb(doc *yaml.Node) bool {
+	orbsNode := findMappingValue(doc, "orbs")
+	if orbsNode == nil {
+		return false
+	}
+	for i := 1; i < len(orbsNode.Content); i += 2 {
+		if strings.HasPrefix(orbsNode.Content[i].Value, "circleci/deploys") {
+			return true
+		}
+	}
+	return false
+}
+
+func extractJobNames(doc *yaml.Node) []string {
+	jobsNode := findMappingValue(doc, "jobs")
+	if jobsNode == nil || jobsNode.Kind != yaml.MappingNode {
+		return nil
+	}
+	var names []string
+	for i := 0; i+1 < len(jobsNode.Content); i += 2 {
+		names = append(names, jobsNode.Content[i].Value)
+	}
+	return names
+}
+
+func extractBranchFilters(doc *yaml.Node) map[string]string {
+	result := make(map[string]string)
+	workflowsNode := findMappingValue(doc, "workflows")
+	if workflowsNode == nil || workflowsNode.Kind != yaml.MappingNode {
+		return result
+	}
+	for i := 0; i+1 < len(workflowsNode.Content); i += 2 {
+		key := workflowsNode.Content[i].Value
+		if key == "version" {
+			continue
+		}
+		wfNode := resolve(workflowsNode.Content[i+1])
+		jobsSeq := findMappingValue(wfNode, "jobs")
+		if jobsSeq == nil || jobsSeq.Kind != yaml.SequenceNode {
+			continue
+		}
+		for _, item := range jobsSeq.Content {
+			name, branch := jobFilterFromItem(resolve(item))
+			if name != "" && branch != "" {
+				result[name] = branch
+			}
+		}
+	}
+	return result
+}
+
+func jobFilterFromItem(item *yaml.Node) (name, branch string) {
+	switch item.Kind {
+	case yaml.ScalarNode:
+		return item.Value, ""
+	case yaml.MappingNode:
+		if len(item.Content) < 2 {
+			return "", ""
+		}
+		name = item.Content[0].Value
+		cfg := resolve(item.Content[1])
+		if cfg.Kind != yaml.MappingNode {
+			return name, ""
+		}
+		filtersNode := findMappingValue(cfg, "filters")
+		if filtersNode == nil {
+			return name, ""
+		}
+		branchesNode := findMappingValue(filtersNode, "branches")
+		if branchesNode == nil {
+			return name, ""
+		}
+		onlyNode := findMappingValue(branchesNode, "only")
+		if onlyNode == nil {
+			return name, ""
+		}
+		switch onlyNode.Kind {
+		case yaml.ScalarNode:
+			return name, onlyNode.Value
+		case yaml.SequenceNode:
+			if len(onlyNode.Content) > 0 {
+				return name, onlyNode.Content[0].Value
+			}
+		}
+	}
+	return "", ""
+}
+
+func findMappingValue(node *yaml.Node, key string) *yaml.Node {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		if node.Content[i].Value == key {
+			return node.Content[i+1]
+		}
+	}
+	return nil
+}
+
+func resolve(n *yaml.Node) *yaml.Node {
+	if n != nil && n.Kind == yaml.AliasNode {
+		return n.Alias
+	}
+	return n
+}
+
+// PatchJob describes a job to instrument.
+type PatchJob struct {
+	Name        string
+	Environment string
+}
+
+// PatchInput describes what to add to the config.
+type PatchInput struct {
+	Component string
+	Jobs      []PatchJob
+}
+
+// Patch modifies configPath in-place, returning true if any changes were made.
+// It is idempotent: if the deploy step is already present it is not duplicated.
+func Patch(configPath string, input PatchInput, useOrb bool) (bool, error) {
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return false, err
+	}
+
+	var root yaml.Node
+	if err := yaml.Unmarshal(data, &root); err != nil {
+		return false, fmt.Errorf("parse %s: %w", configPath, err)
+	}
+	if len(root.Content) == 0 {
+		return false, fmt.Errorf("empty config")
+	}
+	doc := root.Content[0]
+	jobsNode := findMappingValue(doc, "jobs")
+	if jobsNode == nil {
+		return false, nil
+	}
+
+	changed := false
+	for _, pj := range input.Jobs {
+		jobNode := findMappingValue(jobsNode, pj.Name)
+		if jobNode == nil {
+			continue
+		}
+		jobNode = resolve(jobNode)
+		stepsNode := findMappingValue(jobNode, "steps")
+		if stepsNode == nil || stepsNode.Kind != yaml.SequenceNode {
+			continue
+		}
+		if alreadyPatched(stepsNode) {
+			continue
+		}
+		var step *yaml.Node
+		if useOrb {
+			step = makeOrbStep(input.Component, pj.Environment)
+		} else {
+			step = makeRunStep(input.Component, pj.Environment)
+		}
+		stepsNode.Content = append(stepsNode.Content, step)
+		changed = true
+	}
+
+	if !changed {
+		return false, nil
+	}
+
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(&root); err != nil {
+		return false, err
+	}
+	if err := os.WriteFile(configPath, buf.Bytes(), 0o644); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// alreadyPatched returns true if stepsNode already contains a deploy marker step.
+func alreadyPatched(stepsNode *yaml.Node) bool {
+	for _, step := range stepsNode.Content {
+		step = resolve(step)
+		if step.Kind != yaml.MappingNode {
+			continue
+		}
+		// raw run step
+		runNode := findMappingValue(step, "run")
+		if runNode != nil {
+			runNode = resolve(runNode)
+			if runNode.Kind == yaml.MappingNode {
+				cmdNode := findMappingValue(runNode, "command")
+				if cmdNode != nil && strings.Contains(cmdNode.Value, "circleci run release log") {
+					return true
+				}
+			}
+		}
+		// orb step: deploys/log
+		for i := 0; i < len(step.Content); i++ {
+			if step.Content[i].Value == "deploys/log" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func makeRunStep(component, env string) *yaml.Node {
+	cmd := fmt.Sprintf("circleci run release log --component %q --environment %q", component, env)
+	return &yaml.Node{
+		Kind: yaml.MappingNode,
+		Content: []*yaml.Node{
+			scalar("run"),
+			{
+				Kind: yaml.MappingNode,
+				Content: []*yaml.Node{
+					scalar("name"), scalar("Log deploy marker"),
+					scalar("command"), scalar(cmd),
+				},
+			},
+		},
+	}
+}
+
+func makeOrbStep(component, env string) *yaml.Node {
+	return &yaml.Node{
+		Kind: yaml.MappingNode,
+		Content: []*yaml.Node{
+			scalar("deploys/log"),
+			{
+				Kind: yaml.MappingNode,
+				Content: []*yaml.Node{
+					scalar("component"), scalar(component),
+					scalar("environment"), scalar(env),
+				},
+			},
+		},
+	}
+}
+
+func scalar(v string) *yaml.Node {
+	return &yaml.Node{Kind: yaml.ScalarNode, Value: v, Tag: "!!str"}
+}

--- a/internal/deployinit/deployinit.go
+++ b/internal/deployinit/deployinit.go
@@ -77,7 +77,7 @@ func IsDeployJob(name string) bool {
 
 // Detect reads configPath and returns detected deploy jobs.
 func Detect(configPath string) (*DetectResult, error) {
-	data, err := os.ReadFile(configPath)
+	data, err := os.ReadFile(configPath) //nolint:gosec // configPath is supplied by the user via --pipeline-config flag
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +163,7 @@ func extractBranchFilters(doc *yaml.Node) map[string]string {
 }
 
 func jobFilterFromItem(item *yaml.Node) (name, branch string) {
-	switch item.Kind {
+	switch item.Kind { //nolint:exhaustive // DocumentNode/SequenceNode/AliasNode don't appear as workflow job items
 	case yaml.ScalarNode:
 		return item.Value, ""
 	case yaml.MappingNode:
@@ -187,7 +187,7 @@ func jobFilterFromItem(item *yaml.Node) (name, branch string) {
 		if onlyNode == nil {
 			return name, ""
 		}
-		switch onlyNode.Kind {
+		switch onlyNode.Kind { //nolint:exhaustive // only scalar and sequence appear in branch filters
 		case yaml.ScalarNode:
 			return name, onlyNode.Value
 		case yaml.SequenceNode:
@@ -233,7 +233,11 @@ type PatchInput struct {
 // Patch modifies configPath in-place, returning true if any changes were made.
 // It is idempotent: if the deploy step is already present it is not duplicated.
 func Patch(configPath string, input PatchInput, useOrb bool) (bool, error) {
-	data, err := os.ReadFile(configPath)
+	info, err := os.Stat(configPath) //nolint:gosec // configPath is supplied by the user via --pipeline-config flag
+	if err != nil {
+		return false, err
+	}
+	data, err := os.ReadFile(configPath) //nolint:gosec // same
 	if err != nil {
 		return false, err
 	}
@@ -285,7 +289,7 @@ func Patch(configPath string, input PatchInput, useOrb bool) (bool, error) {
 	if err := enc.Encode(&root); err != nil {
 		return false, err
 	}
-	if err := os.WriteFile(configPath, buf.Bytes(), 0o644); err != nil {
+	if err := os.WriteFile(configPath, buf.Bytes(), info.Mode()); err != nil { //nolint:gosec // configPath is user-supplied
 		return false, err
 	}
 	return true, nil


### PR DESCRIPTION
## Summary

Adds `circleci deploy init` — a command that instruments `.circleci/config.yml` for deploy tracking with zero docs required.

- Scans config for deploy-like jobs (names containing `deploy`, `release`, `publish`, or `ship`)
- Infers target environment from job names where possible (`deploy-staging` → `staging`, `deploy-prod` → `production`)
- Asks at most two questions: service name and default environment for jobs whose target can't be inferred
- Patches config to append a `circleci run release log` step to each deploy job, or a `deploys/log` orb step if the config already uses `circleci/deploys`
- Idempotent — running twice makes no duplicate changes
- Works offline — no API calls required
- Prints a direct link to the org deploys dashboard on completion

## Test plan

- [ ] `go test ./acceptance/ -run TestDeployInit` — all golden file tests pass
- [ ] `circleci deploy init` in a repo with deploy jobs — interactive flow works
- [ ] `circleci deploy init --component api --environment production` — fully non-interactive
- [ ] Running twice on the same config prints "Already configured — no changes needed"
- [ ] Config with no deploy jobs exits cleanly with a helpful message