### PR TITLE
No wrapping directory

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -190,8 +190,7 @@ homebrew_casks:
         brew unlink circleci
 
 archives:
-  - wrap_in_directory: true
-    files:
+  - files:
       - LICENSE
       - src: ./share/man/man1/circleci.1
         dst: share/man/man1/circleci.1


### PR DESCRIPTION
- This is the default because it's compatible with the various formats like on Windows and brew
- It will fix the manpage+completion install.