### PR TITLE
Add more help docs

### DIFF
--- a/internal/cmd/root/help.go
+++ b/internal/cmd/root/help.go
@@ -134,6 +134,10 @@ func rootHelp(command *cobra.Command, _ []string) {
 	if longText == "" {
 		longText = command.Short
 	}
+	if longText != "" && command.LocalFlags().Lookup("jq") != nil {
+		longText = strings.TrimRight(longText, "\n") +
+			"\n\nFor more information about output formatting flags, see `circleci help formatting`."
+	}
 	section("", longText)
 
 	section("Usage", "`"+command.UseLine()+"`")
@@ -152,6 +156,10 @@ func rootHelp(command *cobra.Command, _ []string) {
 			rows = append(rows, [2]string{"`" + c.Name() + "`", c.Short})
 		}
 		section(titleCase(g.Title), mdTable("Command", "Description", rows))
+	}
+
+	if isRootCmd(command) {
+		section("Help Topics", topicsMarkdown(helpTopics))
 	}
 
 	section("Flags", mdTable("Flag", "Description", flagRows(command.LocalFlags())))
@@ -174,6 +182,8 @@ func rootHelp(command *cobra.Command, _ []string) {
 
 // mdTable renders rows as a GitHub-flavored markdown table. Returns "" when
 // there are no rows so the caller can skip the section entirely.
+//
+//nolint:unparam
 func mdTable(col1, col2 string, rows [][2]string) string {
 	if len(rows) == 0 {
 		return ""
@@ -255,6 +265,22 @@ func flagDefaultIsZero(f *pflag.Flag) bool {
 		}
 		return false
 	}
+}
+
+// topicsMarkdown renders the help topics as a markdown table of topic name to
+// its short description, sorted by name. Each name is shown as inline code so
+// it reads as the value to pass to `circleci help <topic>`.
+func topicsMarkdown(topics []helpTopic) string {
+	sorted := slices.Clone(topics)
+	slices.SortFunc(sorted, func(a, b helpTopic) int {
+		return strings.Compare(a.name, b.name)
+	})
+
+	rows := make([][2]string, 0, len(sorted))
+	for _, t := range sorted {
+		rows = append(rows, [2]string{"`" + t.name + "`", t.short})
+	}
+	return mdTable("Topic", "Description", rows)
 }
 
 // exampleMarkdown converts the conventional "# comment" / "$ command" example

--- a/internal/cmd/root/help_reference.go
+++ b/internal/cmd/root/help_reference.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package root
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+func stringifyReference(cmd *cobra.Command) string {
+	var buf = bytes.Buffer{}
+	for _, c := range cmd.Commands() {
+		if c.Hidden {
+			continue
+		}
+		cmdRef(&buf, c, 2)
+	}
+	return buf.String()
+}
+
+func cmdRef(w io.Writer, cmd *cobra.Command, depth int) {
+	_, _ = fmt.Fprintf(w, "%s `%s`\n\n", strings.Repeat("#", depth), cmd.UseLine())
+	_, _ = fmt.Fprintf(w, "%s\n\n", cmd.Short)
+
+	flags := cmd.Flags()
+	if flags.HasAvailableFlags() {
+		_, _ = fmt.Fprintf(w, "%s\n\n", mdTable("Flag", "Description", flagRows(flags)))
+	}
+
+	if len(cmd.Aliases) > 0 {
+		_, _ = fmt.Fprintf(w, "%s\n\n", "Aliases:")
+		aliasList := buildAliasList(cmd, cmd.Aliases)
+		for i, a := range aliasList {
+			aliasList[i] = "`" + a + "`"
+		}
+		_, _ = fmt.Fprintf(w, "\n%s\n\n", dedent(strings.Join(aliasList, ", ")))
+	}
+
+	for _, c := range cmd.Commands() {
+		if c.Hidden {
+			continue
+		}
+		cmdRef(w, c, depth+1)
+	}
+}

--- a/internal/cmd/root/help_topic.go
+++ b/internal/cmd/root/help_topic.go
@@ -1,0 +1,178 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package root
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+
+	"github.com/CircleCI-Public/circleci-cli/internal/iostream"
+)
+
+type helpTopic struct {
+	name    string
+	short   string
+	long    string
+	example string
+}
+
+var helpTopics = []helpTopic{
+	{
+		name:  "environment",
+		short: "Environment variables that can be used with circleci",
+		long: heredoc.Docf(`
+			%[1]sCIRCLE_TOKEN%[1]s: an authentication token that will be used for API requests. Setting this avoids
+			being prompted to authenticate and takes precedence over previously stored credentials.
+
+			%[1]sCIRCLE_HOST%[1]s: specify the CircleCI hostname.
+
+			%[1]sNO_COLOR%[1]s: set to any value to avoid printing ANSI escape sequences for color output.
+
+			%[1]sCIRCLE_NO_TELEMETRY%[1]s: set to any value to disable telemetry.
+
+			%[1]sNO_ANALYTICS%[1]s: set to any value to disable telemetry.
+
+			%[1]sDO_NOT_TRACK%[1]s: set to any value to disable telemetry.
+
+		`, "`"),
+	},
+	{
+		name:  "telemetry",
+		short: "Information about telemetry in circleci",
+		long: heredoc.Doc(`
+			circleci collects telemetry to help us understand how the CLI is being used and to improve it.
+
+			To learn more about what data is collected, how it is used, and how to opt out, see:
+			<https://circleci.com/docs/local-cli>
+		`),
+	},
+	{
+		name:  "reference",
+		short: "A comprehensive reference of all circleci commands",
+	},
+	{
+		name:  "formatting",
+		short: "Formatting options for JSON data exported from circleci",
+		long: heredoc.Docf(`
+			By default, the result of %[1]scircleci%[1]s commands are output in markdown text format.
+			Some commands support passing the %[1]s--json%[1]s flag, which converts the output to JSON format.
+			Once in JSON, the output can be further formatted according to a required formatting string by
+			adding either the %[1]s--jq%[1]s or %[1]s--template%[1]s flag. This is useful for selecting a subset of data,
+			creating new data structures, displaying the data in a different format, or as input to another
+			command line script.
+
+			The %[1]s--json%[1]s flag requires a comma separated list of fields to fetch. To view the possible JSON
+			field names for a command omit the string argument to the %[1]s--json%[1]s flag when you run the command.
+			Note that you must pass the %[1]s--json%[1]s flag and field names to use the %[1]s--jq%[1]s flag.
+
+			The %[1]s--jq%[1]s flag requires a string argument in jq query syntax, and will only print
+			those JSON values which match the query. jq queries can be used to select elements from an
+			array, fields from an object, create a new array, and more. The %[1]sjq%[1]s utility does not need
+			to be installed on the system to use this formatting directive. When connected to a terminal,
+			the output is automatically pretty-printed. To learn about jq query syntax, see:
+			<https://jqlang.github.io/jq/manual/>
+
+		`, "`"),
+		example: heredoc.Docf(`
+			## Default output format
+			$ circleci auth me
+			%[1]s%[1]s%[1]stext
+			# User
+			- ID: %[1]sc257a143-1fde-4dfe-8cf9-2a85a955f1f7%[1]s
+			- Name: Your Name
+			- Login: username
+			- Avatar URL: https://avatars.githubusercontent.com/u/9812739817239?v=4
+			%[1]s%[1]s%[1]s
+
+			## Adding the --json flag with a list of field names
+			$ circleci auth me --json
+			%[1]s%[1]s%[1]sjson
+			{
+			  "name": "Your Name",
+			  "login": "username",
+			  "id": "c257a143-1fde-4dfe-8cf9-2a85a955f1f7",
+			  "avatar_url": "https://avatars.githubusercontent.com/u/9812739817239?v=4"
+			}
+			%[1]s%[1]s%[1]s
+
+			## Adding the --jq flag and selecting a field
+			$ circleci auth me --json --jq '.login'
+			%[1]s%[1]s%[1]stext
+			username
+			%[1]s%[1]s%[1]s
+		`, "`"),
+	},
+}
+
+func newCmdHelpTopic(ht helpTopic, initConfig func(cmd *cobra.Command) (func(), error)) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     ht.name,
+		Short:   ht.short,
+		Long:    ht.long,
+		Example: ht.example,
+		Hidden:  true,
+	}
+
+	cmd.SetUsageFunc(func(c *cobra.Command) error {
+		cleanup, err := initConfig(c)
+		if err != nil {
+			return err
+		}
+		cleanup()
+
+		ctx := c.Context()
+		return helpTopicUsageFunc(ctx, c)
+	})
+
+	cmd.SetHelpFunc(func(c *cobra.Command, _ []string) {
+		cleanup, err := initConfig(c)
+		if err == nil {
+			cleanup()
+		}
+		ctx := c.Context()
+		helpTopicHelpFunc(ctx, c)
+	})
+
+	return cmd
+}
+
+func helpTopicHelpFunc(ctx context.Context, command *cobra.Command) {
+	var md bytes.Buffer
+	_, _ = fmt.Fprintf(&md, "# %s\n", titleCase(command.Name()))
+	md.WriteString(command.Long)
+	if command.Example != "" {
+		_, _ = fmt.Fprintf(&md, "\n\nExamples\n")
+		_, _ = fmt.Fprint(&md, iostream.Indent(command.Example, "  "))
+	}
+
+	iostream.PrintMarkdown(ctx, md.String())
+}
+
+func helpTopicUsageFunc(ctx context.Context, command *cobra.Command) error {
+	iostream.ErrPrintf(ctx, "Usage: circleci help %s", command.Use)
+	return nil
+}

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -66,6 +66,84 @@ import (
 // NewRootCmd builds the root cobra command and wires all subcommands.
 func NewRootCmd(version string) *cobra.Command {
 	telem := &delegatingTelemetry{}
+	initConfig := func(cmd *cobra.Command) (func(), error) {
+		if telem.Client != nil {
+			return func() {}, nil
+		}
+
+		ctx := cmd.Context()
+
+		if theme, _ := cmd.Flags().GetString("theme"); !iostream.IsValidTheme(theme) {
+			return func() {}, clierrors.New("flags.invalid_theme", "Invalid theme", "Invalid value for --theme: "+theme).
+				WithSuggestions("Valid themes are: " + strings.Join(iostream.ValidThemes(), ", ")).
+				WithExitCode(clierrors.ExitBadArguments)
+		}
+
+		secureStorage := cmdutil.IsSecureStorage(cmd)
+		configPath := cmdutil.ConfigPath(cmd)
+
+		// Load config before stream setup so a stored "theme" setting can act as
+		// the fallback when --theme is not explicitly passed. config.Load only
+		// uses ctx for its file lock timeout, so the streamless context is fine.
+		cfg, err := config.Load(ctx, configPath, secureStorage)
+		if err != nil {
+			return func() {}, err
+		}
+
+		ctx = iostream.FromCmd(ctx, cmd, cfg.EffectiveTheme())
+		ctx = cmdutil.WithVersion(ctx, version)
+		ctx = cmdutil.WithConfig(ctx, cfg)
+
+		agentName := agent.Detect()
+		ctx = cmdutil.WithAgentName(ctx, agentName)
+
+		jqFilter, _ := cmd.Flags().GetString("jq")
+		ctx = iostream.WithJQFilter(ctx, jqFilter)
+
+		cmd.SetContext(ctx)
+
+		// Only gather host info when telemetry will actually be sent. Skipping
+		// it for telemetry-disabled commands (e.g. completion generation) avoids
+		// gopsutil's `ioreg` lookup, which fails under a restricted PATH such as
+		// Homebrew's sanitized completion-generation environment.
+		var hostInfo *host.InfoStat
+		if cfg.IsTelemetry() && !cmdutil.IsTelemetryDisabled(cmd) {
+			hostInfo, err = host.InfoWithContext(ctx)
+			if err != nil {
+				return func() {}, err
+			}
+		}
+
+		tc, err := telemetry.New(ctx, telemetry.Config{
+			Log:      cfg.IsTelemetry(),
+			Send:     cfg.IsTelemetry(),
+			WriteKey: telemetry.SegmentKey,
+			Endpoint: os.Getenv("CIRCLE_TELEMETRY_ENDPOINT"),
+			Metadata: telemetry.Meta{
+				Version:    version,
+				InstanceID: cfg.DeviceID(),
+				UserID:     cfg.UserID(),
+				HostInfo:   hostInfo,
+				Extra: map[string]any{
+					"agent":          agentName,
+					"is_self_hosted": cfg.EffectiveHost() != "https://circleci.com",
+					"is_tty":         iostream.IsTerminal(ctx),
+				},
+			},
+		})
+		if err != nil {
+			return func() {}, err
+		}
+		telem.Client = tc
+
+		cleanup := func() {
+			if telem.Client != nil {
+				_ = telem.Close()
+			}
+		}
+
+		return cleanup, nil
+	}
 
 	cmd := &cobra.Command{
 		Use:           "circleci",
@@ -115,6 +193,18 @@ func NewRootCmd(version string) *cobra.Command {
 	// Wire in MCP commands
 	cmd.AddCommand(ophis.Command(nil))
 
+	// Help topics
+	var referenceCmd *cobra.Command
+	for _, ht := range helpTopics {
+		helpTopicCmd := newCmdHelpTopic(ht, initConfig)
+		cmd.AddCommand(helpTopicCmd)
+
+		// See bottom of the function for why we explicitly care about the reference cmd
+		if ht.name == "reference" {
+			referenceCmd = helpTopicCmd
+		}
+	}
+
 	// Register extensions found in PATH. Built-in commands always win on name
 	// conflicts — extensions cannot shadow them.
 	builtins := map[string]bool{}
@@ -132,78 +222,12 @@ func NewRootCmd(version string) *cobra.Command {
 		}
 	}
 
-	initConfig := func(cmd *cobra.Command) error {
-		if theme, _ := cmd.Flags().GetString("theme"); !iostream.IsValidTheme(theme) {
-			return clierrors.New("flags.invalid_theme", "Invalid theme", "Invalid value for --theme: "+theme).
-				WithSuggestions("Valid themes are: " + strings.Join(iostream.ValidThemes(), ", ")).
-				WithExitCode(clierrors.ExitBadArguments)
-		}
-
-		secureStorage := cmdutil.IsSecureStorage(cmd)
-		configPath := cmdutil.ConfigPath(cmd)
-
-		// Load config before stream setup so a stored "theme" setting can act as
-		// the fallback when --theme is not explicitly passed. config.Load only
-		// uses ctx for its file lock timeout, so the streamless context is fine.
-		cfg, err := config.Load(cmd.Context(), configPath, secureStorage)
-		if err != nil {
-			return err
-		}
-
-		ctx := iostream.FromCmd(cmd.Context(), cmd, cfg.EffectiveTheme())
-		ctx = cmdutil.WithVersion(ctx, version)
-		ctx = cmdutil.WithConfig(ctx, cfg)
-
-		agentName := agent.Detect()
-		ctx = cmdutil.WithAgentName(ctx, agentName)
-
-		// Only gather host info when telemetry will actually be sent. Skipping
-		// it for telemetry-disabled commands (e.g. completion generation) avoids
-		// gopsutil's `ioreg` lookup, which fails under a restricted PATH such as
-		// Homebrew's sanitized completion-generation environment.
-		var hostInfo *host.InfoStat
-		if cfg.IsTelemetry() && !cmdutil.IsTelemetryDisabled(cmd) {
-			hostInfo, err = host.InfoWithContext(ctx)
-			if err != nil {
-				return err
-			}
-		}
-
-		tc, err := telemetry.New(ctx, telemetry.Config{
-			Log:      cfg.IsTelemetry(),
-			Send:     cfg.IsTelemetry(),
-			WriteKey: telemetry.SegmentKey,
-			Endpoint: os.Getenv("CIRCLE_TELEMETRY_ENDPOINT"),
-			Metadata: telemetry.Meta{
-				Version:    version,
-				InstanceID: cfg.DeviceID(),
-				UserID:     cfg.UserID(),
-				HostInfo:   hostInfo,
-				Extra: map[string]any{
-					"agent":          agentName,
-					"is_self_hosted": cfg.EffectiveHost() != "https://circleci.com",
-					"is_tty":         iostream.IsTerminal(ctx),
-				},
-			},
-		})
-		if err != nil {
-			return err
-		}
-		telem.Client = tc
-
-		jqFilter, _ := cmd.Flags().GetString("jq")
-		ctx = iostream.WithJQFilter(ctx, jqFilter)
-
-		cmd.SetContext(ctx)
-
-		return nil
-	}
-
 	cmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
 		for i := range args {
 			args[i] = strings.TrimSpace(args[i])
 		}
-		return initConfig(cmd)
+		_, err := initConfig(cmd)
+		return err
 	}
 	cmd.PersistentPostRunE = func(_ *cobra.Command, _ []string) error {
 		_ = telem.Close()
@@ -211,36 +235,28 @@ func NewRootCmd(version string) *cobra.Command {
 	}
 
 	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
-		if telem.Client == nil {
-			// --help flag path: pre/post run hooks don't fire, so own the full lifecycle here.
-			if err := initConfig(cmd); err == nil {
-				cmdutil.RecordTelemetryNow(cmd, telem.Client)
-				_ = telem.Close()
-			}
-		} else {
-			// `help` subcommand path: PersistentPreRunE already initialized, PersistentPostRunE will close.
+		if cleanup, err := initConfig(cmd); err == nil {
 			cmdutil.RecordTelemetryNow(cmd, telem.Client)
+			cleanup()
 		}
 
 		rootHelp(cmd, args)
 	})
 
 	cmd.SetUsageFunc(func(cmd *cobra.Command) error {
-		if telem.Client == nil {
-			// --help flag path: pre/post run hooks don't fire, so own the full lifecycle here.
-			if err := initConfig(cmd); err == nil {
-				cmdutil.RecordTelemetryNow(cmd, telem.Client)
-				_ = telem.Close()
-			}
-		} else {
-			// `help` subcommand path: PersistentPreRunE already initialized, PersistentPostRunE will close.
+		if cleanup, err := initConfig(cmd); err == nil {
 			cmdutil.RecordTelemetryNow(cmd, telem.Client)
+			cleanup()
 		}
 
 		return rootUsage(cmd)
 	})
 
 	cmdutil.RecordTelemetryForSubcommands(cmd, telem)
+
+	if referenceCmd != nil {
+		referenceCmd.Long = stringifyReference(cmd)
+	}
 
 	return cmd
 }

--- a/internal/cmd/root/testdata/help/circleci/api.txt
+++ b/internal/cmd/root/testdata/help/circleci/api.txt
@@ -13,6 +13,8 @@ GET/DELETE, JSON body fields for POST/PUT/PATCH).
 
 Exit code reflects the HTTP response: 0 for 2xx, 4 for 4xx/5xx.
 
+For more information about output formatting flags, see `circleci help formatting`.
+
 ## Usage
 
 `circleci api <path> [flags]`

--- a/internal/cmd/root/testdata/help/circleci/artifact.txt
+++ b/internal/cmd/root/testdata/help/circleci/artifact.txt
@@ -7,6 +7,8 @@ them to a local directory.
 
 JSON fields: path, url, node_index
 
+For more information about output formatting flags, see `circleci help formatting`.
+
 ## Usage
 
 `circleci artifact <job-id> [flags]`

--- a/internal/cmd/root/testdata/help/circleci/auth.txt
+++ b/internal/cmd/root/testdata/help/circleci/auth.txt
@@ -9,7 +9,7 @@ Use 'circleci auth logout' to clear your stored credentials.
 
 ## Usage
 
-`circleci auth <command>`
+`circleci auth <command> [flags]`
 
 ## Available Commands
 

--- a/internal/cmd/root/testdata/help/circleci/auth/logout.txt
+++ b/internal/cmd/root/testdata/help/circleci/auth/logout.txt
@@ -2,6 +2,8 @@
 
 Log out of a CircleCI account
 
+For more information about output formatting flags, see `circleci help formatting`.
+
 ## Usage
 
 `circleci auth logout [flags]`

--- a/internal/cmd/root/testdata/help/circleci/auth/me.txt
+++ b/internal/cmd/root/testdata/help/circleci/auth/me.txt
@@ -2,6 +2,8 @@
 
 Display active account information
 
+For more information about output formatting flags, see `circleci help formatting`.
+
 ## Usage
 
 `circleci auth me [flags]`

--- a/internal/cmd/root/testdata/help/circleci/certificate.txt
+++ b/internal/cmd/root/testdata/help/circleci/certificate.txt
@@ -9,7 +9,7 @@ signing config.
 
 ## Usage
 
-`circleci certificate <command>`
+`circleci certificate <command> [flags]`
 
 ## Available Commands
 

--- a/internal/cmd/root/testdata/help/circleci/certificate/list.txt
+++ b/internal/cmd/root/testdata/help/circleci/certificate/list.txt
@@ -8,6 +8,8 @@ unless overridden with --org-id.
 
 JSON fields: id, file_name, org_id, created_at
 
+For more information about output formatting flags, see `circleci help formatting`.
+
 ## Usage
 
 `circleci certificate list [flags]`

--- a/internal/cmd/root/testdata/help/circleci/certificate/upload.txt
+++ b/internal/cmd/root/testdata/help/circleci/certificate/upload.txt
@@ -15,6 +15,8 @@ shell history and process listings.
 
 JSON fields: id, file_name
 
+For more information about output formatting flags, see `circleci help formatting`.
+
 ## Usage
 
 `circleci certificate upload [flags]`

--- a/internal/cmd/root/testdata/help/circleci/completion.txt
+++ b/internal/cmd/root/testdata/help/circleci/completion.txt
@@ -12,7 +12,7 @@ To install manually, add one of the following to your shell profile:
 
 ## Usage
 
-`circleci completion <command>`
+`circleci completion <command> [flags]`
 
 ## Available Commands
 

--- a/internal/cmd/root/testdata/help/circleci/completion/bash.txt
+++ b/internal/cmd/root/testdata/help/circleci/completion/bash.txt
@@ -4,7 +4,7 @@ Generate bash completion script
 
 ## Usage
 
-`circleci completion bash`
+`circleci completion bash [flags]`
 
 ## Inherited Flags
 

--- a/internal/cmd/root/testdata/help/circleci/completion/install.txt
+++ b/internal/cmd/root/testdata/help/circleci/completion/install.txt
@@ -7,7 +7,7 @@ The line is tagged so it can be cleanly removed with:
 
 ## Usage
 
-`circleci completion install`
+`circleci completion install [flags]`
 
 ## Inherited Flags
 

--- a/internal/cmd/root/testdata/help/circleci/completion/uninstall.txt
+++ b/internal/cmd/root/testdata/help/circleci/completion/uninstall.txt
@@ -5,7 +5,7 @@ Other content in your shell profile is left untouched.
 
 ## Usage
 
-`circleci completion uninstall`
+`circleci completion uninstall [flags]`
 
 ## Inherited Flags
 

--- a/internal/cmd/root/testdata/help/circleci/completion/zsh.txt
+++ b/internal/cmd/root/testdata/help/circleci/completion/zsh.txt
@@ -4,7 +4,7 @@ Generate zsh completion script
 
 ## Usage
 
-`circleci completion zsh`
+`circleci completion zsh [flags]`
 
 ## Inherited Flags
 

--- a/internal/cmd/root/testdata/help/circleci/config.txt
+++ b/internal/cmd/root/testdata/help/circleci/config.txt
@@ -7,7 +7,7 @@ tool settings (API token, host, defaults), use 'circleci settings'.
 
 ## Usage
 
-`circleci config <command>`
+`circleci config <command> [flags]`
 
 ## Available Commands
 

--- a/internal/cmd/root/testdata/help/circleci/config/generate.txt
+++ b/internal/cmd/root/testdata/help/circleci/config/generate.txt
@@ -13,7 +13,7 @@ directory is created if needed, and the file is written atomically.
 
 ## Usage
 
-`circleci config generate [path]`
+`circleci config generate [path] [flags]`
 
 ## Inherited Flags
 

--- a/internal/cmd/root/testdata/help/circleci/config/pack.txt
+++ b/internal/cmd/root/testdata/help/circleci/config/pack.txt
@@ -19,7 +19,7 @@ The merged YAML is printed to stdout.
 
 ## Usage
 
-`circleci config pack <path>`
+`circleci config pack <path> [flags]`
 
 ## Inherited Flags
 

--- a/internal/cmd/root/testdata/help/circleci/context.txt
+++ b/internal/cmd/root/testdata/help/circleci/context.txt
@@ -8,7 +8,7 @@ reference a context to inject its variables into the build environment.
 
 ## Usage
 
-`circleci context <command>`
+`circleci context <command> [flags]`
 
 ## Available Commands
 

--- a/internal/cmd/root/testdata/help/circleci/context/create.txt
+++ b/internal/cmd/root/testdata/help/circleci/context/create.txt
@@ -8,6 +8,8 @@ gh/myorg or bitbucket/myorg.
 
 JSON fields: id, name, created_at
 
+For more information about output formatting flags, see `circleci help formatting`.
+
 ## Usage
 
 `circleci context create <name> [flags]`

--- a/internal/cmd/root/testdata/help/circleci/context/get.txt
+++ b/internal/cmd/root/testdata/help/circleci/context/get.txt
@@ -12,6 +12,8 @@ expose secret values after they are set.
 
 JSON fields: id, name, org_id, created_at, environment_variables, restrictions
 
+For more information about output formatting flags, see `circleci help formatting`.
+
 ## Usage
 
 `circleci context get <context-id|context-name> [flags]`

--- a/internal/cmd/root/testdata/help/circleci/context/list.txt
+++ b/internal/cmd/root/testdata/help/circleci/context/list.txt
@@ -8,6 +8,8 @@ gh/myorg or bitbucket/myorg.
 
 JSON fields: id, name, created_at
 
+For more information about output formatting flags, see `circleci help formatting`.
+
 ## Usage
 
 `circleci context list [flags]`

--- a/internal/cmd/root/testdata/help/circleci/context/restriction.txt
+++ b/internal/cmd/root/testdata/help/circleci/context/restriction.txt
@@ -9,7 +9,7 @@ accessible to all members of the organization.
 
 ## Usage
 
-`circleci context restriction <command>`
+`circleci context restriction <command> [flags]`
 
 ## Available Commands
 

--- a/internal/cmd/root/testdata/help/circleci/context/restriction/create.txt
+++ b/internal/cmd/root/testdata/help/circleci/context/restriction/create.txt
@@ -11,6 +11,8 @@ organization can be inferred from the remote.
 
 JSON fields: id, name, restriction_type, restriction_value
 
+For more information about output formatting flags, see `circleci help formatting`.
+
 ## Usage
 
 `circleci context restriction create <context-id|context-name> [flags]`

--- a/internal/cmd/root/testdata/help/circleci/context/secret.txt
+++ b/internal/cmd/root/testdata/help/circleci/context/secret.txt
@@ -7,7 +7,7 @@ context. Variable values are never returned by the API after being set.
 
 ## Usage
 
-`circleci context secret <command>`
+`circleci context secret <command> [flags]`
 
 ## Available Commands
 

--- a/internal/cmd/root/testdata/help/circleci/context/secret/list.txt
+++ b/internal/cmd/root/testdata/help/circleci/context/secret/list.txt
@@ -11,6 +11,8 @@ organization can be inferred from the remote.
 
 JSON fields: variable, truncated_value, context_id, created_at, updated_at
 
+For more information about output formatting flags, see `circleci help formatting`.
+
 ## Usage
 
 `circleci context secret list <context-id|context-name> [flags]`

--- a/internal/cmd/root/testdata/help/circleci/deploy.txt
+++ b/internal/cmd/root/testdata/help/circleci/deploy.txt
@@ -6,7 +6,7 @@ View deployed components and their versions across environments.
 
 ## Usage
 
-`circleci deploy <command>`
+`circleci deploy <command> [flags]`
 
 ## Available Commands
 

--- a/internal/cmd/root/testdata/help/circleci/deploy/list.txt
+++ b/internal/cmd/root/testdata/help/circleci/deploy/list.txt
@@ -9,6 +9,8 @@ version, status, type, and when it was created.
 JSON fields: id, component_name, version, type, status, is_rollback,
              pipeline_id, workflow_id, created_at, ended_at
 
+For more information about output formatting flags, see `circleci help formatting`.
+
 ## Usage
 
 `circleci deploy list [flags]`

--- a/internal/cmd/root/testdata/help/circleci/dlc.txt
+++ b/internal/cmd/root/testdata/help/circleci/dlc.txt
@@ -10,7 +10,7 @@ These commands are also available under 'circleci project dlc'.
 
 ## Usage
 
-`circleci dlc <command>`
+`circleci dlc <command> [flags]`
 
 ## Available Commands
 

--- a/internal/cmd/root/testdata/help/circleci/environment.txt
+++ b/internal/cmd/root/testdata/help/circleci/environment.txt
@@ -1,0 +1,14 @@
+# Environment
+`CIRCLE_TOKEN`: an authentication token that will be used for API requests. Setting this avoids
+being prompted to authenticate and takes precedence over previously stored credentials.
+
+`CIRCLE_HOST`: specify the CircleCI hostname.
+
+`NO_COLOR`: set to any value to avoid printing ANSI escape sequences for color output.
+
+`CIRCLE_NO_TELEMETRY`: set to any value to disable telemetry.
+
+`NO_ANALYTICS`: set to any value to disable telemetry.
+
+`DO_NOT_TRACK`: set to any value to disable telemetry.
+

--- a/internal/cmd/root/testdata/help/circleci/envvar.txt
+++ b/internal/cmd/root/testdata/help/circleci/envvar.txt
@@ -12,7 +12,7 @@ Also available as: circleci project envvar <command>
 
 ## Usage
 
-`circleci envvar <command>`
+`circleci envvar <command> [flags]`
 
 ## Available Commands
 

--- a/internal/cmd/root/testdata/help/circleci/envvar/list.txt
+++ b/internal/cmd/root/testdata/help/circleci/envvar/list.txt
@@ -10,6 +10,8 @@ unless overridden with --project.
 
 JSON fields: name, value
 
+For more information about output formatting flags, see `circleci help formatting`.
+
 ## Usage
 
 `circleci envvar list [flags]`

--- a/internal/cmd/root/testdata/help/circleci/formatting.txt
+++ b/internal/cmd/root/testdata/help/circleci/formatting.txt
@@ -1,0 +1,49 @@
+# Formatting
+By default, the result of `circleci` commands are output in markdown text format.
+Some commands support passing the `--json` flag, which converts the output to JSON format.
+Once in JSON, the output can be further formatted according to a required formatting string by
+adding either the `--jq` or `--template` flag. This is useful for selecting a subset of data,
+creating new data structures, displaying the data in a different format, or as input to another
+command line script.
+
+The `--json` flag requires a comma separated list of fields to fetch. To view the possible JSON
+field names for a command omit the string argument to the `--json` flag when you run the command.
+Note that you must pass the `--json` flag and field names to use the `--jq` flag.
+
+The `--jq` flag requires a string argument in jq query syntax, and will only print
+those JSON values which match the query. jq queries can be used to select elements from an
+array, fields from an object, create a new array, and more. The `jq` utility does not need
+to be installed on the system to use this formatting directive. When connected to a terminal,
+the output is automatically pretty-printed. To learn about jq query syntax, see:
+<https://jqlang.github.io/jq/manual/>
+
+
+
+Examples
+  ## Default output format
+  $ circleci auth me
+  ```text
+  # User
+  - ID: `c257a143-1fde-4dfe-8cf9-2a85a955f1f7`
+  - Name: Your Name
+  - Login: username
+  - Avatar URL: https://avatars.githubusercontent.com/u/9812739817239?v=4
+  ```
+  
+  ## Adding the --json flag with a list of field names
+  $ circleci auth me --json
+  ```json
+  {
+    "name": "Your Name",
+    "login": "username",
+    "id": "c257a143-1fde-4dfe-8cf9-2a85a955f1f7",
+    "avatar_url": "https://avatars.githubusercontent.com/u/9812739817239?v=4"
+  }
+  ```
+  
+  ## Adding the --jq flag and selecting a field
+  $ circleci auth me --json --jq '.login'
+  ```text
+  username
+  ```
+  

--- a/internal/cmd/root/testdata/help/circleci/job.txt
+++ b/internal/cmd/root/testdata/help/circleci/job.txt
@@ -6,7 +6,7 @@ Jobs are the individual units of work within a workflow.
 
 ## Usage
 
-`circleci job <command>`
+`circleci job <command> [flags]`
 
 ## Available Commands
 

--- a/internal/cmd/root/testdata/help/circleci/job/artifact.txt
+++ b/internal/cmd/root/testdata/help/circleci/job/artifact.txt
@@ -7,6 +7,8 @@ them to a local directory.
 
 JSON fields: path, url, node_index
 
+For more information about output formatting flags, see `circleci help formatting`.
+
 ## Usage
 
 `circleci job artifact <job-id> [flags]`

--- a/internal/cmd/root/testdata/help/circleci/job/get.txt
+++ b/internal/cmd/root/testdata/help/circleci/job/get.txt
@@ -9,6 +9,8 @@ JSON fields: id, name, type, status, started_at, stopped_at,
              project_id, pipeline_id, workflow_id,
              executions[].index/steps[].name/type/status/duration/exit_code
 
+For more information about output formatting flags, see `circleci help formatting`.
+
 ## Usage
 
 `circleci job get <job-id> [flags]`

--- a/internal/cmd/root/testdata/help/circleci/job/output.txt
+++ b/internal/cmd/root/testdata/help/circleci/job/output.txt
@@ -7,7 +7,7 @@ jobs, an execution index selects which executor's output to fetch.
 
 ## Usage
 
-`circleci job output <command>`
+`circleci job output <command> [flags]`
 
 ## Available Commands
 

--- a/internal/cmd/root/testdata/help/circleci/job/output/list.txt
+++ b/internal/cmd/root/testdata/help/circleci/job/output/list.txt
@@ -15,6 +15,8 @@ JSON fields: id, name, execution,
              steps[].num/name/type/phase/outcome/started_at/stopped_at/
              exit_code/command/output
 
+For more information about output formatting flags, see `circleci help formatting`.
+
 ## Usage
 
 `circleci job output list <job-id> [flags]`

--- a/internal/cmd/root/testdata/help/circleci/mcp.txt
+++ b/internal/cmd/root/testdata/help/circleci/mcp.txt
@@ -4,7 +4,7 @@ Manage MCP servers for AI assistants and code editors
 
 ## Usage
 
-`circleci mcp`
+`circleci mcp [flags]`
 
 ## Available Commands
 

--- a/internal/cmd/root/testdata/help/circleci/mcp/claude.txt
+++ b/internal/cmd/root/testdata/help/circleci/mcp/claude.txt
@@ -4,7 +4,7 @@ Manage MCP server configuration for Claude Desktop
 
 ## Usage
 
-`circleci mcp claude`
+`circleci mcp claude [flags]`
 
 ## Available Commands
 

--- a/internal/cmd/root/testdata/help/circleci/mcp/cursor.txt
+++ b/internal/cmd/root/testdata/help/circleci/mcp/cursor.txt
@@ -4,7 +4,7 @@ Manage MCP server configuration for Cursor
 
 ## Usage
 
-`circleci mcp cursor`
+`circleci mcp cursor [flags]`
 
 ## Available Commands
 

--- a/internal/cmd/root/testdata/help/circleci/mcp/vscode.txt
+++ b/internal/cmd/root/testdata/help/circleci/mcp/vscode.txt
@@ -4,7 +4,7 @@ Manage MCP server configuration for Visual Studio Code
 
 ## Usage
 
-`circleci mcp vscode`
+`circleci mcp vscode [flags]`
 
 ## Available Commands
 

--- a/internal/cmd/root/testdata/help/circleci/namespace.txt
+++ b/internal/cmd/root/testdata/help/circleci/namespace.txt
@@ -8,7 +8,7 @@ and referenced as <namespace>/<orb>. All published orbs are world-readable.
 
 ## Usage
 
-`circleci namespace <command>`
+`circleci namespace <command> [flags]`
 
 ## Available Commands
 

--- a/internal/cmd/root/testdata/help/circleci/namespace/create.txt
+++ b/internal/cmd/root/testdata/help/circleci/namespace/create.txt
@@ -8,6 +8,8 @@ namespace are world-readable.
 
 JSON fields: id, name
 
+For more information about output formatting flags, see `circleci help formatting`.
+
 ## Usage
 
 `circleci namespace create <name> --org-id <uuid> [flags]`

--- a/internal/cmd/root/testdata/help/circleci/namespace/get.txt
+++ b/internal/cmd/root/testdata/help/circleci/namespace/get.txt
@@ -4,6 +4,8 @@ Display details of a CircleCI orb namespace.
 
 JSON fields: id, name
 
+For more information about output formatting flags, see `circleci help formatting`.
+
 ## Usage
 
 `circleci namespace get <name> [flags]`

--- a/internal/cmd/root/testdata/help/circleci/namespace/rename.txt
+++ b/internal/cmd/root/testdata/help/circleci/namespace/rename.txt
@@ -8,6 +8,8 @@ and orbs still referencing the old name are updated.
 
 JSON fields: id, name
 
+For more information about output formatting flags, see `circleci help formatting`.
+
 ## Usage
 
 `circleci namespace rename <name> <new-name> [flags]`

--- a/internal/cmd/root/testdata/help/circleci/orb.txt
+++ b/internal/cmd/root/testdata/help/circleci/orb.txt
@@ -9,7 +9,7 @@ Use 'circleci namespace' to manage namespaces before publishing orbs.
 
 ## Usage
 
-`circleci orb <command>`
+`circleci orb <command> [flags]`
 
 ## Available Commands
 

--- a/internal/cmd/root/testdata/help/circleci/orb/add-to-category.txt
+++ b/internal/cmd/root/testdata/help/circleci/orb/add-to-category.txt
@@ -7,7 +7,7 @@ to see available categories.
 
 ## Usage
 
-`circleci orb add-to-category <ns>/<orb> <category>`
+`circleci orb add-to-category <ns>/<orb> <category> [flags]`
 
 ## Inherited Flags
 

--- a/internal/cmd/root/testdata/help/circleci/orb/create.txt
+++ b/internal/cmd/root/testdata/help/circleci/orb/create.txt
@@ -10,6 +10,8 @@ to create a namespace if needed.
 
 JSON fields: id, name, namespace, is_private
 
+For more information about output formatting flags, see `circleci help formatting`.
+
 ## Usage
 
 `circleci orb create <namespace>/<orb> [flags]`

--- a/internal/cmd/root/testdata/help/circleci/orb/diff.txt
+++ b/internal/cmd/root/testdata/help/circleci/orb/diff.txt
@@ -9,7 +9,7 @@ Exit code is 0 regardless of whether the versions differ.
 
 ## Usage
 
-`circleci orb diff <ns>/<orb> <v1> <v2>`
+`circleci orb diff <ns>/<orb> <v1> <v2> [flags]`
 
 ## Inherited Flags
 

--- a/internal/cmd/root/testdata/help/circleci/orb/get.txt
+++ b/internal/cmd/root/testdata/help/circleci/orb/get.txt
@@ -9,6 +9,8 @@ all published versions.
 JSON fields: id, name, namespace, is_private, is_listed, created_at,
              latest_version, categories, versions, stats
 
+For more information about output formatting flags, see `circleci help formatting`.
+
 ## Usage
 
 `circleci orb get <ns>/<orb>[@<version>]/<orb-id> [flags]`

--- a/internal/cmd/root/testdata/help/circleci/orb/list-categories.txt
+++ b/internal/cmd/root/testdata/help/circleci/orb/list-categories.txt
@@ -7,6 +7,8 @@ Categories are used to organize and discover orbs. Use
 
 JSON fields: id, name
 
+For more information about output formatting flags, see `circleci help formatting`.
+
 ## Usage
 
 `circleci orb list-categories [flags]`

--- a/internal/cmd/root/testdata/help/circleci/orb/list.txt
+++ b/internal/cmd/root/testdata/help/circleci/orb/list.txt
@@ -10,6 +10,8 @@ Use --private to list only private orbs (requires namespace).
 
 JSON fields: id, name, is_private, is_listed, latest_version
 
+For more information about output formatting flags, see `circleci help formatting`.
+
 ## Usage
 
 `circleci orb list [<namespace>] [flags]`

--- a/internal/cmd/root/testdata/help/circleci/orb/pack.txt
+++ b/internal/cmd/root/testdata/help/circleci/orb/pack.txt
@@ -13,7 +13,7 @@ The merged YAML is written to stdout.
 
 ## Usage
 
-`circleci orb pack <path>`
+`circleci orb pack <path> [flags]`
 
 ## Inherited Flags
 

--- a/internal/cmd/root/testdata/help/circleci/orb/publish.txt
+++ b/internal/cmd/root/testdata/help/circleci/orb/publish.txt
@@ -13,7 +13,7 @@ To increment the latest stable version and publish:
 
 ## Usage
 
-`circleci orb publish <command>`
+`circleci orb publish <command> [flags]`
 
 ## Available Commands
 

--- a/internal/cmd/root/testdata/help/circleci/orb/publish/increment.txt
+++ b/internal/cmd/root/testdata/help/circleci/orb/publish/increment.txt
@@ -10,7 +10,7 @@ Pass '-' as the path to read from stdin.
 
 ## Usage
 
-`circleci orb publish increment <path> <ns>/<orb> major|minor|patch`
+`circleci orb publish increment <path> <ns>/<orb> major|minor|patch [flags]`
 
 ## Inherited Flags
 

--- a/internal/cmd/root/testdata/help/circleci/orb/publish/promote.txt
+++ b/internal/cmd/root/testdata/help/circleci/orb/publish/promote.txt
@@ -8,7 +8,7 @@ from the latest stable release.
 
 ## Usage
 
-`circleci orb publish promote <ns>/<orb>@dev:<label> major|minor|patch`
+`circleci orb publish promote <ns>/<orb>@dev:<label> major|minor|patch [flags]`
 
 ## Inherited Flags
 

--- a/internal/cmd/root/testdata/help/circleci/orb/remove-from-category.txt
+++ b/internal/cmd/root/testdata/help/circleci/orb/remove-from-category.txt
@@ -8,7 +8,7 @@ categories.
 
 ## Usage
 
-`circleci orb remove-from-category <ns>/<orb> <category>`
+`circleci orb remove-from-category <ns>/<orb> <category> [flags]`
 
 ## Inherited Flags
 

--- a/internal/cmd/root/testdata/help/circleci/orb/source.txt
+++ b/internal/cmd/root/testdata/help/circleci/orb/source.txt
@@ -7,7 +7,7 @@ Specify a version with @<version> (e.g. @1.2.3 or @volatile for latest).
 
 ## Usage
 
-`circleci orb source <ns>/<orb>[@<version>]`
+`circleci orb source <ns>/<orb>[@<version>] [flags]`
 
 ## Inherited Flags
 

--- a/internal/cmd/root/testdata/help/circleci/orb/unlist.txt
+++ b/internal/cmd/root/testdata/help/circleci/orb/unlist.txt
@@ -9,7 +9,7 @@ Unlisted orbs can still be used if you know the exact orb reference.
 
 ## Usage
 
-`circleci orb unlist <ns>/<orb> true|false`
+`circleci orb unlist <ns>/<orb> true|false [flags]`
 
 ## Inherited Flags
 

--- a/internal/cmd/root/testdata/help/circleci/pipeline.txt
+++ b/internal/cmd/root/testdata/help/circleci/pipeline.txt
@@ -8,7 +8,7 @@ definition with 'circleci project trigger create'.
 
 ## Usage
 
-`circleci pipeline <command>`
+`circleci pipeline <command> [flags]`
 
 ## Available Commands
 

--- a/internal/cmd/root/testdata/help/circleci/pipeline/create.txt
+++ b/internal/cmd/root/testdata/help/circleci/pipeline/create.txt
@@ -21,6 +21,8 @@ JSON fields: id, name, description, created_at,
              checkout_source.provider,
              checkout_source.repo.external_id, checkout_source.repo.full_name
 
+For more information about output formatting flags, see `circleci help formatting`.
+
 ## Usage
 
 `circleci pipeline create [flags]`

--- a/internal/cmd/root/testdata/help/circleci/pipeline/list.txt
+++ b/internal/cmd/root/testdata/help/circleci/pipeline/list.txt
@@ -11,6 +11,8 @@ JSON fields: id, name, description, created_at,
              checkout_source.provider,
              checkout_source.repo.external_id, checkout_source.repo.full_name
 
+For more information about output formatting flags, see `circleci help formatting`.
+
 ## Usage
 
 `circleci pipeline list [flags]`

--- a/internal/cmd/root/testdata/help/circleci/pipeline/run.txt
+++ b/internal/cmd/root/testdata/help/circleci/pipeline/run.txt
@@ -24,6 +24,8 @@ the command exits 0 and prints the reason to stdout.
 JSON fields (triggered): id, state, number, created_at, triggered
 JSON fields (skipped):   triggered, message
 
+For more information about output formatting flags, see `circleci help formatting`.
+
 ## Usage
 
 `circleci pipeline run [flags]`

--- a/internal/cmd/root/testdata/help/circleci/policy.txt
+++ b/internal/cmd/root/testdata/help/circleci/policy.txt
@@ -11,7 +11,7 @@ Find it at: https://app.circleci.com/settings/organization
 
 ## Usage
 
-`circleci policy <command>`
+`circleci policy <command> [flags]`
 
 ## Available Commands
 

--- a/internal/cmd/root/testdata/help/circleci/policy/decide.txt
+++ b/internal/cmd/root/testdata/help/circleci/policy/decide.txt
@@ -9,6 +9,8 @@ With --strict, exits non-zero for HARD_FAIL or ERROR decisions.
 JSON fields: status, enabled_rules, hard_failures, soft_failures,
              violations, metadata
 
+For more information about output formatting flags, see `circleci help formatting`.
+
 ## Usage
 
 `circleci policy decide [flags]`

--- a/internal/cmd/root/testdata/help/circleci/policy/diff.txt
+++ b/internal/cmd/root/testdata/help/circleci/policy/diff.txt
@@ -5,6 +5,8 @@ bundle without making any changes.
 
 JSON fields: created, deleted, updated (policy names)
 
+For more information about output formatting flags, see `circleci help formatting`.
+
 ## Usage
 
 `circleci policy diff <path> [flags]`

--- a/internal/cmd/root/testdata/help/circleci/policy/fetch.txt
+++ b/internal/cmd/root/testdata/help/circleci/policy/fetch.txt
@@ -7,6 +7,8 @@ Output is always JSON (the bundle is structured data).
 
 JSON fields: policies (map of name → Rego source)
 
+For more information about output formatting flags, see `circleci help formatting`.
+
 ## Usage
 
 `circleci policy fetch [policy-name] [flags]`

--- a/internal/cmd/root/testdata/help/circleci/policy/logs.txt
+++ b/internal/cmd/root/testdata/help/circleci/policy/logs.txt
@@ -12,6 +12,8 @@ Use --out to write results to a file.
 JSON fields: id, status, created_at, org_id, project_id, branch,
              build_number, policies, decision, metadata
 
+For more information about output formatting flags, see `circleci help formatting`.
+
 ## Usage
 
 `circleci policy logs [decision-id] [flags]`

--- a/internal/cmd/root/testdata/help/circleci/policy/push.txt
+++ b/internal/cmd/root/testdata/help/circleci/policy/push.txt
@@ -10,6 +10,8 @@ owner and policy context.
 
 JSON fields: created, deleted, updated (policy names)
 
+For more information about output formatting flags, see `circleci help formatting`.
+
 ## Usage
 
 `circleci policy push <path> [flags]`

--- a/internal/cmd/root/testdata/help/circleci/policy/settings.txt
+++ b/internal/cmd/root/testdata/help/circleci/policy/settings.txt
@@ -7,7 +7,7 @@ against the policy bundle before running.
 
 ## Usage
 
-`circleci policy settings <command>`
+`circleci policy settings <command> [flags]`
 
 ## Available Commands
 

--- a/internal/cmd/root/testdata/help/circleci/policy/settings/get.txt
+++ b/internal/cmd/root/testdata/help/circleci/policy/settings/get.txt
@@ -4,6 +4,8 @@ Retrieve the current policy enforcement settings for an organization.
 
 JSON fields: enabled
 
+For more information about output formatting flags, see `circleci help formatting`.
+
 ## Usage
 
 `circleci policy settings get [flags]`

--- a/internal/cmd/root/testdata/help/circleci/policy/settings/set.txt
+++ b/internal/cmd/root/testdata/help/circleci/policy/settings/set.txt
@@ -7,6 +7,8 @@ before each run. Configs that produce a HARD_FAIL decision are blocked.
 
 JSON fields: enabled
 
+For more information about output formatting flags, see `circleci help formatting`.
+
 ## Usage
 
 `circleci policy settings set [flags]`

--- a/internal/cmd/root/testdata/help/circleci/project.txt
+++ b/internal/cmd/root/testdata/help/circleci/project.txt
@@ -12,7 +12,7 @@ To manage environment variables directly, use the top-level alias:
 
 ## Usage
 
-`circleci project <command>`
+`circleci project <command> [flags]`
 
 ## Available Commands
 

--- a/internal/cmd/root/testdata/help/circleci/project/dlc.txt
+++ b/internal/cmd/root/testdata/help/circleci/project/dlc.txt
@@ -10,7 +10,7 @@ These commands are also available under 'circleci project dlc'.
 
 ## Usage
 
-`circleci project dlc <command>`
+`circleci project dlc <command> [flags]`
 
 ## Available Commands
 

--- a/internal/cmd/root/testdata/help/circleci/project/envvar.txt
+++ b/internal/cmd/root/testdata/help/circleci/project/envvar.txt
@@ -10,7 +10,7 @@ For quick access, use the top-level alias:
 
 ## Usage
 
-`circleci project envvar <command>`
+`circleci project envvar <command> [flags]`
 
 ## Available Commands
 

--- a/internal/cmd/root/testdata/help/circleci/project/envvar/list.txt
+++ b/internal/cmd/root/testdata/help/circleci/project/envvar/list.txt
@@ -10,6 +10,8 @@ unless overridden with --project.
 
 JSON fields: name, value
 
+For more information about output formatting flags, see `circleci help formatting`.
+
 ## Usage
 
 `circleci project envvar list [flags]`

--- a/internal/cmd/root/testdata/help/circleci/project/list.txt
+++ b/internal/cmd/root/testdata/help/circleci/project/list.txt
@@ -8,6 +8,8 @@ following a new project.
 
 JSON fields: slug, name, vcs_type, username, reponame
 
+For more information about output formatting flags, see `circleci help formatting`.
+
 ## Usage
 
 `circleci project list [flags]`

--- a/internal/cmd/root/testdata/help/circleci/project/trigger.txt
+++ b/internal/cmd/root/testdata/help/circleci/project/trigger.txt
@@ -8,7 +8,7 @@ connected via the CircleCI GitHub App are supported.
 
 ## Usage
 
-`circleci project trigger <command>`
+`circleci project trigger <command> [flags]`
 
 ## Available Commands
 

--- a/internal/cmd/root/testdata/help/circleci/project/trigger/create.txt
+++ b/internal/cmd/root/testdata/help/circleci/project/trigger/create.txt
@@ -36,6 +36,8 @@ Valid --event-preset values:
 JSON fields: id, created_at, event_name, event_preset, config_ref,
              checkout_ref, disabled
 
+For more information about output formatting flags, see `circleci help formatting`.
+
 ## Usage
 
 `circleci project trigger create [flags]`

--- a/internal/cmd/root/testdata/help/circleci/project/trigger/list.txt
+++ b/internal/cmd/root/testdata/help/circleci/project/trigger/list.txt
@@ -13,6 +13,8 @@ JSON fields: id, created_at, event_name, event_preset, config_ref,
              checkout_ref, disabled, event_source.provider,
              event_source.repo.external_id, event_source.repo.full_name
 
+For more information about output formatting flags, see `circleci help formatting`.
+
 ## Usage
 
 `circleci project trigger list [flags]`

--- a/internal/cmd/root/testdata/help/circleci/reference.txt
+++ b/internal/cmd/root/testdata/help/circleci/reference.txt
@@ -1,0 +1,1382 @@
+# Reference
+## `circleci api <path> [flags]`
+
+Make an API call
+
+| Flag                       | Description                                                                       |
+| -------------------------- | --------------------------------------------------------------------------------- |
+| `-f, --field stringArray`  | Add a field: key=value (query param for GET/DELETE, JSON body for POST/PUT/PATCH) |
+| `-H, --header stringArray` | Add a request header: "Key: Value"                                                |
+| `--jq string`              | Process values from the response using jq syntax                                  |
+| `-X, --method string`      | HTTP method (default: GET, or POST when -f is used)                               |
+
+
+## `circleci artifact <job-id> [flags]`
+
+List or download job artifacts
+
+| Flag                    | Description                                      |
+| ----------------------- | ------------------------------------------------ |
+| `-d, --download string` | Download artifacts into this directory           |
+| `--jq string`           | Process values from the response using jq syntax |
+| `--json`                | Output as JSON                                   |
+
+
+## `circleci auth <command>`
+
+Authenticate with CircleCI
+
+### `circleci auth id [flags]`
+
+Show the device ID for this CLI installation
+
+| Flag     | Description    |
+| -------- | -------------- |
+| `--json` | Output as JSON |
+
+
+### `circleci auth login [flags]`
+
+Log in to a CircleCI account
+
+| Flag           | Description                                          |
+| -------------- | ---------------------------------------------------- |
+| `--no-browser` | Print the authorize URL instead of opening a browser |
+
+
+### `circleci auth logout [flags]`
+
+Log out of a CircleCI account
+
+| Flag          | Description                                      |
+| ------------- | ------------------------------------------------ |
+| `--jq string` | Process values from the response using jq syntax |
+| `--json`      | Output as JSON                                   |
+
+
+### `circleci auth me [flags]`
+
+Display active account information
+
+| Flag          | Description                                      |
+| ------------- | ------------------------------------------------ |
+| `--jq string` | Process values from the response using jq syntax |
+| `--json`      | Output as JSON                                   |
+
+
+### `circleci auth signup [flags]`
+
+Sign-up for a new CircleCI account
+
+| Flag           | Description                                          |
+| -------------- | ---------------------------------------------------- |
+| `--no-browser` | Print the authorize URL instead of opening a browser |
+
+
+## `circleci certificate <command>`
+
+Manage iOS code signing certificates
+
+### `circleci certificate delete <cert-id> [flags]`
+
+Delete an iOS certificate
+
+| Flag          | Description              |
+| ------------- | ------------------------ |
+| `-f, --force` | skip confirmation prompt |
+
+
+### `circleci certificate list [flags]`
+
+List uploaded iOS certificates
+
+| Flag              | Description                                                                |
+| ----------------- | -------------------------------------------------------------------------- |
+| `--jq string`     | Process values from the response using jq syntax                           |
+| `--json`          | Output as JSON                                                             |
+| `--org-id string` | CircleCI organization UUID; defaults to the org of the current git project |
+
+
+Aliases:
+
+
+`circleci certificate ls`
+
+### `circleci certificate upload [flags]`
+
+Upload a .p12 certificate
+
+| Flag                 | Description                                                                               |
+| -------------------- | ----------------------------------------------------------------------------------------- |
+| `--cert-file string` | Path to the .p12 certificate file                                                         |
+| `--jq string`        | Process values from the response using jq syntax                                          |
+| `--json`             | Output as JSON                                                                            |
+| `--org-id string`    | CircleCI organization UUID; defaults to the org of the current git project                |
+| `--password string`  | Password for the .p12 file. Pass - to read from stdin. Prompted if omitted in a terminal. |
+
+
+## `circleci completion <command>`
+
+Manage shell completions
+
+### `circleci completion install`
+
+Install shell completion into your shell profile
+
+### `circleci completion uninstall`
+
+Remove shell completion from your shell profile
+
+## `circleci config <command>`
+
+Work with pipeline config
+
+### `circleci config generate [path]`
+
+Generate .circleci/config.yml from a repository scan
+
+### `circleci config pack <path>`
+
+Bundle split config files into a single YAML document
+
+### `circleci config process <path> [flags]`
+
+Compile and expand a pipeline config file
+
+| Flag                           | Description                                                  |
+| ------------------------------ | ------------------------------------------------------------ |
+| `--org-id string`              | Organization UUID for private orb resolution                 |
+| `-o, --org-slug string`        | Organization slug for private orb resolution (e.g. gh/myorg) |
+| `--pipeline-parameters string` | Pipeline parameters as a YAML map or path to a YAML file     |
+
+
+### `circleci config validate [flags]`
+
+Validate a pipeline config file
+
+| Flag                    | Description                                                              |
+| ----------------------- | ------------------------------------------------------------------------ |
+| `-c, --config string`   | Path to config file (use "-" for stdin) (default ".circleci/config.yml") |
+| `--json`                | Output as JSON                                                           |
+| `--org-id string`       | Organization UUID for private orb resolution                             |
+| `-o, --org-slug string` | Organization slug for private orb resolution (e.g. gh/myorg)             |
+
+
+## `circleci context <command>`
+
+Manage contexts
+
+### `circleci context create <name> [flags]`
+
+Create a new context
+
+| Flag           | Description                                               |
+| -------------- | --------------------------------------------------------- |
+| `--jq string`  | Process values from the response using jq syntax          |
+| `--json`       | Output as JSON                                            |
+| `--org string` | Organization slug (e.g. gh/myorg); defaults to git remote |
+
+
+### `circleci context delete <context-id|context-name> [flags]`
+
+Delete a context
+
+| Flag           | Description                                                       |
+| -------------- | ----------------------------------------------------------------- |
+| `-f, --force`  | skip confirmation prompt                                          |
+| `--org string` | Organization slug (e.g. gh/myorg); used when resolving name to ID |
+
+
+### `circleci context get <context-id|context-name> [flags]`
+
+Get details of a context
+
+| Flag           | Description                                                       |
+| -------------- | ----------------------------------------------------------------- |
+| `--jq string`  | Process values from the response using jq syntax                  |
+| `--json`       | Output as JSON                                                    |
+| `--org string` | Organization slug (e.g. gh/myorg); used when resolving name to ID |
+
+
+### `circleci context list [flags]`
+
+List contexts for an organization
+
+| Flag            | Description                                               |
+| --------------- | --------------------------------------------------------- |
+| `--jq string`   | Process values from the response using jq syntax          |
+| `--json`        | Output as JSON                                            |
+| `--name string` | Find contexts by name (partial match)                     |
+| `--org string`  | Organization slug (e.g. gh/myorg); defaults to git remote |
+
+
+Aliases:
+
+
+`circleci context ls`
+
+### `circleci context open [flags]`
+
+Open the contexts settings page in the browser
+
+| Flag           | Description                                               |
+| -------------- | --------------------------------------------------------- |
+| `--org string` | Organization slug (e.g. gh/myorg); defaults to git remote |
+
+
+### `circleci context restriction <command>`
+
+Manage context restrictions
+
+#### `circleci context restriction create <context-id|context-name> [flags]`
+
+Add a restriction to a context
+
+| Flag             | Description                                                       |
+| ---------------- | ----------------------------------------------------------------- |
+| `--jq string`    | Process values from the response using jq syntax                  |
+| `--json`         | Output as JSON                                                    |
+| `--org string`   | Organization slug (e.g. gh/myorg); used when resolving name to ID |
+| `--type string`  | Restriction type: project, expression, or group                   |
+| `--value string` | Value of the restriction                                          |
+
+
+#### `circleci context restriction delete <context-id|context-name> [flags]`
+
+Delete a restriction from a context
+
+| Flag                      | Description                                                       |
+| ------------------------- | ----------------------------------------------------------------- |
+| `-f, --force`             | Skip confirmation prompt                                          |
+| `--org string`            | Organization slug (e.g. gh/myorg); used when resolving name to ID |
+| `--restriction-id string` | UUID of the restriction to delete                                 |
+
+
+### `circleci context secret <command>`
+
+Manage context environment variables
+
+#### `circleci context secret delete <context-id|context-name> [flags]`
+
+Delete an environment variable from a context
+
+| Flag            | Description                                                       |
+| --------------- | ----------------------------------------------------------------- |
+| `-f, --force`   | skip confirmation prompt                                          |
+| `--name string` | Name of the environment variable to delete                        |
+| `--org string`  | Organization slug (e.g. gh/myorg); used when resolving name to ID |
+
+
+#### `circleci context secret list <context-id|context-name> [flags]`
+
+List environment variables in a context
+
+| Flag           | Description                                                       |
+| -------------- | ----------------------------------------------------------------- |
+| `--jq string`  | Process values from the response using jq syntax                  |
+| `--json`       | Output as JSON                                                    |
+| `--org string` | Organization slug (e.g. gh/myorg); used when resolving name to ID |
+
+
+Aliases:
+
+
+`circleci context secret ls`
+
+#### `circleci context secret set <context-id|context-name> [flags]`
+
+Set an environment variable in a context
+
+| Flag             | Description                                                           |
+| ---------------- | --------------------------------------------------------------------- |
+| `--name string`  | Name of the environment variable                                      |
+| `--org string`   | Organization slug (e.g. gh/myorg); used when resolving name to ID     |
+| `--value string` | Value of the environment variable (prompted if omitted in a terminal) |
+
+
+## `circleci deploy <command>`
+
+Manage deploys
+
+### `circleci deploy init [flags]`
+
+Instrument your config for deploy tracking
+
+| Flag                       | Description                                                                |
+| -------------------------- | -------------------------------------------------------------------------- |
+| `--component string`       | Service/component name (skips prompt)                                      |
+| `--environment string`     | Default environment for jobs whose target can't be inferred (skips prompt) |
+| `--pipeline-config string` | Path to CircleCI pipeline config file (default ".circleci/config.yml")     |
+
+
+### `circleci deploy list [flags]`
+
+List recent deploys
+
+| Flag               | Description                                             |
+| ------------------ | ------------------------------------------------------- |
+| `--jq string`      | Process values from the response using jq syntax        |
+| `--json`           | Output as JSON                                          |
+| `--project string` | Project slug (e.g. gh/org/repo); defaults to git remote |
+
+
+Aliases:
+
+
+`circleci deploy ls`
+
+### `circleci deploy open [flags]`
+
+Open the deploys page in the browser
+
+| Flag               | Description                                             |
+| ------------------ | ------------------------------------------------------- |
+| `--project string` | Project slug (e.g. gh/org/repo); defaults to git remote |
+
+
+## `circleci dlc <command>`
+
+Manage docker layer caching
+
+### `circleci dlc purge --project <slug> [flags]`
+
+Purge the Docker Layer Cache for a project
+
+| Flag               | Description                                             |
+| ------------------ | ------------------------------------------------------- |
+| `--json`           | Output as JSON                                          |
+| `--project string` | Project slug (e.g. gh/org/repo); defaults to git remote |
+
+
+## `circleci envvar <command>`
+
+Manage project environment variables
+
+### `circleci envvar delete <name> [flags]`
+
+Delete a project environment variable
+
+| Flag               | Description                                             |
+| ------------------ | ------------------------------------------------------- |
+| `-f, --force`      | skip confirmation prompt                                |
+| `--project string` | Project slug (e.g. gh/org/repo); defaults to git remote |
+
+
+### `circleci envvar list [flags]`
+
+List project environment variables
+
+| Flag               | Description                                             |
+| ------------------ | ------------------------------------------------------- |
+| `--jq string`      | Process values from the response using jq syntax        |
+| `--json`           | Output as JSON                                          |
+| `--project string` | Project slug (e.g. gh/org/repo); defaults to git remote |
+
+
+### `circleci envvar set <name> <value> [flags]`
+
+Set a project environment variable
+
+| Flag               | Description                                             |
+| ------------------ | ------------------------------------------------------- |
+| `--project string` | Project slug (e.g. gh/org/repo); defaults to git remote |
+
+
+## `circleci job <command>`
+
+Manage jobs
+
+### `circleci job artifact <job-id> [flags]`
+
+List or download artifacts for a job
+
+| Flag                    | Description                                      |
+| ----------------------- | ------------------------------------------------ |
+| `-d, --download string` | Download artifacts into this directory           |
+| `--jq string`           | Process values from the response using jq syntax |
+| `--json`                | Output as JSON                                   |
+
+
+### `circleci job get <job-id> [flags]`
+
+Get job details
+
+| Flag          | Description                                      |
+| ------------- | ------------------------------------------------ |
+| `--jq string` | Process values from the response using jq syntax |
+| `--json`      | Output as JSON                                   |
+
+
+### `circleci job output <command>`
+
+Work with job step output
+
+#### `circleci job output get <job-id> [flags]`
+
+Get the output of a job step
+
+| Flag              | Description                                             |
+| ----------------- | ------------------------------------------------------- |
+| `--execution int` | Parallel execution index to read output from            |
+| `--step-num int`  | Step number whose output to fetch (required)            |
+| `--strip-ansi`    | Strip ANSI escape codes even when writing to a terminal |
+
+
+#### `circleci job output list <job-id> [flags]`
+
+List a job's steps with their output
+
+| Flag              | Description                                      |
+| ----------------- | ------------------------------------------------ |
+| `--execution int` | Parallel execution index to list output from     |
+| `--jq string`     | Process values from the response using jq syntax |
+| `--json`          | Output as JSON                                   |
+
+
+## `circleci mcp`
+
+MCP server management
+
+### `circleci mcp claude`
+
+Manage Claude Desktop MCP servers
+
+#### `circleci mcp claude disable [flags]`
+
+Remove server from Claude config
+
+| Flag                   | Description                                                              |
+| ---------------------- | ------------------------------------------------------------------------ |
+| `--config-path string` | Path to Claude config file                                               |
+| `--server-name string` | Name of the MCP server to remove (default: derived from executable name) |
+
+
+#### `circleci mcp claude enable [flags]`
+
+Add server to Claude config
+
+| Flag                       | Description                                                                    |
+| -------------------------- | ------------------------------------------------------------------------------ |
+| `--config-path string`     | Path to Claude config file                                                     |
+| `-e, --env stringToString` | Environment variables (e.g., --env KEY1=value1 --env KEY2=value2) (default []) |
+| `--log-level string`       | Log level (debug, info, warn, error)                                           |
+| `--server-name string`     | Name for the MCP server (default: derived from executable name)                |
+
+
+#### `circleci mcp claude list [flags]`
+
+Show Claude MCP servers
+
+| Flag                   | Description                |
+| ---------------------- | -------------------------- |
+| `--config-path string` | Path to Claude config file |
+
+
+### `circleci mcp cursor`
+
+Manage Cursor MCP servers
+
+#### `circleci mcp cursor disable [flags]`
+
+Remove server from Cursor config
+
+| Flag                   | Description                                                                |
+| ---------------------- | -------------------------------------------------------------------------- |
+| `--config-path string` | Path to Cursor config file                                                 |
+| `--server-name string` | Name of the MCP server to remove (default: derived from executable name)   |
+| `--workspace`          | Remove from workspace settings (.cursor/mcp.json) instead of user settings |
+
+
+#### `circleci mcp cursor enable [flags]`
+
+Add server to Cursor config
+
+| Flag                       | Description                                                                    |
+| -------------------------- | ------------------------------------------------------------------------------ |
+| `--config-path string`     | Path to Cursor config file                                                     |
+| `-e, --env stringToString` | Environment variables (e.g., --env KEY1=value1 --env KEY2=value2) (default []) |
+| `--log-level string`       | Log level (debug, info, warn, error)                                           |
+| `--server-name string`     | Name for the MCP server (default: derived from executable name)                |
+| `--workspace`              | Add to workspace settings (.cursor/mcp.json) instead of user settings          |
+
+
+#### `circleci mcp cursor list [flags]`
+
+Show Cursor MCP servers
+
+| Flag                   | Description                                                              |
+| ---------------------- | ------------------------------------------------------------------------ |
+| `--config-path string` | Path to Cursor config file                                               |
+| `--workspace`          | List from workspace settings (.cursor/mcp.json) instead of user settings |
+
+
+### `circleci mcp start [flags]`
+
+Start the MCP server
+
+| Flag                 | Description                          |
+| -------------------- | ------------------------------------ |
+| `--log-level string` | Log level (debug, info, warn, error) |
+
+
+### `circleci mcp stream [flags]`
+
+Stream the MCP server over HTTP
+
+| Flag                 | Description                             |
+| -------------------- | --------------------------------------- |
+| `--host string`      | host to listen on                       |
+| `--log-level string` | Log level (debug, info, warn, error)    |
+| `--port int`         | port number to listen on (default 8080) |
+
+
+### `circleci mcp tools [flags]`
+
+Export tools as JSON
+
+| Flag                 | Description                          |
+| -------------------- | ------------------------------------ |
+| `--log-level string` | Log level (debug, info, warn, error) |
+
+
+### `circleci mcp vscode`
+
+Manage VSCode MCP servers
+
+#### `circleci mcp vscode disable [flags]`
+
+Remove server from VSCode config
+
+| Flag                   | Description                                                                |
+| ---------------------- | -------------------------------------------------------------------------- |
+| `--config-path string` | Path to VSCode config file                                                 |
+| `--server-name string` | Name of the MCP server to remove (default: derived from executable name)   |
+| `--workspace`          | Remove from workspace settings (.vscode/mcp.json) instead of user settings |
+
+
+#### `circleci mcp vscode enable [flags]`
+
+Add server to VSCode config
+
+| Flag                       | Description                                                                    |
+| -------------------------- | ------------------------------------------------------------------------------ |
+| `--config-path string`     | Path to VSCode config file                                                     |
+| `-e, --env stringToString` | Environment variables (e.g., --env KEY1=value1 --env KEY2=value2) (default []) |
+| `--log-level string`       | Log level (debug, info, warn, error)                                           |
+| `--server-name string`     | Name for the MCP server (default: derived from executable name)                |
+| `--workspace`              | Add to workspace settings (.vscode/mcp.json) instead of user settings          |
+
+
+#### `circleci mcp vscode list [flags]`
+
+Show VSCode MCP servers
+
+| Flag                   | Description                                                              |
+| ---------------------- | ------------------------------------------------------------------------ |
+| `--config-path string` | Path to VSCode config file                                               |
+| `--workspace`          | List from workspace settings (.vscode/mcp.json) instead of user settings |
+
+
+## `circleci namespace <command>`
+
+Manage orb namespaces
+
+### `circleci namespace create <name> --org-id <uuid> [flags]`
+
+Create a namespace
+
+| Flag              | Description                                             |
+| ----------------- | ------------------------------------------------------- |
+| `--jq string`     | Process values from the response using jq syntax        |
+| `--json`          | Output as JSON                                          |
+| `--org-id string` | organization UUID to claim the namespace for (required) |
+
+
+### `circleci namespace delete <name> [flags]`
+
+Delete a namespace and all its orbs
+
+| Flag            | Description                                  |
+| --------------- | -------------------------------------------- |
+| `-n, --dry-run` | print what would be deleted without deleting |
+| `-f, --force`   | skip confirmation prompt                     |
+
+
+### `circleci namespace get <name> [flags]`
+
+Get details of a namespace
+
+| Flag          | Description                                      |
+| ------------- | ------------------------------------------------ |
+| `--jq string` | Process values from the response using jq syntax |
+| `--json`      | Output as JSON                                   |
+
+
+### `circleci namespace rename <name> <new-name> [flags]`
+
+Rename a namespace
+
+| Flag          | Description                                      |
+| ------------- | ------------------------------------------------ |
+| `--jq string` | Process values from the response using jq syntax |
+| `--json`      | Output as JSON                                   |
+
+
+## `circleci onboard [path] [flags]`
+
+Guided onboarding: scan, test, generate config, sign up
+
+| Flag           | Description                                       |
+| -------------- | ------------------------------------------------- |
+| `--no-browser` | Print the signup URL instead of opening a browser |
+
+
+## `circleci orb <command>`
+
+Manage orbs
+
+### `circleci orb add-to-category <ns>/<orb> <category>`
+
+Add an orb to a registry category
+
+### `circleci orb create <namespace>/<orb> [flags]`
+
+Reserve an orb name in a namespace
+
+| Flag          | Description                                      |
+| ------------- | ------------------------------------------------ |
+| `--jq string` | Process values from the response using jq syntax |
+| `--json`      | Output as JSON                                   |
+| `--private`   | create as a private orb                          |
+
+
+### `circleci orb diff <ns>/<orb> <v1> <v2>`
+
+Show a unified diff between two orb versions
+
+### `circleci orb get <ns>/<orb>[@<version>]/<orb-id> [flags]`
+
+Get orb metadata and statistics
+
+| Flag          | Description                                      |
+| ------------- | ------------------------------------------------ |
+| `--jq string` | Process values from the response using jq syntax |
+| `--json`      | Output as JSON                                   |
+
+
+### `circleci orb list [<namespace>] [flags]`
+
+List orbs in the registry
+
+| Flag            | Description                                      |
+| --------------- | ------------------------------------------------ |
+| `--jq string`   | Process values from the response using jq syntax |
+| `--json`        | Output as JSON                                   |
+| `--private`     | only list private orbs (requires namespace)      |
+| `--uncertified` | include uncertified orbs                         |
+
+
+Aliases:
+
+
+`circleci orb ls`
+
+### `circleci orb list-categories [flags]`
+
+List orb registry categories
+
+| Flag          | Description                                      |
+| ------------- | ------------------------------------------------ |
+| `--jq string` | Process values from the response using jq syntax |
+| `--json`      | Output as JSON                                   |
+
+
+### `circleci orb pack <path>`
+
+Pack a multi-file orb directory into a single YAML
+
+### `circleci orb process <path> [flags]`
+
+Validate and print expanded orb YAML
+
+| Flag              | Description                                    |
+| ----------------- | ---------------------------------------------- |
+| `--org-id string` | organization UUID for private orb dependencies |
+
+
+### `circleci orb publish <command>`
+
+Publish orb versions
+
+#### `circleci orb publish increment <path> <ns>/<orb> major|minor|patch`
+
+Increment and publish a new orb version
+
+#### `circleci orb publish promote <ns>/<orb>@dev:<label> major|minor|patch`
+
+Promote a dev orb version to a stable semver
+
+### `circleci orb remove-from-category <ns>/<orb> <category>`
+
+Remove an orb from a registry category
+
+### `circleci orb source <ns>/<orb>[@<version>]`
+
+Print the YAML source of an orb version
+
+### `circleci orb unlist <ns>/<orb> true|false`
+
+Hide or restore an orb in the registry
+
+### `circleci orb validate <path> [flags]`
+
+Validate an orb YAML file
+
+| Flag              | Description                                    |
+| ----------------- | ---------------------------------------------- |
+| `--org-id string` | organization UUID for private orb dependencies |
+
+
+## `circleci pipeline <command>`
+
+Manage pipeline definitions
+
+### `circleci pipeline create [flags]`
+
+Create a pipeline definition
+
+| Flag                         | Description                                                             |
+| ---------------------------- | ----------------------------------------------------------------------- |
+| `--checkout-provider string` | Checkout source provider (one of: github_app, github_server)            |
+| `--checkout-repo-id string`  | Checkout source repo external ID                                        |
+| `--config-file string`       | Config file path (e.g. .circleci/config.yml)                            |
+| `--config-provider string`   | Config source provider (one of: github_app, github_server, circleci)    |
+| `--config-repo-id string`    | Config source repo external ID (required for github_app, github_server) |
+| `--description string`       | Pipeline definition description                                         |
+| `--jq string`                | Process values from the response using jq syntax                        |
+| `--json`                     | Output as JSON                                                          |
+| `--name string`              | Pipeline definition name (required)                                     |
+| `--project string`           | Project slug (e.g. gh/org/repo); defaults to git remote                 |
+| `--project-id string`        | Project UUID (overrides --project)                                      |
+
+
+### `circleci pipeline list [flags]`
+
+List pipeline definitions for a project
+
+| Flag                  | Description                                             |
+| --------------------- | ------------------------------------------------------- |
+| `--jq string`         | Process values from the response using jq syntax        |
+| `--json`              | Output as JSON                                          |
+| `--project string`    | Project slug (e.g. gh/org/repo); defaults to git remote |
+| `--project-id string` | Project UUID (overrides --project)                      |
+
+
+### `circleci pipeline run [flags]`
+
+Trigger a new pipeline run
+
+| Flag                     | Description                                                          |
+| ------------------------ | -------------------------------------------------------------------- |
+| `-b, --branch string`    | Branch for config fetch and checkout (mutually exclusive with --tag) |
+| `--definition-id string` | Pipeline definition UUID to run (prompted interactively if omitted)  |
+| `--jq string`            | Process values from the response using jq syntax                     |
+| `--json`                 | Output as JSON                                                       |
+| `--param stringArray`    | Pipeline parameter as key=value (repeatable)                         |
+| `--project string`       | Project slug (e.g. gh/org/repo); defaults to git remote              |
+| `-t, --tag string`       | Tag for config fetch and checkout (mutually exclusive with --branch) |
+
+
+## `circleci policy <command>`
+
+Manage security policies
+
+### `circleci policy decide [flags]`
+
+Evaluate a config against remote policies
+
+| Flag                      | Description                                               |
+| ------------------------- | --------------------------------------------------------- |
+| `--input string`          | Path to input file (e.g. .circleci/config.yml) (required) |
+| `--jq string`             | Process values from the response using jq syntax          |
+| `--json`                  | Output as JSON                                            |
+| `--meta string`           | Decision metadata as a JSON string                        |
+| `--metafile string`       | Path to decision metadata file (YAML or JSON)             |
+| `--owner-id string`       | Organization UUID (required)                              |
+| `--policy-context string` | Policy context (default "config")                         |
+| `--strict`                | Exit non-zero for HARD_FAIL or ERROR decisions            |
+
+
+### `circleci policy diff <path> [flags]`
+
+Show diff between local and remote policy bundles
+
+| Flag                      | Description                                      |
+| ------------------------- | ------------------------------------------------ |
+| `--jq string`             | Process values from the response using jq syntax |
+| `--json`                  | Output as JSON                                   |
+| `--owner-id string`       | Organization UUID (required)                     |
+| `--policy-context string` | Policy context (default "config")                |
+
+
+### `circleci policy fetch [policy-name] [flags]`
+
+Download the remote policy bundle
+
+| Flag                      | Description                                      |
+| ------------------------- | ------------------------------------------------ |
+| `--jq string`             | Process values from the response using jq syntax |
+| `--json`                  | Output as JSON                                   |
+| `--owner-id string`       | Organization UUID (required)                     |
+| `--policy-context string` | Policy context (default "config")                |
+
+
+### `circleci policy logs [decision-id] [flags]`
+
+Get policy decision logs
+
+| Flag                      | Description                                                   |
+| ------------------------- | ------------------------------------------------------------- |
+| `--after string`          | Return logs created after this time (RFC3339 or YYYY-MM-DD)   |
+| `--before string`         | Return logs created before this time (RFC3339 or YYYY-MM-DD)  |
+| `--branch string`         | Filter by branch name                                         |
+| `--jq string`             | Process values from the response using jq syntax              |
+| `--json`                  | Output as JSON                                                |
+| `--out string`            | Write output to this file instead of stdout                   |
+| `--owner-id string`       | Organization UUID (required)                                  |
+| `--policy-bundle`         | Retrieve the policy bundle snapshot for the given decision ID |
+| `--policy-context string` | Policy context (default "config")                             |
+| `--project-id string`     | Filter by project ID                                          |
+| `--status string`         | Filter by decision status (PASS, SOFT_FAIL, HARD_FAIL, ERROR) |
+
+
+### `circleci policy push <path> [flags]`
+
+Push a policy bundle to CircleCI
+
+| Flag                      | Description                                      |
+| ------------------------- | ------------------------------------------------ |
+| `--jq string`             | Process values from the response using jq syntax |
+| `--json`                  | Output as JSON                                   |
+| `--no-prompt`             | Skip confirmation prompt                         |
+| `--owner-id string`       | Organization UUID (required)                     |
+| `--policy-context string` | Policy context (default "config")                |
+
+
+### `circleci policy settings <command>`
+
+Manage policy enforcement settings
+
+#### `circleci policy settings get [flags]`
+
+Get policy enforcement settings
+
+| Flag                      | Description                                      |
+| ------------------------- | ------------------------------------------------ |
+| `--jq string`             | Process values from the response using jq syntax |
+| `--json`                  | Output as JSON                                   |
+| `--owner-id string`       | Organization UUID (required)                     |
+| `--policy-context string` | Policy context (default "config")                |
+
+
+#### `circleci policy settings set [flags]`
+
+Update policy enforcement settings
+
+| Flag                      | Description                                      |
+| ------------------------- | ------------------------------------------------ |
+| `--enabled`               | Enable policy enforcement                        |
+| `--jq string`             | Process values from the response using jq syntax |
+| `--json`                  | Output as JSON                                   |
+| `--owner-id string`       | Organization UUID (required)                     |
+| `--policy-context string` | Policy context (default "config")                |
+
+
+## `circleci project <command>`
+
+Manage projects
+
+### `circleci project create [project-name] --org <vcs/org-slug> [flags]`
+
+Create a new project
+
+| Flag           | Description                       |
+| -------------- | --------------------------------- |
+| `--json`       | Output as JSON                    |
+| `--org string` | organization slug (e.g. gh/myorg) |
+
+
+### `circleci project dlc <command>`
+
+Manage docker layer caching
+
+#### `circleci project dlc purge --project <slug> [flags]`
+
+Purge the Docker Layer Cache for a project
+
+| Flag               | Description                                             |
+| ------------------ | ------------------------------------------------------- |
+| `--json`           | Output as JSON                                          |
+| `--project string` | Project slug (e.g. gh/org/repo); defaults to git remote |
+
+
+### `circleci project envvar <command>`
+
+Manage project environment variables
+
+#### `circleci project envvar delete <name> [flags]`
+
+Delete a project environment variable
+
+| Flag               | Description                                             |
+| ------------------ | ------------------------------------------------------- |
+| `-f, --force`      | skip confirmation prompt                                |
+| `--project string` | Project slug (e.g. gh/org/repo); defaults to git remote |
+
+
+#### `circleci project envvar list [flags]`
+
+List project environment variables
+
+| Flag               | Description                                             |
+| ------------------ | ------------------------------------------------------- |
+| `--jq string`      | Process values from the response using jq syntax        |
+| `--json`           | Output as JSON                                          |
+| `--project string` | Project slug (e.g. gh/org/repo); defaults to git remote |
+
+
+#### `circleci project envvar set <name> <value> [flags]`
+
+Set a project environment variable
+
+| Flag               | Description                                             |
+| ------------------ | ------------------------------------------------------- |
+| `--project string` | Project slug (e.g. gh/org/repo); defaults to git remote |
+
+
+### `circleci project follow [flags]`
+
+Follow a project
+
+| Flag               | Description                                             |
+| ------------------ | ------------------------------------------------------- |
+| `--project string` | Project slug (e.g. gh/org/repo); defaults to git remote |
+
+
+### `circleci project get [flags]`
+
+Show project details
+
+| Flag               | Description                                             |
+| ------------------ | ------------------------------------------------------- |
+| `--json`           | Output as JSON                                          |
+| `--project string` | Project slug (e.g. gh/org/repo); defaults to git remote |
+
+
+### `circleci project link [flags]`
+
+Bind this checkout to a CircleCI project
+
+| Flag               | Description                                                     |
+| ------------------ | --------------------------------------------------------------- |
+| `-f, --force`      | Overwrite an existing .circleci/info.yml                        |
+| `--project string` | Project slug (e.g. gh/org/repo or circleci/<orgID>/<projectID>) |
+
+
+### `circleci project list [flags]`
+
+List followed projects
+
+| Flag          | Description                                      |
+| ------------- | ------------------------------------------------ |
+| `--jq string` | Process values from the response using jq syntax |
+| `--json`      | Output as JSON                                   |
+
+
+Aliases:
+
+
+`circleci project ls`
+
+### `circleci project open [flags]`
+
+Open the project page in the browser
+
+| Flag               | Description                                             |
+| ------------------ | ------------------------------------------------------- |
+| `--project string` | Project slug (e.g. gh/org/repo); defaults to git remote |
+
+
+### `circleci project trigger <command>`
+
+Manage project triggers
+
+#### `circleci project trigger create [flags]`
+
+Create a new project trigger
+
+| Flag                              | Description                                                                                                                                                                                                                                                                                                                                             |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--checkout-ref string`           | Git ref for checking out code (only needed when checkout repo differs from event source repo)                                                                                                                                                                                                                                                           |
+| `--config-ref string`             | Git ref for fetching config (only needed when config repo differs from event source repo)                                                                                                                                                                                                                                                               |
+| `--event-preset string`           | Event preset for filtering trigger events (one of: all-pushes, only-tags, default-branch-pushes, only-build-prs, only-open-prs, only-labeled-prs, only-merged-prs, only-ready-for-review-prs, only-branch-delete, only-build-pushes-to-non-draft-prs, only-merged-or-closed-prs, pr-comment-equals-run-ci, non-draft-pr-opened, pushes-to-merge-queues) |
+| `--jq string`                     | Process values from the response using jq syntax                                                                                                                                                                                                                                                                                                        |
+| `--json`                          | Output as JSON                                                                                                                                                                                                                                                                                                                                          |
+| `--pipeline-definition-id string` | Pipeline definition ID (required)                                                                                                                                                                                                                                                                                                                       |
+| `--project string`                | Project slug (e.g. gh/org/repo); defaults to git remote                                                                                                                                                                                                                                                                                                 |
+| `--project-id string`             | Project UUID (overrides --project)                                                                                                                                                                                                                                                                                                                      |
+| `--provider string`               | Event source provider (one of: github_app, github_server, github_oauth, webhook, schedule) (default "github_app")                                                                                                                                                                                                                                       |
+| `--repo-id string`                | Repository external ID (required for github_app, github_server, github_oauth)                                                                                                                                                                                                                                                                           |
+
+
+#### `circleci project trigger list [flags]`
+
+List triggers for a pipeline definition
+
+| Flag                              | Description                                             |
+| --------------------------------- | ------------------------------------------------------- |
+| `--jq string`                     | Process values from the response using jq syntax        |
+| `--json`                          | Output as JSON                                          |
+| `--pipeline-definition-id string` | Pipeline definition ID (required)                       |
+| `--project string`                | Project slug (e.g. gh/org/repo); defaults to git remote |
+| `--project-id string`             | Project UUID (overrides --project)                      |
+
+
+## `circleci run <command>`
+
+Manage CI runs
+
+### `circleci run cancel <run-number-or-id> [flags]`
+
+Cancel a run
+
+| Flag               | Description                                                     |
+| ------------------ | --------------------------------------------------------------- |
+| `-f, --force`      | skip confirmation prompt                                        |
+| `--project string` | Project slug (e.g. gh/org/repo); used when cancelling by number |
+
+
+### `circleci run get [<run-id>] [flags]`
+
+Get a run's status
+
+| Flag                  | Description                                                 |
+| --------------------- | ----------------------------------------------------------- |
+| `-b, --branch string` | Branch name (defaults to current branch)                    |
+| `--jq string`         | Process values from the response using jq syntax            |
+| `--json`              | Output as JSON                                              |
+| `--project string`    | Project slug (e.g. gh/org/repo); used for latest-run lookup |
+
+
+### `circleci run list [flags]`
+
+List recent runs for a project
+
+| Flag                  | Description                                               |
+| --------------------- | --------------------------------------------------------- |
+| `-b, --branch string` | Filter by branch                                          |
+| `--jq string`         | Process values from the response using jq syntax          |
+| `--json`              | Output as JSON                                            |
+| `--limit int`         | Maximum number of runs to show [default: 10] (default 10) |
+| `--project string`    | Project slug (e.g. gh/org/repo); defaults to git remote   |
+
+
+Aliases:
+
+
+`circleci run ls`
+
+### `circleci run open [flags]`
+
+Open the current project's runs page in the browser
+
+| Flag                  | Description                           |
+| --------------------- | ------------------------------------- |
+| `-b, --branch string` | Filter runs to a specific branch      |
+| `--current-branch`    | Filter runs to the current git branch |
+
+
+### `circleci run trigger [flags]`
+
+Trigger a new run
+
+| Flag                      | Description                                             |
+| ------------------------- | ------------------------------------------------------- |
+| `-b, --branch string`     | Branch to trigger (defaults to current branch)          |
+| `--jq string`             | Process values from the response using jq syntax        |
+| `--json`                  | Output as JSON                                          |
+| `--parameter stringArray` | Run parameter as key=value (repeatable)                 |
+| `--project string`        | Project slug (e.g. gh/org/repo); defaults to git remote |
+
+
+### `circleci run watch [<run-id>] [flags]`
+
+Watch a run until it completes
+
+| Flag                  | Description                                                            |
+| --------------------- | ---------------------------------------------------------------------- |
+| `-b, --branch string` | Branch to watch (defaults to current branch)                           |
+| `--failfast`          | Exit as soon as any job fails, without waiting for the rest of the run |
+| `--project string`    | Project slug (e.g. gh/org/repo); defaults to git remote                |
+| `--sha string`        | Watch run for this commit SHA; polls up to 2m if not yet created       |
+| `--timeout duration`  | Maximum time to wait for run completion (default 30m0s)                |
+
+
+## `circleci runner <command>`
+
+Manage self-hosted runners
+
+### `circleci runner config <resource-class> [flags]`
+
+Generate a runner agent configuration file
+
+| Flag                  | Description                                               |
+| --------------------- | --------------------------------------------------------- |
+| `--nickname string`   | Nickname for the new token                                |
+| `-o, --output string` | Write config to this file instead of stdout               |
+| `--token string`      | Use an existing token value instead of creating a new one |
+
+
+### `circleci runner instance <command>`
+
+Manage runner instances
+
+#### `circleci runner instance list [flags]`
+
+List connected runner instances
+
+| Flag                      | Description                                                       |
+| ------------------------- | ----------------------------------------------------------------- |
+| `--jq string`             | Process values from the response using jq syntax                  |
+| `--json`                  | Output as JSON                                                    |
+| `--namespace string`      | Filter by namespace (organization)                                |
+| `--org string`            | Organization slug (e.g. gh/myorg) or UUID; defaults to git remote |
+| `--resource-class string` | Filter by resource class (namespace/name)                         |
+
+
+Aliases:
+
+
+`circleci runner instance ls`
+
+### `circleci runner open [flags]`
+
+Open the runners inventory page in the browser
+
+| Flag           | Description                                               |
+| -------------- | --------------------------------------------------------- |
+| `--org string` | Organization slug (e.g. gh/myorg); defaults to git remote |
+
+
+### `circleci runner resource-class <command>`
+
+Manage runner resource classes
+
+#### `circleci runner resource-class create <namespace>/<name> [flags]`
+
+Create a runner resource class
+
+| Flag                   | Description                                      |
+| ---------------------- | ------------------------------------------------ |
+| `--description string` | Human-readable description of the resource class |
+| `--jq string`          | Process values from the response using jq syntax |
+| `--json`               | Output as JSON                                   |
+
+
+#### `circleci runner resource-class delete <namespace>/<name> [flags]`
+
+Delete a runner resource class
+
+| Flag          | Description              |
+| ------------- | ------------------------ |
+| `-f, --force` | skip confirmation prompt |
+
+
+#### `circleci runner resource-class list [flags]`
+
+List runner resource classes
+
+| Flag                 | Description                                                       |
+| -------------------- | ----------------------------------------------------------------- |
+| `--jq string`        | Process values from the response using jq syntax                  |
+| `--json`             | Output as JSON                                                    |
+| `--namespace string` | Filter by namespace (organization)                                |
+| `--org string`       | Organization slug (e.g. gh/myorg) or UUID; defaults to git remote |
+
+
+Aliases:
+
+
+`circleci runner resource-class ls`
+
+### `circleci runner task [flags]`
+
+Show task counts for a runner resource class
+
+| Flag                      | Description                                      |
+| ------------------------- | ------------------------------------------------ |
+| `--jq string`             | Process values from the response using jq syntax |
+| `--json`                  | Output as JSON                                   |
+| `--resource-class string` | Resource class to query (namespace/name)         |
+
+
+### `circleci runner token <command>`
+
+Manage runner tokens
+
+#### `circleci runner token create <resource-class> [flags]`
+
+Create a token for a resource class
+
+| Flag                | Description                                      |
+| ------------------- | ------------------------------------------------ |
+| `--jq string`       | Process values from the response using jq syntax |
+| `--json`            | Output as JSON                                   |
+| `--nickname string` | Human-readable nickname for the token            |
+
+
+#### `circleci runner token delete <token-id> [flags]`
+
+Delete a runner token
+
+| Flag          | Description              |
+| ------------- | ------------------------ |
+| `-f, --force` | skip confirmation prompt |
+
+
+#### `circleci runner token list [flags]`
+
+List tokens for a resource class
+
+| Flag                      | Description                                      |
+| ------------------------- | ------------------------------------------------ |
+| `--jq string`             | Process values from the response using jq syntax |
+| `--json`                  | Output as JSON                                   |
+| `--resource-class string` | Filter by resource class (namespace/name)        |
+
+
+Aliases:
+
+
+`circleci runner token ls`
+
+## `circleci settings <command>`
+
+Manage CLI settings
+
+### `circleci settings list [flags]`
+
+List current CLI settings
+
+| Flag          | Description                                      |
+| ------------- | ------------------------------------------------ |
+| `--jq string` | Process values from the response using jq syntax |
+| `--json`      | Output as JSON                                   |
+
+
+### `circleci settings set <key> <value>`
+
+Set a CLI setting
+
+## `circleci signing-config <command>`
+
+Manage iOS signing configs
+
+### `circleci signing-config create [flags]`
+
+Create an iOS signing config
+
+| Flag                    | Description                                                                |
+| ----------------------- | -------------------------------------------------------------------------- |
+| `--cert-id string`      | ID of an uploaded certificate (see: circleci certificate list)             |
+| `--jq string`           | Process values from the response using jq syntax                           |
+| `--json`                | Output as JSON                                                             |
+| `--name string`         | Name for the signing config (referenced in pipeline config)                |
+| `--org-id string`       | CircleCI organization UUID; defaults to the org of the current git project |
+| `--profile stringArray` | Path to a provisioning profile file (repeatable)                           |
+
+
+### `circleci signing-config delete <signing-config-id> [flags]`
+
+Delete an iOS signing config
+
+| Flag          | Description              |
+| ------------- | ------------------------ |
+| `-f, --force` | skip confirmation prompt |
+
+
+### `circleci signing-config list [flags]`
+
+List iOS signing configs
+
+| Flag              | Description                                                                |
+| ----------------- | -------------------------------------------------------------------------- |
+| `--jq string`     | Process values from the response using jq syntax                           |
+| `--json`          | Output as JSON                                                             |
+| `--org-id string` | CircleCI organization UUID; defaults to the org of the current git project |
+
+
+Aliases:
+
+
+`circleci signing-config ls`
+
+## `circleci version [flags]`
+
+Print version information
+
+| Flag     | Description                                        |
+| -------- | -------------------------------------------------- |
+| `--json` | output as JSON (fields: version, commit, modified) |
+
+
+## `circleci workflow <command>`
+
+Manage workflows
+
+### `circleci workflow cancel <workflow-id> [flags]`
+
+Cancel a running workflow
+
+| Flag          | Description              |
+| ------------- | ------------------------ |
+| `-f, --force` | skip confirmation prompt |
+
+
+### `circleci workflow get <workflow-id> [flags]`
+
+Get workflow details
+
+| Flag          | Description                                      |
+| ------------- | ------------------------------------------------ |
+| `--jq string` | Process values from the response using jq syntax |
+| `--json`      | Output as JSON                                   |
+
+
+### `circleci workflow list [<run-id>] [flags]`
+
+List workflows for a run or recent runs
+
+| Flag                  | Description                                                   |
+| --------------------- | ------------------------------------------------------------- |
+| `-b, --branch string` | Filter by branch (recent-runs mode)                           |
+| `--jq string`         | Process values from the response using jq syntax              |
+| `--json`              | Output as JSON                                                |
+| `--limit int`         | Number of recent runs to show (recent-runs mode) (default 10) |
+| `--project string`    | Project slug (e.g. gh/org/repo); defaults to git remote       |
+
+
+Aliases:
+
+
+`circleci workflow ls`
+
+### `circleci workflow rerun <workflow-id> [flags]`
+
+Rerun a workflow
+
+| Flag            | Description            |
+| --------------- | ---------------------- |
+| `--from-failed` | Rerun only failed jobs |
+
+

--- a/internal/cmd/root/testdata/help/circleci/run.txt
+++ b/internal/cmd/root/testdata/help/circleci/run.txt
@@ -7,7 +7,7 @@ one or more workflows, each of which contains jobs.
 
 ## Usage
 
-`circleci run <command>`
+`circleci run <command> [flags]`
 
 ## Available Commands
 

--- a/internal/cmd/root/testdata/help/circleci/run/get.txt
+++ b/internal/cmd/root/testdata/help/circleci/run/get.txt
@@ -12,6 +12,8 @@ JSON fields: id, phase, outcome, current_outcome, branch, revision,
              workflows[].id/name/phase/outcome/current_outcome/duration/
              jobs[].id/name/phase/outcome/current_outcome/type
 
+For more information about output formatting flags, see `circleci help formatting`.
+
 ## Usage
 
 `circleci run get [<run-id>] [flags]`

--- a/internal/cmd/root/testdata/help/circleci/run/list.txt
+++ b/internal/cmd/root/testdata/help/circleci/run/list.txt
@@ -8,6 +8,8 @@ to a single branch.
 
 JSON fields: id, phase, outcome, current_outcome, branch, revision, created_at
 
+For more information about output formatting flags, see `circleci help formatting`.
+
 ## Usage
 
 `circleci run list [flags]`

--- a/internal/cmd/root/testdata/help/circleci/run/trigger.txt
+++ b/internal/cmd/root/testdata/help/circleci/run/trigger.txt
@@ -10,6 +10,8 @@ booleans (true/false), integers, or strings.
 
 JSON fields: id, number, state, created_at
 
+For more information about output formatting flags, see `circleci help formatting`.
+
 ## Usage
 
 `circleci run trigger [flags]`

--- a/internal/cmd/root/testdata/help/circleci/runner.txt
+++ b/internal/cmd/root/testdata/help/circleci/runner.txt
@@ -11,7 +11,7 @@ Resource class names use the format: namespace/name
 
 ## Usage
 
-`circleci runner <command>`
+`circleci runner <command> [flags]`
 
 ## Available Commands
 

--- a/internal/cmd/root/testdata/help/circleci/runner/instance.txt
+++ b/internal/cmd/root/testdata/help/circleci/runner/instance.txt
@@ -6,7 +6,7 @@ Instances are live runner agents currently connected to CircleCI.
 
 ## Usage
 
-`circleci runner instance <command>`
+`circleci runner instance <command> [flags]`
 
 ## Available Commands
 

--- a/internal/cmd/root/testdata/help/circleci/runner/instance/list.txt
+++ b/internal/cmd/root/testdata/help/circleci/runner/instance/list.txt
@@ -15,6 +15,8 @@ The STATUS column is derived from last_connected_at:
 JSON fields: resource_class, hostname, name, version, ip, status,
              first_connected, last_connected, last_used
 
+For more information about output formatting flags, see `circleci help formatting`.
+
 ## Usage
 
 `circleci runner instance list [flags]`

--- a/internal/cmd/root/testdata/help/circleci/runner/resource-class.txt
+++ b/internal/cmd/root/testdata/help/circleci/runner/resource-class.txt
@@ -7,7 +7,7 @@ Each resource class belongs to a namespace (usually your organization).
 
 ## Usage
 
-`circleci runner resource-class <command>`
+`circleci runner resource-class <command> [flags]`
 
 ## Available Commands
 

--- a/internal/cmd/root/testdata/help/circleci/runner/resource-class/create.txt
+++ b/internal/cmd/root/testdata/help/circleci/runner/resource-class/create.txt
@@ -7,6 +7,8 @@ where namespace is your organization name.
 
 JSON fields: id, resource_class, description
 
+For more information about output formatting flags, see `circleci help formatting`.
+
 ## Usage
 
 `circleci runner resource-class create <namespace>/<name> [flags]`

--- a/internal/cmd/root/testdata/help/circleci/runner/resource-class/list.txt
+++ b/internal/cmd/root/testdata/help/circleci/runner/resource-class/list.txt
@@ -8,6 +8,8 @@ or an org UUID. Optionally filter further by namespace.
 
 JSON fields: id, resource_class, description
 
+For more information about output formatting flags, see `circleci help formatting`.
+
 ## Usage
 
 `circleci runner resource-class list [flags]`

--- a/internal/cmd/root/testdata/help/circleci/runner/task.txt
+++ b/internal/cmd/root/testdata/help/circleci/runner/task.txt
@@ -8,6 +8,8 @@ Running tasks are actively executing on a runner instance.
 
 JSON fields: resource_class, unclaimed, running
 
+For more information about output formatting flags, see `circleci help formatting`.
+
 ## Usage
 
 `circleci runner task [flags]`

--- a/internal/cmd/root/testdata/help/circleci/runner/token.txt
+++ b/internal/cmd/root/testdata/help/circleci/runner/token.txt
@@ -9,7 +9,7 @@ Token values are only shown once at creation time and cannot be retrieved afterw
 
 ## Usage
 
-`circleci runner token <command>`
+`circleci runner token <command> [flags]`
 
 ## Available Commands
 

--- a/internal/cmd/root/testdata/help/circleci/runner/token/create.txt
+++ b/internal/cmd/root/testdata/help/circleci/runner/token/create.txt
@@ -8,6 +8,8 @@ a new one.
 
 JSON fields: id, resource_class, nickname, created_at, token
 
+For more information about output formatting flags, see `circleci help formatting`.
+
 ## Usage
 
 `circleci runner token create <resource-class> [flags]`

--- a/internal/cmd/root/testdata/help/circleci/runner/token/list.txt
+++ b/internal/cmd/root/testdata/help/circleci/runner/token/list.txt
@@ -10,6 +10,8 @@ token metadata (ID, nickname, creation date) only.
 
 JSON fields: id, resource_class, nickname, created_at
 
+For more information about output formatting flags, see `circleci help formatting`.
+
 ## Usage
 
 `circleci runner token list [flags]`

--- a/internal/cmd/root/testdata/help/circleci/settings.txt
+++ b/internal/cmd/root/testdata/help/circleci/settings.txt
@@ -10,7 +10,7 @@ For pipeline YAML operations, see 'circleci config'.
 
 ## Usage
 
-`circleci settings <command>`
+`circleci settings <command> [flags]`
 
 ## Available Commands
 

--- a/internal/cmd/root/testdata/help/circleci/settings/list.txt
+++ b/internal/cmd/root/testdata/help/circleci/settings/list.txt
@@ -7,6 +7,8 @@ $XDG_CONFIG_HOME/circleci/config.yml (default: ~/.config/circleci/config.yml).
 
 JSON fields: token_set, host, telemetry, theme
 
+For more information about output formatting flags, see `circleci help formatting`.
+
 ## Usage
 
 `circleci settings list [flags]`

--- a/internal/cmd/root/testdata/help/circleci/settings/set.txt
+++ b/internal/cmd/root/testdata/help/circleci/settings/set.txt
@@ -16,7 +16,7 @@ terminal to pick a theme from a list.
 
 ## Usage
 
-`circleci settings set <key> <value>`
+`circleci settings set <key> <value> [flags]`
 
 ## Inherited Flags
 

--- a/internal/cmd/root/testdata/help/circleci/signing-config.txt
+++ b/internal/cmd/root/testdata/help/circleci/signing-config.txt
@@ -9,7 +9,7 @@ install it onto the macOS runner during a job.
 
 ## Usage
 
-`circleci signing-config <command>`
+`circleci signing-config <command> [flags]`
 
 ## Available Commands
 

--- a/internal/cmd/root/testdata/help/circleci/signing-config/create.txt
+++ b/internal/cmd/root/testdata/help/circleci/signing-config/create.txt
@@ -13,6 +13,8 @@ add additional profiles.
 
 JSON fields: id, name, cert_id
 
+For more information about output formatting flags, see `circleci help formatting`.
+
 ## Usage
 
 `circleci signing-config create [flags]`

--- a/internal/cmd/root/testdata/help/circleci/signing-config/list.txt
+++ b/internal/cmd/root/testdata/help/circleci/signing-config/list.txt
@@ -7,6 +7,8 @@ unless overridden with --org-id.
 
 JSON fields: id, name, certificate, provisioning_profiles
 
+For more information about output formatting flags, see `circleci help formatting`.
+
 ## Usage
 
 `circleci signing-config list [flags]`

--- a/internal/cmd/root/testdata/help/circleci/step.txt
+++ b/internal/cmd/root/testdata/help/circleci/step.txt
@@ -4,7 +4,7 @@ Control job step execution
 
 ## Usage
 
-`circleci step <command>`
+`circleci step <command> [flags]`
 
 ## Available Commands
 

--- a/internal/cmd/root/testdata/help/circleci/step/halt.txt
+++ b/internal/cmd/root/testdata/help/circleci/step/halt.txt
@@ -9,7 +9,7 @@ within a running CircleCI job.
 
 ## Usage
 
-`circleci step halt`
+`circleci step halt [flags]`
 
 ## Inherited Flags
 

--- a/internal/cmd/root/testdata/help/circleci/telemetry.txt
+++ b/internal/cmd/root/testdata/help/circleci/telemetry.txt
@@ -1,0 +1,5 @@
+# Telemetry
+circleci collects telemetry to help us understand how the CLI is being used and to improve it.
+
+To learn more about what data is collected, how it is used, and how to opt out, see:
+<https://circleci.com/docs/local-cli>

--- a/internal/cmd/root/testdata/help/circleci/workflow.txt
+++ b/internal/cmd/root/testdata/help/circleci/workflow.txt
@@ -9,7 +9,7 @@ Workflow IDs are shown in the output of 'circleci run get'.
 
 ## Usage
 
-`circleci workflow <command>`
+`circleci workflow <command> [flags]`
 
 ## Available Commands
 

--- a/internal/cmd/root/testdata/help/circleci/workflow/get.txt
+++ b/internal/cmd/root/testdata/help/circleci/workflow/get.txt
@@ -8,6 +8,8 @@ JSON fields: id, name, phase, outcome, current_outcome, run_id,
              created_at, ended_at,
              jobs[].id/name/phase/outcome/current_outcome/type
 
+For more information about output formatting flags, see `circleci help formatting`.
+
 ## Usage
 
 `circleci workflow get <workflow-id> [flags]`

--- a/internal/cmd/root/testdata/help/circleci/workflow/list.txt
+++ b/internal/cmd/root/testdata/help/circleci/workflow/list.txt
@@ -16,6 +16,8 @@ current git repository unless overridden with --project.
 JSON fields (single run):  id, name, phase, outcome, current_outcome
 JSON fields (recent runs): run_id, id, name, phase, outcome, current_outcome
 
+For more information about output formatting flags, see `circleci help formatting`.
+
 ## Usage
 
 `circleci workflow list [<run-id>] [flags]`

--- a/internal/cmd/root/testdata/usage/circleci/environment.txt
+++ b/internal/cmd/root/testdata/usage/circleci/environment.txt
@@ -1,0 +1,1 @@
+Usage: circleci help environment

--- a/internal/cmd/root/testdata/usage/circleci/formatting.txt
+++ b/internal/cmd/root/testdata/usage/circleci/formatting.txt
@@ -1,0 +1,1 @@
+Usage: circleci help formatting

--- a/internal/cmd/root/testdata/usage/circleci/reference.txt
+++ b/internal/cmd/root/testdata/usage/circleci/reference.txt
@@ -1,0 +1,1 @@
+Usage: circleci help reference

--- a/internal/cmd/root/testdata/usage/circleci/telemetry.txt
+++ b/internal/cmd/root/testdata/usage/circleci/telemetry.txt
@@ -1,0 +1,1 @@
+Usage: circleci help telemetry


### PR DESCRIPTION
- `circleci reference` -- generates complete reference docs for the CLI.
- `circleci help <topic>` -- help on topics like environment variables, formatting.
