### PR TITLE
Remove usage of separate runner domain

### DIFF
--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -28,17 +28,15 @@ import (
 	"fmt"
 	"net/http"
 	"runtime"
-	"strings"
 
 	"github.com/CircleCI-Public/circleci-cli/internal/httpcl"
 )
 
 // Client is an authenticated CircleCI API client.
 type Client struct {
-	main   *httpcl.Client // circleci.com/api/v1.1, /api/v2
-	runner *httpcl.Client // runner.circleci.com/api/v3
-	raw    *httpcl.Client
-	token  string
+	main  *httpcl.Client // circleci.com/api/v1.1, /api/v2
+	raw   *httpcl.Client
+	token string
 }
 
 type Config struct {
@@ -68,14 +66,10 @@ func New(cfg Config) *Client {
 	mainCfg := baseCfg
 	mainCfg.BaseURL = cfg.BaseURL
 
-	runnerCfg := baseCfg
-	runnerCfg.BaseURL = runnerBaseURL(cfg.BaseURL)
-
 	return &Client{
-		main:   httpcl.New(mainCfg),
-		runner: httpcl.New(runnerCfg),
-		raw:    httpcl.New(baseCfg),
-		token:  cfg.Token,
+		main:  httpcl.New(mainCfg),
+		raw:   httpcl.New(baseCfg),
+		token: cfg.Token,
 	}
 }
 
@@ -84,16 +78,6 @@ func UserAgent(goos, goarch, version, agent string) string {
 		return fmt.Sprintf("circleci-cli (%s/%s; %s; %s)", goos, goarch, version, agent)
 	}
 	return fmt.Sprintf("circleci-cli (%s/%s; %s)", goos, goarch, version)
-}
-
-// runnerBaseURL derives the runner API base URL from the main API base URL.
-// For circleci.com cloud the runner API is at runner.circleci.com.
-// For self-hosted server the runner API is co-located at the same host.
-func runnerBaseURL(baseURL string) string {
-	if strings.Contains(baseURL, "circleci.com") {
-		return "https://runner.circleci.com"
-	}
-	return baseURL
 }
 
 func queryParam(key, val string) func(*httpcl.Request) {
@@ -166,26 +150,6 @@ func (c *Client) deleteV2(ctx context.Context, route string, opts ...func(*httpc
 	return err
 }
 
-func (c *Client) getRunner(ctx context.Context, route string, dst any, opts ...func(*httpcl.Request)) error {
-	_, err := c.runner.Call(ctx, httpcl.NewRequest(http.MethodGet, "/api/v3"+route, baseOpts(
-		httpcl.JSONDecoder(dst),
-	).With(opts)...))
-	return err
-}
-
-func (c *Client) postRunner(ctx context.Context, path string, body, dst any, opts ...func(*httpcl.Request)) error {
-	_, err := c.runner.Call(ctx, httpcl.NewRequest(http.MethodPost, "/api/v3"+path, baseOpts(
-		httpcl.Body(body),
-		httpcl.JSONDecoder(dst),
-	).With(opts)...))
-	return err
-}
-
-func (c *Client) deleteRunner(ctx context.Context, route string, opts ...func(*httpcl.Request)) error {
-	_, err := c.runner.Call(ctx, httpcl.NewRequest(http.MethodDelete, "/api/v3"+route, opts...))
-	return err
-}
-
 type v3Entity[T any] struct {
 	Data T `json:"data"`
 }
@@ -228,7 +192,7 @@ func (c *Client) getV3(ctx context.Context, route string, dst any, opts ...func(
 	return err
 }
 
-func (c *Client) getV3Raw(ctx context.Context, route string, dst *string, opts ...func(*httpcl.Request)) error {
+func (c *Client) getV3String(ctx context.Context, route string, dst *string, opts ...func(*httpcl.Request)) error {
 	_, err := c.main.Call(ctx, httpcl.NewRequest(http.MethodGet, "/api/v3"+route, baseOpts(
 		httpcl.StringDecoder(dst),
 	).With(opts)...))

--- a/internal/apiclient/orb.go
+++ b/internal/apiclient/orb.go
@@ -465,7 +465,7 @@ func (c *Client) GetOrbVersionByID(ctx context.Context, id string) (*OrbVersion,
 
 func (c *Client) GetOrbSource(ctx context.Context, id string) (string, error) {
 	body := ""
-	err := c.getV3Raw(ctx, "/orb/versions/%s/source", &body,
+	err := c.getV3String(ctx, "/orb/versions/%s/source", &body,
 		routeParams(id),
 	)
 	if httpcl.HasStatusCode(err, http.StatusNotFound) {

--- a/internal/apiclient/runner.go
+++ b/internal/apiclient/runner.go
@@ -67,7 +67,7 @@ func (c *Client) ListResourceClasses(ctx context.Context, namespace string) ([]R
 	var resp struct {
 		Items []ResourceClass `json:"items"`
 	}
-	err := c.getRunner(ctx, "/runner", &resp,
+	err := c.getV3(ctx, "/runner", &resp,
 		optionalQueryParam("namespace", namespace),
 	)
 	if err != nil {
@@ -83,7 +83,7 @@ func (c *Client) CreateResourceClass(ctx context.Context, resourceClass, descrip
 		"description":    description,
 	}
 	var rc ResourceClass
-	err := c.postRunner(ctx, "/runner/resource", body, &rc)
+	err := c.postV3(ctx, "/runner/resource", body, &rc)
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +92,7 @@ func (c *Client) CreateResourceClass(ctx context.Context, resourceClass, descrip
 
 // DeleteResourceClass deletes a runner resource class by its namespace/name slug.
 func (c *Client) DeleteResourceClass(ctx context.Context, resourceClass string) error {
-	return c.deleteRunner(ctx, "/runner/resource/%s",
+	return c.deleteV3(ctx, "/runner/resource/%s",
 		routeParams(resourceClass),
 	)
 }
@@ -102,7 +102,7 @@ func (c *Client) ListRunnerTokens(ctx context.Context, resourceClass string) ([]
 	var resp struct {
 		Items []RunnerToken `json:"items"`
 	}
-	err := c.getRunner(ctx, "/runner/token", &resp, queryParam("resource-class", resourceClass))
+	err := c.getV3(ctx, "/runner/token", &resp, queryParam("resource-class", resourceClass))
 	if err != nil {
 		return nil, err
 	}
@@ -117,7 +117,7 @@ func (c *Client) CreateRunnerToken(ctx context.Context, resourceClass, nickname 
 		"nickname":       nickname,
 	}
 	var tok RunnerToken
-	err := c.postRunner(ctx, "/runner/token", body, &tok)
+	err := c.postV3(ctx, "/runner/token", body, &tok)
 	if err != nil {
 		return nil, err
 	}
@@ -126,7 +126,7 @@ func (c *Client) CreateRunnerToken(ctx context.Context, resourceClass, nickname 
 
 // DeleteRunnerToken deletes a runner token by its ID.
 func (c *Client) DeleteRunnerToken(ctx context.Context, tokenID string) error {
-	return c.deleteRunner(ctx, "/runner/token/%s",
+	return c.deleteV3(ctx, "/runner/token/%s",
 		routeParams(tokenID),
 	)
 }
@@ -140,11 +140,11 @@ func (c *Client) GetRunnerTaskCounts(ctx context.Context, resourceClass string) 
 	var running struct {
 		Count int `json:"running_runner_tasks"`
 	}
-	err := c.getRunner(ctx, "/runner/tasks", &unclaimed, qp)
+	err := c.getV3(ctx, "/runner/tasks", &unclaimed, qp)
 	if err != nil {
 		return nil, err
 	}
-	err = c.getRunner(ctx, "/runner/tasks/running", &running, qp)
+	err = c.getV3(ctx, "/runner/tasks/running", &running, qp)
 	if err != nil {
 		return nil, err
 	}
@@ -160,7 +160,7 @@ func (c *Client) ListRunnerInstances(ctx context.Context, resourceClass, namespa
 	var resp struct {
 		Items []RunnerInstance `json:"items"`
 	}
-	err := c.getRunner(ctx, "/runner", &resp,
+	err := c.getV3(ctx, "/runner", &resp,
 		optionalQueryParam("resource-class", resourceClass),
 		optionalQueryParam("namespace", namespace),
 	)


### PR DESCRIPTION
- You can now access the user accessible runner APIs on plain circleci.com