### PR TITLE
[FACT-298] Use PAR (RFC 9126) to shorten auth URLs

### DIFF
--- a/acceptance/auth_signup_test.go
+++ b/acceptance/auth_signup_test.go
@@ -70,18 +70,20 @@ func TestAuthSignup_NonInteractive_PrintsSignupURL(t *testing.T) {
 		WorkDir: t.TempDir(),
 	})
 
-	var authURL string
 	assert.Assert(t, t.Run("read signup authorize url", func(t *testing.T) {
 		out, err := console.ExpectString("Waiting for browser authentication")
 		assert.NilError(t, err)
 
-		authURL = terminalURLRe.FindString(out)
+		authURL := terminalURLRe.FindString(out)
 		assert.Assert(t, authURL != "", "authorize URL not found in output: %q", out)
-		assert.Check(t, cmp.Contains(authURL, "signup=true"))
+		// With PAR the browser URL only carries client_id + request_uri; the
+		// signup flag rides in the pushed request body.
+		assert.Check(t, cmp.Contains(authURL, "request_uri="))
+		assert.Check(t, cmp.Equal(fake.LastPARRequest().Get("signup"), "true"))
 	}))
 
 	assert.Assert(t, t.Run("browser callback", func(t *testing.T) {
-		callbackAuthorizeURL(t, authURL)
+		callbackViaPAR(t, fake)
 	}))
 
 	assert.Assert(t, t.Run("logged in", func(t *testing.T) {
@@ -115,8 +117,6 @@ func TestAuthSignup_AlreadyAuthenticated(t *testing.T) {
 // server. The CLI presents the same TUI as login (host selection, method
 // selection, browser OAuth) but with signup=true on the authorize URL.
 func TestAuthSignup_HappyPath(t *testing.T) {
-	ctx := t.Context()
-
 	fake := fakes.NewCircleCI(t)
 	fake.SetMe(map[string]any{
 		"id": "e4a72497-7c55-400d-a72d-dadc4b92255d",
@@ -170,33 +170,20 @@ func TestAuthSignup_HappyPath(t *testing.T) {
 		assert.NilError(t, err)
 	}))
 
-	var authURL string
 	assert.Assert(t, t.Run("read authorize url and open browser", func(t *testing.T) {
 		out, err := console.ExpectString("Press Enter to open in your browser")
 		assert.NilError(t, err)
 
-		authURL = terminalURLRe.FindString(out)
+		authURL := terminalURLRe.FindString(out)
 		assert.Assert(t, authURL != "", "authorize URL not found in output: %q", out)
-		assert.Check(t, cmp.Contains(authURL, "signup=true"))
+		// With PAR the browser URL only carries client_id + request_uri; the
+		// signup flag rides in the pushed request body.
+		assert.Check(t, cmp.Contains(authURL, "request_uri="))
+		assert.Check(t, cmp.Equal(fake.LastPARRequest().Get("signup"), "true"))
 	}))
 
 	assert.Assert(t, t.Run("browser callback", func(t *testing.T) {
-		parsed, err := url.Parse(authURL)
-		assert.NilError(t, err)
-		q := parsed.Query()
-		state := q.Get("state")
-		redirectURI := q.Get("redirect_uri")
-		assert.Assert(t, state != "", "state param missing from authorize URL")
-		assert.Assert(t, redirectURI != "", "redirect_uri param missing from authorize URL")
-
-		callbackURL := redirectURI + "?code=fake-auth-code&state=" + url.QueryEscape(state)
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, callbackURL, nil)
-		assert.NilError(t, err)
-
-		resp, err := http.DefaultClient.Do(req)
-		assert.NilError(t, err)
-		_ = resp.Body.Close()
-		assert.Equal(t, resp.StatusCode, http.StatusOK)
+		callbackViaPAR(t, fake)
 	}))
 
 	assert.Assert(t, t.Run("logged in", func(t *testing.T) {
@@ -214,16 +201,18 @@ func TestAuthSignup_HappyPath(t *testing.T) {
 	}))
 }
 
-func callbackAuthorizeURL(t *testing.T, authURL string) {
+// callbackViaPAR simulates the browser redirect by recovering the loopback
+// redirect_uri and state from the pushed authorization request the CLI sent to
+// /oauth/par — these no longer travel in the browser-facing authorize URL.
+func callbackViaPAR(t *testing.T, fake *fakes.CircleCI) {
 	t.Helper()
 
-	parsed, err := url.Parse(authURL)
-	assert.NilError(t, err)
-	q := parsed.Query()
-	state := q.Get("state")
-	redirectURI := q.Get("redirect_uri")
-	assert.Assert(t, state != "", "state param missing from authorize URL")
-	assert.Assert(t, redirectURI != "", "redirect_uri param missing from authorize URL")
+	par := fake.LastPARRequest()
+	assert.Assert(t, par != nil, "no pushed authorization request recorded")
+	state := par.Get("state")
+	redirectURI := par.Get("redirect_uri")
+	assert.Assert(t, state != "", "state param missing from PAR request")
+	assert.Assert(t, redirectURI != "", "redirect_uri param missing from PAR request")
 
 	callbackURL := redirectURI + "?code=fake-auth-code&state=" + url.QueryEscape(state)
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, callbackURL, nil)

--- a/acceptance/login_test.go
+++ b/acceptance/login_test.go
@@ -108,16 +108,27 @@ func TestAuthLogin_Browser(t *testing.T) {
 		// detects it as a clickable link. It is the only https?:// token here.
 		authURL = regexp.MustCompile(`https?://\S+`).FindString(out)
 		assert.Assert(t, authURL != "", "authorize URL not found in output: %q", out)
-	}))
 
-	assert.Assert(t, t.Run("browser callback", func(t *testing.T) {
+		// With Pushed Authorization Requests (RFC 9126) the browser URL only
+		// carries client_id + request_uri; the real parameters were POSTed to
+		// /oauth/par. The URL must be short and must not leak them.
 		parsed, err := url.Parse(authURL)
 		assert.NilError(t, err)
 		q := parsed.Query()
-		state := q.Get("state")
-		redirectURI := q.Get("redirect_uri")
-		assert.Assert(t, state != "", "state param missing from authorize URL")
-		assert.Assert(t, redirectURI != "", "redirect_uri param missing from authorize URL")
+		assert.Equal(t, q.Get("request_uri") != "", true, "authorize URL missing request_uri")
+		assert.Equal(t, q.Get("code_challenge"), "", "PKCE challenge must not appear in the browser URL")
+		assert.Equal(t, q.Get("redirect_uri"), "", "redirect_uri must not appear in the browser URL")
+	}))
+
+	assert.Assert(t, t.Run("browser callback", func(t *testing.T) {
+		// Recover the loopback redirect_uri and state from the pushed
+		// authorization request the CLI sent to /oauth/par.
+		par := fake.LastPARRequest()
+		assert.Assert(t, par != nil, "no pushed authorization request recorded")
+		state := par.Get("state")
+		redirectURI := par.Get("redirect_uri")
+		assert.Assert(t, state != "", "state param missing from PAR request")
+		assert.Assert(t, redirectURI != "", "redirect_uri param missing from PAR request")
 
 		// Hit the loopback callback server directly — the same request a browser
 		// would make after the user approves the OAuth consent screen.

--- a/internal/cmd/cmdauth/login.go
+++ b/internal/cmd/cmdauth/login.go
@@ -122,9 +122,11 @@ func runLoginBrowser(ctx context.Context, host string, deviceID string, signup, 
 		flow, err = oauth.Start(ctx, host, deviceID, runtime.GOOS)
 	}
 	if err != nil {
-		return clierrors.New("auth.login.listen_failed",
-			"Could not start local callback server", err.Error()).
-			WithSuggestions("Check that no other process is blocking loopback ports").
+		return clierrors.New("auth.login.start_failed",
+			"Could not start the login flow", err.Error()).
+			WithSuggestions(
+				"Check that no other process is blocking loopback ports",
+				"Verify the host is reachable and supports OAuth: "+host).
 			WithExitCode(clierrors.ExitGeneralError)
 	}
 	defer func() { _ = flow.Close() }()

--- a/internal/oauth/login.go
+++ b/internal/oauth/login.go
@@ -21,16 +21,23 @@
 // SPDX-License-Identifier: MIT
 
 // Package oauth implements the client side of the CircleCI OAuth 2.0
-// Authorization Code + PKCE flow (RFC 6749 + RFC 7636 + RFC 8252).
+// Authorization Code + PKCE flow (RFC 6749 + RFC 7636 + RFC 8252) with
+// Pushed Authorization Requests (RFC 9126).
 //
 // The flow:
 //  1. Start a localhost listener on 127.0.0.1:0.
-//  2. Build an authorize URL with a PKCE code challenge and random state.
-//  3. The caller opens the URL in the user's browser.
-//  4. Wait for the OAuth provider to redirect to the loopback server with
+//  2. Assemble the authorization request — PKCE code challenge, state, and
+//     the loopback redirect_uri — and POST it to the server's PAR endpoint
+//     (/oauth/par), which returns a request_uri.
+//  3. Build a short authorize URL carrying only client_id and request_uri.
+//  4. The caller opens that URL in the user's browser.
+//  5. Wait for the OAuth provider to redirect to the loopback server with
 //     ?code=...&state=... and validate the state.
-//  5. Return the captured code and PKCE verifier so the caller can exchange
-//     them for a token (once /oauth/token ships).
+//  6. Exchange the captured code (with the PKCE verifier) for a token via
+//     POST /oauth/token.
+//
+// Pushing the request keeps sensitive parameters off the browser URL and
+// makes the URL short enough to log and click.
 //
 // Two entry points share the same underlying flow:
 //   - Start lands the user on the OAuth login page.
@@ -42,10 +49,13 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -154,8 +164,32 @@ func start(ctx context.Context, host, deviceID, osInfo string, signup bool) (*Fl
 		params = append(params, oauth2.SetAuthURLParam("signup", "true"))
 	}
 
+	// Let the oauth2 library assemble the complete authorization request —
+	// response_type, client_id, redirect_uri, state, and the PKCE challenge —
+	// then push that exact parameter set to the server (RFC 9126) instead of
+	// embedding it in the browser URL. AuthCodeURL builds a URL; we only want
+	// its query string as the PAR request body.
+	full, err := url.Parse(cfg.AuthCodeURL(state, params...))
+	if err != nil {
+		_ = listener.Close()
+		return nil, fmt.Errorf("building authorization request: %w", err)
+	}
+
+	requestURI, err := pushAuthorizationRequest(ctx, host+"/oauth/par", full.RawQuery)
+	if err != nil {
+		_ = listener.Close()
+		return nil, err
+	}
+
+	// After a successful push, the browser only needs the request_uri — the
+	// server resolves the client and every other parameter from the pushed
+	// request it points at.
+	authorizeURL := cfg.Endpoint.AuthURL + "?" + url.Values{
+		"request_uri": {requestURI},
+	}.Encode()
+
 	f := &Flow{
-		AuthorizeURL: cfg.AuthCodeURL(state, params...),
+		AuthorizeURL: authorizeURL,
 		cfg:          cfg,
 		verifier:     verifier,
 		state:        state,
@@ -205,6 +239,64 @@ func (f *Flow) Exchange(ctx context.Context, code string) (*TokenResponse, error
 		ExpiresIn:    tok.ExpiresIn,
 		RefreshToken: tok.RefreshToken,
 	}, nil
+}
+
+// parResponse is the response to a pushed authorization request
+// (RFC 9126 §2.2): the request_uri the browser presents to the authorization
+// endpoint, plus how many seconds it remains valid.
+type parResponse struct {
+	RequestURI string `json:"request_uri"`
+	ExpiresIn  int64  `json:"expires_in"`
+}
+
+// pushAuthorizationRequest POSTs an assembled authorization request to the
+// server's PAR endpoint (RFC 9126) and returns the request_uri the browser
+// must present at the authorization endpoint. body is the urlencoded query
+// string of the authorization parameters.
+func pushAuthorizationRequest(ctx context.Context, endpoint, body string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(body))
+	if err != nil {
+		return "", fmt.Errorf("building pushed authorization request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := parHTTPClient(ctx).Do(req)
+	if err != nil {
+		return "", fmt.Errorf("pushing authorization request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	data, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return "", fmt.Errorf("reading pushed authorization response: %w", err)
+	}
+
+	// RFC 9126 §2.2: a successful push returns 201 Created.
+	if resp.StatusCode != http.StatusCreated {
+		return "", fmt.Errorf("pushed authorization request rejected (%s): %s",
+			resp.Status, strings.TrimSpace(string(data)))
+	}
+
+	var par parResponse
+	if err := json.Unmarshal(data, &par); err != nil {
+		return "", fmt.Errorf("decoding pushed authorization response: %w", err)
+	}
+	if par.RequestURI == "" {
+		return "", errors.New("pushed authorization response did not include a request_uri")
+	}
+	return par.RequestURI, nil
+}
+
+// parHTTPClient returns the HTTP client to use for the PAR call. It honors an
+// *http.Client stashed in ctx under oauth2.HTTPClient — the same override the
+// oauth2 library uses for token exchange — and otherwise uses the default
+// client, so PAR and Exchange always travel the same path.
+func parHTTPClient(ctx context.Context) *http.Client {
+	if c, ok := ctx.Value(oauth2.HTTPClient).(*http.Client); ok && c != nil {
+		return c
+	}
+	return http.DefaultClient
 }
 
 // Close shuts down the loopback server. Safe to call multiple times.

--- a/internal/oauth/login_test.go
+++ b/internal/oauth/login_test.go
@@ -32,6 +32,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -39,13 +40,66 @@ import (
 	is "gotest.tools/v3/assert/cmp"
 )
 
-// startFlow returns a Flow against the given host with a Cleanup that closes it.
-func startFlow(t *testing.T, host string) *Flow {
+// parRecorder captures the body of the most recent pushed authorization
+// request so tests can assert on parameters that PAR keeps off the browser URL.
+type parRecorder struct {
+	mu   sync.Mutex
+	last url.Values
+}
+
+func (p *parRecorder) form() url.Values {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.last
+}
+
+// writeFakePAR writes a minimal RFC 9126 success response (201 Created plus a
+// request_uri).
+func writeFakePAR(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"request_uri": "urn:ietf:params:oauth:request_uri:test",
+		"expires_in":  int64(90),
+	})
+}
+
+// newPARServer starts a server that handles POST /oauth/par, recording each
+// request body, and returns the server and its recorder.
+func newPARServer(t *testing.T) (*httptest.Server, *parRecorder) {
+	t.Helper()
+	rec := &parRecorder{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/oauth/par" {
+			http.NotFound(w, r)
+			return
+		}
+		_ = r.ParseForm()
+		rec.mu.Lock()
+		rec.last = r.PostForm
+		rec.mu.Unlock()
+		writeFakePAR(w)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, rec
+}
+
+// startFlowAgainst returns a Flow against the given host with a Cleanup that
+// closes it. The host must serve POST /oauth/par.
+func startFlowAgainst(t *testing.T, host string) *Flow {
 	t.Helper()
 	flow, err := Start(context.Background(), host, "test-device-id", "test-os")
 	assert.NilError(t, err)
 	t.Cleanup(func() { _ = flow.Close() })
 	return flow
+}
+
+// startFlow spins up a fake PAR server, starts a Flow against it, and returns
+// both the Flow and the recorder that captured the pushed request.
+func startFlow(t *testing.T) (*Flow, *parRecorder) {
+	t.Helper()
+	srv, rec := newPARServer(t)
+	return startFlowAgainst(t, srv.URL), rec
 }
 
 // callback issues a GET to the loopback redirect_uri with the given query params.
@@ -65,98 +119,115 @@ func callback(t *testing.T, redirectURI string, params map[string]string) {
 }
 
 func TestStart_AuthorizeURL(t *testing.T) {
-	flow := startFlow(t, "https://example.com")
+	flow, rec := startFlow(t)
 
 	u, err := url.Parse(flow.AuthorizeURL)
 	assert.NilError(t, err)
 
-	t.Run("base URL", func(t *testing.T) {
-		assert.Check(t, is.Equal(u.Scheme, "https"))
-		assert.Check(t, is.Equal(u.Host, "example.com"))
+	t.Run("authorize URL carries only request_uri", func(t *testing.T) {
 		assert.Check(t, is.Equal(u.Path, "/oauth/authorize"))
+		q := u.Query()
+		assert.Check(t, q.Get("request_uri") != "")
+		// PAR keeps every other parameter off the browser URL; the server
+		// resolves the client from the pushed request.
+		assert.Check(t, is.Equal(q.Get("client_id"), ""))
+		assert.Check(t, is.Equal(q.Get("code_challenge"), ""))
+		assert.Check(t, is.Equal(q.Get("state"), ""))
+		assert.Check(t, is.Equal(q.Get("redirect_uri"), ""))
 	})
 
-	t.Run("required PKCE and OAuth params", func(t *testing.T) {
-		q := u.Query()
-		assert.Check(t, is.Equal(q.Get("client_id"), ClientID))
-		assert.Check(t, is.Equal(q.Get("response_type"), "code"))
-		assert.Check(t, is.Equal(q.Get("code_challenge_method"), "S256"))
-		assert.Check(t, q.Get("code_challenge") != "")
-		assert.Check(t, q.Get("state") != "")
+	par := rec.form()
+
+	t.Run("pushed request carries the OAuth + PKCE params", func(t *testing.T) {
+		assert.Check(t, is.Equal(par.Get("client_id"), ClientID))
+		assert.Check(t, is.Equal(par.Get("response_type"), "code"))
+		assert.Check(t, is.Equal(par.Get("code_challenge_method"), "S256"))
+		assert.Check(t, par.Get("code_challenge") != "")
+		assert.Check(t, par.Get("state") != "")
 	})
 
-	t.Run("device_id and os params", func(t *testing.T) {
-		q := u.Query()
-		assert.Check(t, is.Equal(q.Get("device_id"), "test-device-id"))
-		assert.Check(t, is.Equal(q.Get("os"), "test-os"))
+	t.Run("pushed request carries device_id and os", func(t *testing.T) {
+		assert.Check(t, is.Equal(par.Get("device_id"), "test-device-id"))
+		assert.Check(t, is.Equal(par.Get("os"), "test-os"))
 	})
 
 	t.Run("code_challenge is SHA256(verifier)", func(t *testing.T) {
 		h := sha256.Sum256([]byte(flow.verifier))
 		want := base64.RawURLEncoding.EncodeToString(h[:])
-		assert.Check(t, is.Equal(u.Query().Get("code_challenge"), want))
+		assert.Check(t, is.Equal(par.Get("code_challenge"), want))
 	})
 
 	t.Run("state is 32 hex chars", func(t *testing.T) {
-		s := u.Query().Get("state")
-		assert.Check(t, is.Len(s, 32))
+		assert.Check(t, is.Len(par.Get("state"), 32))
 	})
 
 	t.Run("redirect_uri is loopback", func(t *testing.T) {
-		r := u.Query().Get("redirect_uri")
+		r := par.Get("redirect_uri")
 		assert.Check(t, strings.HasPrefix(r, "http://127.0.0.1:"), r)
 		assert.Check(t, strings.HasSuffix(r, "/callback"), r)
 	})
 }
 
 func TestStart_TrimsTrailingSlashFromHost(t *testing.T) {
-	flow := startFlow(t, "https://example.com/")
-	assert.Check(t, strings.HasPrefix(flow.AuthorizeURL, "https://example.com/oauth/authorize?"))
+	srv, _ := newPARServer(t)
+	flow := startFlowAgainst(t, srv.URL+"/")
+	assert.Check(t, strings.HasPrefix(flow.AuthorizeURL, srv.URL+"/oauth/authorize?"))
 }
 
 func TestStart_FlowsAreUnique(t *testing.T) {
-	a := startFlow(t, "https://example.com")
-	b := startFlow(t, "https://example.com")
+	a, _ := startFlow(t)
+	b, _ := startFlow(t)
 
 	assert.Check(t, a.verifier != b.verifier, "verifier must be per-flow")
 	assert.Check(t, a.state != b.state, "state must be per-flow")
 }
 
 func TestStart_DoesNotIncludeSignupParam(t *testing.T) {
-	flow := startFlow(t, "https://example.com")
-	u, err := url.Parse(flow.AuthorizeURL)
-	assert.NilError(t, err)
-	assert.Check(t, is.Equal(u.Query().Get("signup"), ""),
-		"Start must not send signup=true; that's reserved for StartSignup")
+	_, rec := startFlow(t)
+	assert.Check(t, is.Equal(rec.form().Get("signup"), ""),
+		"Start must not push signup=true; that's reserved for StartSignup")
+}
+
+func TestStart_PARFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"error":             "invalid_request",
+			"error_description": "redirect_uri not registered",
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := Start(context.Background(), srv.URL, "test-device-id", "test-os")
+	assert.ErrorContains(t, err, "pushed authorization request rejected")
 }
 
 func TestStartSignup_IncludesSignupParam(t *testing.T) {
-	flow, err := StartSignup(context.Background(), "https://example.com", "test-device-id", "test-os")
+	srv, rec := newPARServer(t)
+	flow, err := StartSignup(context.Background(), srv.URL, "test-device-id", "test-os")
 	assert.NilError(t, err)
 	t.Cleanup(func() { _ = flow.Close() })
 
-	u, err := url.Parse(flow.AuthorizeURL)
-	assert.NilError(t, err)
-	assert.Check(t, is.Equal(u.Query().Get("signup"), "true"))
+	par := rec.form()
+	assert.Check(t, is.Equal(par.Get("signup"), "true"))
 
 	// Everything else should be identical to a regular Start flow.
-	q := u.Query()
-	assert.Check(t, is.Equal(q.Get("client_id"), ClientID))
-	assert.Check(t, is.Equal(q.Get("response_type"), "code"))
-	assert.Check(t, is.Equal(q.Get("code_challenge_method"), "S256"))
-	assert.Check(t, q.Get("code_challenge") != "")
-	assert.Check(t, q.Get("state") != "")
-	assert.Check(t, is.Equal(q.Get("device_id"), "test-device-id"))
-	assert.Check(t, is.Equal(q.Get("os"), "test-os"))
+	assert.Check(t, is.Equal(par.Get("client_id"), ClientID))
+	assert.Check(t, is.Equal(par.Get("response_type"), "code"))
+	assert.Check(t, is.Equal(par.Get("code_challenge_method"), "S256"))
+	assert.Check(t, par.Get("code_challenge") != "")
+	assert.Check(t, par.Get("state") != "")
+	assert.Check(t, is.Equal(par.Get("device_id"), "test-device-id"))
+	assert.Check(t, is.Equal(par.Get("os"), "test-os"))
 }
 
 func TestFlow_Wait_Success(t *testing.T) {
-	flow := startFlow(t, "https://example.com")
-	u, _ := url.Parse(flow.AuthorizeURL)
+	flow, _ := startFlow(t)
 
-	go callback(t, u.Query().Get("redirect_uri"), map[string]string{
+	go callback(t, flow.cfg.RedirectURL, map[string]string{
 		"code":  "test-code",
-		"state": u.Query().Get("state"),
+		"state": flow.state,
 	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -169,10 +240,9 @@ func TestFlow_Wait_Success(t *testing.T) {
 }
 
 func TestFlow_Wait_StateMismatch(t *testing.T) {
-	flow := startFlow(t, "https://example.com")
-	u, _ := url.Parse(flow.AuthorizeURL)
+	flow, _ := startFlow(t)
 
-	go callback(t, u.Query().Get("redirect_uri"), map[string]string{
+	go callback(t, flow.cfg.RedirectURL, map[string]string{
 		"code":  "test-code",
 		"state": "wrong-state",
 	})
@@ -185,10 +255,9 @@ func TestFlow_Wait_StateMismatch(t *testing.T) {
 }
 
 func TestFlow_Wait_OAuthError(t *testing.T) {
-	flow := startFlow(t, "https://example.com")
-	u, _ := url.Parse(flow.AuthorizeURL)
+	flow, _ := startFlow(t)
 
-	go callback(t, u.Query().Get("redirect_uri"), map[string]string{
+	go callback(t, flow.cfg.RedirectURL, map[string]string{
 		"error":             "access_denied",
 		"error_description": "User declined the request",
 	})
@@ -202,11 +271,10 @@ func TestFlow_Wait_OAuthError(t *testing.T) {
 }
 
 func TestFlow_Wait_MissingCode(t *testing.T) {
-	flow := startFlow(t, "https://example.com")
-	u, _ := url.Parse(flow.AuthorizeURL)
+	flow, _ := startFlow(t)
 
-	go callback(t, u.Query().Get("redirect_uri"), map[string]string{
-		"state": u.Query().Get("state"),
+	go callback(t, flow.cfg.RedirectURL, map[string]string{
+		"state": flow.state,
 	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -217,7 +285,7 @@ func TestFlow_Wait_MissingCode(t *testing.T) {
 }
 
 func TestFlow_Wait_ContextCancelled(t *testing.T) {
-	flow := startFlow(t, "https://example.com")
+	flow, _ := startFlow(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -227,7 +295,7 @@ func TestFlow_Wait_ContextCancelled(t *testing.T) {
 }
 
 func TestFlow_Wait_ContextDeadline(t *testing.T) {
-	flow := startFlow(t, "https://example.com")
+	flow, _ := startFlow(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
@@ -237,10 +305,9 @@ func TestFlow_Wait_ContextDeadline(t *testing.T) {
 }
 
 func TestFlow_Callback_RejectsUnknownPath(t *testing.T) {
-	flow := startFlow(t, "https://example.com")
-	u, _ := url.Parse(flow.AuthorizeURL)
+	flow, _ := startFlow(t)
 
-	r, _ := url.Parse(u.Query().Get("redirect_uri"))
+	r, _ := url.Parse(flow.cfg.RedirectURL)
 	r.Path = "/not-callback"
 
 	resp, err := http.Get(r.String())
@@ -254,6 +321,10 @@ func TestFlow_Exchange_Success(t *testing.T) {
 	var gotForm url.Values
 	var gotPath string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/oauth/par" {
+			writeFakePAR(w)
+			return
+		}
 		gotPath = r.URL.Path
 		body, _ := io.ReadAll(r.Body)
 		gotForm, _ = url.ParseQuery(string(body))
@@ -267,7 +338,7 @@ func TestFlow_Exchange_Success(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	flow := startFlow(t, srv.URL)
+	flow := startFlowAgainst(t, srv.URL)
 	tok, err := flow.Exchange(context.Background(), "test-code")
 	assert.NilError(t, err)
 
@@ -283,7 +354,11 @@ func TestFlow_Exchange_Success(t *testing.T) {
 }
 
 func TestFlow_Exchange_ServerError(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/oauth/par" {
+			writeFakePAR(w)
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadRequest)
 		_ = json.NewEncoder(w).Encode(map[string]any{
@@ -293,7 +368,7 @@ func TestFlow_Exchange_ServerError(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	flow := startFlow(t, srv.URL)
+	flow := startFlowAgainst(t, srv.URL)
 	_, err := flow.Exchange(context.Background(), "bad-code")
 	assert.ErrorContains(t, err, "invalid_grant")
 }

--- a/internal/testing/fakes/circleci.go
+++ b/internal/testing/fakes/circleci.go
@@ -28,6 +28,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strconv"
 	"strings"
 	"sync"
@@ -126,10 +127,12 @@ type CircleCI struct {
 	iosBundleCounter  int              // monotonic ID generator for created bundles
 
 	// Auth state.
-	me                 any   // response for GET /api/v3/users?filter[user_id]=me
-	collaborations     []any // response for GET /api/v2/me/collaborations
-	oauthTokenResponse any   // response body for POST /oauth/token
-	oauthTokenStatus   int   // HTTP status for POST /oauth/token (0 → 200 OK)
+	me                 any          // response for GET /api/v3/users?filter[user_id]=me
+	collaborations     []any        // response for GET /api/v2/me/collaborations
+	oauthTokenResponse any          // response body for POST /oauth/token
+	oauthTokenStatus   int          // HTTP status for POST /oauth/token (0 → 200 OK)
+	parRequests        []url.Values // recorded POST /oauth/par request bodies, in order
+	parCounter         int          // monotonic ID generator for request_uri values
 
 	// Orb state (v3).
 	orbPackages         map[string]map[string]any // id → package object
@@ -268,6 +271,7 @@ func NewCircleCI(t *testing.T) *CircleCI {
 	r.Post("/api/v2/organization/{vcs}/{org}/project", f.handleCreateProject)
 	r.Get("/api/v3/users", f.handleGetMe)
 	r.Get("/api/v2/me/collaborations", f.handleGetCollaborations)
+	r.Post("/oauth/par", f.handleOAuthPAR)
 	r.Post("/oauth/token", f.handleOAuthToken)
 	// Context routes.
 	r.Get("/api/v2/context", f.handleListContexts)
@@ -1251,6 +1255,42 @@ func (f *CircleCI) SetOAuthTokenError(status int, resp any) {
 	defer f.mu.Unlock()
 	f.oauthTokenStatus = status
 	f.oauthTokenResponse = resp
+}
+
+// LastPARRequest returns the form parameters of the most recent
+// POST /oauth/par (RFC 9126), or nil if none has been received. Acceptance
+// tests use it to recover the redirect_uri and state, which no longer travel
+// in the browser-facing authorize URL.
+func (f *CircleCI) LastPARRequest() url.Values {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	if len(f.parRequests) == 0 {
+		return nil
+	}
+	return f.parRequests[len(f.parRequests)-1]
+}
+
+// handleOAuthPAR implements the pushed-authorization-request endpoint
+// (RFC 9126). It records the pushed parameters and returns a fresh
+// request_uri with the mandatory 201 Created status.
+func (f *CircleCI) handleOAuthPAR(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		render.Status(r, http.StatusBadRequest)
+		render.JSON(w, r, map[string]any{"error": "invalid_request"})
+		return
+	}
+
+	f.mu.Lock()
+	f.parRequests = append(f.parRequests, r.PostForm)
+	f.parCounter++
+	id := f.parCounter
+	f.mu.Unlock()
+
+	render.Status(r, http.StatusCreated)
+	render.JSON(w, r, map[string]any{
+		"request_uri": fmt.Sprintf("urn:ietf:params:oauth:request_uri:fake-%d", id),
+		"expires_in":  int64(90),
+	})
 }
 
 func (f *CircleCI) handleOAuthToken(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
<img width="978" height="71" alt="Screenshot 2026-06-09 at 21 51 08" src="https://github.com/user-attachments/assets/bbc5d42a-33ec-469f-b0c6-03af5e961baf" />
