### PR TITLE
Implement `circleci step halt`

### DIFF
--- a/acceptance/certificate_test.go
+++ b/acceptance/certificate_test.go
@@ -29,6 +29,7 @@ import (
 	"testing"
 
 	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/golden"
 
 	"github.com/CircleCI-Public/circleci-cli/internal/testing/binary"
@@ -306,7 +307,9 @@ func TestCertificateList_NoOrgIDOutsideGit(t *testing.T) {
 	})
 
 	assert.Equal(t, result.ExitCode, 2, "stderr: %s", result.Stderr)
-	assert.Check(t, golden.String(result.Stderr, t.Name()+".stderr.txt"))
+	// git's "not a git repo" wording varies by version; assert only on the parts we own.
+	assert.Check(t, cmp.Contains(result.Stderr, "could not read git remote"))
+	assert.Check(t, cmp.Contains(result.Stderr, "--org-id"))
 }
 
 // --- certificate delete ---

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -49,6 +49,7 @@ import (
 	"github.com/CircleCI-Public/circleci-cli/internal/cmd/runner"
 	"github.com/CircleCI-Public/circleci-cli/internal/cmd/settings"
 	"github.com/CircleCI-Public/circleci-cli/internal/cmd/signingconfig"
+	"github.com/CircleCI-Public/circleci-cli/internal/cmd/step"
 	cmdversion "github.com/CircleCI-Public/circleci-cli/internal/cmd/version"
 	"github.com/CircleCI-Public/circleci-cli/internal/cmd/workflow"
 	"github.com/CircleCI-Public/circleci-cli/internal/cmdutil"
@@ -120,6 +121,7 @@ func NewRootCmd(version string) *cobra.Command {
 	cmd.AddCommand(runner.NewRunnerCmd())
 	cmd.AddCommand(settings.NewSettingsCmd())
 	cmd.AddCommand(signingconfig.NewSigningConfigCmd())
+	cmd.AddCommand(step.NewStepCmd())
 	cmd.AddCommand(workflow.NewWorkflowCmd())
 
 	// Wire in MCP commands

--- a/internal/cmd/root/testdata/usage/circleci/step.txt
+++ b/internal/cmd/root/testdata/usage/circleci/step.txt
@@ -1,0 +1,12 @@
+Usage:
+  circleci step [command]
+
+Available Commands:
+  halt        Halt the current job and mark it as successful
+
+Global Flags:
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected
+
+Use "circleci step [command] --help" for more information about a command.

--- a/internal/cmd/root/testdata/usage/circleci/step/halt.txt
+++ b/internal/cmd/root/testdata/usage/circleci/step/halt.txt
@@ -1,0 +1,7 @@
+Usage:
+  circleci step halt [flags]
+
+Global Flags:
+  -c, --config string   path to config file (default: ~/.config/circleci/config.yml)
+      --debug           enable debug logging
+  -q, --quiet           suppress informational output; data on stdout is unaffected

--- a/internal/cmd/step/halt.go
+++ b/internal/cmd/step/halt.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package step
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+
+	clierrors "github.com/CircleCI-Public/circleci-cli/internal/errors"
+)
+
+func newHaltCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "halt",
+		Short: "Halt the current job and mark it as successful",
+		Long: heredoc.Doc(`
+			Halt the running CircleCI job immediately and mark it as successful.
+
+			Any steps that follow in the job configuration will not execute.
+
+			This command delegates to circleci-agent and must be called from
+			within a running CircleCI job.
+		`),
+		DisableFlagParsing: true,
+		RunE: func(_ *cobra.Command, args []string) error {
+			agent, err := exec.LookPath("circleci-agent")
+			if err != nil {
+				return clierrors.New(
+					"step.agent_not_found",
+					"circleci-agent not found",
+					"circleci step halt must be called from within a running CircleCI job",
+				).WithExitCode(clierrors.ExitNotFound)
+			}
+
+			argv := append([]string{agent, "step", "halt"}, args...)
+			return syscall.Exec(agent, argv, os.Environ()) // #nosec
+		},
+	}
+}

--- a/internal/cmd/step/step.go
+++ b/internal/cmd/step/step.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+// Package step implements the "circleci step" command group.
+package step
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// NewStepCmd returns the "circleci step" command group.
+func NewStepCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "step <command>",
+		Short:  "Control job step execution",
+		Hidden: true,
+	}
+
+	cmd.AddCommand(newHaltCmd())
+
+	return cmd
+}


### PR DESCRIPTION
I believe this is a backwards compatibility layer and it's unclear if it's still needed, but it's cheap enough to include.
