### PR TITLE
Accept default value when Enter pressed on empty prompt field

### DIFF
--- a/acceptance/pipeline_test.go
+++ b/acceptance/pipeline_test.go
@@ -309,6 +309,37 @@ func TestPipelineCreate_ProjectNotFound(t *testing.T) {
 	assert.Equal(t, result.ExitCode, 5, "stderr: %s", result.Stderr)
 }
 
+func TestPipelineCreate_Interactive_DefaultConfigPath(t *testing.T) {
+	_, env := setupPipelineFake(t)
+
+	console := binary.RunCLIInteractive(t, binary.RunOpts{
+		Binary: binaryPath,
+		Args: []string{
+			"pipeline", "create",
+			"--project", "gh/myorg/myrepo",
+			"--name", "my-pipeline",
+			"--config-provider", "github_app",
+			"--config-repo-id", pipelineRepoID,
+			// Skip --config-file to trigger prompt
+			"--checkout-provider", "github_app",
+			"--checkout-repo-id", pipelineRepoID,
+		},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	// Step 1: verify the default config file path is shown in the footer and accept it.
+	_, err := console.ExpectString("Config file path")
+	assert.NilError(t, err)
+	_, err = console.ExpectString("(default: .circleci/config.yml · enter to confirm, esc to cancel)")
+	assert.NilError(t, err)
+	_, err = console.Send("\r")
+	assert.NilError(t, err)
+
+	_, err = console.ExpectString("Pipeline definition created")
+	assert.NilError(t, err)
+}
+
 // --- pipeline list ---
 
 func TestPipelineList(t *testing.T) {

--- a/internal/cmd/pipeline/create.go
+++ b/internal/cmd/pipeline/create.go
@@ -168,7 +168,7 @@ func runCreate(
 		return err
 	}
 
-	name, err = resolveRequired(ctx, name, "Pipeline definition name", "e.g. my-pipeline", "--name is required")
+	name, err = resolveRequired(ctx, name, "Pipeline definition name", "e.g. my-pipeline", "", "--name is required")
 	if err != nil {
 		return err
 	}
@@ -196,7 +196,7 @@ func runCreate(
 		}
 	}
 
-	configFile, err = resolveRequired(ctx, configFile, "Config file path", ".circleci/config.yml", "--config-file is required")
+	configFile, err = resolveRequired(ctx, configFile, "Config file path", ".circleci/config.yml", ".circleci/config.yml", "--config-file is required")
 	if err != nil {
 		return err
 	}
@@ -248,7 +248,7 @@ func runCreate(
 	return nil
 }
 
-func resolveRequired(ctx context.Context, val, prompt, placeholder, errMsg string) (string, error) {
+func resolveRequired(ctx context.Context, val, prompt, placeholder, defaultVal, errMsg string) (string, error) {
 	if val != "" {
 		return val, nil
 	}
@@ -260,7 +260,7 @@ func resolveRequired(ctx context.Context, val, prompt, placeholder, errMsg strin
 			).
 			WithExitCode(clierrors.ExitBadArguments)
 	}
-	v, err := iostream.PromptText(ctx, prompt, placeholder)
+	v, err := iostream.PromptText(ctx, prompt, placeholder, defaultVal)
 	if err != nil {
 		return "", err
 	}

--- a/internal/iostream/streams.go
+++ b/internal/iostream/streams.go
@@ -155,12 +155,17 @@ func PromptSelect(ctx context.Context, prompt string, options []string) (int, er
 
 // PromptText presents a plain (non-secret) single-line text input via
 // bubbletea. header is the bold heading above the input; placeholder is
-// shown inside the empty field. Returns ("", nil) if the user cancels with
-// esc or ctrl+c.
-func PromptText(ctx context.Context, header, placeholder string) (string, error) {
+// shown inside the empty field; defaultVal (optional) is returned when the
+// user presses Enter with an empty field. Returns ("", nil) if the user
+// cancels with esc or ctrl+c.
+func PromptText(ctx context.Context, header, placeholder string, defaultVal ...string) (string, error) {
+	dv := ""
+	if len(defaultVal) > 0 {
+		dv = defaultVal[0]
+	}
 	s := fromContext(ctx)
 	p := tea.NewProgram(
-		ui.NewPromptModel(header, placeholder),
+		ui.NewPromptModel(header, placeholder, dv),
 		tea.WithContext(ctx),
 		tea.WithInput(s.In),
 		tea.WithOutput(s.Err),

--- a/internal/ui/prompt.go
+++ b/internal/ui/prompt.go
@@ -37,13 +37,15 @@ type PromptModel struct {
 	textInput   textinput.Model
 	header      string
 	placeholder string
+	defaultVal  string
 	quitting    bool
 	value       string
 }
 
-// NewPromptModel creates a PromptModel with the given header and an optional
-// placeholder shown inside the empty input field.
-func NewPromptModel(header, placeholder string) PromptModel {
+// NewPromptModel creates a PromptModel with the given header, an optional
+// placeholder shown inside the empty input field, and an optional default
+// value accepted when the user presses Enter with an empty field.
+func NewPromptModel(header, placeholder, defaultVal string) PromptModel {
 	ti := textinput.New()
 	ti.SetVirtualCursor(false)
 	if placeholder != "" {
@@ -52,7 +54,7 @@ func NewPromptModel(header, placeholder string) PromptModel {
 	}
 	ti.Focus()
 
-	return PromptModel{textInput: ti, header: header, placeholder: placeholder}
+	return PromptModel{textInput: ti, header: header, placeholder: placeholder, defaultVal: defaultVal}
 }
 
 // Quitting reports whether the user pressed Esc or Ctrl+C without confirming.
@@ -75,6 +77,9 @@ func (m PromptModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 		case components.KeyEnter:
 			m.value = m.textInput.Value()
+			if m.value == "" {
+				m.value = m.defaultVal
+			}
 			return m, tea.Quit
 		}
 	}
@@ -106,5 +111,8 @@ func (m PromptModel) View() tea.View {
 
 func (m PromptModel) headerView() string { return theme.TitleStyle.Render(m.header) }
 func (m PromptModel) footerView() string {
+	if m.defaultVal != "" {
+		return theme.HelperStyle.Render("(default: " + m.defaultVal + " · enter to confirm, esc to cancel)")
+	}
 	return theme.HelperStyle.Render("(enter to confirm, esc to cancel)")
 }


### PR DESCRIPTION
## Summary

- `PromptModel` treated `placeholder` as ghost text only — pressing Enter with an empty field committed `""` rather than the displayed hint, causing `resolveRequired` to error with `No value entered for: Config file path` even when `.circleci/config.yml` was visible as a suggestion
- Added `defaultVal` to `PromptModel` (separate from `placeholder`) that is committed on Enter when the field is empty; the footer also updates to show `(default: X · enter to confirm, esc to cancel)`
- `PromptText` accepts an optional variadic `defaultVal` so existing callers need no changes
- `resolveRequired` gains a `defaultVal` parameter; the config file prompt passes `.circleci/config.yml`, the pipeline name prompt passes `""` (it's an example hint, not a real default)

## Test plan

- [ ] Run `circleci pipeline create` interactively, reach the Config file path prompt, press Enter — confirm `.circleci/config.yml` is accepted
- [ ] Verify pipeline name prompt still errors when Enter is pressed with an empty field (no default)
- [ ] Confirm `go build ./...` passes