### PR TITLE
Sharpen top-level command descriptions

### DIFF
--- a/internal/cmd/api/api.go
+++ b/internal/cmd/api/api.go
@@ -56,7 +56,7 @@ func NewAPICmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "api <path>",
-		Short: "Make an API call",
+		Short: "Call the CircleCI REST API directly",
 		Annotations: map[string]string{
 			"help:arguments": heredoc.Doc(`
 				<path> is the request path. It is relative to /api/v2 by default

--- a/internal/cmd/artifacts/artifacts.go
+++ b/internal/cmd/artifacts/artifacts.go
@@ -44,7 +44,7 @@ func NewArtifactCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "artifact <job-id>",
-		Short: "List or download job artifacts",
+		Short: "List and download a job's artifact files",
 		Annotations: map[string]string{
 			"help:arguments": heredoc.Doc(`
 				<job-id> is the UUID of the job whose artifacts you want to

--- a/internal/cmd/cmdauth/auth.go
+++ b/internal/cmd/cmdauth/auth.go
@@ -39,7 +39,7 @@ import (
 func NewAuthCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "auth <command>",
-		Short: "Authenticate with CircleCI",
+		Short: "Log in, sign up and check your CircleCI identity",
 		Long: heredoc.Doc(`
 			Manage authentication for the CLI.
 

--- a/internal/cmd/completion/completion.go
+++ b/internal/cmd/completion/completion.go
@@ -44,7 +44,7 @@ const completionTag = "# circleci shell completion"
 func NewCompletionCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "completion <command>",
-		Short: "Manage shell completions",
+		Short: "Install, remove or print shell completions",
 		Long: heredoc.Doc(`
 			Manage shell tab-completion for circleci.
 

--- a/internal/cmd/config/config.go
+++ b/internal/cmd/config/config.go
@@ -46,7 +46,7 @@ import (
 func NewConfigCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "config <command>",
-		Short: "Work with pipeline config",
+		Short: "Generate, validate, process and pack config YAML",
 		Long: heredoc.Doc(`
 			Work with the pipeline configuration file at .circleci/config.yml.
 

--- a/internal/cmd/context/context.go
+++ b/internal/cmd/context/context.go
@@ -35,7 +35,7 @@ import (
 func NewContextCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "context <command>",
-		Short: "Manage contexts",
+		Short: "Manage secret env vars shared across pipelines",
 		Long: heredoc.Doc(`
 			Work with CircleCI contexts.
 

--- a/internal/cmd/deploy/deploy.go
+++ b/internal/cmd/deploy/deploy.go
@@ -34,7 +34,7 @@ import (
 func NewDeployCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "deploy <command>",
-		Short: "Manage deploys",
+		Short: "Track released components and versions",
 		Long: heredoc.Doc(`
 			Work with CircleCI Deploys.
 

--- a/internal/cmd/dlc/dlc.go
+++ b/internal/cmd/dlc/dlc.go
@@ -34,7 +34,7 @@ import (
 func NewDLCCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "dlc <command>",
-		Short: "Manage docker layer caching",
+		Short: "Purge a project's Docker layer cache (DLC)",
 		Long: heredoc.Doc(`
 			Manage docker layer caching (DLC) for projects.
 

--- a/internal/cmd/envvar/env.go
+++ b/internal/cmd/envvar/env.go
@@ -38,7 +38,7 @@ import (
 func NewEnvVarCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "envvar <command>",
-		Short: "Manage project environment variables",
+		Short: "List, set and delete a project's environment variables",
 		Long: heredoc.Doc(`
 			List, set, and delete environment variables for a CircleCI project.
 

--- a/internal/cmd/job/job.go
+++ b/internal/cmd/job/job.go
@@ -31,7 +31,7 @@ import (
 func NewJobCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "job <command>",
-		Short: "Manage jobs",
+		Short: "Inspect a job's details, output and artifacts",
 		Long: heredoc.Doc(`
 			Work with CircleCI jobs.
 

--- a/internal/cmd/namespace/namespace.go
+++ b/internal/cmd/namespace/namespace.go
@@ -39,7 +39,7 @@ import (
 func NewNamespaceCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "namespace <command>",
-		Short: "Manage orb namespaces",
+		Short: "Manage the org namespace orbs publish under",
 		Long: heredoc.Doc(`
 			Work with CircleCI orb namespaces.
 

--- a/internal/cmd/orb/orb.go
+++ b/internal/cmd/orb/orb.go
@@ -39,9 +39,9 @@ import (
 func NewOrbCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "orb <command>",
-		Short: "Manage orbs",
+		Short: "Create, publish and inspect orbs (reusable config)",
 		Long: heredoc.Doc(`
-			Managed orbs in the orb registry.
+			Manage orbs in the orb registry.
 
 			Orbs are reusable packages of CircleCI configuration. They can be
 			published to a namespace and shared with the community or kept private.

--- a/internal/cmd/pipeline/pipeline.go
+++ b/internal/cmd/pipeline/pipeline.go
@@ -34,13 +34,14 @@ import (
 func NewPipelineCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "pipeline <command>",
-		Short: "Manage pipeline definitions",
+		Short: "Define what will happen in a run",
 		Long: heredoc.Doc(`
 			Create and list pipeline definitions for a CircleCI project.
 
-			A pipeline definition specifies where CircleCI finds the config YAML
-			and which repository to use for code checkout. Attach triggers to a
-			definition with 'circleci project trigger create'.
+			A pipeline definition decides what happens when a run is triggered:
+			which repository to check out and where to find the config YAML that
+			CircleCI compiles into workflows. Attach triggers to a definition with
+			'circleci project trigger create'.
 		`),
 		RunE:               cmdutil.GroupRunE,
 		FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},

--- a/internal/cmd/policy/policy.go
+++ b/internal/cmd/policy/policy.go
@@ -35,7 +35,7 @@ import (
 func NewPolicyCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "policy <command>",
-		Short: "Manage security policies",
+		Short: "Govern config with Rego security policies",
 		Long: heredoc.Doc(`
 			Manage security policies.
 

--- a/internal/cmd/project/env.go
+++ b/internal/cmd/project/env.go
@@ -43,7 +43,7 @@ import (
 func newEnvCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "envvar <command>",
-		Short: "Manage project environment variables",
+		Short: "List, set and delete a project's environment variables",
 		Long: heredoc.Doc(`
 			List, set, and delete environment variables for a CircleCI project.
 

--- a/internal/cmd/project/project.go
+++ b/internal/cmd/project/project.go
@@ -32,7 +32,7 @@ import (
 func NewProjectCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "project <command>",
-		Short: "Manage projects",
+		Short: "List, follow and configure CircleCI projects",
 		Long: heredoc.Doc(`
 			List, follow, and manage settings for CircleCI projects.
 

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -205,8 +205,11 @@ func NewRootCmd(version string) *cobra.Command {
 	cmd.AddCommand(step.NewStepCmd())
 	cmd.AddCommand(workflow.NewWorkflowCmd())
 
-	// Wire in MCP commands
-	cmd.AddCommand(ophis.Command(nil))
+	// Wire in MCP commands. ophis sets its own terse Short; override it so the
+	// root command table explains what the command actually does.
+	mcpCmd := ophis.Command(nil)
+	mcpCmd.Short = "Run the CLI as an MCP server for AI tools"
+	cmd.AddCommand(mcpCmd)
 
 	// Help topics
 	var referenceCmd *cobra.Command

--- a/internal/cmd/root/testdata/help/circleci/orb.txt
+++ b/internal/cmd/root/testdata/help/circleci/orb.txt
@@ -1,6 +1,6 @@
 # CircleCI CLI
 
-Managed orbs in the orb registry.
+Manage orbs in the orb registry.
 
 Orbs are reusable packages of CircleCI configuration. They can be
 published to a namespace and shared with the community or kept private.

--- a/internal/cmd/root/testdata/help/circleci/pipeline.txt
+++ b/internal/cmd/root/testdata/help/circleci/pipeline.txt
@@ -2,9 +2,10 @@
 
 Create and list pipeline definitions for a CircleCI project.
 
-A pipeline definition specifies where CircleCI finds the config YAML
-and which repository to use for code checkout. Attach triggers to a
-definition with 'circleci project trigger create'.
+A pipeline definition decides what happens when a run is triggered:
+which repository to check out and where to find the config YAML that
+CircleCI compiles into workflows. Attach triggers to a definition with
+'circleci project trigger create'.
 
 ## Usage
 

--- a/internal/cmd/root/testdata/help/circleci/project.txt
+++ b/internal/cmd/root/testdata/help/circleci/project.txt
@@ -16,17 +16,17 @@ To manage environment variables directly, use the top-level alias:
 
 ## Available Commands
 
-| Command   | Description                              |
-| --------- | ---------------------------------------- |
-| `create`  | Create a new project                     |
-| `dlc`     | Manage docker layer caching              |
-| `envvar`  | Manage project environment variables     |
-| `follow`  | Follow a project                         |
-| `get`     | Show project details                     |
-| `link`    | Bind this checkout to a CircleCI project |
-| `list`    | List followed projects                   |
-| `open`    | Open the project page in the browser     |
-| `trigger` | Manage project triggers                  |
+| Command   | Description                                            |
+| --------- | ------------------------------------------------------ |
+| `create`  | Create a new project                                   |
+| `dlc`     | Purge a project's Docker layer cache (DLC)             |
+| `envvar`  | List, set and delete a project's environment variables |
+| `follow`  | Follow a project                                       |
+| `get`     | Show project details                                   |
+| `link`    | Bind this checkout to a CircleCI project               |
+| `list`    | List followed projects                                 |
+| `open`    | Open the project page in the browser                   |
+| `trigger` | Manage project triggers                                |
 
 ## Inherited Flags
 

--- a/internal/cmd/root/testdata/help/circleci/reference.txt
+++ b/internal/cmd/root/testdata/help/circleci/reference.txt
@@ -12,7 +12,7 @@ Work with CircleCI from the command line.
 
 ## `circleci api <path> [flags]`
 
-Make an API call
+Call the CircleCI REST API directly
 
 | Flag                       | Description                                                                       |
 | -------------------------- | --------------------------------------------------------------------------------- |
@@ -31,7 +31,7 @@ prefix, include it explicitly, e.g. "/api/v1.1/me".
 
 ## `circleci artifact <job-id> [flags]`
 
-List or download job artifacts
+List and download a job's artifact files
 
 | Flag                    | Description                                      |
 | ----------------------- | ------------------------------------------------ |
@@ -48,7 +48,7 @@ e.g. 5034460f-c7c4-4c43-9457-de07e2029e7b.
 
 ## `circleci auth <command>`
 
-Authenticate with CircleCI
+Log in, sign up and check your CircleCI identity
 
 ### `circleci auth id [flags]`
 
@@ -146,7 +146,7 @@ Upload a .p12 certificate
 
 ## `circleci completion <command>`
 
-Manage shell completions
+Install, remove or print shell completions
 
 ### `circleci completion install`
 
@@ -158,7 +158,7 @@ Remove shell completion from your shell profile
 
 ## `circleci config <command>`
 
-Work with pipeline config
+Generate, validate, process and pack config YAML
 
 ### `circleci config generate [path]`
 
@@ -205,7 +205,7 @@ Validate a pipeline config file
 
 ## `circleci context <command>`
 
-Manage contexts
+Manage secret env vars shared across pipelines
 
 ### `circleci context create <name> [flags]`
 
@@ -383,7 +383,7 @@ A context can be specified in the form:
 
 ## `circleci deploy <command>`
 
-Manage deploys
+Track released components and versions
 
 ### `circleci deploy init [flags]`
 
@@ -423,7 +423,7 @@ Open the deploys page in the browser
 
 ## `circleci dlc <command>`
 
-Manage docker layer caching
+Purge a project's Docker layer cache (DLC)
 
 ### `circleci dlc purge --project <slug> [flags]`
 
@@ -437,7 +437,7 @@ Purge the Docker Layer Cache for a project
 
 ## `circleci envvar <command>`
 
-Manage project environment variables
+List, set and delete a project's environment variables
 
 ### `circleci envvar delete <name> [flags]`
 
@@ -482,7 +482,7 @@ after being set and is masked in all subsequent list output.
 
 ## `circleci job <command>`
 
-Manage jobs
+Inspect a job's details, output and artifacts
 
 ### `circleci job artifact <job-id> [flags]`
 
@@ -556,7 +556,7 @@ UUIDs are shown in the output of "circleci workflow get" and
 
 ## `circleci mcp`
 
-MCP server management
+Run the CLI as an MCP server for AI tools
 
 ### `circleci mcp claude`
 
@@ -700,7 +700,7 @@ Show VSCode MCP servers
 
 ## `circleci namespace <command>`
 
-Manage orb namespaces
+Manage the org namespace orbs publish under
 
 ### `circleci namespace create <name> --org-id <uuid> [flags]`
 
@@ -772,7 +772,7 @@ Guided onboarding: scan, test, generate config, sign up
 
 ## `circleci orb <command>`
 
-Manage orbs
+Create, publish and inspect orbs (reusable config)
 
 ### `circleci orb add-to-category <ns>/<orb> <category>`
 
@@ -944,7 +944,7 @@ Validate an orb YAML file
 
 ## `circleci pipeline <command>`
 
-Manage pipeline definitions
+Define what will happen in a run
 
 ### `circleci pipeline create [flags]`
 
@@ -994,7 +994,7 @@ Trigger a new pipeline run
 
 ## `circleci policy <command>`
 
-Manage security policies
+Govern config with Rego security policies
 
 ### `circleci policy decide [flags]`
 
@@ -1111,7 +1111,7 @@ Update policy enforcement settings
 
 ## `circleci project <command>`
 
-Manage projects
+List, follow and configure CircleCI projects
 
 ### `circleci project create [project-name] --org <vcs/org-slug> [flags]`
 
@@ -1132,7 +1132,7 @@ non-interactive mode it is used automatically.
 
 ### `circleci project dlc <command>`
 
-Manage docker layer caching
+Purge a project's Docker layer cache (DLC)
 
 #### `circleci project dlc purge --project <slug> [flags]`
 
@@ -1146,7 +1146,7 @@ Purge the Docker Layer Cache for a project
 
 ### `circleci project envvar <command>`
 
-Manage project environment variables
+List, set and delete a project's environment variables
 
 #### `circleci project envvar delete <name> [flags]`
 
@@ -1279,7 +1279,7 @@ List triggers for a pipeline definition
 
 ## `circleci run <command>`
 
-Manage CI runs
+Trigger, watch and cancel CI runs
 
 ### `circleci run cancel <run-number-or-id> [flags]`
 
@@ -1547,7 +1547,7 @@ List tokens for a resource class
 
 ## `circleci setting <command>`
 
-Manage CLI settings
+Configure the CLI itself (token, host, defaults)
 
 ### `circleci setting list [flags]`
 
@@ -1636,7 +1636,7 @@ Print version information
 
 ## `circleci workflow <command>`
 
-Manage workflows
+Inspect, rerun and cancel workflows (job graphs)
 
 ### `circleci workflow cancel <workflow-id> [flags]`
 

--- a/internal/cmd/root/testdata/help/circleci/run.txt
+++ b/internal/cmd/root/testdata/help/circleci/run.txt
@@ -2,8 +2,9 @@
 
 Work with CircleCI runs.
 
-Runs are the top-level unit of work in CircleCI — they contain
-one or more workflows, each of which contains jobs.
+A run is created each time a trigger fires for a pipeline. It carries
+the VCS context for that firing and groups the workflows it produced;
+each workflow in turn contains jobs.
 
 ## Usage
 

--- a/internal/cmd/run/run.go
+++ b/internal/cmd/run/run.go
@@ -36,12 +36,13 @@ import (
 func NewRunCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "run <command>",
-		Short: "Manage CI runs",
+		Short: "Trigger, watch and cancel CI runs",
 		Long: heredoc.Doc(`
 			Work with CircleCI runs.
 
-			Runs are the top-level unit of work in CircleCI — they contain
-			one or more workflows, each of which contains jobs.
+			A run is created each time a trigger fires for a pipeline. It carries
+			the VCS context for that firing and groups the workflows it produced;
+			each workflow in turn contains jobs.
 		`),
 	}
 

--- a/internal/cmd/setting/setting.go
+++ b/internal/cmd/setting/setting.go
@@ -33,7 +33,7 @@ import (
 func NewSettingCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "setting <command>",
-		Short: "Manage CLI settings",
+		Short: "Configure the CLI itself (token, host, defaults)",
 		Long: heredoc.Doc(`
 			View and modify settings for the circleci CLI tool.
 

--- a/internal/cmd/workflow/workflow.go
+++ b/internal/cmd/workflow/workflow.go
@@ -35,7 +35,7 @@ import (
 func NewWorkflowCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "workflow <command>",
-		Short: "Manage workflows",
+		Short: "Inspect, rerun and cancel workflows (job graphs)",
 		Long: heredoc.Doc(`
 			Work with CircleCI workflows.
 


### PR DESCRIPTION
## Summary
- Rewrite the `Short` one-liner for each top-level command group so it describes what the entity actually *is* — grounded in the public-api-service V3 entity design docs and apispec registry — instead of a generic "Manage X".
- Tighten the `pipeline` and `run` `Long` descriptions to match the V3 model (pipeline = what happens when a run is triggered; run = created each time a trigger fires, grouping the workflows it produced).
- Fix the "Managed orbs" typo in the orb `Long`.
- Override the externally-supplied `mcp` `Short` (from the `ophis` package) in `root.go` so the command table explains what it does.
- Align `project envvar`'s `Short` with the top-level `envvar` alias.
- Regenerate the affected help golden snapshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)