### PR TITLE
Use 2-space indents in all yaml

### DIFF
--- a/acceptance/testdata/TestOrbPack_Directory.txt
+++ b/acceptance/testdata/TestOrbPack_Directory.txt
@@ -1,18 +1,18 @@
 commands:
-    zomg:
-        description: a command inside a folder in an orb
-        parameters:
-            tm:
-                description: Tell me something.
-                type: string
-        steps:
-            - run: echo "You don't say... << parameters.saywhat >>"
+  zomg:
+    description: a command inside a folder in an orb
+    parameters:
+      tm:
+        description: Tell me something.
+        type: string
+    steps:
+      - run: echo "You don't say... << parameters.saywhat >>"
 description: A simple encapsulation of common tasks in Hugo
 executors:
-    default:
-        docker:
-            - image: cibuilds/hugo:<< parameters.image >>
-        parameters:
-            tag:
-                description: The tag to use on the image
-                type: string
+  default:
+    docker:
+      - image: cibuilds/hugo:<< parameters.image >>
+    parameters:
+      tag:
+        description: The tag to use on the image
+        type: string

--- a/internal/cmd/orb/pack.go
+++ b/internal/cmd/orb/pack.go
@@ -170,13 +170,15 @@ func runOrbPack(ctx context.Context, path string) error {
 		}
 	}
 
-	out, err := yaml.Marshal(base)
-	if err != nil {
+	var buf strings.Builder
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(base); err != nil {
 		return clierrors.New("orb.pack_error", "Failed to render merged orb YAML",
 			err.Error()).
 			WithExitCode(clierrors.ExitGeneralError)
 	}
 
-	iostream.Print(ctx, string(out))
+	iostream.Print(ctx, buf.String())
 	return nil
 }


### PR DESCRIPTION
That's what our docs show for everything, so format accordingly

(this is a forward-port of #677)