### PR TITLE
Note in info help that it aliases project get

### DIFF
--- a/internal/cmd/project/get.go
+++ b/internal/cmd/project/get.go
@@ -42,20 +42,31 @@ func NewGetCmd(use string) *cobra.Command {
 		jsonOut     bool
 	)
 
+	// When invoked as the top-level `info` alias, prepend a note pointing at
+	// the canonical `project get` command.
+	short := "Show project details"
+	aliasNote := ""
+	if use == "info" {
+		short = "Show project details (alias for 'project get')"
+		aliasNote = "This command is an alias for 'circleci project get'.\n\n"
+	}
+
+	long := heredoc.Docf(`
+		Display detailed information about a CircleCI project, including
+		its UUID, organization ID, and VCS configuration.
+
+		%sThe project is inferred from the current git repository's remote
+		unless overridden with --project. The slug must be in the form
+		vcs/org/repo (e.g. gh/myorg/myrepo).
+
+		JSON fields: id, slug, name, organization_name, organization_slug,
+		             organization_id, vcs_provider, vcs_default_branch, vcs_url
+	`, aliasNote)
+
 	cmd := &cobra.Command{
 		Use:   use,
-		Short: "Show project details",
-		Long: heredoc.Doc(`
-			Display detailed information about a CircleCI project, including
-			its UUID, organization ID, and VCS configuration.
-
-			The project is inferred from the current git repository's remote
-			unless overridden with --project. The slug must be in the form
-			vcs/org/repo (e.g. gh/myorg/myrepo).
-
-			JSON fields: id, slug, name, organization_name, organization_slug,
-			             organization_id, vcs_provider, vcs_default_branch, vcs_url
-		`),
+		Short: short,
+		Long:  long,
 		Example: heredoc.Doc(`
 			# Show details for the current git repository's project
 			$ circleci project get

--- a/internal/cmd/root/testdata/usage/circleci.txt
+++ b/internal/cmd/root/testdata/usage/circleci.txt
@@ -12,7 +12,7 @@ Available Commands:
   deploy         Manage deploys
   dlc            Manage Docker Layer Caching
   envvar         Manage project environment variables
-  info           Show project details
+  info           Show project details (alias for 'project get')
   job            Manage jobs
   logs           Fetch job logs
   mcp            MCP server management


### PR DESCRIPTION
Makes the `info`/`project get` alias relationship discoverable in help:

- `circleci help` lists info as `Show project details (alias for 'project get')`
- `circleci info --help` states it's an alias for `circleci project get`

Help-text only — no behavior or JSON output change. `project get` help is unchanged.