### PR TITLE
Update help snapshots for settings unset command

### DIFF
--- a/internal/cmd/root/testdata/help/circleci/reference.txt
+++ b/internal/cmd/root/testdata/help/circleci/reference.txt
@@ -1279,6 +1279,10 @@ List current CLI settings
 
 Set a CLI setting
 
+### `circleci settings unset <key>`
+
+Remove a stored CLI setting
+
 ## `circleci signing-config <command>`
 
 Manage iOS signing configs

--- a/internal/cmd/root/testdata/help/circleci/settings/unset.txt
+++ b/internal/cmd/root/testdata/help/circleci/settings/unset.txt
@@ -7,7 +7,7 @@ Supported keys:
 
 ## Usage
 
-`circleci settings unset <key>`
+`circleci settings unset <key> [flags]`
 
 ## Inherited Flags
 


### PR DESCRIPTION
## Summary

- Add missing `circleci settings unset` entry to the full reference help snapshot
- Update usage line in the `settings/unset` snapshot to include `[flags]`

## Test plan

- [ ] `go test ./internal/cmd/root/...` passes