### PR TITLE
Migrate workflow rerun from v2 to v3 API

### DIFF
--- a/acceptance/workflow_test.go
+++ b/acceptance/workflow_test.go
@@ -236,7 +236,7 @@ func TestWorkflowRerun(t *testing.T) {
 	t.Run("check request", func(t *testing.T) {
 		assert.Check(t, cmp.DeepEqual(fake.LastRequest(), &httprecorder.Request{
 			Method: http.MethodPost,
-			URL:    url.URL{Path: "/api/v2/workflow/" + testWorkflowDetailID + "/rerun"},
+			URL:    url.URL{Path: "/api/v3/workflows/" + testWorkflowDetailID + "/rerun"},
 			Header: http.Header{
 				"Authorization": {"Bearer test-token"},
 				"User-Agent":    {apiclient.UserAgent(runtime.GOOS, runtime.GOARCH, "dev", "")},
@@ -277,7 +277,7 @@ func TestWorkflowRerun_FromFailed(t *testing.T) {
 	t.Run("check request", func(t *testing.T) {
 		assert.Check(t, cmp.DeepEqual(fake.LastRequest(), &httprecorder.Request{
 			Method: http.MethodPost,
-			URL:    url.URL{Path: "/api/v2/workflow/" + testWorkflowDetailID + "/rerun"},
+			URL:    url.URL{Path: "/api/v3/workflows/" + testWorkflowDetailID + "/rerun"},
 			Header: http.Header{
 				"Authorization": {"Bearer test-token"},
 				"User-Agent":    {apiclient.UserAgent(runtime.GOOS, runtime.GOARCH, "dev", "")},

--- a/internal/apiclient/workflow.go
+++ b/internal/apiclient/workflow.go
@@ -119,10 +119,10 @@ func (c *Client) GetEventWorkflows(ctx context.Context, eventID string) ([]Workf
 // true only the failed jobs are rerun; otherwise all jobs restart from scratch.
 func (c *Client) RerunWorkflow(ctx context.Context, id string, fromFailed bool) error {
 	body := map[string]any{"from_failed": fromFailed}
-	var resp struct {
-		Message string `json:"message"`
-	}
-	return c.post(ctx, "/workflow/%s/rerun", body, &resp,
+	var resp v3Entity[struct {
+		WorkflowID string `json:"workflow_id"`
+	}]
+	return c.postV3(ctx, "/workflows/%s/rerun", body, &resp,
 		routeParams(id),
 	)
 }

--- a/internal/testing/fakes/circleci.go
+++ b/internal/testing/fakes/circleci.go
@@ -256,7 +256,7 @@ func NewCircleCI(t *testing.T) *CircleCI {
 	r.Use(chirecorder.Middleware(f.RequestRecorder))
 	r.Get("/api/v2/pipeline/{id}", f.handleGetPipeline)
 	r.Post("/api/v2/pipeline/{id}/cancel", f.handleCancelPipeline)
-	r.Post("/api/v2/workflow/{id}/rerun", f.handleRerunWorkflow)
+	r.Post("/api/v3/workflows/{id}/rerun", f.handleRerunWorkflow)
 	r.Post("/api/v3/workflows/{id}/cancel", f.handleCancelWorkflow)
 	r.Get("/api/v2/project/{vcs}/{org}/{repo}/pipeline", f.handleListProjectPipelines)
 	r.Get("/api/v2/project/{vcs}/{org}/{repo}/pipeline/{number}", f.handleGetPipelineByNumber)
@@ -949,7 +949,7 @@ func (f *CircleCI) handleRerunWorkflow(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	render.Status(r, status)
-	render.JSON(w, r, map[string]any{"message": "Accepted."})
+	render.JSON(w, r, map[string]any{"data": map[string]any{"workflow_id": id}})
 }
 
 func (f *CircleCI) handleCancelWorkflow(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

- Switches `RerunWorkflow()` in `internal/apiclient/workflow.go` from `c.post` (v2) to `c.postV3` (v3), updating the route from `/workflow/%s/rerun` to `/workflows/%s/rerun`
- Updates the response struct from a v2-style `{"message": string}` to `v3Entity` with a `workflow_id` field
- Updates the fake server route and handler response body to match the v3 contract
- Updates acceptance test path assertions to the v3 path

## Test plan

- [x] `go test -count=1 ./acceptance/... -run Rerun` — all rerun acceptance tests pass
- [x] `task lint` — 0 issues
- [x] `task fmt` — no changes

Closes FACT-304

🤖 Generated with [Claude Code](https://claude.com/claude-code)