### PR TITLE
Remove deprecated pipeline.git.ssh_checkout_url value

### DIFF
--- a/internal/configcmd/pipeline.go
+++ b/internal/configcmd/pipeline.go
@@ -84,7 +84,6 @@ func LocalPipelineValues(params map[string]any) map[string]any {
 		"pipeline.git.repo_name":                                     "",
 		"pipeline.git.repo_owner":                                    "",
 		"pipeline.git.repo_url":                                      gitURL,
-		"pipeline.git.ssh_checkout_url":                              "",
 		"pipeline.trigger_parameters.circleci.event_time":            "2020-01-01T00:00:00Z",
 		"pipeline.trigger_parameters.circleci.trigger_type":          "github_app",
 		"pipeline.trigger_parameters.circleci.event_type":            "push",


### PR DESCRIPTION
<!--
  Thank you for contributing to CircleCI CLI!
  For PRs adding new features, please raise an issue first.
-->

Remove `pipeline.git.ssh_checkout_url` from `LocalPipelineValues()`. This undocumented pipeline value is being removed server-side by the SoC team (SC-2993) and has no alternative. Dropping it from the CLI ensures it no longer sends this unsupported key to the compile API during local config validation/processing.