### PR TITLE
Implement `circleci runner config`

### DIFF
--- a/acceptance/runner_test.go
+++ b/acceptance/runner_test.go
@@ -25,6 +25,7 @@ package acceptance_test
 import (
 	"encoding/json"
 	"net/http"
+	"os"
 	"strings"
 	"testing"
 
@@ -646,6 +647,86 @@ func TestRunnerInstanceList_NoToken(t *testing.T) {
 	})
 
 	assert.Equal(t, result.ExitCode, 3, "stderr: %s", result.Stderr)
+	assert.Check(t, golden.String(result.Stderr, t.Name()+".stderr.txt"))
+}
+
+// --- runner config ---
+
+func TestRunnerConfig(t *testing.T) {
+	_, env := setupRunnerFake(t)
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"runner", "config", "my-org/linux-runner"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Check(t, golden.String(result.Stdout, t.Name()+".yaml"))
+}
+
+func TestRunnerConfig_Nickname(t *testing.T) {
+	_, env := setupRunnerFake(t)
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"runner", "config", "my-org/linux-runner", "--nickname", "prod-server-1"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Check(t, golden.String(result.Stdout, t.Name()+".yaml"))
+}
+
+func TestRunnerConfig_ExistingToken(t *testing.T) {
+	// --token skips the API call entirely; no fake server needed.
+	env := testenv.New(t)
+	env.Token = testToken
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"runner", "config", "my-org/linux-runner", "--token", "my-existing-token-value"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Check(t, golden.String(result.Stdout, t.Name()+".yaml"))
+}
+
+func TestRunnerConfig_OutputFile(t *testing.T) {
+	_, env := setupRunnerFake(t)
+	dir := t.TempDir()
+	outPath := dir + "/launch-agent-config.yaml"
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"runner", "config", "my-org/linux-runner", "--output", outPath},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Equal(t, strings.TrimSpace(result.Stdout), "")
+
+	contents, err := os.ReadFile(outPath)
+	assert.NilError(t, err)
+	assert.Check(t, golden.String(string(contents), t.Name()+".yaml"))
+}
+
+func TestRunnerConfig_NoArgs(t *testing.T) {
+	_, env := setupRunnerFake(t)
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"runner", "config"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 2, "stderr: %s", result.Stderr)
 	assert.Check(t, golden.String(result.Stderr, t.Name()+".stderr.txt"))
 }
 

--- a/acceptance/testdata/TestRunnerConfig.yaml
+++ b/acceptance/testdata/TestRunnerConfig.yaml
@@ -1,0 +1,2 @@
+api:
+    auth_token: fake-runner-token-value

--- a/acceptance/testdata/TestRunnerConfig_ExistingToken.yaml
+++ b/acceptance/testdata/TestRunnerConfig_ExistingToken.yaml
@@ -1,0 +1,2 @@
+api:
+    auth_token: my-existing-token-value

--- a/acceptance/testdata/TestRunnerConfig_Nickname.yaml
+++ b/acceptance/testdata/TestRunnerConfig_Nickname.yaml
@@ -1,0 +1,2 @@
+api:
+    auth_token: fake-runner-token-value

--- a/acceptance/testdata/TestRunnerConfig_NoArgs.stderr.txt
+++ b/acceptance/testdata/TestRunnerConfig_NoArgs.stderr.txt
@@ -1,0 +1,1 @@
+error: Required argument missing: <resource-class>

--- a/acceptance/testdata/TestRunnerConfig_OutputFile.yaml
+++ b/acceptance/testdata/TestRunnerConfig_OutputFile.yaml
@@ -1,0 +1,2 @@
+api:
+    auth_token: fake-runner-token-value

--- a/internal/cmd/root/testdata/usage/circleci/runner.txt
+++ b/internal/cmd/root/testdata/usage/circleci/runner.txt
@@ -2,6 +2,7 @@ Usage:
   circleci runner [command]
 
 Available Commands:
+  config         Generate a runner agent configuration file
   instance       Manage runner instances
   open           Open the runners inventory page in the browser
   resource-class Manage runner resource classes

--- a/internal/cmd/root/testdata/usage/circleci/runner/config.txt
+++ b/internal/cmd/root/testdata/usage/circleci/runner/config.txt
@@ -1,0 +1,26 @@
+Usage:
+  circleci runner config <resource-class> [flags]
+
+Examples:
+# Create a new token and print config to stdout
+$ circleci runner config my-org/my-runner
+
+# Write config directly to a file
+$ circleci runner config my-org/my-runner --output launch-agent-config.yaml
+
+# Create a nicely-labeled token and write to a file
+$ circleci runner config my-org/my-runner --nickname "prod-server-1" --output /etc/circleci/launch-agent-config.yaml
+
+# Generate config from an existing token value (no API token creation)
+$ circleci runner config my-org/my-runner --token "$EXISTING_TOKEN_VALUE"
+
+
+Flags:
+      --nickname string   Nickname for the new token
+  -o, --output string     Write config to this file instead of stdout
+      --token string      Use an existing token value instead of creating a new one
+
+Global Flags:
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected

--- a/internal/cmd/runner/config.go
+++ b/internal/cmd/runner/config.go
@@ -1,0 +1,142 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package runner
+
+import (
+	"context"
+	"io"
+	"os"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
+	"github.com/CircleCI-Public/circleci-cli/internal/apiclient"
+	"github.com/CircleCI-Public/circleci-cli/internal/cmdutil"
+	clierrors "github.com/CircleCI-Public/circleci-cli/internal/errors"
+	"github.com/CircleCI-Public/circleci-cli/internal/iostream"
+)
+
+func newConfigCmd() *cobra.Command {
+	var nickname string
+	var tokenValue string
+	var outputPath string
+
+	cmd := &cobra.Command{
+		Use:   "config <resource-class>",
+		Short: "Generate a runner agent configuration file",
+		Long: heredoc.Doc(`
+			Generate a runner agent configuration YAML for a resource class.
+
+			By default, a new authentication token is created and the resulting
+			config is written to stdout. Redirect stdout or use --output to
+			write directly to a file.
+
+			If you already have a token value (e.g. from a prior
+			'circleci runner token create'), pass it with --token to generate
+			the YAML without making an API call.
+
+			The generated YAML is suitable for use as the runner agent's
+			launch-agent-config.yaml.
+		`),
+		Example: heredoc.Doc(`
+			# Create a new token and print config to stdout
+			$ circleci runner config my-org/my-runner
+
+			# Write config directly to a file
+			$ circleci runner config my-org/my-runner --output launch-agent-config.yaml
+
+			# Create a nicely-labeled token and write to a file
+			$ circleci runner config my-org/my-runner --nickname "prod-server-1" --output /etc/circleci/launch-agent-config.yaml
+
+			# Generate config from an existing token value (no API token creation)
+			$ circleci runner config my-org/my-runner --token "$EXISTING_TOKEN_VALUE"
+		`),
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if cliErr := cmdutil.RequireArgs(args, "resource-class"); cliErr != nil {
+				return cliErr
+			}
+			ctx := iostream.FromCmd(cmd.Context(), cmd)
+
+			var tok string
+			if tokenValue != "" {
+				tok = tokenValue
+			} else {
+				client, err := cmdutil.LoadClient(ctx, cmd)
+				if err != nil {
+					return err
+				}
+				created, err := runConfigCreateToken(ctx, client, args[0], nickname)
+				if err != nil {
+					return err
+				}
+				tok = created
+			}
+
+			var w io.Writer
+			if outputPath != "" {
+				f, err := os.Create(outputPath) //#nosec:G304 // path is user-supplied
+				if err != nil {
+					return clierrors.New("runner.config_write_failed", "Could not write config file",
+						err.Error()).
+						WithExitCode(clierrors.ExitGeneralError)
+				}
+				defer func() { _ = f.Close() }()
+				w = f
+			} else {
+				w = iostream.Get(ctx).Out
+			}
+
+			return writeAgentConfig(tok, w)
+		},
+	}
+
+	cmd.Flags().StringVar(&nickname, "nickname", "", "Nickname for the new token")
+	cmd.Flags().StringVar(&tokenValue, "token", "", "Use an existing token value instead of creating a new one")
+	cmd.Flags().StringVarP(&outputPath, "output", "o", "", "Write config to this file instead of stdout")
+
+	return cmd
+}
+
+func runConfigCreateToken(ctx context.Context, client *apiclient.Client, resourceClass, nickname string) (string, error) {
+	tok, err := client.CreateRunnerToken(ctx, resourceClass, nickname)
+	if err != nil {
+		return "", apiErr(err, resourceClass)
+	}
+	return tok.Token, nil
+}
+
+type agentConfig struct {
+	API agentAPIConfig `yaml:"api"`
+}
+
+type agentAPIConfig struct {
+	AuthToken string `yaml:"auth_token"`
+}
+
+func writeAgentConfig(token string, w io.Writer) error {
+	return yaml.NewEncoder(w).Encode(agentConfig{
+		API: agentAPIConfig{AuthToken: token},
+	})
+}

--- a/internal/cmd/runner/runner.go
+++ b/internal/cmd/runner/runner.go
@@ -53,6 +53,7 @@ func NewRunnerCmd() *cobra.Command {
 	cmd.AddCommand(newInstanceCmd())
 	cmd.AddCommand(newOpenCmd())
 	cmd.AddCommand(newTasksCmd())
+	cmd.AddCommand(newConfigCmd())
 
 	return cmd
 }


### PR DESCRIPTION
In a slight change from main, this implementation will take an optional, pre-existing token with the `--token` flag, but will create a new one for the namespace if not passed.
