### PR TITLE
Rename run to event in V3 client wire paths

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,9 +78,8 @@ internal/
 │   ├── config/           circleci config validate/process/pack/generate
 │   ├── context/          circleci context + circleci context secret
 │   ├── event/            circleci event list/get/create/cancel/watch/open.
-│   │                     An event is the record of a trigger firing (the V3 API still
-│   │                     calls this entity a "run" on the wire). "Pipeline" only ever
-│   │                     means the definition — never an execution instance.
+│   │                     An event is the record of a trigger firing. "Pipeline" only
+│   │                     ever means the definition — never an execution instance.
 │   ├── job/              circleci job artifacts (deep path; wraps internal/artifacts)
 │   ├── open/             circleci open (opens current project in the CircleCI web UI)
 │   ├── pipeline/         circleci pipeline create/list (definitions only; fire one

--- a/acceptance/event_test.go
+++ b/acceptance/event_test.go
@@ -43,9 +43,9 @@ import (
 )
 
 const (
-	getRunID         = "5034460f-c7c4-4c43-9457-de07e2029e7b"
-	testWfID         = "wf-uuid-001"
-	runTestProjectID = "proj-uuid-001"
+	getEventID         = "5034460f-c7c4-4c43-9457-de07e2029e7b"
+	testWfID           = "wf-uuid-001"
+	eventTestProjectID = "proj-uuid-001"
 
 	// Shared across multiple test files.
 	testPipelineID = "aaaaaaaa-0000-0000-0000-000000000001"
@@ -55,8 +55,8 @@ const (
 
 var v3TimeFormat = time.RFC3339
 
-// fakeRunV3 returns a V3 run payload for the fake server.
-func fakeRunV3(id, projectID, phase, outcome, branch, revision string) map[string]any {
+// fakeEventV3 returns a V3 event payload for the fake server.
+func fakeEventV3(id, projectID, phase, outcome, branch, revision string) map[string]any {
 	createdAt := time.Date(2020, 1, 1, 12, 0, 0, 0, time.UTC)
 	attrs := map[string]any{
 		"phase":      phase,
@@ -66,7 +66,7 @@ func fakeRunV3(id, projectID, phase, outcome, branch, revision string) map[strin
 			"revision": revision,
 		},
 	}
-	// The real V3 runs API reports only current_outcome, never outcome,
+	// The real V3 events API reports only current_outcome, never outcome,
 	// regardless of phase.
 	if outcome != "" {
 		attrs["current_outcome"] = outcome
@@ -82,7 +82,7 @@ func fakeRunV3(id, projectID, phase, outcome, branch, revision string) map[strin
 }
 
 // fakeWorkflowV3 returns a V3 workflow payload for the fake server.
-func fakeWorkflowV3(id, name, runID, projectID, phase, outcome string) map[string]any {
+func fakeWorkflowV3(id, name, eventID, projectID, phase, outcome string) map[string]any {
 	created := time.Date(2020, 1, 1, 12, 0, 0, 0, time.UTC)
 	attrs := map[string]any{
 		"name":       name,
@@ -100,7 +100,7 @@ func fakeWorkflowV3(id, name, runID, projectID, phase, outcome string) map[strin
 		"id":         id,
 		"attributes": attrs,
 		"references": map[string]any{
-			"run":     map[string]any{"id": runID},
+			"event":   map[string]any{"id": eventID},
 			"project": map[string]any{"id": projectID},
 			"user":    map[string]any{"id": "user-uuid-001"},
 		},
@@ -162,17 +162,17 @@ func addProjectInfo(fake *fakes.CircleCI, slug, projectID string) {
 	})
 }
 
-// --- run get (V3) ---
+// --- event get (V3) ---
 
 func TestEventGet_ByID(t *testing.T) {
 	fake := fakes.NewCircleCI(t)
-	runID := getRunID
+	eventID := getEventID
 	wfID := testWfID
-	fake.AddRunV3(runID, runTestProjectID, fakeRunV3(runID, runTestProjectID, "ended", "succeeded", "main", "abc1234def5678"))
-	fake.AddRunWorkflowsV3(runID, fakeWorkflowV3(wfID, "build", runID, runTestProjectID, "ended", "succeeded"))
+	fake.AddEventV3(eventID, eventTestProjectID, fakeEventV3(eventID, eventTestProjectID, "ended", "succeeded", "main", "abc1234def5678"))
+	fake.AddEventWorkflowsV3(eventID, fakeWorkflowV3(wfID, "build", eventID, eventTestProjectID, "ended", "succeeded"))
 	fake.AddWorkflowJobsV3(wfID,
-		fakeJobV3("job-uuid-1", "run-tests", wfID, runTestProjectID),
-		fakeJobV3("job-uuid-2", "deploy", wfID, runTestProjectID),
+		fakeJobV3("job-uuid-1", "run-tests", wfID, eventTestProjectID),
+		fakeJobV3("job-uuid-2", "deploy", wfID, eventTestProjectID),
 	)
 
 	env := testenv.New(t)
@@ -181,7 +181,7 @@ func TestEventGet_ByID(t *testing.T) {
 
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    []string{"event", "get", runID},
+		Args:    []string{"event", "get", eventID},
 		Env:     env.Environ(),
 		WorkDir: t.TempDir(),
 	})
@@ -192,9 +192,9 @@ func TestEventGet_ByID(t *testing.T) {
 
 func TestEventGet_ByID_WorkflowsNotFound(t *testing.T) {
 	fake := fakes.NewCircleCI(t)
-	runID := getRunID
-	fake.AddRunV3(runID, runTestProjectID, fakeRunV3(runID, runTestProjectID, "created", "", "main", "abc1234def5678"))
-	fake.SetRunWorkflowsV3NotFound(runID)
+	eventID := getEventID
+	fake.AddEventV3(eventID, eventTestProjectID, fakeEventV3(eventID, eventTestProjectID, "created", "", "main", "abc1234def5678"))
+	fake.SetEventWorkflowsV3NotFound(eventID)
 
 	env := testenv.New(t)
 	env.Token = testToken
@@ -202,7 +202,7 @@ func TestEventGet_ByID_WorkflowsNotFound(t *testing.T) {
 
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    []string{"event", "get", runID},
+		Args:    []string{"event", "get", eventID},
 		Env:     env.Environ(),
 		WorkDir: t.TempDir(),
 	})
@@ -213,13 +213,13 @@ func TestEventGet_ByID_WorkflowsNotFound(t *testing.T) {
 
 func TestEventGet_ByID_Color(t *testing.T) {
 	fake := fakes.NewCircleCI(t)
-	runID := getRunID
+	eventID := getEventID
 	wfID := testWfID
-	fake.AddRunV3(runID, runTestProjectID, fakeRunV3(runID, runTestProjectID, "ended", "succeeded", "main", "abc1234def5678"))
-	fake.AddRunWorkflowsV3(runID, fakeWorkflowV3(wfID, "build", runID, runTestProjectID, "ended", "succeeded"))
+	fake.AddEventV3(eventID, eventTestProjectID, fakeEventV3(eventID, eventTestProjectID, "ended", "succeeded", "main", "abc1234def5678"))
+	fake.AddEventWorkflowsV3(eventID, fakeWorkflowV3(wfID, "build", eventID, eventTestProjectID, "ended", "succeeded"))
 	fake.AddWorkflowJobsV3(wfID,
-		fakeJobV3("job-uuid-1", "run-tests", wfID, runTestProjectID),
-		fakeJobV3("job-uuid-2", "deploy", wfID, runTestProjectID),
+		fakeJobV3("job-uuid-1", "run-tests", wfID, eventTestProjectID),
+		fakeJobV3("job-uuid-2", "deploy", wfID, eventTestProjectID),
 	)
 
 	env := testenv.New(t)
@@ -228,7 +228,7 @@ func TestEventGet_ByID_Color(t *testing.T) {
 
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    []string{"event", "get", runID},
+		Args:    []string{"event", "get", eventID},
 		Env:     env.Environ(),
 		WorkDir: t.TempDir(),
 		TTY:     true,
@@ -240,11 +240,11 @@ func TestEventGet_ByID_Color(t *testing.T) {
 
 func TestEventGet_ByID_JSON(t *testing.T) {
 	fake := fakes.NewCircleCI(t)
-	runID := getRunID
+	eventID := getEventID
 	wfID := testWfID
-	fake.AddRunV3(runID, runTestProjectID, fakeRunV3(runID, runTestProjectID, "ended", "succeeded", "main", "abc1234def5678"))
-	fake.AddRunWorkflowsV3(runID, fakeWorkflowV3(wfID, "build", runID, runTestProjectID, "ended", "succeeded"))
-	fake.AddWorkflowJobsV3(wfID, fakeJobV3("job-uuid-1", "run-tests", wfID, runTestProjectID))
+	fake.AddEventV3(eventID, eventTestProjectID, fakeEventV3(eventID, eventTestProjectID, "ended", "succeeded", "main", "abc1234def5678"))
+	fake.AddEventWorkflowsV3(eventID, fakeWorkflowV3(wfID, "build", eventID, eventTestProjectID, "ended", "succeeded"))
+	fake.AddWorkflowJobsV3(wfID, fakeJobV3("job-uuid-1", "run-tests", wfID, eventTestProjectID))
 
 	env := testenv.New(t)
 	env.Token = testToken
@@ -252,7 +252,7 @@ func TestEventGet_ByID_JSON(t *testing.T) {
 
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    []string{"event", "get", "--json", runID},
+		Args:    []string{"event", "get", "--json", eventID},
 		Env:     env.Environ(),
 		WorkDir: t.TempDir(),
 	})
@@ -262,7 +262,7 @@ func TestEventGet_ByID_JSON(t *testing.T) {
 	var out map[string]any
 	err := json.Unmarshal([]byte(result.Stdout), &out)
 	assert.NilError(t, err)
-	assert.Check(t, cmp.Equal(out["id"], runID))
+	assert.Check(t, cmp.Equal(out["id"], eventID))
 	assert.Check(t, cmp.Equal(out["phase"], "ended"))
 	assert.Check(t, cmp.Equal(out["current_outcome"], "succeeded"))
 
@@ -277,11 +277,11 @@ func TestEventGet_ByID_JSON(t *testing.T) {
 
 func TestEventGet_ByID_JQ(t *testing.T) {
 	fake := fakes.NewCircleCI(t)
-	runID := getRunID
+	eventID := getEventID
 	wfID := testWfID
-	fake.AddRunV3(runID, runTestProjectID, fakeRunV3(runID, runTestProjectID, "ended", "succeeded", "main", "abc1234def5678"))
-	fake.AddRunWorkflowsV3(runID, fakeWorkflowV3(wfID, "build", runID, runTestProjectID, "ended", "succeeded"))
-	fake.AddWorkflowJobsV3(wfID, fakeJobV3("job-uuid-1", "run-tests", wfID, runTestProjectID))
+	fake.AddEventV3(eventID, eventTestProjectID, fakeEventV3(eventID, eventTestProjectID, "ended", "succeeded", "main", "abc1234def5678"))
+	fake.AddEventWorkflowsV3(eventID, fakeWorkflowV3(wfID, "build", eventID, eventTestProjectID, "ended", "succeeded"))
+	fake.AddWorkflowJobsV3(wfID, fakeJobV3("job-uuid-1", "run-tests", wfID, eventTestProjectID))
 
 	env := testenv.New(t)
 	env.Token = testToken
@@ -289,22 +289,22 @@ func TestEventGet_ByID_JQ(t *testing.T) {
 
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    []string{"event", "get", "--json", "--jq", ".id", runID},
+		Args:    []string{"event", "get", "--json", "--jq", ".id", eventID},
 		Env:     env.Environ(),
 		WorkDir: t.TempDir(),
 	})
 
 	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
-	assert.Check(t, cmp.Equal(strings.TrimSpace(result.Stdout), runID))
+	assert.Check(t, cmp.Equal(strings.TrimSpace(result.Stdout), eventID))
 }
 
 func TestEventGet_ByID_JSON_Color(t *testing.T) {
 	fake := fakes.NewCircleCI(t)
-	runID := getRunID
+	eventID := getEventID
 	wfID := testWfID
-	fake.AddRunV3(runID, runTestProjectID, fakeRunV3(runID, runTestProjectID, "ended", "succeeded", "main", "abc1234def5678"))
-	fake.AddRunWorkflowsV3(runID, fakeWorkflowV3(wfID, "build", runID, runTestProjectID, "ended", "succeeded"))
-	fake.AddWorkflowJobsV3(wfID, fakeJobV3("job-uuid-1", "run-tests", wfID, runTestProjectID))
+	fake.AddEventV3(eventID, eventTestProjectID, fakeEventV3(eventID, eventTestProjectID, "ended", "succeeded", "main", "abc1234def5678"))
+	fake.AddEventWorkflowsV3(eventID, fakeWorkflowV3(wfID, "build", eventID, eventTestProjectID, "ended", "succeeded"))
+	fake.AddWorkflowJobsV3(wfID, fakeJobV3("job-uuid-1", "run-tests", wfID, eventTestProjectID))
 
 	env := testenv.New(t)
 	env.Token = testToken
@@ -312,7 +312,7 @@ func TestEventGet_ByID_JSON_Color(t *testing.T) {
 
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    []string{"event", "get", "--json", runID},
+		Args:    []string{"event", "get", "--json", eventID},
 		Env:     env.Environ(),
 		WorkDir: t.TempDir(),
 		TTY:     true,
@@ -324,13 +324,13 @@ func TestEventGet_ByID_JSON_Color(t *testing.T) {
 
 func TestEventGet_WithErrors(t *testing.T) {
 	fake := fakes.NewCircleCI(t)
-	runID := getRunID
+	eventID := getEventID
 
-	run := fakeRunV3(runID, runTestProjectID, "ended", "failed", "main", "abc1234def5678")
-	run["attributes"].(map[string]any)["errors"] = []map[string]any{
+	event := fakeEventV3(eventID, eventTestProjectID, "ended", "failed", "main", "abc1234def5678")
+	event["attributes"].(map[string]any)["errors"] = []map[string]any{
 		{"type": "config", "message": "Could not find config file"},
 	}
-	fake.AddRunV3(runID, runTestProjectID, run)
+	fake.AddEventV3(eventID, eventTestProjectID, event)
 
 	env := testenv.New(t)
 	env.Token = testToken
@@ -338,7 +338,7 @@ func TestEventGet_WithErrors(t *testing.T) {
 
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    []string{"event", "get", runID},
+		Args:    []string{"event", "get", eventID},
 		Env:     env.Environ(),
 		WorkDir: t.TempDir(),
 	})
@@ -349,13 +349,13 @@ func TestEventGet_WithErrors(t *testing.T) {
 
 func TestEventGet_WithErrors_JSON(t *testing.T) {
 	fake := fakes.NewCircleCI(t)
-	runID := getRunID
+	eventID := getEventID
 
-	run := fakeRunV3(runID, runTestProjectID, "ended", "failed", "main", "abc1234def5678")
-	run["attributes"].(map[string]any)["errors"] = []map[string]any{
+	event := fakeEventV3(eventID, eventTestProjectID, "ended", "failed", "main", "abc1234def5678")
+	event["attributes"].(map[string]any)["errors"] = []map[string]any{
 		{"type": "config", "message": "Could not find config file"},
 	}
-	fake.AddRunV3(runID, runTestProjectID, run)
+	fake.AddEventV3(eventID, eventTestProjectID, event)
 
 	env := testenv.New(t)
 	env.Token = testToken
@@ -363,7 +363,7 @@ func TestEventGet_WithErrors_JSON(t *testing.T) {
 
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    []string{"event", "get", "--json", runID},
+		Args:    []string{"event", "get", "--json", eventID},
 		Env:     env.Environ(),
 		WorkDir: t.TempDir(),
 	})
@@ -412,15 +412,15 @@ func TestEventGet_NoToken(t *testing.T) {
 	assert.Check(t, golden.String(result.Stderr, t.Name()+".stderr.txt"))
 }
 
-// --- run list (V3 search) ---
+// --- event list (V3 search) ---
 
 func TestEventList(t *testing.T) {
 	fake := fakes.NewCircleCI(t)
 	slug := watchSlug
-	addProjectInfo(fake, slug, runTestProjectID)
-	fake.AddRunV3("pid-1", runTestProjectID, fakeRunV3("pid-1", runTestProjectID, "ended", "succeeded", "main", "abc1234def5678"))
-	fake.AddRunV3("pid-2", runTestProjectID, fakeRunV3("pid-2", runTestProjectID, "ended", "failed", "feature", "deadbeef12345678"))
-	fake.AddRunV3("pid-3", runTestProjectID, fakeRunV3("pid-3", runTestProjectID, "ended", "succeeded", "main", "1111111122222222"))
+	addProjectInfo(fake, slug, eventTestProjectID)
+	fake.AddEventV3("pid-1", eventTestProjectID, fakeEventV3("pid-1", eventTestProjectID, "ended", "succeeded", "main", "abc1234def5678"))
+	fake.AddEventV3("pid-2", eventTestProjectID, fakeEventV3("pid-2", eventTestProjectID, "ended", "failed", "feature", "deadbeef12345678"))
+	fake.AddEventV3("pid-3", eventTestProjectID, fakeEventV3("pid-3", eventTestProjectID, "ended", "succeeded", "main", "1111111122222222"))
 
 	env := testenv.New(t)
 	env.Token = testToken
@@ -440,10 +440,10 @@ func TestEventList(t *testing.T) {
 func TestEventList_Color(t *testing.T) {
 	fake := fakes.NewCircleCI(t)
 	slug := watchSlug
-	addProjectInfo(fake, slug, runTestProjectID)
-	fake.AddRunV3("pid-1", runTestProjectID, fakeRunV3("pid-1", runTestProjectID, "ended", "succeeded", "main", "abc1234def5678"))
-	fake.AddRunV3("pid-2", runTestProjectID, fakeRunV3("pid-2", runTestProjectID, "ended", "failed", "feature", "deadbeef12345678"))
-	fake.AddRunV3("pid-3", runTestProjectID, fakeRunV3("pid-3", runTestProjectID, "ended", "succeeded", "main", "1111111122222222"))
+	addProjectInfo(fake, slug, eventTestProjectID)
+	fake.AddEventV3("pid-1", eventTestProjectID, fakeEventV3("pid-1", eventTestProjectID, "ended", "succeeded", "main", "abc1234def5678"))
+	fake.AddEventV3("pid-2", eventTestProjectID, fakeEventV3("pid-2", eventTestProjectID, "ended", "failed", "feature", "deadbeef12345678"))
+	fake.AddEventV3("pid-3", eventTestProjectID, fakeEventV3("pid-3", eventTestProjectID, "ended", "succeeded", "main", "1111111122222222"))
 
 	env := testenv.New(t)
 	env.Token = testToken
@@ -464,10 +464,10 @@ func TestEventList_Color(t *testing.T) {
 func TestEventList_Limit(t *testing.T) {
 	fake := fakes.NewCircleCI(t)
 	slug := watchSlug
-	addProjectInfo(fake, slug, runTestProjectID)
-	fake.AddRunV3("pid-1", runTestProjectID, fakeRunV3("pid-1", runTestProjectID, "ended", "succeeded", "main", "abc1234def5678"))
-	fake.AddRunV3("pid-2", runTestProjectID, fakeRunV3("pid-2", runTestProjectID, "ended", "succeeded", "main", "deadbeef12345678"))
-	fake.AddRunV3("pid-3", runTestProjectID, fakeRunV3("pid-3", runTestProjectID, "ended", "succeeded", "main", "1111111122222222"))
+	addProjectInfo(fake, slug, eventTestProjectID)
+	fake.AddEventV3("pid-1", eventTestProjectID, fakeEventV3("pid-1", eventTestProjectID, "ended", "succeeded", "main", "abc1234def5678"))
+	fake.AddEventV3("pid-2", eventTestProjectID, fakeEventV3("pid-2", eventTestProjectID, "ended", "succeeded", "main", "deadbeef12345678"))
+	fake.AddEventV3("pid-3", eventTestProjectID, fakeEventV3("pid-3", eventTestProjectID, "ended", "succeeded", "main", "1111111122222222"))
 
 	env := testenv.New(t)
 	env.Token = testToken
@@ -487,10 +487,10 @@ func TestEventList_Limit(t *testing.T) {
 func TestEventList_Limit_Color(t *testing.T) {
 	fake := fakes.NewCircleCI(t)
 	slug := watchSlug
-	addProjectInfo(fake, slug, runTestProjectID)
-	fake.AddRunV3("pid-1", runTestProjectID, fakeRunV3("pid-1", runTestProjectID, "ended", "succeeded", "main", "abc1234def5678"))
-	fake.AddRunV3("pid-2", runTestProjectID, fakeRunV3("pid-2", runTestProjectID, "ended", "succeeded", "main", "deadbeef12345678"))
-	fake.AddRunV3("pid-3", runTestProjectID, fakeRunV3("pid-3", runTestProjectID, "ended", "succeeded", "main", "1111111122222222"))
+	addProjectInfo(fake, slug, eventTestProjectID)
+	fake.AddEventV3("pid-1", eventTestProjectID, fakeEventV3("pid-1", eventTestProjectID, "ended", "succeeded", "main", "abc1234def5678"))
+	fake.AddEventV3("pid-2", eventTestProjectID, fakeEventV3("pid-2", eventTestProjectID, "ended", "succeeded", "main", "deadbeef12345678"))
+	fake.AddEventV3("pid-3", eventTestProjectID, fakeEventV3("pid-3", eventTestProjectID, "ended", "succeeded", "main", "1111111122222222"))
 
 	env := testenv.New(t)
 	env.Token = testToken
@@ -511,9 +511,9 @@ func TestEventList_Limit_Color(t *testing.T) {
 func TestEventList_JSON(t *testing.T) {
 	fake := fakes.NewCircleCI(t)
 	slug := watchSlug
-	addProjectInfo(fake, slug, runTestProjectID)
-	fake.AddRunV3("pid-1", runTestProjectID, fakeRunV3("pid-1", runTestProjectID, "ended", "succeeded", "main", "abc1234def5678"))
-	fake.AddRunV3("pid-2", runTestProjectID, fakeRunV3("pid-2", runTestProjectID, "ended", "failed", "feature", "deadbeef12345678"))
+	addProjectInfo(fake, slug, eventTestProjectID)
+	fake.AddEventV3("pid-1", eventTestProjectID, fakeEventV3("pid-1", eventTestProjectID, "ended", "succeeded", "main", "abc1234def5678"))
+	fake.AddEventV3("pid-2", eventTestProjectID, fakeEventV3("pid-2", eventTestProjectID, "ended", "failed", "feature", "deadbeef12345678"))
 
 	env := testenv.New(t)
 	env.Token = testToken
@@ -543,9 +543,9 @@ func TestEventList_JSON(t *testing.T) {
 func TestEventList_JSON_Color(t *testing.T) {
 	fake := fakes.NewCircleCI(t)
 	slug := watchSlug
-	addProjectInfo(fake, slug, runTestProjectID)
-	fake.AddRunV3("pid-1", runTestProjectID, fakeRunV3("pid-1", runTestProjectID, "ended", "succeeded", "main", "abc1234def5678"))
-	fake.AddRunV3("pid-2", runTestProjectID, fakeRunV3("pid-2", runTestProjectID, "ended", "failed", "feature", "deadbeef12345678"))
+	addProjectInfo(fake, slug, eventTestProjectID)
+	fake.AddEventV3("pid-1", eventTestProjectID, fakeEventV3("pid-1", eventTestProjectID, "ended", "succeeded", "main", "abc1234def5678"))
+	fake.AddEventV3("pid-2", eventTestProjectID, fakeEventV3("pid-2", eventTestProjectID, "ended", "failed", "feature", "deadbeef12345678"))
 
 	env := testenv.New(t)
 	env.Token = testToken
@@ -734,17 +734,17 @@ func TestEventCreate_NoToken(t *testing.T) {
 
 func TestArgWhitespaceTrimmed(t *testing.T) {
 	fake := fakes.NewCircleCI(t)
-	runID := getRunID
+	eventID := getEventID
 	wfID := testWfID
-	fake.AddRunV3(runID, runTestProjectID, fakeRunV3(runID, runTestProjectID, "ended", "succeeded", "main", "abc1234"))
-	fake.AddRunWorkflowsV3(runID, fakeWorkflowV3(wfID, "build", runID, runTestProjectID, "ended", "succeeded"))
-	fake.AddWorkflowJobsV3(wfID, fakeJobV3("job-uuid-1", "run-tests", wfID, runTestProjectID))
+	fake.AddEventV3(eventID, eventTestProjectID, fakeEventV3(eventID, eventTestProjectID, "ended", "succeeded", "main", "abc1234"))
+	fake.AddEventWorkflowsV3(eventID, fakeWorkflowV3(wfID, "build", eventID, eventTestProjectID, "ended", "succeeded"))
+	fake.AddWorkflowJobsV3(wfID, fakeJobV3("job-uuid-1", "run-tests", wfID, eventTestProjectID))
 
 	env := testenv.New(t)
 	env.Token = testToken
 	env.CircleCIURL = fake.URL()
 
-	for _, arg := range []string{runID + " ", " " + runID, " " + runID + " ", runID + "\t"} {
+	for _, arg := range []string{eventID + " ", " " + eventID, " " + eventID + " ", eventID + "\t"} {
 		result := binary.RunCLI(t, binary.RunOpts{
 			Binary:  binaryPath,
 			Args:    []string{"event", "get", arg},
@@ -759,10 +759,10 @@ func TestArgWhitespaceTrimmed(t *testing.T) {
 
 func TestEventCancel(t *testing.T) {
 	fake := fakes.NewCircleCI(t)
-	runID := getRunID
+	eventID := getEventID
 	wfID := "wf-cancel-001"
-	fake.AddRun(runID, fakeRun(runID, 42, "created", watchSlug, "main"))
-	fake.AddRunWorkflowsV3(runID, fakeWorkflowV3(wfID, "build", runID, "proj-cancel", "started", ""))
+	fake.AddRun(eventID, fakeRun(eventID, 42, "created", watchSlug, "main"))
+	fake.AddEventWorkflowsV3(eventID, fakeWorkflowV3(wfID, "build", eventID, "proj-cancel", "started", ""))
 	fake.SetCancelResponse(wfID, 202)
 
 	env := testenv.New(t)
@@ -771,7 +771,7 @@ func TestEventCancel(t *testing.T) {
 
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    []string{"event", "cancel", "--force", runID},
+		Args:    []string{"event", "cancel", "--force", eventID},
 		Env:     env.Environ(),
 		WorkDir: t.TempDir(),
 	})
@@ -794,10 +794,10 @@ func TestEventCancel(t *testing.T) {
 
 func TestEventCancel_Started(t *testing.T) {
 	fake := fakes.NewCircleCI(t)
-	runID := getRunID
+	eventID := getEventID
 	wfID := "wf-cancel-started"
-	fake.AddRun(runID, fakeRun(runID, 42, "running", watchSlug, "main"))
-	fake.AddRunWorkflowsV3(runID, fakeWorkflowV3(wfID, "build", runID, "proj-cancel", "started", ""))
+	fake.AddRun(eventID, fakeRun(eventID, 42, "running", watchSlug, "main"))
+	fake.AddEventWorkflowsV3(eventID, fakeWorkflowV3(wfID, "build", eventID, "proj-cancel", "started", ""))
 	fake.SetCancelResponse(wfID, 202)
 
 	env := testenv.New(t)
@@ -806,7 +806,7 @@ func TestEventCancel_Started(t *testing.T) {
 
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    []string{"event", "cancel", "--force", runID},
+		Args:    []string{"event", "cancel", "--force", eventID},
 		Env:     env.Environ(),
 		WorkDir: t.TempDir(),
 	})
@@ -816,8 +816,8 @@ func TestEventCancel_Started(t *testing.T) {
 
 func TestEventCancel_RequiresForce(t *testing.T) {
 	fake := fakes.NewCircleCI(t)
-	runID := getRunID
-	fake.AddRun(runID, fakeRun(runID, 42, "created", watchSlug, "main"))
+	eventID := getEventID
+	fake.AddRun(eventID, fakeRun(eventID, 42, "created", watchSlug, "main"))
 
 	env := testenv.New(t)
 	env.Token = testToken
@@ -825,7 +825,7 @@ func TestEventCancel_RequiresForce(t *testing.T) {
 
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    []string{"event", "cancel", runID},
+		Args:    []string{"event", "cancel", eventID},
 		Env:     env.Environ(),
 		WorkDir: t.TempDir(),
 	})
@@ -836,10 +836,10 @@ func TestEventCancel_RequiresForce(t *testing.T) {
 
 func TestEventCancel_AlreadyDone(t *testing.T) {
 	fake := fakes.NewCircleCI(t)
-	runID := "5034460f-c7c4-4c43-9457-de07e2029e7c"
+	eventID := "5034460f-c7c4-4c43-9457-de07e2029e7c"
 	wfID := "wf-cancel-002"
-	fake.AddRun(runID, fakeRun(runID, 43, "created", watchSlug, "main"))
-	fake.AddRunWorkflowsV3(runID, fakeWorkflowV3(wfID, "build", runID, "proj-cancel", "ended", "succeeded"))
+	fake.AddRun(eventID, fakeRun(eventID, 43, "created", watchSlug, "main"))
+	fake.AddEventWorkflowsV3(eventID, fakeWorkflowV3(wfID, "build", eventID, "proj-cancel", "ended", "succeeded"))
 
 	env := testenv.New(t)
 	env.Token = testToken
@@ -847,7 +847,7 @@ func TestEventCancel_AlreadyDone(t *testing.T) {
 
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    []string{"event", "cancel", "--force", runID},
+		Args:    []string{"event", "cancel", "--force", eventID},
 		Env:     env.Environ(),
 		WorkDir: t.TempDir(),
 	})
@@ -893,7 +893,7 @@ func TestEventCancel_NoToken(t *testing.T) {
 
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    []string{"event", "cancel", "--force", getRunID},
+		Args:    []string{"event", "cancel", "--force", getEventID},
 		Env:     env.Environ(),
 		WorkDir: t.TempDir(),
 	})

--- a/acceptance/watch_test.go
+++ b/acceptance/watch_test.go
@@ -44,32 +44,32 @@ import (
 const watchSlug = "gh/testorg/testrepo"
 const watchProjectID = "proj-uuid-watch"
 
-// setupWatchFake builds a fake with one run whose single workflow has the
-// given status. It registers the run in both V2 (for number lookup and
-// workflow fetching) and V3 (for run detail), plus project info for
+// setupWatchFake builds a fake with one event whose single workflow has the
+// given status. It registers the event in both V2 (for number lookup and
+// workflow fetching) and V3 (for event detail), plus project info for
 // search-based lookups.
-func setupWatchFake(t *testing.T, runID, wfID, wfStatus string) (*fakes.CircleCI, *testenv.TestEnv) {
+func setupWatchFake(t *testing.T, eventID, wfID, wfStatus string) (*fakes.CircleCI, *testenv.TestEnv) {
 	t.Helper()
-	v2Run := fakeRun(runID, 75, "created", watchSlug, "main")
+	v2Run := fakeRun(eventID, 75, "created", watchSlug, "main")
 	v2Run["vcs"].(map[string]any)["revision"] = "abc1234def5678abcdef"
 
-	// Map V2 workflow status to V3 outcome for the run.
+	// Map V2 workflow status to V3 outcome for the event.
 	v3Outcome := wfStatus
 	if v3Outcome == "success" {
 		v3Outcome = "succeeded"
 	}
-	v3Run := fakeRunV3(runID, watchProjectID, "ended", v3Outcome, "main", "abc1234def5678abcdef")
+	v3Event := fakeEventV3(eventID, watchProjectID, "ended", v3Outcome, "main", "abc1234def5678abcdef")
 
 	fake := fakes.NewCircleCI(t)
 	addProjectInfo(fake, watchSlug, watchProjectID)
-	fake.AddRunV3(runID, watchProjectID, v3Run)
-	fake.AddRun(runID, v2Run)
+	fake.AddEventV3(eventID, watchProjectID, v3Event)
+	fake.AddRun(eventID, v2Run)
 	fake.AddProjectRuns(watchSlug, v2Run)
 	v3WfOutcome := wfStatus
 	if v3WfOutcome == "success" {
 		v3WfOutcome = "succeeded"
 	}
-	fake.AddRunWorkflowsV3(runID, fakeWorkflowV3(wfID, "build", runID, watchProjectID, "ended", v3WfOutcome))
+	fake.AddEventWorkflowsV3(eventID, fakeWorkflowV3(wfID, "build", eventID, watchProjectID, "ended", v3WfOutcome))
 	fake.AddWorkflowJobsV3(wfID,
 		fakeJobV3("job-1", "lint", wfID, watchProjectID),
 		fakeJobV3("job-2", "test", wfID, watchProjectID),
@@ -101,31 +101,31 @@ func TestEventWatch_ByNumber(t *testing.T) {
 // --- watch by UUID (no --project or --branch needed) ---
 
 func TestEventWatch_ByUUID(t *testing.T) {
-	runID := "0b0e6eca-4e9a-43d7-b74e-a7ed4b7d11cd"
-	_, env := setupWatchFake(t, runID, "watch-wf-uuid-001", "success")
+	eventID := "0b0e6eca-4e9a-43d7-b74e-a7ed4b7d11cd"
+	_, env := setupWatchFake(t, eventID, "watch-wf-uuid-001", "success")
 
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    []string{"event", "watch", runID},
+		Args:    []string{"event", "watch", eventID},
 		Env:     env.Environ(),
 		WorkDir: t.TempDir(),
 	})
 
 	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
-	assert.Check(t, cmp.Contains(result.Stderr, runID), "stderr: %s", result.Stderr)
+	assert.Check(t, cmp.Contains(result.Stderr, eventID), "stderr: %s", result.Stderr)
 	assert.Check(t, cmp.Contains(result.Stderr, "succeeded"), "stderr: %s", result.Stderr)
 }
 
 // --- watch latest (no number arg) ---
 
 func TestEventWatch_Latest(t *testing.T) {
-	runID := "watch-pid-002"
+	eventID := "watch-pid-002"
 	wfID := "watch-wf-002"
 
 	fake := fakes.NewCircleCI(t)
 	addProjectInfo(fake, watchSlug, watchProjectID)
-	fake.AddRunV3(runID, watchProjectID, fakeRunV3(runID, watchProjectID, "ended", "succeeded", "main", "abc1234def5678"))
-	fake.AddRunWorkflowsV3(runID, fakeWorkflowV3(wfID, "build", runID, watchProjectID, "ended", "succeeded"))
+	fake.AddEventV3(eventID, watchProjectID, fakeEventV3(eventID, watchProjectID, "ended", "succeeded", "main", "abc1234def5678"))
+	fake.AddEventWorkflowsV3(eventID, fakeWorkflowV3(wfID, "build", eventID, watchProjectID, "ended", "succeeded"))
 	fake.AddWorkflowJobsV3(wfID, fakeJobV3("job-1", "test", wfID, watchProjectID))
 
 	env := testenv.New(t)
@@ -143,7 +143,7 @@ func TestEventWatch_Latest(t *testing.T) {
 	assert.Check(t, cmp.Contains(result.Stderr, "succeeded"), "stderr: %s", result.Stderr)
 }
 
-// --- failed run → exit 1 ---
+// --- failed event → exit 1 ---
 
 func TestEventWatch_Failed(t *testing.T) {
 	_, env := setupWatchFake(t, "watch-pid-003", "watch-wf-003", "failed")
@@ -163,7 +163,7 @@ func TestEventWatch_Failed(t *testing.T) {
 // --- failed pipeline with a failed job → suggests viewing logs ---
 
 func TestEventWatch_Failed_SuggestsJobLogs(t *testing.T) {
-	runID := "watch-pid-failedjob"
+	eventID := "watch-pid-failedjob"
 	wfID := "watch-wf-failedjob"
 
 	failedJob := fakeJobV3("job-1", "integration-test", wfID, watchProjectID)
@@ -172,10 +172,10 @@ func TestEventWatch_Failed_SuggestsJobLogs(t *testing.T) {
 
 	fake := fakes.NewCircleCI(t)
 	addProjectInfo(fake, watchSlug, watchProjectID)
-	fake.AddRunV3(runID, watchProjectID, fakeRunV3(runID, watchProjectID, "ended", "failed", "main", "abc1234def5678"))
-	fake.AddRun(runID, fakeRun(runID, 75, "created", watchSlug, "main"))
-	fake.AddProjectRuns(watchSlug, fakeRun(runID, 75, "created", watchSlug, "main"))
-	fake.AddRunWorkflowsV3(runID, fakeWorkflowV3(wfID, "build", runID, watchProjectID, "ended", "failed"))
+	fake.AddEventV3(eventID, watchProjectID, fakeEventV3(eventID, watchProjectID, "ended", "failed", "main", "abc1234def5678"))
+	fake.AddRun(eventID, fakeRun(eventID, 75, "created", watchSlug, "main"))
+	fake.AddProjectRuns(watchSlug, fakeRun(eventID, 75, "created", watchSlug, "main"))
+	fake.AddEventWorkflowsV3(eventID, fakeWorkflowV3(wfID, "build", eventID, watchProjectID, "ended", "failed"))
 	fake.AddWorkflowJobsV3(wfID,
 		failedJob,
 		fakeJobV3("job-2", "lint", wfID, watchProjectID),
@@ -198,7 +198,7 @@ func TestEventWatch_Failed_SuggestsJobLogs(t *testing.T) {
 	assert.Check(t, cmp.Contains(result.Stderr, "circleci logs --last-failed"), "stderr: %s", result.Stderr)
 }
 
-// --- cancelled run → exit 6 ---
+// --- cancelled event → exit 6 ---
 
 func TestEventWatch_Cancelled(t *testing.T) {
 	_, env := setupWatchFake(t, "watch-pid-004", "watch-wf-004", "canceled")
@@ -214,7 +214,7 @@ func TestEventWatch_Cancelled(t *testing.T) {
 	assert.Check(t, cmp.Contains(result.Stderr, "cancelled"), "stderr: %s", result.Stderr)
 }
 
-// --- --sha: run already present ---
+// --- --sha: event already present ---
 
 func TestEventWatch_SHA(t *testing.T) {
 	_, env := setupWatchFake(t, "watch-pid-005", "watch-wf-005", "success")
@@ -254,10 +254,10 @@ func TestEventWatch_SHA_NotFound(t *testing.T) {
 	assert.Check(t, cmp.Contains(result.Stderr, "No event found"), "stderr: %s", result.Stderr)
 }
 
-// --- --failfast: exit immediately when a job fails, without waiting for the rest of the run ---
+// --- --failfast: exit immediately when a job fails, without waiting for the rest of the event ---
 
 func TestEventWatch_FailFast(t *testing.T) {
-	runID := "watch-pid-failfast"
+	eventID := "watch-pid-failfast"
 	wfID := "watch-wf-failfast"
 
 	failedJob := fakeJobV3("job-1", "integration-test", wfID, watchProjectID)
@@ -266,10 +266,10 @@ func TestEventWatch_FailFast(t *testing.T) {
 
 	fake := fakes.NewCircleCI(t)
 	addProjectInfo(fake, watchSlug, watchProjectID)
-	fake.AddRunV3(runID, watchProjectID, fakeRunV3(runID, watchProjectID, "started", "", "main", "abc1234def5678"))
-	fake.AddRun(runID, fakeRun(runID, 79, "created", watchSlug, "main"))
-	fake.AddProjectRuns(watchSlug, fakeRun(runID, 79, "created", watchSlug, "main"))
-	fake.AddRunWorkflowsV3(runID, fakeWorkflowV3(wfID, "build", runID, watchProjectID, "started", ""))
+	fake.AddEventV3(eventID, watchProjectID, fakeEventV3(eventID, watchProjectID, "started", "", "main", "abc1234def5678"))
+	fake.AddRun(eventID, fakeRun(eventID, 79, "created", watchSlug, "main"))
+	fake.AddProjectRuns(watchSlug, fakeRun(eventID, 79, "created", watchSlug, "main"))
+	fake.AddEventWorkflowsV3(eventID, fakeWorkflowV3(wfID, "build", eventID, watchProjectID, "started", ""))
 	fake.AddWorkflowJobsV3(wfID,
 		failedJob,
 		fakeJobV3("job-2", "lint", wfID, watchProjectID),
@@ -294,15 +294,15 @@ func TestEventWatch_FailFast(t *testing.T) {
 // --- watch timeout while run still running → exit 8 ---
 
 func TestEventWatch_Timeout(t *testing.T) {
-	runID := "watch-pid-006"
+	eventID := "watch-pid-006"
 	wfID := "watch-wf-006"
 
 	fake := fakes.NewCircleCI(t)
 	addProjectInfo(fake, watchSlug, watchProjectID)
-	fake.AddRunV3(runID, watchProjectID, fakeRunV3(runID, watchProjectID, "started", "", "main", "abc1234def5678"))
-	fake.AddRun(runID, fakeRun(runID, 77, "created", watchSlug, "main"))
-	fake.AddProjectRuns(watchSlug, fakeRun(runID, 77, "created", watchSlug, "main"))
-	fake.AddRunWorkflowsV3(runID, fakeWorkflowV3(wfID, "build", runID, watchProjectID, "started", ""))
+	fake.AddEventV3(eventID, watchProjectID, fakeEventV3(eventID, watchProjectID, "started", "", "main", "abc1234def5678"))
+	fake.AddRun(eventID, fakeRun(eventID, 77, "created", watchSlug, "main"))
+	fake.AddProjectRuns(watchSlug, fakeRun(eventID, 77, "created", watchSlug, "main"))
+	fake.AddEventWorkflowsV3(eventID, fakeWorkflowV3(wfID, "build", eventID, watchProjectID, "started", ""))
 	fake.AddWorkflowJobsV3(wfID, fakeJobV3("job-1", "test", wfID, watchProjectID))
 
 	env := testenv.New(t)
@@ -324,15 +324,15 @@ func TestEventWatch_Timeout(t *testing.T) {
 func TestEventWatch_InterruptDuringPolling(t *testing.T) {
 	skip.If(t, runtime.GOOS == "windows", "os.Interrupt is not supported on Windows")
 
-	runID := "watch-pid-interrupt"
+	eventID := "watch-pid-interrupt"
 	wfID := "watch-wf-interrupt"
 
 	fake := fakes.NewCircleCI(t)
 	addProjectInfo(fake, watchSlug, watchProjectID)
-	fake.AddRunV3(runID, watchProjectID, fakeRunV3(runID, watchProjectID, "started", "", "main", "abc1234def5678"))
-	fake.AddRun(runID, fakeRun(runID, 78, "created", watchSlug, "main"))
-	fake.AddProjectRuns(watchSlug, fakeRun(runID, 78, "created", watchSlug, "main"))
-	fake.AddRunWorkflowsV3(runID, fakeWorkflowV3(wfID, "build", runID, watchProjectID, "started", ""))
+	fake.AddEventV3(eventID, watchProjectID, fakeEventV3(eventID, watchProjectID, "started", "", "main", "abc1234def5678"))
+	fake.AddRun(eventID, fakeRun(eventID, 78, "created", watchSlug, "main"))
+	fake.AddProjectRuns(watchSlug, fakeRun(eventID, 78, "created", watchSlug, "main"))
+	fake.AddEventWorkflowsV3(eventID, fakeWorkflowV3(wfID, "build", eventID, watchProjectID, "started", ""))
 	fake.AddWorkflowJobsV3(wfID, fakeJobV3("job-1", "test", wfID, watchProjectID))
 
 	env := testenv.New(t)

--- a/internal/apiclient/event.go
+++ b/internal/apiclient/event.go
@@ -75,9 +75,7 @@ type EventError struct {
 
 // Event is the record of a trigger firing — it groups the workflows
 // produced by that firing and carries their shared VCS context and any
-// pre-workflow errors. The V3 API currently exposes this entity as a
-// "run"; the wire paths below still say /runs until the events API
-// ships, at which point only the paths change.
+// pre-workflow errors.
 type Event struct {
 	ID             string       `json:"id"`
 	Phase          string       `json:"phase"`
@@ -118,8 +116,7 @@ func (w eventWire) toEvent() *Event {
 // GetEvent fetches a single event by UUID from the V3 API.
 func (c *Client) GetEvent(ctx context.Context, id string) (*Event, error) {
 	var env v3Entity[eventWire]
-	// Target endpoint: GET /events/:id.
-	if err := c.getV3(ctx, "/runs/%s", &env, routeParams(id)); err != nil {
+	if err := c.getV3(ctx, "/events/%s", &env, routeParams(id)); err != nil {
 		return nil, err
 	}
 	return env.Data.toEvent(), nil
@@ -175,8 +172,7 @@ func (c *Client) SearchEvents(ctx context.Context, params EventSearchParams) ([]
 	}
 
 	var resp v3List[eventWire]
-	// Target endpoint: POST /events/search.
-	if err := c.postV3(ctx, "/runs/search", body, &resp); err != nil {
+	if err := c.postV3(ctx, "/events/search", body, &resp); err != nil {
 		return nil, err
 	}
 

--- a/internal/apiclient/workflow.go
+++ b/internal/apiclient/workflow.go
@@ -39,9 +39,9 @@ type workflowAttributesWire struct {
 }
 
 type workflowReferencesWire struct {
-	Run struct {
+	Event struct {
 		ID string `json:"id"`
-	} `json:"run"`
+	} `json:"event"`
 	Project struct {
 		ID string `json:"id"`
 	} `json:"project"`
@@ -66,7 +66,7 @@ func (w workflowWire) toWorkflowV3() WorkflowV3 {
 		CurrentOutcome: a.CurrentOutcome,
 		CreatedAt:      a.CreatedAt,
 		EndedAt:        a.EndedAt,
-		EventID:        w.References.Run.ID,
+		EventID:        w.References.Event.ID,
 		ProjectID:      w.References.Project.ID,
 	}
 }
@@ -105,8 +105,7 @@ func (c *Client) GetWorkflowV3(ctx context.Context, id string) (*WorkflowV3, err
 // from the V3 API.
 func (c *Client) GetEventWorkflows(ctx context.Context, eventID string) ([]WorkflowV3, error) {
 	var resp v3List[workflowWire]
-	// Target filter: event_id (the wire still calls the event a run).
-	if err := c.getV3(ctx, "/workflows", &resp, filterParam("run_id", eventID)); err != nil {
+	if err := c.getV3(ctx, "/workflows", &resp, filterParam("event_id", eventID)); err != nil {
 		return nil, err
 	}
 	workflows := make([]WorkflowV3, len(resp.Data))

--- a/internal/testing/fakes/circleci.go
+++ b/internal/testing/fakes/circleci.go
@@ -78,13 +78,13 @@ type CircleCI struct {
 	jobStderr      map[string][]byte // "jobID/index/stepNum" → plain text stderr
 
 	// Run (v3) state.
-	runsV3          map[string]any   // run UUID → V3 response data (inner, not wrapped)
-	runsV3ByProject map[string][]any // project UUID → ordered V3 run data items
+	eventsV3          map[string]any   // event UUID → V3 response data (inner, not wrapped)
+	eventsV3ByProject map[string][]any // project UUID → ordered V3 event data items
 
 	// Workflow (v3) state.
 	workflowsV3         map[string]any   // workflow UUID → V3 workflow data (inner, not wrapped)
-	workflowsV3ByRun    map[string][]any // run UUID → V3 workflow data items
-	workflowsV3NotFound map[string]bool  // run UUID → workflows list returns 404
+	workflowsV3ByEvent  map[string][]any // event UUID → V3 workflow data items
+	workflowsV3NotFound map[string]bool  // event UUID → workflows list returns 404
 
 	// Runner (v3) state.
 	resourceClasses []any            // all resource classes
@@ -203,10 +203,10 @@ func NewCircleCI(t *testing.T) *CircleCI {
 		workflowJobsV3:                    map[string][]any{},
 		jobStdout:                         map[string][]byte{},
 		jobStderr:                         map[string][]byte{},
-		runsV3:                            map[string]any{},
-		runsV3ByProject:                   map[string][]any{},
+		eventsV3:                          map[string]any{},
+		eventsV3ByProject:                 map[string][]any{},
 		workflowsV3:                       map[string]any{},
-		workflowsV3ByRun:                  map[string][]any{},
+		workflowsV3ByEvent:                map[string][]any{},
 		workflowsV3NotFound:               map[string]bool{},
 		resourceClasses:                   []any{},
 		runnerTokens:                      map[string][]any{},
@@ -326,8 +326,8 @@ func NewCircleCI(t *testing.T) *CircleCI {
 	r.Get("/api/v3/workflows/{id}", f.handleGetWorkflowV3ByID)
 	r.Get("/api/v3/workflows", f.handleGetWorkflowsV3)
 	// Run (v3) routes.
-	r.Get("/api/v3/runs/{id}", f.handleGetRunV3)
-	r.Post("/api/v3/runs/search", f.handleSearchRunsV3)
+	r.Get("/api/v3/events/{id}", f.handleGetEventV3)
+	r.Post("/api/v3/events/search", f.handleSearchEventsV3)
 	// Runner (v3) routes. GET /runner lists instances (scoped by ?org-id= and/or
 	// ?resource-class=); GET /runner/resource lists resource classes (scoped by
 	// ?org-id= and/or ?namespace=). GET /runner also still accepts ?namespace=
@@ -832,20 +832,20 @@ func (f *CircleCI) AddWorkflowV3(id string, workflow any) {
 	f.workflowsV3[id] = workflow
 }
 
-// AddRunWorkflowsV3 registers V3 workflow responses for a run.
-func (f *CircleCI) AddRunWorkflowsV3(runID string, workflows ...any) {
+// AddEventWorkflowsV3 registers V3 workflow responses for an event.
+func (f *CircleCI) AddEventWorkflowsV3(eventID string, workflows ...any) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	f.workflowsV3ByRun[runID] = workflows
+	f.workflowsV3ByEvent[eventID] = workflows
 }
 
-// SetRunWorkflowsV3NotFound makes GET /api/v3/workflows?filter[run_id]=<runID>
-// return 404 for the given run, mirroring the real API for runs whose
+// SetEventWorkflowsV3NotFound makes GET /api/v3/workflows?filter[event_id]=<eventID>
+// return 404 for the given event, mirroring the real API for events whose
 // workflows have not materialised.
-func (f *CircleCI) SetRunWorkflowsV3NotFound(runID string) {
+func (f *CircleCI) SetEventWorkflowsV3NotFound(eventID string) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	f.workflowsV3NotFound[runID] = true
+	f.workflowsV3NotFound[eventID] = true
 }
 
 func (f *CircleCI) handleGetWorkflowV3ByID(w http.ResponseWriter, r *http.Request) {
@@ -863,16 +863,16 @@ func (f *CircleCI) handleGetWorkflowV3ByID(w http.ResponseWriter, r *http.Reques
 }
 
 func (f *CircleCI) handleGetWorkflowsV3(w http.ResponseWriter, r *http.Request) {
-	runID := r.URL.Query().Get("filter[run_id]")
+	eventID := r.URL.Query().Get("filter[event_id]")
 	f.mu.RLock()
-	workflows := f.workflowsV3ByRun[runID]
-	notFound := f.workflowsV3NotFound[runID]
+	workflows := f.workflowsV3ByEvent[eventID]
+	notFound := f.workflowsV3NotFound[eventID]
 	f.mu.RUnlock()
 
 	if notFound {
 		render.Status(r, http.StatusNotFound)
 		render.JSON(w, r, map[string]any{
-			"error": map[string]any{"type": "not_found", "detail": "run not found", "id": "fake-error-id"},
+			"error": map[string]any{"type": "not_found", "detail": "event not found", "id": "fake-error-id"},
 		})
 		return
 	}
@@ -882,19 +882,19 @@ func (f *CircleCI) handleGetWorkflowsV3(w http.ResponseWriter, r *http.Request) 
 	render.JSON(w, r, map[string]any{"data": workflows})
 }
 
-// AddRunV3 registers a V3 run response and associates it with a project.
-// The run must have an "id" and "references.project.id" field.
-func (f *CircleCI) AddRunV3(id, projectID string, run any) {
+// AddEventV3 registers a V3 event response and associates it with a project.
+// The event must have an "id" and "references.project.id" field.
+func (f *CircleCI) AddEventV3(id, projectID string, event any) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	f.runsV3[id] = run
-	f.runsV3ByProject[projectID] = append(f.runsV3ByProject[projectID], run)
+	f.eventsV3[id] = event
+	f.eventsV3ByProject[projectID] = append(f.eventsV3ByProject[projectID], event)
 }
 
-func (f *CircleCI) handleGetRunV3(w http.ResponseWriter, r *http.Request) {
+func (f *CircleCI) handleGetEventV3(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 	f.mu.RLock()
-	run, ok := f.runsV3[id]
+	event, ok := f.eventsV3[id]
 	f.mu.RUnlock()
 
 	if !ok {
@@ -902,10 +902,10 @@ func (f *CircleCI) handleGetRunV3(w http.ResponseWriter, r *http.Request) {
 		render.JSON(w, r, map[string]any{"message": "not found"})
 		return
 	}
-	render.JSON(w, r, map[string]any{"data": run})
+	render.JSON(w, r, map[string]any{"data": event})
 }
 
-func (f *CircleCI) handleSearchRunsV3(w http.ResponseWriter, r *http.Request) {
+func (f *CircleCI) handleSearchEventsV3(w http.ResponseWriter, r *http.Request) {
 	var body struct {
 		Scope struct {
 			ProjectIDs []string `json:"project_ids"`
@@ -923,7 +923,7 @@ func (f *CircleCI) handleSearchRunsV3(w http.ResponseWriter, r *http.Request) {
 	f.mu.RLock()
 	var results []any
 	for _, pid := range body.Scope.ProjectIDs {
-		results = append(results, f.runsV3ByProject[pid]...)
+		results = append(results, f.eventsV3ByProject[pid]...)
 	}
 	f.mu.RUnlock()
 


### PR DESCRIPTION
Mirror circleci/query#1142: `/api/v3/runs{,/:id,/search}` become `/api/v3/events`, the workflows list filter becomes `filter[event_id]`, and the workflow references field is now `"event"`. Fake server routes, handlers, and acceptance test helpers follow the rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)