### PR TITLE
Show run details when workflows lookup 404s

### DIFF
--- a/acceptance/run_test.go
+++ b/acceptance/run_test.go
@@ -190,6 +190,27 @@ func TestRunGet_ByID(t *testing.T) {
 	assert.Check(t, golden.String(result.Stdout, t.Name()+".txt"))
 }
 
+func TestRunGet_ByID_WorkflowsNotFound(t *testing.T) {
+	fake := fakes.NewCircleCI(t)
+	runID := getRunID
+	fake.AddRunV3(runID, runTestProjectID, fakeRunV3(runID, runTestProjectID, "created", "", "main", "abc1234def5678"))
+	fake.SetRunWorkflowsV3NotFound(runID)
+
+	env := testenv.New(t)
+	env.Token = testToken
+	env.CircleCIURL = fake.URL()
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"run", "get", runID},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 0)
+	assert.Check(t, golden.String(result.Stdout, t.Name()+".txt"))
+}
+
 func TestRunGet_ByID_Color(t *testing.T) {
 	fake := fakes.NewCircleCI(t)
 	runID := getRunID

--- a/acceptance/testdata/TestRunGet_ByID_WorkflowsNotFound.txt
+++ b/acceptance/testdata/TestRunGet_ByID_WorkflowsNotFound.txt
@@ -2,10 +2,7 @@
 - ID: `5034460f-c7c4-4c43-9457-de07e2029e7b`
 - Branch: main
 - Commit: abc1234
-- Status: failed
+- Status: created
 - Created: 2020-01-01 12:00:00 UTC
-
-## Errors
-- **config**: Could not find config file
 
 No workflows found for this run.

--- a/internal/cmd/run/get.go
+++ b/internal/cmd/run/get.go
@@ -25,6 +25,7 @@ package run
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strings"
 	"time"
 
@@ -34,6 +35,7 @@ import (
 	"github.com/CircleCI-Public/circleci-cli/internal/apiclient"
 	"github.com/CircleCI-Public/circleci-cli/internal/cmdutil"
 	"github.com/CircleCI-Public/circleci-cli/internal/gitremote"
+	"github.com/CircleCI-Public/circleci-cli/internal/httpcl"
 	"github.com/CircleCI-Public/circleci-cli/internal/iostream"
 	"github.com/CircleCI-Public/circleci-cli/internal/mdtable"
 )
@@ -181,7 +183,12 @@ func runGet(ctx context.Context, client *apiclient.Client, args []string, projec
 
 	workflows, err := client.GetRunWorkflowsV3(ctx, r.ID)
 	if err != nil {
-		return apiErr(err, r.ID)
+		// The workflows API can 404 for a run that exists (e.g. workflows
+		// not yet materialised) — still show the run, with no workflows.
+		if !httpcl.HasStatusCode(err, http.StatusNotFound) {
+			return apiErr(err, r.ID)
+		}
+		workflows = nil
 	}
 
 	wfJobs := make([][]apiclient.WorkflowJobV3, len(workflows))
@@ -306,7 +313,9 @@ func printRun(ctx context.Context, r runGetOutput) {
 	}
 	md.WriteString("\n")
 
-	if len(r.Workflows) > 0 {
+	if len(r.Workflows) == 0 {
+		md.WriteString("No workflows found for this run.\n")
+	} else {
 		md.WriteString("## Workflows\n")
 		for _, w := range r.Workflows {
 			_, _ = fmt.Fprintf(&md, "### %s\n", w.Name)

--- a/internal/testing/fakes/circleci.go
+++ b/internal/testing/fakes/circleci.go
@@ -82,8 +82,9 @@ type CircleCI struct {
 	runsV3ByProject map[string][]any // project UUID → ordered V3 run data items
 
 	// Workflow (v3) state.
-	workflowsV3      map[string]any   // workflow UUID → V3 workflow data (inner, not wrapped)
-	workflowsV3ByRun map[string][]any // run UUID → V3 workflow data items
+	workflowsV3         map[string]any   // workflow UUID → V3 workflow data (inner, not wrapped)
+	workflowsV3ByRun    map[string][]any // run UUID → V3 workflow data items
+	workflowsV3NotFound map[string]bool  // run UUID → workflows list returns 404
 
 	// Runner (v3) state.
 	resourceClasses []any            // all resource classes
@@ -206,6 +207,7 @@ func NewCircleCI(t *testing.T) *CircleCI {
 		runsV3ByProject:                   map[string][]any{},
 		workflowsV3:                       map[string]any{},
 		workflowsV3ByRun:                  map[string][]any{},
+		workflowsV3NotFound:               map[string]bool{},
 		resourceClasses:                   []any{},
 		runnerTokens:                      map[string][]any{},
 		runnerInstances:                   []any{},
@@ -837,6 +839,15 @@ func (f *CircleCI) AddRunWorkflowsV3(runID string, workflows ...any) {
 	f.workflowsV3ByRun[runID] = workflows
 }
 
+// SetRunWorkflowsV3NotFound makes GET /api/v3/workflows?filter[run_id]=<runID>
+// return 404 for the given run, mirroring the real API for runs whose
+// workflows have not materialised.
+func (f *CircleCI) SetRunWorkflowsV3NotFound(runID string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.workflowsV3NotFound[runID] = true
+}
+
 func (f *CircleCI) handleGetWorkflowV3ByID(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 	f.mu.RLock()
@@ -855,8 +866,16 @@ func (f *CircleCI) handleGetWorkflowsV3(w http.ResponseWriter, r *http.Request) 
 	runID := r.URL.Query().Get("filter[run_id]")
 	f.mu.RLock()
 	workflows := f.workflowsV3ByRun[runID]
+	notFound := f.workflowsV3NotFound[runID]
 	f.mu.RUnlock()
 
+	if notFound {
+		render.Status(r, http.StatusNotFound)
+		render.JSON(w, r, map[string]any{
+			"error": map[string]any{"type": "not_found", "detail": "run not found", "id": "fake-error-id"},
+		})
+		return
+	}
 	if workflows == nil {
 		workflows = []any{}
 	}


### PR DESCRIPTION
`run get <uuid>` failed with "No run found" when the run itself fetched fine but `GET /api/v3/workflows` returned 404 (workflows not yet materialised). Treat that 404 as no workflows: print the run details as usual plus a "No workflows found for this run." note; JSON output gets an empty workflows array.

🤖 Generated with [Claude Code](https://claude.com/claude-code)