### PR TITLE
Add auth login and getting-started suggestions to token missing error

### DIFF
--- a/acceptance/testdata/TestArtifact_NoToken.stderr.txt
+++ b/acceptance/testdata/TestArtifact_NoToken.stderr.txt
@@ -3,5 +3,6 @@ error: No CircleCI API token found.
 Suggestions:
   • Run: circleci setting set token <your-token>
   • Or set the CIRCLE_TOKEN environment variable
+  • See: circleci help getting-started
 
 Reference: https://app.circleci.com/settings/user/tokens

--- a/acceptance/testdata/TestAuthMe_NoToken.stderr.txt
+++ b/acceptance/testdata/TestAuthMe_NoToken.stderr.txt
@@ -3,5 +3,6 @@ error: No CircleCI API token found.
 Suggestions:
   • Run: circleci setting set token <your-token>
   • Or set the CIRCLE_TOKEN environment variable
+  • See: circleci help getting-started
 
 Reference: https://app.circleci.com/settings/user/tokens

--- a/acceptance/testdata/TestCertificateUpload_NoToken.stderr.txt
+++ b/acceptance/testdata/TestCertificateUpload_NoToken.stderr.txt
@@ -3,5 +3,6 @@ error: No CircleCI API token found.
 Suggestions:
   • Run: circleci setting set token <your-token>
   • Or set the CIRCLE_TOKEN environment variable
+  • See: circleci help getting-started
 
 Reference: https://app.circleci.com/settings/user/tokens

--- a/acceptance/testdata/TestProjectList_NoToken.stderr.txt
+++ b/acceptance/testdata/TestProjectList_NoToken.stderr.txt
@@ -3,5 +3,6 @@ error: No CircleCI API token found.
 Suggestions:
   • Run: circleci setting set token <your-token>
   • Or set the CIRCLE_TOKEN environment variable
+  • See: circleci help getting-started
 
 Reference: https://app.circleci.com/settings/user/tokens

--- a/acceptance/testdata/TestRunGet_NoToken.stderr.txt
+++ b/acceptance/testdata/TestRunGet_NoToken.stderr.txt
@@ -3,5 +3,6 @@ error: No CircleCI API token found.
 Suggestions:
   • Run: circleci setting set token <your-token>
   • Or set the CIRCLE_TOKEN environment variable
+  • See: circleci help getting-started
 
 Reference: https://app.circleci.com/settings/user/tokens

--- a/acceptance/testdata/TestRunList_NoToken.stderr.txt
+++ b/acceptance/testdata/TestRunList_NoToken.stderr.txt
@@ -3,5 +3,6 @@ error: No CircleCI API token found.
 Suggestions:
   • Run: circleci setting set token <your-token>
   • Or set the CIRCLE_TOKEN environment variable
+  • See: circleci help getting-started
 
 Reference: https://app.circleci.com/settings/user/tokens

--- a/acceptance/testdata/TestRunTrigger_NoToken.stderr.txt
+++ b/acceptance/testdata/TestRunTrigger_NoToken.stderr.txt
@@ -3,5 +3,6 @@ error: No CircleCI API token found.
 Suggestions:
   • Run: circleci setting set token <your-token>
   • Or set the CIRCLE_TOKEN environment variable
+  • See: circleci help getting-started
 
 Reference: https://app.circleci.com/settings/user/tokens

--- a/acceptance/testdata/TestRunnerInstanceList_NoToken.stderr.txt
+++ b/acceptance/testdata/TestRunnerInstanceList_NoToken.stderr.txt
@@ -3,5 +3,6 @@ error: No CircleCI API token found.
 Suggestions:
   • Run: circleci setting set token <your-token>
   • Or set the CIRCLE_TOKEN environment variable
+  • See: circleci help getting-started
 
 Reference: https://app.circleci.com/settings/user/tokens

--- a/acceptance/testdata/TestRunnerResourceClassList_NoToken.stderr.txt
+++ b/acceptance/testdata/TestRunnerResourceClassList_NoToken.stderr.txt
@@ -3,5 +3,6 @@ error: No CircleCI API token found.
 Suggestions:
   • Run: circleci setting set token <your-token>
   • Or set the CIRCLE_TOKEN environment variable
+  • See: circleci help getting-started
 
 Reference: https://app.circleci.com/settings/user/tokens

--- a/acceptance/testdata/TestWorkflowCancel_NoToken.stderr.txt
+++ b/acceptance/testdata/TestWorkflowCancel_NoToken.stderr.txt
@@ -3,5 +3,6 @@ error: No CircleCI API token found.
 Suggestions:
   • Run: circleci setting set token <your-token>
   • Or set the CIRCLE_TOKEN environment variable
+  • See: circleci help getting-started
 
 Reference: https://app.circleci.com/settings/user/tokens

--- a/acceptance/testdata/TestWorkflowGet_NoToken.stderr.txt
+++ b/acceptance/testdata/TestWorkflowGet_NoToken.stderr.txt
@@ -3,5 +3,6 @@ error: No CircleCI API token found.
 Suggestions:
   • Run: circleci setting set token <your-token>
   • Or set the CIRCLE_TOKEN environment variable
+  • See: circleci help getting-started
 
 Reference: https://app.circleci.com/settings/user/tokens

--- a/acceptance/testdata/TestWorkflowList_NoToken.stderr.txt
+++ b/acceptance/testdata/TestWorkflowList_NoToken.stderr.txt
@@ -3,5 +3,6 @@ error: No CircleCI API token found.
 Suggestions:
   • Run: circleci setting set token <your-token>
   • Or set the CIRCLE_TOKEN environment variable
+  • See: circleci help getting-started
 
 Reference: https://app.circleci.com/settings/user/tokens

--- a/acceptance/testdata/TestWorkflowRerun_NoToken.stderr.txt
+++ b/acceptance/testdata/TestWorkflowRerun_NoToken.stderr.txt
@@ -3,5 +3,6 @@ error: No CircleCI API token found.
 Suggestions:
   • Run: circleci setting set token <your-token>
   • Or set the CIRCLE_TOKEN environment variable
+  • See: circleci help getting-started
 
 Reference: https://app.circleci.com/settings/user/tokens

--- a/internal/cmdutil/client.go
+++ b/internal/cmdutil/client.go
@@ -125,6 +125,7 @@ func LoadClient(ctx context.Context) (*apiclient.Client, error) {
 			WithSuggestions(
 				"Run: circleci setting set token <your-token>",
 				"Or set the CIRCLE_TOKEN environment variable",
+				"See: circleci help getting-started",
 			).
 			WithRef("https://app.circleci.com/settings/user/tokens").
 			WithExitCode(clierrors.ExitAuthError)
@@ -160,8 +161,12 @@ func APIErr(err error, subject, notFoundCode, notFoundMsg string, notFoundSugges
 	if httpcl.HasStatusCode(err, http.StatusUnauthorized) {
 		return clierrors.New("auth.token_invalid", "Authentication failed",
 			"The API token was rejected by CircleCI.").
-			WithSuggestions("Run: circleci setting set token <your-token>").
-			WithRef("https://app.circleci.com/settings/user/tokens").
+			WithSuggestions(
+				"Run: circleci auth login",
+				"Or set the CIRCLE_TOKEN environment variable",
+				"See: circleci help getting-started",
+			).
+			WithRef("https://app.circleci.com/settings/user/oauth-clients").
 			WithExitCode(clierrors.ExitAuthError)
 	}
 	if httpcl.HasStatusCode(err, http.StatusNotFound) {


### PR DESCRIPTION
## Summary

- Adds `circleci auth login` as the first suggestion when no API token is found
- Adds `circleci help getting-started` as an additional suggestion

## Test plan

- [ ] Run a command without a token set and verify the new suggestions appear in the error output