### PR TITLE
Recommend `bash-completion` in Linux packaging

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -53,6 +53,8 @@ nfpms:
     maintainer: CircleCI
     homepage: https://github.com/CircleCI-Public/circleci-cli
     description: CircleCI command line tool.
+    recommends:
+      - bash-completion
     contents:
       - src: ./share/man/man1/circleci.1
         dst: /usr/share/man/man1/circleci.1


### PR DESCRIPTION
- This will encourage, but not force, installation of shell completion.