### PR TITLE
Cancel runs with started or queued workflows

### DIFF
--- a/acceptance/run_test.go
+++ b/acceptance/run_test.go
@@ -771,6 +771,28 @@ func TestRunCancel(t *testing.T) {
 	})
 }
 
+func TestRunCancel_Started(t *testing.T) {
+	fake := fakes.NewCircleCI(t)
+	runID := getRunID
+	wfID := "wf-cancel-started"
+	fake.AddRun(runID, fakeRun(runID, 42, "running", watchSlug, "main"))
+	fake.AddRunWorkflowsV3(runID, fakeWorkflowV3(wfID, "build", runID, "proj-cancel", "started", ""))
+	fake.SetCancelResponse(wfID, 202)
+
+	env := testenv.New(t)
+	env.Token = testToken
+	env.CircleCIURL = fake.URL()
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"run", "cancel", "--force", runID},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+}
+
 func TestRunCancel_RequiresForce(t *testing.T) {
 	fake := fakes.NewCircleCI(t)
 	runID := getRunID

--- a/acceptance/run_test.go
+++ b/acceptance/run_test.go
@@ -761,12 +761,12 @@ func TestRunCancel(t *testing.T) {
 	t.Run("check request", func(t *testing.T) {
 		assert.Check(t, cmp.DeepEqual(fake.LastRequest(), &httprecorder.Request{
 			Method: http.MethodPost,
-			URL:    url.URL{Path: "/api/v2/workflow/" + wfID + "/cancel"},
+			URL:    url.URL{Path: "/api/v3/workflows/" + wfID + "/cancel"},
 			Header: http.Header{
 				"Authorization": {"Bearer test-token"},
 				"User-Agent":    {apiclient.UserAgent(runtime.GOOS, runtime.GOARCH, "dev", "")},
 			},
-			Body: new("{}"),
+			Body: new(""),
 		}, ignoreCommonHeaders))
 	})
 }

--- a/acceptance/workflow_test.go
+++ b/acceptance/workflow_test.go
@@ -638,12 +638,12 @@ func TestWorkflowCancel(t *testing.T) {
 	t.Run("check request", func(t *testing.T) {
 		assert.Check(t, cmp.DeepEqual(fake.LastRequest(), &httprecorder.Request{
 			Method: http.MethodPost,
-			URL:    url.URL{Path: "/api/v2/workflow/" + testWorkflowDetailID + "/cancel"},
+			URL:    url.URL{Path: "/api/v3/workflows/" + testWorkflowDetailID + "/cancel"},
 			Header: http.Header{
 				"Authorization": {"Bearer test-token"},
 				"User-Agent":    {apiclient.UserAgent(runtime.GOOS, runtime.GOARCH, "dev", "")},
 			},
-			Body: new(`{}`),
+			Body: new(``),
 		}, ignoreCommonHeaders))
 	})
 }

--- a/internal/apiclient/workflow.go
+++ b/internal/apiclient/workflow.go
@@ -126,12 +126,13 @@ func (c *Client) RerunWorkflow(ctx context.Context, id string, fromFailed bool) 
 	)
 }
 
-// CancelWorkflow requests cancellation of a running workflow.
+// CancelWorkflow requests cancellation of a running workflow. Cancellation
+// is processed asynchronously; the V3 API acknowledges with the workflow id.
 func (c *Client) CancelWorkflow(ctx context.Context, id string) error {
-	var resp struct {
-		Message string `json:"message"`
-	}
-	return c.post(ctx, "/workflow/%s/cancel", map[string]any{}, &resp,
+	var resp v3Entity[struct {
+		ID string `json:"id"`
+	}]
+	return c.postV3(ctx, "/workflows/%s/cancel", nil, &resp,
 		routeParams(id),
 	)
 }

--- a/internal/run/cancel.go
+++ b/internal/run/cancel.go
@@ -42,7 +42,7 @@ func (e *ErrNothingToCancel) Error() string {
 
 // Cancel cancels a run by cancelling each of its active workflows.
 // The CircleCI API has no run-level cancel endpoint; cancellation operates
-// at the workflow level via POST /api/v2/workflow/{id}/cancel.
+// at the workflow level via POST /api/v3/workflows/{id}/cancel.
 //
 // Returns ErrNothingToCancel when the run exists but all workflows are
 // already in a terminal state.

--- a/internal/testing/fakes/circleci.go
+++ b/internal/testing/fakes/circleci.go
@@ -255,7 +255,7 @@ func NewCircleCI(t *testing.T) *CircleCI {
 	r.Get("/api/v2/pipeline/{id}", f.handleGetPipeline)
 	r.Post("/api/v2/pipeline/{id}/cancel", f.handleCancelPipeline)
 	r.Post("/api/v2/workflow/{id}/rerun", f.handleRerunWorkflow)
-	r.Post("/api/v2/workflow/{id}/cancel", f.handleCancelWorkflow)
+	r.Post("/api/v3/workflows/{id}/cancel", f.handleCancelWorkflow)
 	r.Get("/api/v2/project/{vcs}/{org}/{repo}/pipeline", f.handleListProjectPipelines)
 	r.Get("/api/v2/project/{vcs}/{org}/{repo}/pipeline/{number}", f.handleGetPipelineByNumber)
 	r.Get("/api/v2/workflow/{id}/job", f.handleGetWorkflowJobs)
@@ -393,7 +393,7 @@ func (f *CircleCI) SetRerunResponse(workflowID string, status int) {
 	f.rerunResponses[workflowID] = status
 }
 
-// SetCancelResponse sets the HTTP status code returned for POST /api/v2/workflow/<id>/cancel.
+// SetCancelResponse sets the HTTP status code returned for POST /api/v3/workflows/<id>/cancel.
 // Use http.StatusAccepted (202) for success.
 func (f *CircleCI) SetCancelResponse(workflowID string, status int) {
 	f.mu.Lock()
@@ -945,7 +945,7 @@ func (f *CircleCI) handleCancelWorkflow(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	render.Status(r, status)
-	render.JSON(w, r, map[string]any{"message": "Accepted."})
+	render.JSON(w, r, map[string]any{"data": map[string]any{"id": id}})
 }
 
 func (f *CircleCI) handleRawStepOutput(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
The V3 API uses "started" for actively running workflows, not "running". Add "started" and "queued" to the active phases checked before cancelling.
