### PR TITLE
`GITHUB_TOKEN` is the default token

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -118,7 +118,6 @@ winget:
       owner: CircleCI-Public
       name: winget-pkgs
       branch: "circleci-cli"
-      token: '{{ envOrDefault "GITHUB_TOKEN" "" }}'
       pull_request:
         base:
           owner: microsoft
@@ -151,7 +150,6 @@ brews:
       owner: CircleCI-Public
       name: homebrew-circleci
       branch: main
-      token: '{{ envOrDefault "GITHUB_TOKEN" "" }}'
     homepage: "https://circleci.com"
     description: "CircleCI command line tool."
     license: "MIT"


### PR DESCRIPTION
- Doesn't need specifying explicitly.
