### PR TITLE
Add --next parameter to config validation for cli next too

### DIFF
--- a/internal/apiclient/config.go
+++ b/internal/apiclient/config.go
@@ -33,6 +33,7 @@ type CompileConfigRequest struct {
 // CompileConfigOptions controls org ownership and pipeline context for compilation.
 type CompileConfigOptions struct {
 	OwnerID            string         `json:"owner_id,omitempty"`
+	Next               bool           `json:"next,omitempty"`
 	PipelineValues     map[string]any `json:"pipeline_values,omitempty"`
 	PipelineParameters map[string]any `json:"pipeline_parameters,omitempty"`
 }
@@ -52,11 +53,12 @@ type CompileConfigError struct {
 
 // CompileConfig sends a config YAML to the compilation API and returns the result.
 // Transport failures are returned as errors; API-level validation errors are in the response.
-func (c *Client) CompileConfig(ctx context.Context, configYAML, orgID string, pipelineValues, pipelineParams map[string]any) (*CompileConfigResponse, error) {
+func (c *Client) CompileConfig(ctx context.Context, configYAML, orgID string, previewNext bool, pipelineValues, pipelineParams map[string]any) (*CompileConfigResponse, error) {
 	req := CompileConfigRequest{
 		ConfigYAML: configYAML,
 		Options: CompileConfigOptions{
 			OwnerID:            orgID,
+			Next:               previewNext,
 			PipelineValues:     pipelineValues,
 			PipelineParameters: pipelineParams,
 		},

--- a/internal/cmd/config/process.go
+++ b/internal/cmd/config/process.go
@@ -41,6 +41,7 @@ func newProcessCmd() *cobra.Command {
 	var (
 		orgID          string
 		orgSlug        string
+		previewNext    bool
 		pipelineParams string
 	)
 
@@ -92,7 +93,7 @@ func newProcessCmd() *cobra.Command {
 
 			orgID = resolveOrgID(ctx, client, orgSlug, orgID)
 
-			result, err := configcmd.Process(ctx, client, configYAML, orgID, params)
+			result, err := configcmd.Process(ctx, client, configYAML, orgID, previewNext, params)
 			if err != nil {
 				return configAPIErr(err)
 			}
@@ -113,6 +114,7 @@ func newProcessCmd() *cobra.Command {
 
 	cmd.Flags().StringVar(&orgID, "org-id", "", "Organization UUID for private orb resolution")
 	cmd.Flags().StringVarP(&orgSlug, "org-slug", "o", "", "Organization slug for private orb resolution (e.g. gh/myorg)")
+	cmd.Flags().BoolVarP(&previewNext, "next", "n", false, "Enable config next which previews upcoming potentially breaking config changes")
 	cmd.Flags().StringVar(&pipelineParams, "pipeline-parameters", "", "Pipeline parameters as a YAML map or path to a YAML file")
 
 	return cmd

--- a/internal/cmd/config/validate.go
+++ b/internal/cmd/config/validate.go
@@ -36,10 +36,11 @@ import (
 
 func newValidateCmd() *cobra.Command {
 	var (
-		configPath string
-		orgID      string
-		orgSlug    string
-		jsonOut    bool
+		configPath  string
+		orgID       string
+		orgSlug     string
+		previewNext bool
+		jsonOut     bool
 	)
 
 	cmd := &cobra.Command{
@@ -84,7 +85,7 @@ func newValidateCmd() *cobra.Command {
 
 			orgID = resolveOrgID(ctx, client, orgSlug, orgID)
 
-			result, err := configcmd.Validate(ctx, client, yaml, orgID)
+			result, err := configcmd.Validate(ctx, client, yaml, orgID, previewNext)
 			if err != nil {
 				return configAPIErr(err)
 			}
@@ -117,6 +118,7 @@ func newValidateCmd() *cobra.Command {
 
 	cmd.Flags().StringVarP(&configPath, "config", "c", ".circleci/config.yml", "Path to config file (use \"-\" for stdin)")
 	cmd.Flags().StringVar(&orgID, "org-id", "", "Organization UUID for private orb resolution")
+	cmd.Flags().BoolVarP(&previewNext, "next", "n", false, "Enable config next which previews upcoming potentially breaking config changes")
 	cmd.Flags().StringVarP(&orgSlug, "org-slug", "o", "", "Organization slug for private orb resolution (e.g. gh/myorg)")
 	cmdutil.AddJSONFlag(cmd, &jsonOut)
 

--- a/internal/cmd/root/testdata/help/circleci/config/process.txt
+++ b/internal/cmd/root/testdata/help/circleci/config/process.txt
@@ -14,11 +14,12 @@ Pass a file path or "-" to read from stdin.
 
 ## Flags
 
-| Flag                           | Description                                                  |
-| ------------------------------ | ------------------------------------------------------------ |
-| `--org-id string`              | Organization UUID for private orb resolution                 |
-| `-o, --org-slug string`        | Organization slug for private orb resolution (e.g. gh/myorg) |
-| `--pipeline-parameters string` | Pipeline parameters as a YAML map or path to a YAML file     |
+| Flag                           | Description                                                                    |
+| ------------------------------ | ------------------------------------------------------------------------------ |
+| `-n, --next`                   | Enable config next which previews upcoming potentially breaking config changes |
+| `--org-id string`              | Organization UUID for private orb resolution                                   |
+| `-o, --org-slug string`        | Organization slug for private orb resolution (e.g. gh/myorg)                   |
+| `--pipeline-parameters string` | Pipeline parameters as a YAML map or path to a YAML file                       |
 
 ## Inherited Flags
 

--- a/internal/cmd/root/testdata/help/circleci/config/validate.txt
+++ b/internal/cmd/root/testdata/help/circleci/config/validate.txt
@@ -16,12 +16,13 @@ JSON fields (--json):
 
 ## Flags
 
-| Flag                    | Description                                                              |
-| ----------------------- | ------------------------------------------------------------------------ |
-| `-c, --config string`   | Path to config file (use "-" for stdin) (default ".circleci/config.yml") |
-| `--json`                | Output as JSON                                                           |
-| `--org-id string`       | Organization UUID for private orb resolution                             |
-| `-o, --org-slug string` | Organization slug for private orb resolution (e.g. gh/myorg)             |
+| Flag                    | Description                                                                    |
+| ----------------------- | ------------------------------------------------------------------------------ |
+| `-c, --config string`   | Path to config file (use "-" for stdin) (default ".circleci/config.yml")       |
+| `--json`                | Output as JSON                                                                 |
+| `-n, --next`            | Enable config next which previews upcoming potentially breaking config changes |
+| `--org-id string`       | Organization UUID for private orb resolution                                   |
+| `-o, --org-slug string` | Organization slug for private orb resolution (e.g. gh/myorg)                   |
 
 ## Inherited Flags
 

--- a/internal/cmd/root/testdata/help/circleci/reference.txt
+++ b/internal/cmd/root/testdata/help/circleci/reference.txt
@@ -144,23 +144,25 @@ Bundle split config files into a single YAML document
 
 Compile and expand a pipeline config file
 
-| Flag                           | Description                                                  |
-| ------------------------------ | ------------------------------------------------------------ |
-| `--org-id string`              | Organization UUID for private orb resolution                 |
-| `-o, --org-slug string`        | Organization slug for private orb resolution (e.g. gh/myorg) |
-| `--pipeline-parameters string` | Pipeline parameters as a YAML map or path to a YAML file     |
+| Flag                           | Description                                                                    |
+| ------------------------------ | ------------------------------------------------------------------------------ |
+| `-n, --next`                   | Enable config next which previews upcoming potentially breaking config changes |
+| `--org-id string`              | Organization UUID for private orb resolution                                   |
+| `-o, --org-slug string`        | Organization slug for private orb resolution (e.g. gh/myorg)                   |
+| `--pipeline-parameters string` | Pipeline parameters as a YAML map or path to a YAML file                       |
 
 
 ### `circleci config validate [flags]`
 
 Validate a pipeline config file
 
-| Flag                    | Description                                                              |
-| ----------------------- | ------------------------------------------------------------------------ |
-| `-c, --config string`   | Path to config file (use "-" for stdin) (default ".circleci/config.yml") |
-| `--json`                | Output as JSON                                                           |
-| `--org-id string`       | Organization UUID for private orb resolution                             |
-| `-o, --org-slug string` | Organization slug for private orb resolution (e.g. gh/myorg)             |
+| Flag                    | Description                                                                    |
+| ----------------------- | ------------------------------------------------------------------------------ |
+| `-c, --config string`   | Path to config file (use "-" for stdin) (default ".circleci/config.yml")       |
+| `--json`                | Output as JSON                                                                 |
+| `-n, --next`            | Enable config next which previews upcoming potentially breaking config changes |
+| `--org-id string`       | Organization UUID for private orb resolution                                   |
+| `-o, --org-slug string` | Organization slug for private orb resolution (e.g. gh/myorg)                   |
 
 
 ## `circleci context <command>`

--- a/internal/cmd/root/testdata/usage/circleci/config/process.txt
+++ b/internal/cmd/root/testdata/usage/circleci/config/process.txt
@@ -1,6 +1,7 @@
 Usage:  circleci config process <path> [flags]
 
 Flags:
+  -n, --next                         Enable config next which previews upcoming potentially breaking config changes
       --org-id string                Organization UUID for private orb resolution
   -o, --org-slug string              Organization slug for private orb resolution (e.g. gh/myorg)
       --pipeline-parameters string   Pipeline parameters as a YAML map or path to a YAML file

--- a/internal/cmd/root/testdata/usage/circleci/config/validate.txt
+++ b/internal/cmd/root/testdata/usage/circleci/config/validate.txt
@@ -3,6 +3,7 @@ Usage:  circleci config validate [flags]
 Flags:
   -c, --config string     Path to config file (use "-" for stdin) (default ".circleci/config.yml")
       --json              Output as JSON
+  -n, --next              Enable config next which previews upcoming potentially breaking config changes
       --org-id string     Organization UUID for private orb resolution
   -o, --org-slug string   Organization slug for private orb resolution (e.g. gh/myorg)
   

--- a/internal/configcmd/compile.go
+++ b/internal/configcmd/compile.go
@@ -37,8 +37,8 @@ type ValidateResult struct {
 
 // Validate compiles the config YAML against the CircleCI API and returns whether it
 // is valid. orgID may be empty; pass one to enable private orb resolution.
-func Validate(ctx context.Context, client *apiclient.Client, configYAML, orgID string) (*ValidateResult, error) {
-	resp, err := client.CompileConfig(ctx, configYAML, orgID, LocalPipelineValues(nil), nil)
+func Validate(ctx context.Context, client *apiclient.Client, configYAML, orgID string, previewNext bool) (*ValidateResult, error) {
+	resp, err := client.CompileConfig(ctx, configYAML, orgID, previewNext, LocalPipelineValues(nil), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -55,8 +55,8 @@ func Validate(ctx context.Context, client *apiclient.Client, configYAML, orgID s
 
 // Process compiles the config YAML and returns the fully expanded output YAML.
 // params are pipeline parameters injected at << pipeline.parameters.* >>.
-func Process(ctx context.Context, client *apiclient.Client, configYAML, orgID string, params map[string]any) (*ValidateResult, error) {
-	resp, err := client.CompileConfig(ctx, configYAML, orgID, LocalPipelineValues(params), params)
+func Process(ctx context.Context, client *apiclient.Client, configYAML, orgID string, previewNext bool, params map[string]any) (*ValidateResult, error) {
+	resp, err := client.CompileConfig(ctx, configYAML, orgID, previewNext, LocalPipelineValues(params), params)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Checklist

=========

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)
- [x] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/main/CONTRIBUTING.md).

### Internal Checklist
- [x] I am requesting a review from my own team as well as the owning team
- [x] I have a plan in place for the monitoring of the changes that I am making (this can include new monitors, logs to be aware of, etc...)

## Changes

=======

- Add --next parameter to validate config validate & process to be used to demo upcoming config (breaking) changes

## Rationale

=========

Enable customers to easily iterate & prototype upcoming changes (potentially breaking) to config compilation.
I added this to main in https://github.com/CircleCI-Public/circleci-cli/pull/1359, also adding into "next" cli.

## Considerations

==============

n/a

## Screenshots

============

<h4>Before</h4>
Image or [gif](https://giphy.com/apps/giphycapture)

<h4>After</h4>
Image or gif where change can be clearly seen