### PR TITLE
Add Homebrew tap publishing to goreleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -145,6 +145,23 @@ snapcrafts:
           - network
         command: circleci
 
+brews:
+  - name: circleci@2
+    repository:
+      owner: CircleCI-Public
+      name: homebrew-circleci
+      branch: main
+      token: '{{ envOrDefault "GITHUB_TOKEN" "" }}'
+    homepage: "https://circleci.com"
+    description: "CircleCI command line tool."
+    license: "MIT"
+    custom_block: |
+      keg_only :versioned_formula
+    install: |
+      bin.install "circleci"
+    test: |
+      system "#{bin}/circleci", "--help"
+
 archives:
   - wrap_in_directory: true
     format_overrides:


### PR DESCRIPTION
## Summary

- Adds a `brews` section to `.goreleaser.yml` targeting `CircleCI-Public/homebrew-circleci`
- Setup a new pipeline for testing the brew flow to no impact the main build
- Exclude brew publication for the default release task
- Configure keg support to allow side by side installation of the old and new CLI
- Temporarily use the chunk context since we know it has access to the tap repo