### PR TITLE
Remove a trailing error from `circleci help`

### DIFF
--- a/acceptance/help_test.go
+++ b/acceptance/help_test.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package acceptance_test
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+
+	"github.com/CircleCI-Public/circleci-cli/internal/testing/binary"
+	testenv "github.com/CircleCI-Public/circleci-cli/internal/testing/env"
+)
+
+// TestHelpNoStderr guards against telemetry lifecycle bugs (e.g. double-close)
+// that leak error messages onto stderr when help is requested.
+func TestHelpNoStderr(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"subcommand", []string{"help"}},
+		{"flag", []string{"--help"}},
+		{"subcommand topic", []string{"help", "pipeline"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			env := testenv.New(t)
+
+			result := binary.RunCLI(t, binary.RunOpts{
+				Binary:  binaryPath,
+				Args:    tc.args,
+				Env:     env.Environ(),
+				WorkDir: t.TempDir(),
+			})
+
+			assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+			assert.Check(t, cmp.Equal(result.Stderr, ""), "expected no stderr output, got: %q", result.Stderr)
+		})
+	}
+}

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -193,19 +193,30 @@ func NewRootCmd(version string) *cobra.Command {
 	}
 
 	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
-		err := initConfig(cmd, new(0))
-		if err == nil {
+		if telem.Client == nil {
+			// --help flag path: pre/post run hooks don't fire, so own the full lifecycle here.
+			if err := initConfig(cmd, new(0)); err == nil {
+				cmdutil.RecordTelemetryNow(cmd, telem.Client)
+				_ = telem.Close()
+			}
+		} else {
+			// `help` subcommand path: PersistentPreRunE already initialized, PersistentPostRunE will close.
 			cmdutil.RecordTelemetryNow(cmd, telem.Client)
-			_ = telem.Close()
 		}
 
 		rootHelp(cmd, args)
 	})
 
 	cmd.SetUsageFunc(func(cmd *cobra.Command) error {
-		err := initConfig(cmd, new(0))
-		if err == nil {
-			_ = telem.Close()
+		if telem.Client == nil {
+			// --help flag path: pre/post run hooks don't fire, so own the full lifecycle here.
+			if err := initConfig(cmd, new(0)); err == nil {
+				cmdutil.RecordTelemetryNow(cmd, telem.Client)
+				_ = telem.Close()
+			}
+		} else {
+			// `help` subcommand path: PersistentPreRunE already initialized, PersistentPostRunE will close.
+			cmdutil.RecordTelemetryNow(cmd, telem.Client)
 		}
 
 		return rootUsage(cmd)


### PR DESCRIPTION
`help` and `--help` follow slightly different paths, so we let's only close the telemetry if it won't automatically get closed.
