### PR TITLE
Add circleci policy command group

### DIFF
--- a/acceptance/policy_test.go
+++ b/acceptance/policy_test.go
@@ -1,0 +1,384 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package acceptance_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/CircleCI-Public/circleci-cli/internal/testing/binary"
+	testenv "github.com/CircleCI-Public/circleci-cli/internal/testing/env"
+	"github.com/CircleCI-Public/circleci-cli/internal/testing/fakes"
+)
+
+const testOwnerID = "462d67f8-b232-4da4-a7de-0c86dd667d3f"
+const testPolicyCtx = "config"
+const testDecisionID = "d0000001-0000-4000-8000-000000000001"
+
+// writePolicyDir creates a temporary directory with a single .rego file and returns its path.
+func writePolicyDir(t *testing.T, name, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, name+".rego"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// --- policy push ---
+
+func TestPolicyPush(t *testing.T) {
+	fake := fakes.NewCircleCI(t)
+
+	env := testenv.New(t)
+	env.Token = testToken
+	env.CircleCIURL = fake.URL()
+
+	dir := writePolicyDir(t, "my_policy", "package main\n")
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"policy", "push", dir, "--owner-id", testOwnerID, "--no-prompt"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Check(t, strings.Contains(result.Stdout, "created") || strings.Contains(result.Stdout, "updated") || strings.Contains(result.Stdout, "deleted"))
+}
+
+func TestPolicyPush_DryRun(t *testing.T) {
+	fake := fakes.NewCircleCI(t)
+
+	env := testenv.New(t)
+	env.Token = testToken
+	env.CircleCIURL = fake.URL()
+
+	dir := writePolicyDir(t, "my_policy", "package main\n")
+
+	// With --no-prompt, it first does a dry-run diff then applies.
+	// We test the JSON output matches the diff format.
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"policy", "push", dir, "--owner-id", testOwnerID, "--no-prompt", "--json"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	var out map[string]any
+	assert.NilError(t, json.Unmarshal([]byte(result.Stdout), &out))
+	assert.Check(t, out["created"] != nil)
+}
+
+// --- policy diff ---
+
+func TestPolicyDiff(t *testing.T) {
+	fake := fakes.NewCircleCI(t)
+
+	env := testenv.New(t)
+	env.Token = testToken
+	env.CircleCIURL = fake.URL()
+
+	dir := writePolicyDir(t, "my_policy", "package main\n")
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"policy", "diff", dir, "--owner-id", testOwnerID},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Check(t, strings.Contains(result.Stdout, "created") || strings.Contains(result.Stdout, "updated") || strings.Contains(result.Stdout, "deleted"))
+}
+
+// --- policy fetch ---
+
+func TestPolicyFetch(t *testing.T) {
+	fake := fakes.NewCircleCI(t)
+	fake.AddPolicyBundle(testOwnerID, testPolicyCtx, map[string]string{
+		"my_policy": "package main\n",
+	})
+
+	env := testenv.New(t)
+	env.Token = testToken
+	env.CircleCIURL = fake.URL()
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"policy", "fetch", "--owner-id", testOwnerID},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Check(t, strings.Contains(result.Stdout, "my_policy"))
+}
+
+func TestPolicyFetch_JSON(t *testing.T) {
+	fake := fakes.NewCircleCI(t)
+	fake.AddPolicyBundle(testOwnerID, testPolicyCtx, map[string]string{
+		"my_policy": "package main\n",
+	})
+
+	env := testenv.New(t)
+	env.Token = testToken
+	env.CircleCIURL = fake.URL()
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"policy", "fetch", "--owner-id", testOwnerID, "--json"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	var out map[string]any
+	assert.NilError(t, json.Unmarshal([]byte(result.Stdout), &out))
+	assert.Check(t, out["my_policy"] != nil)
+}
+
+func TestPolicyFetch_ByName(t *testing.T) {
+	fake := fakes.NewCircleCI(t)
+	fake.AddPolicyBundle(testOwnerID, testPolicyCtx, map[string]string{
+		"my_policy": "package main\n",
+	})
+
+	env := testenv.New(t)
+	env.Token = testToken
+	env.CircleCIURL = fake.URL()
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"policy", "fetch", "my_policy", "--owner-id", testOwnerID},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Check(t, strings.Contains(result.Stdout, "my_policy"))
+}
+
+// --- policy logs ---
+
+func TestPolicyLogs(t *testing.T) {
+	fake := fakes.NewCircleCI(t)
+	fake.AddDecisionLog(testOwnerID, testPolicyCtx, map[string]any{
+		"id":     testDecisionID,
+		"status": "PASS",
+	})
+
+	env := testenv.New(t)
+	env.Token = testToken
+	env.CircleCIURL = fake.URL()
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"policy", "logs", "--owner-id", testOwnerID},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Check(t, strings.Contains(result.Stdout, testDecisionID))
+	assert.Check(t, strings.Contains(result.Stdout, "PASS"))
+}
+
+func TestPolicyLogs_ByDecisionID(t *testing.T) {
+	fake := fakes.NewCircleCI(t)
+	fake.AddDecisionLog(testOwnerID, testPolicyCtx, map[string]any{
+		"id":     testDecisionID,
+		"status": "SOFT_FAIL",
+	})
+
+	env := testenv.New(t)
+	env.Token = testToken
+	env.CircleCIURL = fake.URL()
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"policy", "logs", testDecisionID, "--owner-id", testOwnerID},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Check(t, strings.Contains(result.Stdout, "SOFT_FAIL"))
+}
+
+// --- policy decide ---
+
+func TestPolicyDecide(t *testing.T) {
+	fake := fakes.NewCircleCI(t)
+	fake.SetDecisionResult(testOwnerID, testPolicyCtx, map[string]any{
+		"status": "PASS",
+	})
+
+	env := testenv.New(t)
+	env.Token = testToken
+	env.CircleCIURL = fake.URL()
+
+	dir := t.TempDir()
+	configFile := filepath.Join(dir, "config.yml")
+	if err := os.WriteFile(configFile, []byte("version: 2.1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"policy", "decide", "--owner-id", testOwnerID, "--input", configFile},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Check(t, strings.Contains(result.Stdout, "PASS"))
+}
+
+func TestPolicyDecide_Strict(t *testing.T) {
+	fake := fakes.NewCircleCI(t)
+	fake.SetDecisionResult(testOwnerID, testPolicyCtx, map[string]any{
+		"status": "HARD_FAIL",
+	})
+
+	env := testenv.New(t)
+	env.Token = testToken
+	env.CircleCIURL = fake.URL()
+
+	dir := t.TempDir()
+	configFile := filepath.Join(dir, "config.yml")
+	if err := os.WriteFile(configFile, []byte("version: 2.1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"policy", "decide", "--owner-id", testOwnerID, "--input", configFile, "--strict"},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	assert.Equal(t, result.ExitCode, 7, "expected ExitValidationFail, stderr: %s", result.Stderr) // ExitValidationFail
+	assert.Check(t, strings.Contains(result.Stdout, "HARD_FAIL"))
+}
+
+// --- policy settings ---
+
+func TestPolicySettingsGet(t *testing.T) {
+	fake := fakes.NewCircleCI(t)
+	fake.SetPolicyEnabled(testOwnerID, testPolicyCtx, true)
+
+	env := testenv.New(t)
+	env.Token = testToken
+	env.CircleCIURL = fake.URL()
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"policy", "settings", "get", "--owner-id", testOwnerID},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Check(t, strings.Contains(result.Stdout, "true"))
+}
+
+func TestPolicySettingsGet_JSON(t *testing.T) {
+	fake := fakes.NewCircleCI(t)
+	fake.SetPolicyEnabled(testOwnerID, testPolicyCtx, true)
+
+	env := testenv.New(t)
+	env.Token = testToken
+	env.CircleCIURL = fake.URL()
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"policy", "settings", "get", "--owner-id", testOwnerID, "--json"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	var out map[string]any
+	assert.NilError(t, json.Unmarshal([]byte(result.Stdout), &out))
+	assert.Check(t, out["enabled"] == true)
+}
+
+func TestPolicySettingsSet(t *testing.T) {
+	fake := fakes.NewCircleCI(t)
+
+	env := testenv.New(t)
+	env.Token = testToken
+	env.CircleCIURL = fake.URL()
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"policy", "settings", "set", "--owner-id", testOwnerID, "--enabled"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Check(t, strings.Contains(result.Stdout, "enabled"))
+}
+
+func TestPolicySettingsSet_JSON(t *testing.T) {
+	fake := fakes.NewCircleCI(t)
+
+	env := testenv.New(t)
+	env.Token = testToken
+	env.CircleCIURL = fake.URL()
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"policy", "settings", "set", "--owner-id", testOwnerID, "--enabled", "--json"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	var out map[string]any
+	assert.NilError(t, json.Unmarshal([]byte(result.Stdout), &out))
+	assert.Check(t, out["enabled"] == true)
+}
+
+// --- no token ---
+
+func TestPolicy_NoToken(t *testing.T) {
+	env := testenv.New(t)
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"policy", "fetch", "--owner-id", testOwnerID},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 3) // ExitAuthError
+}

--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -154,6 +154,14 @@ func (c *Client) put(ctx context.Context, route string, body, dst any, opts ...f
 	return err
 }
 
+func (c *Client) patch(ctx context.Context, route string, body, dst any, opts ...func(*httpcl.Request)) error {
+	_, err := c.main.Call(ctx, httpcl.NewRequest(http.MethodPatch, "/api/v2"+route, baseOpts(
+		httpcl.Body(body),
+		httpcl.JSONDecoder(dst),
+	).With(opts)...))
+	return err
+}
+
 func (c *Client) deleteV2(ctx context.Context, route string, opts ...func(*httpcl.Request)) error {
 	_, err := c.main.Call(ctx, httpcl.NewRequest(http.MethodDelete, "/api/v2"+route, opts...))
 	return err

--- a/internal/apiclient/policy.go
+++ b/internal/apiclient/policy.go
@@ -1,0 +1,155 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package apiclient
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/CircleCI-Public/circleci-cli/internal/httpcl"
+)
+
+// PolicyBundle is a map of policy name to Rego source content.
+type PolicyBundle map[string]string
+
+// DecisionSettings controls whether policy decisions are enforced for an owner.
+type DecisionSettings struct {
+	Enabled bool `json:"enabled"`
+}
+
+// DecisionLogsRequest holds optional filters for GetDecisionLogs.
+type DecisionLogsRequest struct {
+	Status    string
+	After     *time.Time
+	Before    *time.Time
+	Branch    string
+	ProjectID string
+	Offset    int
+}
+
+// CreatePolicyBundle uploads a policy bundle. When dryRun is true it performs
+// a diff-only check without applying changes.
+func (c *Client) CreatePolicyBundle(ctx context.Context, ownerID, policyCtx string, policies PolicyBundle, dryRun bool) (json.RawMessage, error) {
+	body := map[string]any{"policies": policies}
+	route := fmt.Sprintf("/owner/%s/context/%s/policy-bundle", ownerID, policyCtx)
+	var out json.RawMessage
+	var err error
+	if dryRun {
+		err = c.post(ctx, route, body, &out, queryParam("dry", "true"))
+	} else {
+		err = c.post(ctx, route, body, &out)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// FetchPolicyBundle downloads the full bundle or a single named policy.
+// Pass an empty policyName to fetch the entire bundle.
+func (c *Client) FetchPolicyBundle(ctx context.Context, ownerID, policyCtx, policyName string) (json.RawMessage, error) {
+	route := fmt.Sprintf("/owner/%s/context/%s/policy-bundle", ownerID, policyCtx)
+	if policyName != "" {
+		route += "/" + policyName
+	}
+	var out json.RawMessage
+	if err := c.get(ctx, route, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// GetDecisionLogs returns one page of policy decision logs. The caller is
+// responsible for pagination (increment Offset until an empty slice is returned).
+func (c *Client) GetDecisionLogs(ctx context.Context, ownerID, policyCtx string, req DecisionLogsRequest) ([]json.RawMessage, error) {
+	route := fmt.Sprintf("/owner/%s/context/%s/decision", ownerID, policyCtx)
+	opts := []func(*httpcl.Request){
+		optionalQueryParam("status", req.Status),
+		optionalQueryParam("branch", req.Branch),
+		optionalQueryParam("project_id", req.ProjectID),
+	}
+	if req.After != nil {
+		opts = append(opts, queryParam("after", req.After.Format(time.RFC3339)))
+	}
+	if req.Before != nil {
+		opts = append(opts, queryParam("before", req.Before.Format(time.RFC3339)))
+	}
+	if req.Offset > 0 {
+		opts = append(opts, queryParam("offset", fmt.Sprintf("%d", req.Offset)))
+	}
+	var out []json.RawMessage
+	if err := c.get(ctx, route, &out, opts...); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// GetDecisionLog returns a single decision log by ID.
+// When policyBundleOnly is true, returns only the policy bundle snapshot.
+func (c *Client) GetDecisionLog(ctx context.Context, ownerID, policyCtx, decisionID string, policyBundleOnly bool) (json.RawMessage, error) {
+	route := fmt.Sprintf("/owner/%s/context/%s/decision/%s", ownerID, policyCtx, decisionID)
+	if policyBundleOnly {
+		route += "/policy-bundle"
+	}
+	var out json.RawMessage
+	if err := c.get(ctx, route, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// MakeDecision evaluates input against remote policies for the given owner and context.
+func (c *Client) MakeDecision(ctx context.Context, ownerID, policyCtx string, input string, metadata map[string]any) (json.RawMessage, error) {
+	body := map[string]any{"input": input}
+	if len(metadata) > 0 {
+		body["metadata"] = metadata
+	}
+	route := fmt.Sprintf("/owner/%s/context/%s/decision", ownerID, policyCtx)
+	var out json.RawMessage
+	if err := c.post(ctx, route, body, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// GetPolicySettings retrieves whether policy enforcement is enabled.
+func (c *Client) GetPolicySettings(ctx context.Context, ownerID, policyCtx string) (DecisionSettings, error) {
+	route := fmt.Sprintf("/owner/%s/context/%s/decision/settings", ownerID, policyCtx)
+	var out DecisionSettings
+	if err := c.get(ctx, route, &out); err != nil {
+		return DecisionSettings{}, err
+	}
+	return out, nil
+}
+
+// SetPolicySettings enables or disables policy enforcement.
+func (c *Client) SetPolicySettings(ctx context.Context, ownerID, policyCtx string, settings DecisionSettings) (DecisionSettings, error) {
+	route := fmt.Sprintf("/owner/%s/context/%s/decision/settings", ownerID, policyCtx)
+	var out DecisionSettings
+	if err := c.patch(ctx, route, settings, &out); err != nil {
+		return DecisionSettings{}, err
+	}
+	return out, nil
+}

--- a/internal/cmd/policy/bundle.go
+++ b/internal/cmd/policy/bundle.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package policy
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/CircleCI-Public/circleci-cli/internal/apiclient"
+	clierrors "github.com/CircleCI-Public/circleci-cli/internal/errors"
+)
+
+// loadPolicyBundle reads all .rego files under root and returns them as a
+// PolicyBundle. Returns a structured error if root is not a directory.
+func loadPolicyBundle(root string) (apiclient.PolicyBundle, error) {
+	root = filepath.Clean(root)
+
+	info, err := os.Stat(root)
+	if err != nil {
+		return nil, clierrors.New("policy.bundle_read_failed", "Could not read policy directory",
+			err.Error()).
+			WithSuggestions("Check that the path exists and is readable").
+			WithExitCode(clierrors.ExitBadArguments)
+	}
+	if !info.IsDir() {
+		return nil, clierrors.New("policy.bundle_not_dir", "Policy path is not a directory",
+			root+" is not a directory").
+			WithSuggestions("Pass the path to a directory containing .rego files").
+			WithExitCode(clierrors.ExitBadArguments)
+	}
+
+	bundle := make(apiclient.PolicyBundle)
+	err = filepath.WalkDir(root, func(path string, f fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if f.IsDir() || filepath.Ext(path) != ".rego" {
+			return nil
+		}
+		content, err := os.ReadFile(filepath.Clean(path)) //nolint:gosec // path comes from WalkDir
+		if err != nil {
+			return clierrors.New("policy.bundle_read_failed", "Could not read policy file",
+				err.Error()).WithExitCode(clierrors.ExitBadArguments)
+		}
+		bundle[path] = string(content)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return bundle, nil
+}

--- a/internal/cmd/policy/decide.go
+++ b/internal/cmd/policy/decide.go
@@ -1,0 +1,168 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package policy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
+	"github.com/CircleCI-Public/circleci-cli/internal/apiclient"
+	"github.com/CircleCI-Public/circleci-cli/internal/cmdutil"
+	clierrors "github.com/CircleCI-Public/circleci-cli/internal/errors"
+	"github.com/CircleCI-Public/circleci-cli/internal/iostream"
+)
+
+func newDecideCmd() *cobra.Command {
+	var (
+		ownerID   string
+		policyCtx string
+		inputFile string
+		meta      string
+		metaFile  string
+		strict    bool
+		jsonOut   bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "decide",
+		Short: "Evaluate a config against remote policies",
+		Long: heredoc.Doc(`
+			Evaluate a CircleCI pipeline config against the remote policy bundle
+			and return a policy decision.
+
+			The decision status will be one of: PASS, SOFT_FAIL, HARD_FAIL, ERROR.
+			With --strict, exits non-zero for HARD_FAIL or ERROR decisions.
+
+			JSON fields: status, enabled_rules, hard_failures, soft_failures,
+			             violations, metadata
+		`),
+		Example: heredoc.Doc(`
+			# Evaluate a config against remote policies
+			$ circleci policy decide --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --input .circleci/config.yml
+
+			# Exit non-zero on hard failures
+			$ circleci policy decide --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --input .circleci/config.yml --strict
+
+			# Pass metadata alongside the decision
+			$ circleci policy decide --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --input .circleci/config.yml --meta '{"project_id":"abc"}'
+
+			# Output decision as JSON
+			$ circleci policy decide --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --input .circleci/config.yml --json
+		`),
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := iostream.FromCmd(cmd.Context(), cmd)
+			client, err := cmdutil.LoadClient(ctx, cmd)
+			if err != nil {
+				return err
+			}
+			return runDecide(ctx, client, ownerID, policyCtx, inputFile, meta, metaFile, strict, jsonOut)
+		},
+	}
+
+	cmd.Flags().StringVar(&ownerID, "owner-id", "", "Organization UUID (required)")
+	cmd.Flags().StringVar(&policyCtx, "policy-context", "config", "Policy context")
+	cmd.Flags().StringVar(&inputFile, "input", "", "Path to input file (e.g. .circleci/config.yml) (required)")
+	cmd.Flags().StringVar(&meta, "meta", "", "Decision metadata as a JSON string")
+	cmd.Flags().StringVar(&metaFile, "metafile", "", "Path to decision metadata file (YAML or JSON)")
+	cmd.Flags().BoolVar(&strict, "strict", false, "Exit non-zero for HARD_FAIL or ERROR decisions")
+	cmdutil.AddJSONFlag(cmd, &jsonOut)
+	cmdutil.AddJQFlag(cmd)
+	_ = cmd.MarkFlagRequired("owner-id")
+	_ = cmd.MarkFlagRequired("input")
+
+	return cmd
+}
+
+func runDecide(ctx context.Context, client *apiclient.Client, ownerID, policyCtx, inputFile, meta, metaFile string, strict, jsonOut bool) error {
+	inputBytes, err := os.ReadFile(inputFile) //nolint:gosec // inputFile is user-supplied
+	if err != nil {
+		return clierrors.New("policy.decide_input_read_failed", "Could not read input file", err.Error()).
+			WithSuggestions("Check that the file exists and is readable").
+			WithExitCode(clierrors.ExitBadArguments)
+	}
+
+	metadata, err := readMetadata(meta, metaFile)
+	if err != nil {
+		return err
+	}
+
+	decision, err := client.MakeDecision(ctx, ownerID, policyCtx, string(inputBytes), metadata)
+	if err != nil {
+		return policyAPIErr(err, ownerID)
+	}
+
+	if strict {
+		var parsed struct {
+			Status string `json:"status"`
+		}
+		if jerr := json.Unmarshal(decision, &parsed); jerr == nil {
+			if parsed.Status == "HARD_FAIL" || parsed.Status == "ERROR" {
+				_ = cmdutil.WriteJSON(iostream.Out(ctx), decision)
+				return clierrors.New("policy.hard_fail", "Policy decision failed",
+					fmt.Sprintf("Policy decision status: %s", parsed.Status)).
+					WithExitCode(clierrors.ExitValidationFail)
+			}
+		}
+	}
+
+	if jsonOut {
+		return iostream.PrintJSON(ctx, decision)
+	}
+	return cmdutil.WriteJSON(iostream.Out(ctx), decision)
+}
+
+func readMetadata(meta, metaFile string) (map[string]any, error) {
+	if meta != "" && metaFile != "" {
+		return nil, clierrors.New("policy.meta_conflict", "Conflicting flags",
+			"Use either --meta or --metafile, not both.").
+			WithExitCode(clierrors.ExitBadArguments)
+	}
+	var metadata map[string]any
+	if meta != "" {
+		if err := json.Unmarshal([]byte(meta), &metadata); err != nil {
+			return nil, clierrors.New("policy.meta_invalid", "Invalid --meta value", err.Error()).
+				WithSuggestions("Pass a valid JSON object, e.g.: --meta '{\"key\":\"value\"}'").
+				WithExitCode(clierrors.ExitBadArguments)
+		}
+	}
+	if metaFile != "" {
+		raw, err := os.ReadFile(metaFile) //nolint:gosec // metaFile is user-supplied
+		if err != nil {
+			return nil, clierrors.New("policy.metafile_read_failed", "Could not read metafile", err.Error()).
+				WithExitCode(clierrors.ExitBadArguments)
+		}
+		if err := yaml.Unmarshal(raw, &metadata); err != nil {
+			return nil, clierrors.New("policy.metafile_invalid", "Invalid metafile content", err.Error()).
+				WithSuggestions("The metafile must be valid YAML or JSON").
+				WithExitCode(clierrors.ExitBadArguments)
+		}
+	}
+	return metadata, nil
+}

--- a/internal/cmd/policy/diff.go
+++ b/internal/cmd/policy/diff.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package policy
+
+import (
+	"context"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+
+	"github.com/CircleCI-Public/circleci-cli/internal/apiclient"
+	"github.com/CircleCI-Public/circleci-cli/internal/cmdutil"
+	"github.com/CircleCI-Public/circleci-cli/internal/iostream"
+)
+
+func newDiffCmd() *cobra.Command {
+	var (
+		ownerID   string
+		policyCtx string
+		jsonOut   bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "diff <path>",
+		Short: "Show diff between local and remote policy bundles",
+		Long: heredoc.Doc(`
+			Compare a local directory of .rego files against the remote policy
+			bundle without making any changes.
+
+			JSON fields: created, deleted, updated (policy names)
+		`),
+		Example: heredoc.Doc(`
+			# Diff policies in ./policies against the remote bundle
+			$ circleci policy diff ./policies --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f
+
+			# Diff against a custom policy context
+			$ circleci policy diff ./policies --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --policy-context config
+
+			# Output diff as JSON for scripting
+			$ circleci policy diff ./policies --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --json
+		`),
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := iostream.FromCmd(cmd.Context(), cmd)
+			client, err := cmdutil.LoadClient(ctx, cmd)
+			if err != nil {
+				return err
+			}
+			return runDiff(ctx, client, args[0], ownerID, policyCtx, jsonOut)
+		},
+	}
+
+	cmd.Flags().StringVar(&ownerID, "owner-id", "", "Organization UUID (required)")
+	cmd.Flags().StringVar(&policyCtx, "policy-context", "config", "Policy context")
+	cmdutil.AddJSONFlag(cmd, &jsonOut)
+	cmdutil.AddJQFlag(cmd)
+	_ = cmd.MarkFlagRequired("owner-id")
+
+	return cmd
+}
+
+func runDiff(ctx context.Context, client *apiclient.Client, path, ownerID, policyCtx string, jsonOut bool) error {
+	bundle, err := loadPolicyBundle(path)
+	if err != nil {
+		return err
+	}
+
+	diff, err := client.CreatePolicyBundle(ctx, ownerID, policyCtx, bundle, true)
+	if err != nil {
+		return policyAPIErr(err, ownerID)
+	}
+
+	if jsonOut {
+		return iostream.PrintJSON(ctx, diff)
+	}
+	return cmdutil.WriteJSON(iostream.Out(ctx), diff)
+}

--- a/internal/cmd/policy/fetch.go
+++ b/internal/cmd/policy/fetch.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package policy
+
+import (
+	"context"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+
+	"github.com/CircleCI-Public/circleci-cli/internal/apiclient"
+	"github.com/CircleCI-Public/circleci-cli/internal/cmdutil"
+	"github.com/CircleCI-Public/circleci-cli/internal/iostream"
+)
+
+func newFetchCmd() *cobra.Command {
+	var (
+		ownerID   string
+		policyCtx string
+		jsonOut   bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "fetch [policy-name]",
+		Short: "Download the remote policy bundle",
+		Long: heredoc.Doc(`
+			Download the remote policy bundle for the given owner and context.
+			Pass a policy name to fetch a single policy.
+
+			Output is always JSON (the bundle is structured data).
+
+			JSON fields: policies (map of name → Rego source)
+		`),
+		Example: heredoc.Doc(`
+			# Fetch the full policy bundle
+			$ circleci policy fetch --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f
+
+			# Fetch a single policy by name
+			$ circleci policy fetch my-policy --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f
+
+			# Output as JSON with jq filtering
+			$ circleci policy fetch --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --json --jq 'keys'
+		`),
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := iostream.FromCmd(cmd.Context(), cmd)
+			client, err := cmdutil.LoadClient(ctx, cmd)
+			if err != nil {
+				return err
+			}
+			policyName := ""
+			if len(args) == 1 {
+				policyName = args[0]
+			}
+			return runFetch(ctx, client, ownerID, policyCtx, policyName, jsonOut)
+		},
+	}
+
+	cmd.Flags().StringVar(&ownerID, "owner-id", "", "Organization UUID (required)")
+	cmd.Flags().StringVar(&policyCtx, "policy-context", "config", "Policy context")
+	cmdutil.AddJSONFlag(cmd, &jsonOut)
+	cmdutil.AddJQFlag(cmd)
+	_ = cmd.MarkFlagRequired("owner-id")
+
+	return cmd
+}
+
+func runFetch(ctx context.Context, client *apiclient.Client, ownerID, policyCtx, policyName string, jsonOut bool) error {
+	bundle, err := client.FetchPolicyBundle(ctx, ownerID, policyCtx, policyName)
+	if err != nil {
+		return policyAPIErr(err, ownerID)
+	}
+
+	if jsonOut {
+		return iostream.PrintJSON(ctx, bundle)
+	}
+	return cmdutil.WriteJSON(iostream.Out(ctx), bundle)
+}

--- a/internal/cmd/policy/logs.go
+++ b/internal/cmd/policy/logs.go
@@ -1,0 +1,201 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package policy
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"time"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+
+	"github.com/CircleCI-Public/circleci-cli/internal/apiclient"
+	"github.com/CircleCI-Public/circleci-cli/internal/cmdutil"
+	clierrors "github.com/CircleCI-Public/circleci-cli/internal/errors"
+	"github.com/CircleCI-Public/circleci-cli/internal/iostream"
+)
+
+func newLogsCmd() *cobra.Command {
+	var (
+		ownerID      string
+		policyCtx    string
+		after        string
+		before       string
+		status       string
+		branch       string
+		projectID    string
+		outputFile   string
+		policyBundle bool
+		jsonOut      bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "logs [decision-id]",
+		Short: "Get policy decision logs",
+		Long: heredoc.Doc(`
+			Retrieve policy decision logs for an owner.
+
+			Without a decision ID, returns all logs (paginated automatically).
+			Pass a decision ID to retrieve a single log entry. Use --policy-bundle
+			to retrieve only the policy bundle snapshot for a given decision.
+
+			Logs can be filtered by status, branch, project, and time range.
+			Use --out to write results to a file.
+
+			JSON fields: id, status, created_at, org_id, project_id, branch,
+			             build_number, policies, decision, metadata
+		`),
+		Example: heredoc.Doc(`
+			# Get all decision logs
+			$ circleci policy logs --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f
+
+			# Get a specific decision log
+			$ circleci policy logs abc123 --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f
+
+			# Filter by status and branch
+			$ circleci policy logs --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --status HARD_FAIL --branch main
+
+			# Write output to a file
+			$ circleci policy logs --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --out logs.json
+		`),
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := iostream.FromCmd(cmd.Context(), cmd)
+			client, err := cmdutil.LoadClient(ctx, cmd)
+			if err != nil {
+				return err
+			}
+			decisionID := ""
+			if len(args) == 1 {
+				decisionID = args[0]
+			}
+			req := apiclient.DecisionLogsRequest{
+				Status:    status,
+				Branch:    branch,
+				ProjectID: projectID,
+			}
+			if after != "" {
+				t, err := parseTime(after)
+				if err != nil {
+					return clierrors.New("policy.logs_invalid_after", "Invalid --after value", err.Error()).
+						WithSuggestions("Use RFC3339 format: 2006-01-02T15:04:05Z").
+						WithExitCode(clierrors.ExitBadArguments)
+				}
+				req.After = &t
+			}
+			if before != "" {
+				t, err := parseTime(before)
+				if err != nil {
+					return clierrors.New("policy.logs_invalid_before", "Invalid --before value", err.Error()).
+						WithSuggestions("Use RFC3339 format: 2006-01-02T15:04:05Z").
+						WithExitCode(clierrors.ExitBadArguments)
+				}
+				req.Before = &t
+			}
+			return runLogs(ctx, client, ownerID, policyCtx, decisionID, outputFile, policyBundle, jsonOut, req)
+		},
+	}
+
+	cmd.Flags().StringVar(&ownerID, "owner-id", "", "Organization UUID (required)")
+	cmd.Flags().StringVar(&policyCtx, "policy-context", "config", "Policy context")
+	cmd.Flags().StringVar(&after, "after", "", "Return logs created after this time (RFC3339 or YYYY-MM-DD)")
+	cmd.Flags().StringVar(&before, "before", "", "Return logs created before this time (RFC3339 or YYYY-MM-DD)")
+	cmd.Flags().StringVar(&status, "status", "", "Filter by decision status (PASS, SOFT_FAIL, HARD_FAIL, ERROR)")
+	cmd.Flags().StringVar(&branch, "branch", "", "Filter by branch name")
+	cmd.Flags().StringVar(&projectID, "project-id", "", "Filter by project ID")
+	cmd.Flags().StringVar(&outputFile, "out", "", "Write output to this file instead of stdout")
+	cmd.Flags().BoolVar(&policyBundle, "policy-bundle", false, "Retrieve the policy bundle snapshot for the given decision ID")
+	cmdutil.AddJSONFlag(cmd, &jsonOut)
+	cmdutil.AddJQFlag(cmd)
+	_ = cmd.MarkFlagRequired("owner-id")
+
+	return cmd
+}
+
+func runLogs(ctx context.Context, client *apiclient.Client, ownerID, policyCtx, decisionID, outputFile string, policyBundle, jsonOut bool, req apiclient.DecisionLogsRequest) error {
+	var (
+		result any
+		err    error
+	)
+
+	if decisionID != "" {
+		result, err = client.GetDecisionLog(ctx, ownerID, policyCtx, decisionID, policyBundle)
+		if err != nil {
+			return policyAPIErr(err, decisionID)
+		}
+	} else {
+		spin := iostream.Spinner(ctx, !jsonOut, "Fetching decision logs...")
+		defer spin.Stop()
+
+		var all []json.RawMessage
+		for {
+			batch, err := client.GetDecisionLogs(ctx, ownerID, policyCtx, req)
+			if err != nil {
+				return policyAPIErr(err, ownerID)
+			}
+			if len(batch) == 0 {
+				break
+			}
+			all = append(all, batch...)
+			req.Offset = len(all)
+		}
+		spin.Stop()
+		result = all
+	}
+
+	if outputFile != "" {
+		f, err := os.Create(outputFile) //nolint:gosec // outputFile is user-supplied
+		if err != nil {
+			return clierrors.New("policy.logs_write_failed", "Could not open output file", err.Error()).
+				WithExitCode(clierrors.ExitGeneralError)
+		}
+		defer func() { _ = f.Close() }()
+		iostream.ErrPrintf(ctx, "Writing logs to %s...\n", outputFile)
+		return cmdutil.WriteJSON(f, result)
+	}
+
+	if jsonOut {
+		return iostream.PrintJSON(ctx, result)
+	}
+	return cmdutil.WriteJSON(iostream.Out(ctx), result)
+}
+
+var timeFormats = []string{
+	time.RFC3339,
+	"2006-01-02T15:04:05",
+	"2006-01-02",
+	"2006/01/02",
+}
+
+func parseTime(s string) (time.Time, error) {
+	for _, layout := range timeFormats {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t, nil
+		}
+	}
+	return time.Time{}, clierrors.New("policy.invalid_time", "Invalid time format", s+": unrecognised time format").
+		WithSuggestions("Use RFC3339 format: 2006-01-02T15:04:05Z, or date only: 2006-01-02").
+		WithExitCode(clierrors.ExitBadArguments)
+}

--- a/internal/cmd/policy/policy.go
+++ b/internal/cmd/policy/policy.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+// Package policy implements the "circleci policy" command group.
+package policy
+
+import (
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+
+	"github.com/CircleCI-Public/circleci-cli/internal/cmdutil"
+	clierrors "github.com/CircleCI-Public/circleci-cli/internal/errors"
+)
+
+// NewPolicyCmd returns the "circleci policy" command group.
+func NewPolicyCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "policy <command>",
+		Short: "Manage security policies",
+		Long: heredoc.Doc(`
+			Manage CircleCI security policies.
+
+			Policies are written in Rego and evaluated against pipeline configs
+			to enforce organizational security rules. Use these commands to push,
+			inspect, and test policy bundles, and to query decision logs.
+
+			Most commands require --owner-id, which is your organization's UUID.
+			Find it at: https://app.circleci.com/settings/organization
+		`),
+		RunE:               cmdutil.GroupRunE,
+		FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
+	}
+
+	cmd.AddCommand(newPushCmd())
+	cmd.AddCommand(newDiffCmd())
+	cmd.AddCommand(newFetchCmd())
+	cmd.AddCommand(newLogsCmd())
+	cmd.AddCommand(newDecideCmd())
+	cmd.AddCommand(newSettingsCmd())
+
+	return cmd
+}
+
+func policyAPIErr(err error, subject string) *clierrors.CLIError {
+	return cmdutil.APIErr(err, subject,
+		"policy.not_found", "No policy found for %q.",
+		"Check the owner ID and policy context",
+		"Run: circleci policy fetch --owner-id <id>")
+}

--- a/internal/cmd/policy/push.go
+++ b/internal/cmd/policy/push.go
@@ -1,0 +1,129 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package policy
+
+import (
+	"context"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+
+	"github.com/CircleCI-Public/circleci-cli/internal/apiclient"
+	"github.com/CircleCI-Public/circleci-cli/internal/cmdutil"
+	clierrors "github.com/CircleCI-Public/circleci-cli/internal/errors"
+	"github.com/CircleCI-Public/circleci-cli/internal/iostream"
+)
+
+func newPushCmd() *cobra.Command {
+	var (
+		ownerID   string
+		policyCtx string
+		noPrompt  bool
+		jsonOut   bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "push <path>",
+		Short: "Push a policy bundle to CircleCI",
+		Long: heredoc.Doc(`
+			Upload a directory of .rego files as a policy bundle.
+
+			Before applying changes, a diff is shown and confirmation is
+			requested. Pass --no-prompt to skip confirmation (useful in CI).
+
+			The policy bundle replaces the existing bundle for the given
+			owner and policy context.
+
+			JSON fields: created, deleted, updated (policy names)
+		`),
+		Example: heredoc.Doc(`
+			# Push policies in the ./policies directory
+			$ circleci policy push ./policies --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f
+
+			# Push without confirmation prompt
+			$ circleci policy push ./policies --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --no-prompt
+
+			# Push to a custom policy context
+			$ circleci policy push ./policies --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --policy-context config
+
+			# Output the diff as JSON
+			$ circleci policy push ./policies --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --no-prompt --json
+		`),
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := iostream.FromCmd(cmd.Context(), cmd)
+			client, err := cmdutil.LoadClient(ctx, cmd)
+			if err != nil {
+				return err
+			}
+			return runPush(ctx, client, args[0], ownerID, policyCtx, noPrompt, jsonOut)
+		},
+	}
+
+	cmd.Flags().StringVar(&ownerID, "owner-id", "", "Organization UUID (required)")
+	cmd.Flags().StringVar(&policyCtx, "policy-context", "config", "Policy context")
+	cmd.Flags().BoolVar(&noPrompt, "no-prompt", false, "Skip confirmation prompt")
+	cmdutil.AddJSONFlag(cmd, &jsonOut)
+	cmdutil.AddJQFlag(cmd)
+	_ = cmd.MarkFlagRequired("owner-id")
+
+	return cmd
+}
+
+func runPush(ctx context.Context, client *apiclient.Client, path, ownerID, policyCtx string, noPrompt, jsonOut bool) error {
+	bundle, err := loadPolicyBundle(path)
+	if err != nil {
+		return err
+	}
+
+	if !noPrompt {
+		diff, err := client.CreatePolicyBundle(ctx, ownerID, policyCtx, bundle, true)
+		if err != nil {
+			return policyAPIErr(err, ownerID)
+		}
+		iostream.ErrPrintln(ctx, "The following changes will be applied:")
+		_ = cmdutil.WriteJSON(iostream.Err(ctx), diff)
+		iostream.ErrPrintln(ctx, "")
+
+		abortErr := clierrors.New("policy.push_aborted", "Push aborted", "User cancelled the push.").
+			WithExitCode(clierrors.ExitCancelled)
+		requireForceErr := clierrors.New("policy.push_requires_prompt", "Use --no-prompt in non-interactive mode",
+			"Cannot confirm policy push in a non-interactive terminal.").
+			WithExitCode(clierrors.ExitBadArguments)
+		if err := cmdutil.ConfirmOrForce(ctx, iostream.Get(ctx), false, "Do you wish to continue?", abortErr, requireForceErr); err != nil {
+			return err
+		}
+	}
+
+	result, err := client.CreatePolicyBundle(ctx, ownerID, policyCtx, bundle, false)
+	if err != nil {
+		return policyAPIErr(err, ownerID)
+	}
+
+	iostream.ErrPrintln(ctx, "Policy bundle pushed successfully.")
+
+	if jsonOut {
+		return iostream.PrintJSON(ctx, result)
+	}
+	return cmdutil.WriteJSON(iostream.Out(ctx), result)
+}

--- a/internal/cmd/policy/settings.go
+++ b/internal/cmd/policy/settings.go
@@ -1,0 +1,184 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package policy
+
+import (
+	"context"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+
+	"github.com/CircleCI-Public/circleci-cli/internal/apiclient"
+	"github.com/CircleCI-Public/circleci-cli/internal/cmdutil"
+	"github.com/CircleCI-Public/circleci-cli/internal/iostream"
+)
+
+func newSettingsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "settings <command>",
+		Short: "Manage policy enforcement settings",
+		Long: heredoc.Doc(`
+			Get or update policy enforcement settings for an organization.
+
+			Policy enforcement controls whether pipeline configs are evaluated
+			against the policy bundle before running.
+		`),
+		RunE:               cmdutil.GroupRunE,
+		FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
+	}
+
+	cmd.AddCommand(newSettingsGetCmd())
+	cmd.AddCommand(newSettingsSetCmd())
+
+	return cmd
+}
+
+func newSettingsGetCmd() *cobra.Command {
+	var (
+		ownerID   string
+		policyCtx string
+		jsonOut   bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "get",
+		Short: "Get policy enforcement settings",
+		Long: heredoc.Doc(`
+			Retrieve the current policy enforcement settings for an organization.
+
+			JSON fields: enabled
+		`),
+		Example: heredoc.Doc(`
+			# Get policy enforcement settings
+			$ circleci policy settings get --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f
+
+			# Output as JSON
+			$ circleci policy settings get --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --json
+
+			# Use with jq to extract the enabled field
+			$ circleci policy settings get --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --json --jq '.enabled'
+		`),
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := iostream.FromCmd(cmd.Context(), cmd)
+			client, err := cmdutil.LoadClient(ctx, cmd)
+			if err != nil {
+				return err
+			}
+			return runSettingsGet(ctx, client, ownerID, policyCtx, jsonOut)
+		},
+	}
+
+	cmd.Flags().StringVar(&ownerID, "owner-id", "", "Organization UUID (required)")
+	cmd.Flags().StringVar(&policyCtx, "policy-context", "config", "Policy context")
+	cmdutil.AddJSONFlag(cmd, &jsonOut)
+	cmdutil.AddJQFlag(cmd)
+	_ = cmd.MarkFlagRequired("owner-id")
+
+	return cmd
+}
+
+func newSettingsSetCmd() *cobra.Command {
+	var (
+		ownerID   string
+		policyCtx string
+		enabled   bool
+		jsonOut   bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "set",
+		Short: "Update policy enforcement settings",
+		Long: heredoc.Doc(`
+			Enable or disable policy enforcement for an organization.
+
+			When enabled, pipeline configs are evaluated against the policy bundle
+			before each run. Configs that produce a HARD_FAIL decision are blocked.
+
+			JSON fields: enabled
+		`),
+		Example: heredoc.Doc(`
+			# Enable policy enforcement
+			$ circleci policy settings set --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --enabled
+
+			# Disable policy enforcement
+			$ circleci policy settings set --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --enabled=false
+
+			# Output result as JSON
+			$ circleci policy settings set --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --enabled --json
+		`),
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := iostream.FromCmd(cmd.Context(), cmd)
+			client, err := cmdutil.LoadClient(ctx, cmd)
+			if err != nil {
+				return err
+			}
+			return runSettingsSet(ctx, client, ownerID, policyCtx, enabled, jsonOut)
+		},
+	}
+
+	cmd.Flags().StringVar(&ownerID, "owner-id", "", "Organization UUID (required)")
+	cmd.Flags().StringVar(&policyCtx, "policy-context", "config", "Policy context")
+	cmd.Flags().BoolVar(&enabled, "enabled", false, "Enable policy enforcement")
+	cmdutil.AddJSONFlag(cmd, &jsonOut)
+	cmdutil.AddJQFlag(cmd)
+	_ = cmd.MarkFlagRequired("owner-id")
+	_ = cmd.MarkFlagRequired("enabled")
+
+	return cmd
+}
+
+func runSettingsGet(ctx context.Context, client *apiclient.Client, ownerID, policyCtx string, jsonOut bool) error {
+	s, err := client.GetPolicySettings(ctx, ownerID, policyCtx)
+	if err != nil {
+		return policyAPIErr(err, ownerID)
+	}
+
+	if jsonOut {
+		return iostream.PrintJSON(ctx, s)
+	}
+	iostream.Printf(ctx, "Enabled: %v\n", s.Enabled)
+	return nil
+}
+
+func runSettingsSet(ctx context.Context, client *apiclient.Client, ownerID, policyCtx string, enabled, jsonOut bool) error {
+	s, err := client.SetPolicySettings(ctx, ownerID, policyCtx, apiclient.DecisionSettings{Enabled: enabled})
+	if err != nil {
+		return policyAPIErr(err, ownerID)
+	}
+
+	if jsonOut {
+		return iostream.PrintJSON(ctx, s)
+	}
+	iostream.Printf(ctx, "Policy enforcement %s.\n", enabledLabel(enabled))
+	_ = s
+	return nil
+}
+
+func enabledLabel(b bool) string {
+	if b {
+		return "enabled"
+	}
+	return "disabled"
+}

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -44,6 +44,7 @@ import (
 	cmdnamespace "github.com/CircleCI-Public/circleci-cli/internal/cmd/namespace"
 	cmdorb "github.com/CircleCI-Public/circleci-cli/internal/cmd/orb"
 	"github.com/CircleCI-Public/circleci-cli/internal/cmd/pipeline"
+	cmdpolicy "github.com/CircleCI-Public/circleci-cli/internal/cmd/policy"
 	"github.com/CircleCI-Public/circleci-cli/internal/cmd/project"
 	cmdrun "github.com/CircleCI-Public/circleci-cli/internal/cmd/run"
 	"github.com/CircleCI-Public/circleci-cli/internal/cmd/runner"
@@ -115,6 +116,7 @@ func NewRootCmd(version string) *cobra.Command {
 	cmd.AddCommand(project.NewGetCmd("info")) // Alias to project get
 	cmd.AddCommand(job.NewJobCmd())
 	cmd.AddCommand(pipeline.NewPipelineCmd())
+	cmd.AddCommand(cmdpolicy.NewPolicyCmd())
 	cmd.AddCommand(cmdrun.NewRunCmd())
 	cmd.AddCommand(project.NewProjectCmd())
 	cmd.AddCommand(runner.NewRunnerCmd())

--- a/internal/cmd/root/testdata/usage/circleci.txt
+++ b/internal/cmd/root/testdata/usage/circleci.txt
@@ -18,6 +18,7 @@ Available Commands:
   namespace      Manage orb namespaces
   orb            Manage orbs in the CircleCI orb registry
   pipeline       Manage pipeline definitions
+  policy         Manage security policies
   project        Manage CircleCI projects
   run            Manage runs
   runner         Manage self-hosted runners

--- a/internal/cmd/root/testdata/usage/circleci/policy.txt
+++ b/internal/cmd/root/testdata/usage/circleci/policy.txt
@@ -1,0 +1,18 @@
+Usage:
+  circleci policy <command> [flags]
+  circleci policy [command]
+
+Available Commands:
+  decide      Evaluate a config against remote policies
+  diff        Show diff between local and remote policy bundles
+  fetch       Download the remote policy bundle
+  logs        Get policy decision logs
+  push        Push a policy bundle to CircleCI
+  settings    Manage policy enforcement settings
+
+Global Flags:
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected
+
+Use "circleci policy [command] --help" for more information about a command.

--- a/internal/cmd/root/testdata/usage/circleci/policy/decide.txt
+++ b/internal/cmd/root/testdata/usage/circleci/policy/decide.txt
@@ -1,0 +1,31 @@
+Usage:
+  circleci policy decide [flags]
+
+Examples:
+# Evaluate a config against remote policies
+$ circleci policy decide --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --input .circleci/config.yml
+
+# Exit non-zero on hard failures
+$ circleci policy decide --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --input .circleci/config.yml --strict
+
+# Pass metadata alongside the decision
+$ circleci policy decide --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --input .circleci/config.yml --meta '{"project_id":"abc"}'
+
+# Output decision as JSON
+$ circleci policy decide --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --input .circleci/config.yml --json
+
+
+Flags:
+      --input string            Path to input file (e.g. .circleci/config.yml) (required)
+      --jq string               Process values from the response using jq syntax
+      --json                    Output as JSON
+      --meta string             Decision metadata as a JSON string
+      --metafile string         Path to decision metadata file (YAML or JSON)
+      --owner-id string         Organization UUID (required)
+      --policy-context string   Policy context (default "config")
+      --strict                  Exit non-zero for HARD_FAIL or ERROR decisions
+
+Global Flags:
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/policy/diff.txt
+++ b/internal/cmd/root/testdata/usage/circleci/policy/diff.txt
@@ -1,0 +1,24 @@
+Usage:
+  circleci policy diff <path> [flags]
+
+Examples:
+# Diff policies in ./policies against the remote bundle
+$ circleci policy diff ./policies --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f
+
+# Diff against a custom policy context
+$ circleci policy diff ./policies --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --policy-context config
+
+# Output diff as JSON for scripting
+$ circleci policy diff ./policies --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --json
+
+
+Flags:
+      --jq string               Process values from the response using jq syntax
+      --json                    Output as JSON
+      --owner-id string         Organization UUID (required)
+      --policy-context string   Policy context (default "config")
+
+Global Flags:
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/policy/fetch.txt
+++ b/internal/cmd/root/testdata/usage/circleci/policy/fetch.txt
@@ -1,0 +1,24 @@
+Usage:
+  circleci policy fetch [policy-name] [flags]
+
+Examples:
+# Fetch the full policy bundle
+$ circleci policy fetch --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f
+
+# Fetch a single policy by name
+$ circleci policy fetch my-policy --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f
+
+# Output as JSON with jq filtering
+$ circleci policy fetch --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --json --jq 'keys'
+
+
+Flags:
+      --jq string               Process values from the response using jq syntax
+      --json                    Output as JSON
+      --owner-id string         Organization UUID (required)
+      --policy-context string   Policy context (default "config")
+
+Global Flags:
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/policy/logs.txt
+++ b/internal/cmd/root/testdata/usage/circleci/policy/logs.txt
@@ -1,0 +1,34 @@
+Usage:
+  circleci policy logs [decision-id] [flags]
+
+Examples:
+# Get all decision logs
+$ circleci policy logs --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f
+
+# Get a specific decision log
+$ circleci policy logs abc123 --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f
+
+# Filter by status and branch
+$ circleci policy logs --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --status HARD_FAIL --branch main
+
+# Write output to a file
+$ circleci policy logs --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --out logs.json
+
+
+Flags:
+      --after string            Return logs created after this time (RFC3339 or YYYY-MM-DD)
+      --before string           Return logs created before this time (RFC3339 or YYYY-MM-DD)
+      --branch string           Filter by branch name
+      --jq string               Process values from the response using jq syntax
+      --json                    Output as JSON
+      --out string              Write output to this file instead of stdout
+      --owner-id string         Organization UUID (required)
+      --policy-bundle           Retrieve the policy bundle snapshot for the given decision ID
+      --policy-context string   Policy context (default "config")
+      --project-id string       Filter by project ID
+      --status string           Filter by decision status (PASS, SOFT_FAIL, HARD_FAIL, ERROR)
+
+Global Flags:
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/policy/push.txt
+++ b/internal/cmd/root/testdata/usage/circleci/policy/push.txt
@@ -1,0 +1,28 @@
+Usage:
+  circleci policy push <path> [flags]
+
+Examples:
+# Push policies in the ./policies directory
+$ circleci policy push ./policies --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f
+
+# Push without confirmation prompt
+$ circleci policy push ./policies --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --no-prompt
+
+# Push to a custom policy context
+$ circleci policy push ./policies --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --policy-context config
+
+# Output the diff as JSON
+$ circleci policy push ./policies --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --no-prompt --json
+
+
+Flags:
+      --jq string               Process values from the response using jq syntax
+      --json                    Output as JSON
+      --no-prompt               Skip confirmation prompt
+      --owner-id string         Organization UUID (required)
+      --policy-context string   Policy context (default "config")
+
+Global Flags:
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/policy/settings.txt
+++ b/internal/cmd/root/testdata/usage/circleci/policy/settings.txt
@@ -1,0 +1,14 @@
+Usage:
+  circleci policy settings <command> [flags]
+  circleci policy settings [command]
+
+Available Commands:
+  get         Get policy enforcement settings
+  set         Update policy enforcement settings
+
+Global Flags:
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected
+
+Use "circleci policy settings [command] --help" for more information about a command.

--- a/internal/cmd/root/testdata/usage/circleci/policy/settings/get.txt
+++ b/internal/cmd/root/testdata/usage/circleci/policy/settings/get.txt
@@ -1,0 +1,24 @@
+Usage:
+  circleci policy settings get [flags]
+
+Examples:
+# Get policy enforcement settings
+$ circleci policy settings get --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f
+
+# Output as JSON
+$ circleci policy settings get --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --json
+
+# Use with jq to extract the enabled field
+$ circleci policy settings get --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --json --jq '.enabled'
+
+
+Flags:
+      --jq string               Process values from the response using jq syntax
+      --json                    Output as JSON
+      --owner-id string         Organization UUID (required)
+      --policy-context string   Policy context (default "config")
+
+Global Flags:
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected

--- a/internal/cmd/root/testdata/usage/circleci/policy/settings/set.txt
+++ b/internal/cmd/root/testdata/usage/circleci/policy/settings/set.txt
@@ -1,0 +1,25 @@
+Usage:
+  circleci policy settings set [flags]
+
+Examples:
+# Enable policy enforcement
+$ circleci policy settings set --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --enabled
+
+# Disable policy enforcement
+$ circleci policy settings set --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --enabled=false
+
+# Output result as JSON
+$ circleci policy settings set --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --enabled --json
+
+
+Flags:
+      --enabled                 Enable policy enforcement
+      --jq string               Process values from the response using jq syntax
+      --json                    Output as JSON
+      --owner-id string         Organization UUID (required)
+      --policy-context string   Policy context (default "config")
+
+Global Flags:
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected

--- a/internal/testing/fakes/circleci.go
+++ b/internal/testing/fakes/circleci.go
@@ -91,6 +91,12 @@ type CircleCI struct {
 	// Deploy state.
 	deploys map[string][]any // project id → deploys
 
+	// Policy state.
+	policyBundles   map[string]map[string]string // "ownerID/ctx" → bundle
+	decisionLogs    map[string][]any             // "ownerID/ctx" → logs
+	decisionResults map[string]any               // "ownerID/ctx" → decision response
+	policySettings  map[string]bool              // "ownerID/ctx" → enabled
+
 	// iOS code signing state.
 	iosCerts          map[string][]any // org id → certificate objects
 	iosBundles        map[string][]any // org id → signing bundle objects
@@ -174,6 +180,10 @@ func NewCircleCI(t *testing.T) *CircleCI {
 		deletedContextRestrictions:        map[string]bool{},
 		projectInfos:                      map[string]any{},
 		deploys:                           map[string][]any{},
+		policyBundles:                     make(map[string]map[string]string),
+		decisionLogs:                      make(map[string][]any),
+		decisionResults:                   make(map[string]any),
+		policySettings:                    make(map[string]bool),
 		namespaces:                        map[string]any{},
 		namespacesByName:                  map[string]string{},
 		deletedNamespaces:                 map[string]bool{},
@@ -231,6 +241,17 @@ func NewCircleCI(t *testing.T) *CircleCI {
 	r.Post("/api/v2/projects/{projectID}/pipeline-definitions", f.handleCreatePipelineDefinition)
 	r.Get("/api/v2/projects/{projectID}/pipeline-definitions/{pipelineDefinitionID}/triggers", f.handleListTriggers)
 	r.Post("/api/v2/projects/{projectID}/pipeline-definitions/{pipelineDefinitionID}/triggers", f.handleCreateTrigger)
+	// Policy routes.
+	r.Route("/api/v2/owner/{ownerID}/context/{policyCtx}", func(r chi.Router) {
+		r.Post("/policy-bundle", f.handleCreatePolicyBundle)
+		r.Get("/policy-bundle", f.handleFetchPolicyBundle)
+		r.Get("/policy-bundle/{name}", f.handleFetchPolicyBundleByName)
+		r.Get("/decision", f.handleGetDecisionLogs)
+		r.Post("/decision", f.handleMakeDecision)
+		r.Get("/decision/settings", f.handleGetPolicySettings)
+		r.Patch("/decision/settings", f.handleSetPolicySettings)
+		r.Get("/decision/{id}", f.handleGetDecisionLog)
+	})
 	// Deploy routes.
 	r.Get("/api/v2/deploy/projects/{project_id}/releases", f.handleListDeploys)
 	// iOS code signing routes.
@@ -2685,4 +2706,161 @@ func parseIntOrZero(s string) int {
 	var n int
 	_, _ = fmt.Sscanf(s, "%d", &n)
 	return n
+}
+
+// --- Policy helpers ---
+
+// AddPolicyBundle registers a policy bundle for the given owner and context.
+func (f *CircleCI) AddPolicyBundle(ownerID, policyCtx string, bundle map[string]string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	key := ownerID + "/" + policyCtx
+	f.policyBundles[key] = bundle
+}
+
+// AddDecisionLog appends a decision log entry for the given owner and context.
+func (f *CircleCI) AddDecisionLog(ownerID, policyCtx string, log any) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	key := ownerID + "/" + policyCtx
+	f.decisionLogs[key] = append(f.decisionLogs[key], log)
+}
+
+// SetDecisionResult sets the response returned by MakeDecision for the given owner and context.
+func (f *CircleCI) SetDecisionResult(ownerID, policyCtx string, result any) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	key := ownerID + "/" + policyCtx
+	f.decisionResults[key] = result
+}
+
+// SetPolicyEnabled sets the policy enforcement enabled flag for the given owner and context.
+func (f *CircleCI) SetPolicyEnabled(ownerID, policyCtx string, enabled bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	key := ownerID + "/" + policyCtx
+	f.policySettings[key] = enabled
+}
+
+// --- Policy handlers ---
+
+func (f *CircleCI) handleCreatePolicyBundle(w http.ResponseWriter, r *http.Request) {
+	ownerID := chi.URLParam(r, "ownerID")
+	policyCtx := chi.URLParam(r, "policyCtx")
+	isDry := r.URL.Query().Get("dry") == "true"
+
+	var body struct {
+		Policies map[string]string `json:"policies"`
+	}
+	_ = json.NewDecoder(r.Body).Decode(&body)
+
+	f.mu.Lock()
+	key := ownerID + "/" + policyCtx
+	if !isDry {
+		f.policyBundles[key] = body.Policies
+	}
+	f.mu.Unlock()
+
+	render.JSON(w, r, map[string]any{"created": []string{}, "deleted": []string{}, "updated": []string{}})
+}
+
+func (f *CircleCI) handleFetchPolicyBundle(w http.ResponseWriter, r *http.Request) {
+	ownerID := chi.URLParam(r, "ownerID")
+	policyCtx := chi.URLParam(r, "policyCtx")
+	f.mu.RLock()
+	bundle := f.policyBundles[ownerID+"/"+policyCtx]
+	f.mu.RUnlock()
+	if bundle == nil {
+		bundle = map[string]string{}
+	}
+	render.JSON(w, r, bundle)
+}
+
+func (f *CircleCI) handleFetchPolicyBundleByName(w http.ResponseWriter, r *http.Request) {
+	ownerID := chi.URLParam(r, "ownerID")
+	policyCtx := chi.URLParam(r, "policyCtx")
+	name := chi.URLParam(r, "name")
+	f.mu.RLock()
+	bundle := f.policyBundles[ownerID+"/"+policyCtx]
+	f.mu.RUnlock()
+	if bundle == nil {
+		http.NotFound(w, r)
+		return
+	}
+	content, ok := bundle[name]
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	render.JSON(w, r, map[string]string{name: content})
+}
+
+func (f *CircleCI) handleGetDecisionLogs(w http.ResponseWriter, r *http.Request) {
+	ownerID := chi.URLParam(r, "ownerID")
+	policyCtx := chi.URLParam(r, "policyCtx")
+	offsetStr := r.URL.Query().Get("offset")
+	offset := 0
+	if offsetStr != "" {
+		offset, _ = strconv.Atoi(offsetStr)
+	}
+	f.mu.RLock()
+	all := f.decisionLogs[ownerID+"/"+policyCtx]
+	f.mu.RUnlock()
+	if offset >= len(all) {
+		render.JSON(w, r, []any{})
+		return
+	}
+	render.JSON(w, r, all[offset:])
+}
+
+func (f *CircleCI) handleGetDecisionLog(w http.ResponseWriter, r *http.Request) {
+	ownerID := chi.URLParam(r, "ownerID")
+	policyCtx := chi.URLParam(r, "policyCtx")
+	id := chi.URLParam(r, "id")
+	f.mu.RLock()
+	all := f.decisionLogs[ownerID+"/"+policyCtx]
+	f.mu.RUnlock()
+	for _, l := range all {
+		if m, ok := l.(map[string]any); ok {
+			if m["id"] == id {
+				render.JSON(w, r, l)
+				return
+			}
+		}
+	}
+	http.NotFound(w, r)
+}
+
+func (f *CircleCI) handleMakeDecision(w http.ResponseWriter, r *http.Request) {
+	ownerID := chi.URLParam(r, "ownerID")
+	policyCtx := chi.URLParam(r, "policyCtx")
+	f.mu.RLock()
+	result := f.decisionResults[ownerID+"/"+policyCtx]
+	f.mu.RUnlock()
+	if result == nil {
+		result = map[string]any{"status": "PASS"}
+	}
+	render.JSON(w, r, result)
+}
+
+func (f *CircleCI) handleGetPolicySettings(w http.ResponseWriter, r *http.Request) {
+	ownerID := chi.URLParam(r, "ownerID")
+	policyCtx := chi.URLParam(r, "policyCtx")
+	f.mu.RLock()
+	enabled := f.policySettings[ownerID+"/"+policyCtx]
+	f.mu.RUnlock()
+	render.JSON(w, r, map[string]any{"enabled": enabled})
+}
+
+func (f *CircleCI) handleSetPolicySettings(w http.ResponseWriter, r *http.Request) {
+	ownerID := chi.URLParam(r, "ownerID")
+	policyCtx := chi.URLParam(r, "policyCtx")
+	var body struct {
+		Enabled bool `json:"enabled"`
+	}
+	_ = json.NewDecoder(r.Body).Decode(&body)
+	f.mu.Lock()
+	f.policySettings[ownerID+"/"+policyCtx] = body.Enabled
+	f.mu.Unlock()
+	render.JSON(w, r, map[string]any{"enabled": body.Enabled})
 }


### PR DESCRIPTION
## Summary

Ports all `circleci policy` commands from the `main` branch into the `next`-style architecture.

- `policy push <path>` — upload a `.rego` bundle; shows dry-run diff and confirms before applying; `--no-prompt` for CI
- `policy diff <path>` — diff local vs remote bundle without applying changes
- `policy fetch [name]` — download full bundle or a single named policy
- `policy logs [decision-id]` — paginated decision logs with `--status`, `--branch`, `--project-id`, `--after`, `--before`, `--out` filters
- `policy decide --input <file>` — remote policy evaluation; `--strict` exits 7 on HARD_FAIL/ERROR
- `policy settings get/set` — get or toggle policy enforcement for an org

## Implementation notes

- `internal/apiclient/policy.go` — 7 typed API methods on `*Client`; `patch()` added to client
- `internal/cmd/policy/` — thin Cobra wrappers following the same patterns as `context/`, `workflow/`
- `--policy-context` instead of `--context` to avoid confusion with the `circleci context` command group
- Fake server gets a chi sub-router for all policy routes (handles `/decision/settings` vs `/decision/{id}` conflict correctly)

## Not yet implemented (feature gaps vs `main`)

The following features exist on `main` but are deferred here. They require pulling in the `circle-policy-agent/cpa` dependency and local OPA evaluation support.

### Missing commands
- **`policy eval`** — local-only raw OPA evaluation against a policy file/directory; supports a `--query` flag (default `data`) for arbitrary OPA queries, plus `--no-compile` and `--pipeline-parameters`
- **`policy test`** — runs Rego unit test files; `--run` regex filter, `-v`/`--verbose`, `--debug`, `--format json|junit`; calls the `compile-config-with-defaults` API endpoint internally

### Missing modes and flags on `policy decide`
- **Local evaluation mode** — on `main`, passing a positional `[policy_file_or_dir_path]` arg skips the API and evaluates locally using the embedded OPA engine; `--owner-id` is only required for remote mode
- **`--no-compile`** — skips automatic config compilation before evaluation
- **`--pipeline-parameters`** — passes YAML/JSON pipeline parameters into the compilation step
- **Auto-compilation** — on `main`, when `--policy-context=config` (the default), the config is automatically compiled via the CircleCI compile endpoint before being sent for evaluation; this branch sends the raw input as-is

## Test plan

- [ ] All policy acceptance tests pass: `go test ./acceptance/ -run TestPolicy -count=1 -v`
- [ ] `circleci policy push ./policies --owner-id <id> --no-prompt` uploads bundle
- [ ] `circleci policy decide --owner-id <id> --input config.yml --strict` exits 7 on HARD_FAIL
- [ ] `circleci policy settings set --owner-id <id> --enabled` enables enforcement
- [ ] `circleci policy logs --owner-id <id>` paginates automatically
- [ ] All static checks pass: `task check`