### PR TITLE
Mark `circleci@next` as conflicting with `circleci`

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -155,6 +155,13 @@ homebrew_casks:
     description: "CircleCI command line tool."
     binaries:
       - circleci
+    caveats: |
+      This preview build installs a `circleci` binary that conflicts with the
+      stable `circleci` formula from homebrew-core. Homebrew cannot declare a
+      cask/formula conflict automatically, so if you have the core formula
+      installed, unlink it first to avoid a clashing symlink:
+
+        brew unlink circleci
     hooks:
       post:
         install: |

--- a/README.md
+++ b/README.md
@@ -15,8 +15,14 @@ This is CircleCI's command-line application.
 
 CircleCI CLI is available on the following package managers:
 
-Homebrew:
+Homebrew (preview):
+```shell
+brew tap circleci-public/homebrew-circleci
+brew install circleci@next
 ```
+
+Homebrew (stable):
+```shell
 brew install circleci
 ```
 


### PR DESCRIPTION
- They can't both be installed at the same time
