### PR TITLE
Add --current-branch (-B) flag to circleci run list

### DIFF
--- a/internal/cmd/root/testdata/help/circleci/run/list.txt
+++ b/internal/cmd/root/testdata/help/circleci/run/list.txt
@@ -4,7 +4,8 @@ List recent runs for a CircleCI project.
 
 The project is inferred from the current git repository's remote
 unless overridden with --project. Use --branch to filter results
-to a single branch.
+to a single branch, or --current-branch (-B) to automatically use
+the branch you have checked out.
 
 JSON fields: id, phase, outcome, current_outcome, branch, revision, created_at
 
@@ -18,13 +19,14 @@ JSON fields: id, phase, outcome, current_outcome, branch, revision, created_at
 
 ## Flags
 
-| Flag                  | Description                                               |
-| --------------------- | --------------------------------------------------------- |
-| `-b, --branch string` | Filter by branch                                          |
-| `--jq string`         | Process values from the response using jq syntax          |
-| `--json`              | Output as JSON                                            |
-| `--limit int`         | Maximum number of runs to show [default: 10] (default 10) |
-| `--project string`    | Project slug (e.g. gh/org/repo); defaults to git remote   |
+| Flag                   | Description                                               |
+| ---------------------- | --------------------------------------------------------- |
+| `-b, --branch string`  | Filter by branch                                          |
+| `-B, --current-branch` | Filter by the currently checked-out branch                |
+| `--jq string`          | Process values from the response using jq syntax          |
+| `--json`               | Output as JSON                                            |
+| `--limit int`          | Maximum number of runs to show [default: 10] (default 10) |
+| `--project string`     | Project slug (e.g. gh/org/repo); defaults to git remote   |
 
 ## Inherited Flags
 
@@ -38,6 +40,8 @@ JSON fields: id, phase, outcome, current_outcome, branch, revision, created_at
 
 - List recent runs for the current project: 
   `circleci run list`
+- Filter to the branch you have checked out: 
+  `circleci run list --current-branch`
 - Filter to a specific branch: 
   `circleci run list --branch main`
 - List runs for an explicit project: 

--- a/internal/cmd/root/testdata/usage/circleci/run/list.txt
+++ b/internal/cmd/root/testdata/usage/circleci/run/list.txt
@@ -2,6 +2,7 @@ Usage:  circleci run list [flags]
 
 Flags:
   -b, --branch string    Filter by branch
+  -B, --current-branch   Filter by the currently checked-out branch
       --jq string        Process values from the response using jq syntax
       --json             Output as JSON
       --limit int        Maximum number of runs to show [default: 10] (default 10)

--- a/internal/cmd/run/list.go
+++ b/internal/cmd/run/list.go
@@ -38,10 +38,11 @@ import (
 
 func newListCmd() *cobra.Command {
 	var (
-		projectSlug string
-		branch      string
-		limit       int
-		jsonOut     bool
+		projectSlug   string
+		branch        string
+		currentBranch bool
+		limit         int
+		jsonOut       bool
 	)
 
 	cmd := &cobra.Command{
@@ -53,13 +54,17 @@ func newListCmd() *cobra.Command {
 
 			The project is inferred from the current git repository's remote
 			unless overridden with --project. Use --branch to filter results
-			to a single branch.
+			to a single branch, or --current-branch (-B) to automatically use
+			the branch you have checked out.
 
 			JSON fields: id, phase, outcome, current_outcome, branch, revision, created_at
 		`),
 		Example: heredoc.Doc(`
 			# List recent runs for the current project
 			$ circleci run list
+
+			# Filter to the branch you have checked out
+			$ circleci run list --current-branch
 
 			# Filter to a specific branch
 			$ circleci run list --branch main
@@ -80,12 +85,20 @@ func newListCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			if currentBranch && branch == "" {
+				info, err := gitremote.Detect()
+				if err != nil {
+					return cmdutil.GitDetectErr(err, "Or specify the branch explicitly: circleci run list --branch <name>")
+				}
+				branch = info.Branch
+			}
 			return runList(ctx, client, projectSlug, branch, limit, jsonOut)
 		},
 	}
 
 	cmd.Flags().StringVar(&projectSlug, "project", "", "Project slug (e.g. gh/org/repo); defaults to git remote")
 	cmd.Flags().StringVarP(&branch, "branch", "b", "", "Filter by branch")
+	cmd.Flags().BoolVarP(&currentBranch, "current-branch", "B", false, "Filter by the currently checked-out branch")
 	cmd.Flags().IntVar(&limit, "limit", 10, "Maximum number of runs to show [default: 10]")
 	cmdutil.AddJSONFlag(cmd, &jsonOut)
 	cmdutil.AddJQFlag(cmd)


### PR DESCRIPTION
## Summary

- Adds `--current-branch` / `-B` flag to `circleci run list`
- When set, the flag reads the current git branch via `gitremote.Detect()` and uses it as the branch filter automatically
- If `--branch` is also supplied, it takes precedence and `-B` is a no-op

## Test plan

- [ ] `circleci run list -B` filters to the current branch without needing to pass it explicitly
- [ ] `circleci run list --branch foo -B` uses `foo` (explicit `--branch` wins)
- [ ] `circleci run list -B` outside a git repo returns a helpful error