### PR TITLE
Parse v3 API error envelope into structured errors

### DIFF
--- a/internal/apiclient/error.go
+++ b/internal/apiclient/error.go
@@ -1,0 +1,100 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package apiclient
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/CircleCI-Public/circleci-cli/internal/httpcl"
+)
+
+// Error is the common error envelope returned by v3 API endpoints:
+//
+//	{"error": {"id": "...", "title": "...", "detail": "...", "source": {...}}}
+type Error struct {
+	ID     string      `json:"id"`
+	Title  string      `json:"title"`
+	Detail string      `json:"detail"`
+	Source ErrorSource `json:"source"`
+}
+
+// ErrorSource locates the cause of an Error within the request,
+// e.g. a JSON pointer to an invalid field.
+type ErrorSource struct {
+	Error   string `json:"error"`
+	Offset  int    `json:"offset"`
+	Pointer string `json:"pointer"`
+}
+
+func (e *Error) Error() string {
+	if e.Detail == "" {
+		return e.Title
+	}
+	if e.Title == "" {
+		return e.Detail
+	}
+	return e.Title + ": " + e.Detail
+}
+
+// Message renders the error for human display: "title: detail" on the first
+// line, followed by the source location and error id when present.
+func (e *Error) Message() string {
+	var b strings.Builder
+	b.WriteString(e.Error())
+	if e.Source.Pointer != "" {
+		_, _ = fmt.Fprintf(&b, "\n  at %s", e.Source.Pointer)
+		if e.Source.Offset > 0 {
+			_, _ = fmt.Fprintf(&b, " (offset %d)", e.Source.Offset)
+		}
+	}
+	if e.Source.Error != "" {
+		_, _ = fmt.Fprintf(&b, "\n  %s", e.Source.Error)
+	}
+	if e.ID != "" {
+		_, _ = fmt.Fprintf(&b, "\nerror id: %s", e.ID)
+	}
+	return b.String()
+}
+
+// ParseError extracts the v3 error envelope from the response body of an
+// *httpcl.HTTPError. It returns false when err is not an HTTP error or the
+// body does not carry the envelope (e.g. v1/v2 endpoints, HTML error pages).
+func ParseError(err error) (*Error, bool) {
+	he, ok := errors.AsType[*httpcl.HTTPError](err)
+	if !ok || len(he.Body) == 0 {
+		return nil, false
+	}
+	var env struct {
+		Error *Error `json:"error"`
+	}
+	if json.Unmarshal(he.Body, &env) != nil || env.Error == nil {
+		return nil, false
+	}
+	if env.Error.Title == "" && env.Error.Detail == "" {
+		return nil, false
+	}
+	return env.Error, true
+}

--- a/internal/apiclient/error_test.go
+++ b/internal/apiclient/error_test.go
@@ -1,0 +1,113 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package apiclient_test
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+
+	"github.com/CircleCI-Public/circleci-cli/internal/apiclient"
+	"github.com/CircleCI-Public/circleci-cli/internal/httpcl"
+)
+
+func httpErr(body string) error {
+	return &httpcl.HTTPError{
+		Method:     http.MethodGet,
+		Route:      "/api/v3/things",
+		StatusCode: http.StatusBadRequest,
+		Body:       []byte(body),
+	}
+}
+
+func TestParseError(t *testing.T) {
+	t.Run("full envelope", func(t *testing.T) {
+		e, ok := apiclient.ParseError(httpErr(`{"error": {
+			"id": "0196d5c2-1111-2222-3333-444455556666",
+			"title": "Missing Required Filter",
+			"detail": "Query parameter 'filter[workflow_id]' is required.",
+			"source": {"pointer": "/filter/workflow_id", "offset": 12, "error": "missing"}
+		}}`))
+		assert.Assert(t, ok)
+		assert.Check(t, cmp.Equal(e.ID, "0196d5c2-1111-2222-3333-444455556666"))
+		assert.Check(t, cmp.Equal(e.Title, "Missing Required Filter"))
+		assert.Check(t, cmp.Equal(e.Detail, "Query parameter 'filter[workflow_id]' is required."))
+		assert.Check(t, cmp.Equal(e.Source.Pointer, "/filter/workflow_id"))
+		assert.Check(t, cmp.Equal(e.Source.Offset, 12))
+		assert.Check(t, cmp.Equal(e.Source.Error, "missing"))
+	})
+
+	t.Run("not an HTTPError", func(t *testing.T) {
+		_, ok := apiclient.ParseError(errors.New("dial tcp: connection refused"))
+		assert.Check(t, !ok)
+	})
+
+	t.Run("non-JSON body", func(t *testing.T) {
+		_, ok := apiclient.ParseError(httpErr("<html>502 Bad Gateway</html>"))
+		assert.Check(t, !ok)
+	})
+
+	t.Run("JSON without envelope", func(t *testing.T) {
+		_, ok := apiclient.ParseError(httpErr(`{"message": "not found"}`))
+		assert.Check(t, !ok)
+	})
+
+	t.Run("empty envelope", func(t *testing.T) {
+		_, ok := apiclient.ParseError(httpErr(`{"error": {}}`))
+		assert.Check(t, !ok)
+	})
+
+	t.Run("string error field", func(t *testing.T) {
+		_, ok := apiclient.ParseError(httpErr(`{"error": "boom"}`))
+		assert.Check(t, !ok)
+	})
+}
+
+func TestError_Message(t *testing.T) {
+	t.Run("title and detail", func(t *testing.T) {
+		e := &apiclient.Error{Title: "Bad Request", Detail: "name is required"}
+		assert.Check(t, cmp.Equal(e.Message(), "Bad Request: name is required"))
+	})
+
+	t.Run("detail only", func(t *testing.T) {
+		e := &apiclient.Error{Detail: "name is required"}
+		assert.Check(t, cmp.Equal(e.Message(), "name is required"))
+	})
+
+	t.Run("everything", func(t *testing.T) {
+		e := &apiclient.Error{
+			ID:     "abc-123",
+			Title:  "Invalid Config",
+			Detail: "field is not a string",
+			Source: apiclient.ErrorSource{Pointer: "/spec/name", Offset: 42, Error: "expected string, got int"},
+		}
+		assert.Check(t, cmp.Equal(e.Message(),
+			"Invalid Config: field is not a string\n"+
+				"  at /spec/name (offset 42)\n"+
+				"  expected string, got int\n"+
+				"error id: abc-123"))
+	})
+}

--- a/internal/cmdutil/client.go
+++ b/internal/cmdutil/client.go
@@ -146,7 +146,12 @@ func APIErr(err error, subject, notFoundCode, notFoundMsg string, notFoundSugges
 	}
 	if httpcl.HasStatusCode(err, http.StatusNotFound) {
 		msg := fmt.Sprintf(notFoundMsg, subject)
-		if he, ok := errors.AsType[*httpcl.HTTPError](err); ok && len(he.Body) > 0 {
+		if apiErr, ok := apiclient.ParseError(err); ok {
+			// The API detail just restates "not found" — keep only the error id.
+			if apiErr.ID != "" {
+				msg += "\nerror id: " + apiErr.ID
+			}
+		} else if he, ok := errors.AsType[*httpcl.HTTPError](err); ok && len(he.Body) > 0 {
 			msg += "\nAPI: " + string(he.Body)
 		}
 		nf := clierrors.New(notFoundCode, "Not found", msg).
@@ -157,6 +162,15 @@ func APIErr(err error, subject, notFoundCode, notFoundMsg string, notFoundSugges
 		return nf
 	}
 	if he, ok := errors.AsType[*httpcl.HTTPError](err); ok {
+		if apiErr, ok := apiclient.ParseError(err); ok {
+			title := apiErr.Title
+			if title == "" {
+				title = "CircleCI API error"
+			}
+			return clierrors.New("api.error", title,
+				fmt.Sprintf("API returned %d: %s", he.StatusCode, apiErr.Message())).
+				WithExitCode(clierrors.ExitAPIError)
+		}
 		return clierrors.New("api.error", "CircleCI API error",
 			fmt.Sprintf("API returned %d: %s", he.StatusCode, string(he.Body))).
 			WithExitCode(clierrors.ExitAPIError)

--- a/internal/cmdutil/client_test.go
+++ b/internal/cmdutil/client_test.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package cmdutil
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+
+	clierrors "github.com/CircleCI-Public/circleci-cli/internal/errors"
+	"github.com/CircleCI-Public/circleci-cli/internal/httpcl"
+)
+
+func httpErr(status int, body string) error {
+	return &httpcl.HTTPError{
+		Method:     http.MethodGet,
+		Route:      "/api/v3/things",
+		StatusCode: status,
+		Body:       []byte(body),
+	}
+}
+
+func TestAPIErr(t *testing.T) {
+	t.Run("v3 envelope", func(t *testing.T) {
+		err := APIErr(httpErr(http.StatusBadRequest, `{"error": {
+			"id": "abc-123",
+			"title": "Missing Required Filter",
+			"detail": "Query parameter 'filter[workflow_id]' is required."
+		}}`), "x", "thing.not_found", "No thing found for %q")
+		assert.Check(t, cmp.Equal(err.Code, "api.error"))
+		assert.Check(t, cmp.Equal(err.Title, "Missing Required Filter"))
+		assert.Check(t, cmp.Equal(err.Message,
+			"API returned 400: Missing Required Filter: Query parameter 'filter[workflow_id]' is required.\nerror id: abc-123"))
+		assert.Check(t, cmp.Equal(err.ExitCode, clierrors.ExitAPIError))
+	})
+
+	t.Run("v3 envelope on 404 keeps resource message, drops redundant detail", func(t *testing.T) {
+		err := APIErr(httpErr(http.StatusNotFound, `{"error": {
+			"id": "abc-123",
+			"title": "Not Found",
+			"detail": "Pipeline run not found."
+		}}`), "wf-1", "workflow.not_found", "No workflow found for %q")
+		assert.Check(t, cmp.Equal(err.Code, "workflow.not_found"))
+		assert.Check(t, cmp.Equal(err.Message,
+			"No workflow found for \"wf-1\"\nerror id: abc-123"))
+		assert.Check(t, cmp.Equal(err.ExitCode, clierrors.ExitNotFound))
+	})
+
+	t.Run("v3 envelope on 404 without id adds nothing", func(t *testing.T) {
+		err := APIErr(httpErr(http.StatusNotFound, `{"error": {
+			"title": "Not Found",
+			"detail": "Pipeline run not found."
+		}}`), "wf-1", "workflow.not_found", "No workflow found for %q")
+		assert.Check(t, cmp.Equal(err.Message, `No workflow found for "wf-1"`))
+	})
+
+	t.Run("non-envelope body falls back to raw", func(t *testing.T) {
+		err := APIErr(httpErr(http.StatusInternalServerError, `{"message": "boom"}`), "x", "thing.not_found", "No thing found for %q")
+		assert.Check(t, cmp.Equal(err.Code, "api.error"))
+		assert.Check(t, cmp.Equal(err.Message, `API returned 500: {"message": "boom"}`))
+	})
+
+	t.Run("unauthorized", func(t *testing.T) {
+		err := APIErr(httpErr(http.StatusUnauthorized, ""), "x", "thing.not_found", "No thing found for %q")
+		assert.Check(t, cmp.Equal(err.Code, "auth.token_invalid"))
+		assert.Check(t, cmp.Equal(err.ExitCode, clierrors.ExitAuthError))
+	})
+
+	t.Run("non-HTTP error", func(t *testing.T) {
+		err := APIErr(errors.New("dial tcp: connection refused"), "x", "thing.not_found", "No thing found for %q")
+		assert.Check(t, cmp.Equal(err.Code, "api.error"))
+		assert.Check(t, cmp.Equal(err.Message, "dial tcp: connection refused"))
+	})
+}


### PR DESCRIPTION
## Summary
- v3 endpoints return a common envelope: `{"error": {"id", "title", "detail", "source": {...}}}`
- Add `apiclient.Error` + `ParseError` to decode it from an `HTTPError` body
- Use it in `cmdutil.APIErr` so failures render title/detail/source/error-id instead of dumping the raw JSON body
- On 404 the API detail just restates "not found", so only the error id is appended to the per-resource message
- Non-envelope bodies (v1/v2, HTML) fall back to the previous raw output

🤖 Generated with [Claude Code](https://claude.com/claude-code)