### PR TITLE
Add --branch/-b and --current-branch flags to run open

### DIFF
--- a/internal/cmd/root/testdata/usage/circleci/run/open.txt
+++ b/internal/cmd/root/testdata/usage/circleci/run/open.txt
@@ -5,12 +5,22 @@ Examples:
 # Open runs for the current repo
 $ circleci run open
 
-# Open from a specific directory
-$ circleci run open --config ~/.config/circleci/config.yml
+# Open runs filtered to the current git branch
+$ circleci run open --current-branch
+
+# Open runs filtered to a specific branch
+$ circleci run open --branch my-feature
+
+# Open runs filtered to a specific branch (short flag)
+$ circleci run open -b main
 
 # Open when your remote is on CircleCI server
 $ circleci run open --host https://circleci.example.com
 
+
+Flags:
+  -b, --branch string    Filter runs to a specific branch
+      --current-branch   Filter runs to the current git branch
 
 Global Flags:
   -c, --config string   path to config file (default: ~/.config/circleci/config.yml)

--- a/internal/cmd/run/open.go
+++ b/internal/cmd/run/open.go
@@ -33,7 +33,10 @@ import (
 )
 
 func newOpenCmd() *cobra.Command {
-	return &cobra.Command{
+	var branch string
+	var currentBranch bool
+
+	cmd := &cobra.Command{
 		Use:   "open",
 		Short: "Open the current project's runs page in the browser",
 		Long: heredoc.Doc(`
@@ -42,18 +45,32 @@ func newOpenCmd() *cobra.Command {
 
 			The project is inferred from the current git repository's remote.
 			Supports GitHub, Bitbucket, and GitLab remotes.
+
+			Use --current-branch or --branch/-b to filter runs to a specific branch.
 		`),
 		Example: heredoc.Doc(`
 			# Open runs for the current repo
 			$ circleci run open
 
-			# Open from a specific directory
-			$ circleci run open --config ~/.config/circleci/config.yml
+			# Open runs filtered to the current git branch
+			$ circleci run open --current-branch
+
+			# Open runs filtered to a specific branch
+			$ circleci run open --branch my-feature
+
+			# Open runs filtered to a specific branch (short flag)
+			$ circleci run open -b main
 
 			# Open when your remote is on CircleCI server
 			$ circleci run open --host https://circleci.example.com
 		`),
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			if branch != "" && currentBranch {
+				return clierrors.New("flag.conflict",
+					"--branch and --current-branch are mutually exclusive", "").
+					WithExitCode(clierrors.ExitBadArguments)
+			}
+
 			ctx := cmd.Context()
 
 			info, err := gitremote.Detect()
@@ -71,7 +88,16 @@ func newOpenCmd() *cobra.Command {
 				return err
 			}
 
-			u, err := cmdutil.PipelinesURL(appURL, info.Slug)
+			if currentBranch {
+				branch = info.Branch
+			}
+
+			var u string
+			if branch != "" {
+				u, err = cmdutil.PipelinesURLForBranch(appURL, info.Slug, branch)
+			} else {
+				u, err = cmdutil.PipelinesURL(appURL, info.Slug)
+			}
 			if err != nil {
 				return err
 			}
@@ -79,4 +105,9 @@ func newOpenCmd() *cobra.Command {
 			return browser.OpenURL(u)
 		},
 	}
+
+	cmd.Flags().StringVarP(&branch, "branch", "b", "", "Filter runs to a specific branch")
+	cmd.Flags().BoolVar(&currentBranch, "current-branch", false, "Filter runs to the current git branch")
+
+	return cmd
 }

--- a/internal/cmd/run/open.go
+++ b/internal/cmd/run/open.go
@@ -67,7 +67,9 @@ func newOpenCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if branch != "" && currentBranch {
 				return clierrors.New("flag.conflict",
-					"--branch and --current-branch are mutually exclusive", "").
+					"conflicting flags",
+					"--branch and --current-branch cannot be used together").
+					WithSuggestions("Use --current-branch to filter by your checked-out branch, or --branch <name> to specify one explicitly").
 					WithExitCode(clierrors.ExitBadArguments)
 			}
 

--- a/internal/cmdutil/appurls.go
+++ b/internal/cmdutil/appurls.go
@@ -44,6 +44,15 @@ func PipelinesURL(appURL, slug string) (string, error) {
 	), nil
 }
 
+// PipelinesURLForBranch returns the CircleCI pipelines page URL filtered to a specific branch.
+func PipelinesURLForBranch(appURL, slug, branch string) (string, error) {
+	base, err := PipelinesURL(appURL, slug)
+	if err != nil {
+		return "", err
+	}
+	return base + "?branch=" + url.QueryEscape(branch), nil
+}
+
 // ProjectURL returns the CircleCI project page URL for the given project slug.
 func ProjectURL(appURL, slug string) (string, error) {
 	parts := strings.SplitN(slug, "/", 3)

--- a/internal/cmdutil/appurls_test.go
+++ b/internal/cmdutil/appurls_test.go
@@ -58,6 +58,25 @@ func TestPipelinesURL(t *testing.T) {
 	})
 }
 
+func TestPipelinesURLForBranch(t *testing.T) {
+	t.Run("adds branch query param", func(t *testing.T) {
+		got, err := PipelinesURLForBranch(testAppURL, "gh/bar/foo", "my-feature")
+		assert.NilError(t, err)
+		assert.Check(t, cmp.Equal(got, "https://app.circleci.com/pipelines/gh/bar/foo?branch=my-feature"))
+	})
+
+	t.Run("encodes branch with special characters", func(t *testing.T) {
+		got, err := PipelinesURLForBranch(testAppURL, "gh/bar/foo", "feat/my feature")
+		assert.NilError(t, err)
+		assert.Check(t, cmp.Equal(got, "https://app.circleci.com/pipelines/gh/bar/foo?branch=feat%2Fmy+feature"))
+	})
+
+	t.Run("invalid slug", func(t *testing.T) {
+		_, err := PipelinesURLForBranch(testAppURL, "invalid", "main")
+		assert.Check(t, err != nil, "expected error for invalid slug")
+	})
+}
+
 func TestDeployURL(t *testing.T) {
 	proj := &apiclient.ProjectInfo{
 		ID:               "7097f60c-74d1-4936-8d1a-268d4042a493",


### PR DESCRIPTION
## Summary

- Adds `--branch`/`-b <name>` to filter the runs page to a specific branch
- Adds `--current-branch` to automatically use the current git branch
- Using both flags together returns an error
- Adds `PipelinesURLForBranch` helper to `cmdutil/appurls.go` with tests

## Test plan

- [ ] `circleci run open` — opens project runs page (unchanged behaviour)
- [ ] `circleci run open --current-branch` — opens runs filtered to current branch
- [ ] `circleci run open -b main` — opens runs filtered to `main`
- [ ] `circleci run open --branch my-feature` — opens runs filtered to `my-feature`
- [ ] `circleci run open --branch foo --current-branch` — exits with error
- [ ] `go test ./internal/cmdutil/...` passes