### PR TITLE
Add circleci settings unset token

### DIFF
--- a/acceptance/settings_test.go
+++ b/acceptance/settings_test.go
@@ -446,3 +446,64 @@ func TestSettingsSetTheme_Interactive_StartsAtCurrent(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Equal(t, cfg.EffectiveTheme(), "dracula")
 }
+
+func TestSettingsUnsetToken(t *testing.T) {
+	env := testenv.New(t)
+	dir := t.TempDir()
+
+	// Set a token first, confirm it is stored.
+	set := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"settings", "set", "token", "mytoken123"},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+	assert.Equal(t, set.ExitCode, 0, "stderr: %s", set.Stderr)
+
+	list := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"settings", "list", "--json"},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+	assert.Equal(t, list.ExitCode, 0, "stderr: %s", list.Stderr)
+	var before map[string]any
+	assert.NilError(t, json.Unmarshal([]byte(list.Stdout), &before))
+	assert.Check(t, cmp.Equal(before["token_set"], true))
+
+	// Unset the token.
+	unset := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"settings", "unset", "token"},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+	assert.Equal(t, unset.ExitCode, 0, "stderr: %s", unset.Stderr)
+	assert.Check(t, strings.Contains(unset.Stderr, "Removed token"),
+		"expected 'Removed token' in stderr, got: %q", unset.Stderr)
+
+	// Confirm the token is gone.
+	verify := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"settings", "list", "--json"},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+	assert.Equal(t, verify.ExitCode, 0, "stderr: %s", verify.Stderr)
+	var after map[string]any
+	assert.NilError(t, json.Unmarshal([]byte(verify.Stdout), &after))
+	assert.Check(t, cmp.Equal(after["token_set"], false))
+}
+
+func TestSettingsUnsetToken_UnknownKey(t *testing.T) {
+	env := testenv.New(t)
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"settings", "unset", "bogus"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 2, "expected exit code 2 for unknown key")
+}

--- a/internal/cmd/root/testdata/help/circleci/settings/unset.txt
+++ b/internal/cmd/root/testdata/help/circleci/settings/unset.txt
@@ -1,25 +1,13 @@
 # CircleCI CLI
 
-View and modify settings for the circleci CLI tool.
+Remove a stored CLI setting by key.
 
-Use 'circleci settings set token' to configure your personal API token.
-Use 'circleci settings unset token' to remove your stored API token.
-Use 'circleci settings set telemetry on/off' to manage telemetry preferences.
-Use 'circleci settings list' to view current settings.
-
-For pipeline YAML operations, see 'circleci config'.
+Supported keys:
+  token      Remove your stored CircleCI personal API token
 
 ## Usage
 
-`circleci settings <command>`
-
-## Available Commands
-
-| Command | Description                 |
-| ------- | --------------------------- |
-| `list`  | List current CLI settings   |
-| `set`   | Set a CLI setting           |
-| `unset` | Remove a stored CLI setting |
+`circleci settings unset <key>`
 
 ## Inherited Flags
 
@@ -28,6 +16,11 @@ For pipeline YAML operations, see 'circleci config'.
 | `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
 | `--debug`             | enable debug logging                                         |
 | `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+
+## Examples
+
+- Remove your stored API token: 
+  `circleci settings unset token`
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/usage/circleci/settings.txt
+++ b/internal/cmd/root/testdata/usage/circleci/settings.txt
@@ -3,3 +3,4 @@ Usage:  circleci settings <command>
 Available commands:
   list
   set
+  unset

--- a/internal/cmd/root/testdata/usage/circleci/settings/unset.txt
+++ b/internal/cmd/root/testdata/usage/circleci/settings/unset.txt
@@ -1,0 +1,1 @@
+Usage:  circleci settings unset <key>

--- a/internal/cmd/settings/settings.go
+++ b/internal/cmd/settings/settings.go
@@ -38,6 +38,7 @@ func NewSettingsCmd() *cobra.Command {
 			View and modify settings for the circleci CLI tool.
 
 			Use 'circleci settings set token' to configure your personal API token.
+			Use 'circleci settings unset token' to remove your stored API token.
 			Use 'circleci settings set telemetry on/off' to manage telemetry preferences.
 			Use 'circleci settings list' to view current settings.
 
@@ -48,6 +49,7 @@ func NewSettingsCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(newSetCmd())
+	cmd.AddCommand(newUnsetCmd())
 	cmd.AddCommand(newListCmd())
 
 	return cmd

--- a/internal/cmd/settings/unset.go
+++ b/internal/cmd/settings/unset.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package settings
+
+import (
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+
+	"github.com/CircleCI-Public/circleci-cli/internal/cmdutil"
+	"github.com/CircleCI-Public/circleci-cli/internal/config"
+	clierrors "github.com/CircleCI-Public/circleci-cli/internal/errors"
+	"github.com/CircleCI-Public/circleci-cli/internal/iostream"
+)
+
+func newUnsetCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "unset <key>",
+		Short: "Remove a stored CLI setting",
+		Long: heredoc.Doc(`
+			Remove a stored CLI setting by key.
+
+			Supported keys:
+			  token      Remove your stored CircleCI personal API token
+		`),
+		Example: heredoc.Doc(`
+			# Remove your stored API token
+			$ circleci settings unset token
+		`),
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			secureStorage := cmdutil.IsSecureStorage(cmd)
+			configPath := cmdutil.ConfigPath(cmd)
+
+			switch args[0] {
+			case "token":
+				if err := config.DeleteToken(ctx, secureStorage); err != nil {
+					return clierrors.New("settings.unset_failed", "Failed to remove token", err.Error()).
+						WithExitCode(clierrors.ExitGeneralError)
+				}
+				if secureStorage {
+					iostream.ErrPrintf(ctx, "%s Removed token from keyring\n", iostream.SymbolOK(ctx))
+				} else {
+					iostream.ErrPrintf(ctx, "%s Removed token from %s\n", iostream.SymbolOK(ctx), configPath)
+				}
+				return nil
+			default:
+				return clierrors.New("settings.unknown_key", "Unknown setting", "Unknown setting key: "+args[0]).
+					WithSuggestions("Valid keys are: token").
+					WithExitCode(clierrors.ExitBadArguments)
+			}
+		},
+	}
+	return cmd
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -191,6 +191,12 @@ func SetToken(ctx context.Context, token string, secureStorage bool) error {
 	})
 }
 
+// DeleteToken removes the stored API token from both the config file and the
+// system keyring (when secure storage is in use).
+func DeleteToken(ctx context.Context, secureStorage bool) error {
+	return SetToken(ctx, "", secureStorage)
+}
+
 // SetHost persists the CircleCI server host. The host is not a secret, so it is
 // always written to the config file and never touches secure storage (passing
 // secureStorage here would make saveTo delete the keyring token).


### PR DESCRIPTION
## Summary

- Adds `circleci settings unset token` to remove a stored API token
- Works with both insecure (config file) and secure (keyring) storage
- Returns exit code 2 for unknown keys with a helpful suggestion

## Test plan

- [ ] `circleci settings unset token` after setting a token clears it (verified via `settings list --json` showing `token_set: false`)
- [ ] `circleci settings unset bogus` exits with code 2 and suggests valid keys
- [ ] Acceptance tests: `TestSettingsUnsetToken`, `TestSettingsUnsetToken_UnknownKey`