### PR TITLE
Consolidate org flags

### DIFF
--- a/acceptance/certificate_test.go
+++ b/acceptance/certificate_test.go
@@ -102,7 +102,7 @@ func TestCertificateUpload(t *testing.T) {
 		Binary: binaryPath,
 		Args: []string{
 			"certificate", "upload",
-			"--org-id", testIOSOrgID,
+			"--org", testIOSOrgID,
 			"--cert-file", certPath,
 			"--password", "hunter2",
 		},
@@ -137,7 +137,7 @@ func TestCertificateUpload_JSON(t *testing.T) {
 		Binary: binaryPath,
 		Args: []string{
 			"certificate", "upload",
-			"--org-id", testIOSOrgID,
+			"--org", testIOSOrgID,
 			"--cert-file", certPath,
 			"--password", "hunter2",
 			"--json",
@@ -161,7 +161,7 @@ func TestCertificateUpload_PasswordFromStdin(t *testing.T) {
 		Binary: binaryPath,
 		Args: []string{
 			"certificate", "upload",
-			"--org-id", testIOSOrgID,
+			"--org", testIOSOrgID,
 			"--cert-file", certPath,
 			"--password", "-",
 			"--json",
@@ -186,7 +186,7 @@ func TestCertificateUpload_MissingPasswordNonInteractive(t *testing.T) {
 		Binary: binaryPath,
 		Args: []string{
 			"certificate", "upload",
-			"--org-id", testIOSOrgID,
+			"--org", testIOSOrgID,
 			"--cert-file", certPath,
 		},
 		Env:     env.Environ(),
@@ -208,7 +208,7 @@ func TestCertificateUpload_EmptyFile(t *testing.T) {
 		Binary: binaryPath,
 		Args: []string{
 			"certificate", "upload",
-			"--org-id", testIOSOrgID,
+			"--org", testIOSOrgID,
 			"--cert-file", certPath,
 			"--password", "x",
 		},
@@ -229,7 +229,7 @@ func TestCertificateUpload_NoToken(t *testing.T) {
 		Binary: binaryPath,
 		Args: []string{
 			"certificate", "upload",
-			"--org-id", testIOSOrgID,
+			"--org", testIOSOrgID,
 			"--cert-file", certPath,
 			"--password", "p",
 		},
@@ -251,7 +251,7 @@ func TestCertificateList(t *testing.T) {
 
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    []string{"certificate", "list", "--org-id", testIOSOrgID},
+		Args:    []string{"certificate", "list", "--org", testIOSOrgID},
 		Env:     env.Environ(),
 		WorkDir: t.TempDir(),
 	})
@@ -268,7 +268,7 @@ func TestCertificateList_Color(t *testing.T) {
 
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    []string{"certificate", "list", "--org-id", testIOSOrgID},
+		Args:    []string{"certificate", "list", "--org", testIOSOrgID},
 		Env:     env.Environ(),
 		WorkDir: t.TempDir(),
 		TTY:     true,
@@ -286,7 +286,7 @@ func TestCertificateList_JSON(t *testing.T) {
 
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    []string{"certificate", "list", "--org-id", testIOSOrgID, "--json"},
+		Args:    []string{"certificate", "list", "--org", testIOSOrgID, "--json"},
 		Env:     env.Environ(),
 		WorkDir: t.TempDir(),
 	})
@@ -301,7 +301,7 @@ func TestCertificateList_Empty(t *testing.T) {
 
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    []string{"certificate", "list", "--org-id", testIOSOrgID},
+		Args:    []string{"certificate", "list", "--org", testIOSOrgID},
 		Env:     env.Environ(),
 		WorkDir: t.TempDir(),
 	})
@@ -315,7 +315,7 @@ func TestCertificateList_NoOrgIDOutsideGit(t *testing.T) {
 	env := setupIOSEnv(t, fake)
 
 	// t.TempDir is not a git repo, so auto-detection fails and the user is
-	// pointed at --org-id.
+	// pointed at --org.
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
 		Args:    []string{"certificate", "list"},
@@ -326,7 +326,7 @@ func TestCertificateList_NoOrgIDOutsideGit(t *testing.T) {
 	assert.Equal(t, result.ExitCode, 2, "stderr: %s", result.Stderr)
 	// git's "not a git repo" wording varies by version; assert only on the parts we own.
 	assert.Check(t, cmp.Contains(result.Stderr, "could not read git remote"))
-	assert.Check(t, cmp.Contains(result.Stderr, "--org-id"))
+	assert.Check(t, cmp.Contains(result.Stderr, "--org"))
 }
 
 // --- certificate delete ---

--- a/acceptance/config_test.go
+++ b/acceptance/config_test.go
@@ -164,9 +164,11 @@ func TestConfigValidate_FileNotFound(t *testing.T) {
 	assert.Check(t, golden.String(result.Stderr, t.Name()+".stderr.txt"))
 }
 
+const testOrgUUID = "00000000-0000-0000-0000-0000000000aa"
+
 func TestConfigValidate_WithOrgSlug(t *testing.T) {
 	fake := fakes.NewCircleCI(t)
-	fake.AddOrg("org-uuid-001", "gh/myorg", "My Org", "github")
+	fake.AddOrg(testOrgUUID, "gh/myorg", "My Org", "github")
 
 	env := testenv.New(t)
 	env.Token = testToken
@@ -177,14 +179,65 @@ func TestConfigValidate_WithOrgSlug(t *testing.T) {
 
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    []string{"config", "validate", "--config", ".circleci/config.yml", "--org-slug", "gh/myorg"},
+		Args:    []string{"config", "validate", "--config", ".circleci/config.yml", "--org", "gh/myorg"},
 		Env:     env.Environ(),
 		WorkDir: dir,
 	})
 
 	assert.Check(t, cmp.Equal(result.ExitCode, 0))
 	assert.Check(t, cmp.Contains(result.Stdout, ".circleci/config.yml"))
+	// The slug was resolved to its org UUID before the compile call.
+	assert.Check(t, cmp.Equal(fake.LastCompileOwnerID(), testOrgUUID))
 	assert.Check(t, golden.String(result.Stderr, t.Name()+".stderr.txt"))
+}
+
+// TestConfigValidate_WithOrgUUID is the UUID counterpart of
+// TestConfigValidate_WithOrgSlug: passing the org UUID directly to --org must
+// reach the compile endpoint as the same owner_id, with no slug lookup needed
+// (no AddOrg is registered).
+func TestConfigValidate_WithOrgUUID(t *testing.T) {
+	fake := fakes.NewCircleCI(t)
+
+	env := testenv.New(t)
+	env.Token = testToken
+	env.CircleCIURL = fake.URL()
+
+	dir := t.TempDir()
+	writeConfig(t, dir, testConfigYAML)
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"config", "validate", "--config", ".circleci/config.yml", "--org", testOrgUUID},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	assert.Check(t, cmp.Equal(result.ExitCode, 0))
+	assert.Check(t, cmp.Contains(result.Stdout, ".circleci/config.yml"))
+	assert.Check(t, cmp.Equal(fake.LastCompileOwnerID(), testOrgUUID))
+}
+
+// TestConfigValidate_RemovedOrgFlags pins the clean break from the legacy org
+// flag names: --org-id and --org-slug were collapsed into --org and must no
+// longer be accepted. Cobra reports unknown flags with a non-zero exit and an
+// "unknown flag" message on stderr.
+func TestConfigValidate_RemovedOrgFlags(t *testing.T) {
+	for _, flag := range []string{"--org-id", "--org-slug"} {
+		t.Run(flag, func(t *testing.T) {
+			env := testenv.New(t)
+			env.Token = testToken
+
+			result := binary.RunCLI(t, binary.RunOpts{
+				Binary:  binaryPath,
+				Args:    []string{"config", "validate", flag, "gh/myorg"},
+				Env:     env.Environ(),
+				WorkDir: t.TempDir(),
+			})
+
+			assert.Check(t, result.ExitCode != 0)
+			assert.Check(t, cmp.Contains(result.Stderr, "unknown flag: "+flag))
+		})
+	}
 }
 
 // --- config process ---

--- a/acceptance/namespace_test.go
+++ b/acceptance/namespace_test.go
@@ -120,7 +120,7 @@ func TestNamespaceCreate(t *testing.T) {
 
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    []string{"namespace", "create", testNamespaceName, "--org-id", testOrgID},
+		Args:    []string{"namespace", "create", testNamespaceName, "--org", testOrgID},
 		Env:     env.Environ(),
 		WorkDir: t.TempDir(),
 	})
@@ -152,7 +152,7 @@ func TestNamespaceCreate_JSON(t *testing.T) {
 
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    []string{"namespace", "create", testNamespaceName, "--org-id", testOrgID, "--json"},
+		Args:    []string{"namespace", "create", testNamespaceName, "--org", testOrgID, "--json"},
 		Env:     env.Environ(),
 		WorkDir: t.TempDir(),
 	})

--- a/acceptance/policy_test.go
+++ b/acceptance/policy_test.go
@@ -69,7 +69,7 @@ func TestPolicyPush(t *testing.T) {
 
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    []string{"policy", "push", dir, "--owner-id", testOwnerID, "--no-prompt"},
+		Args:    []string{"policy", "push", dir, "--org", testOwnerID, "--no-prompt"},
 		Env:     env.Environ(),
 		WorkDir: t.TempDir(),
 	})
@@ -109,7 +109,7 @@ func TestPolicyPush_DryRun(t *testing.T) {
 	// We test the JSON output matches the diff format.
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    []string{"policy", "push", dir, "--owner-id", testOwnerID, "--no-prompt", "--json"},
+		Args:    []string{"policy", "push", dir, "--org", testOwnerID, "--no-prompt", "--json"},
 		Env:     env.Environ(),
 		WorkDir: t.TempDir(),
 	})
@@ -133,7 +133,7 @@ func TestPolicyDiff(t *testing.T) {
 
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    []string{"policy", "diff", dir, "--owner-id", testOwnerID},
+		Args:    []string{"policy", "diff", dir, "--org", testOwnerID},
 		Env:     env.Environ(),
 		WorkDir: t.TempDir(),
 	})
@@ -156,7 +156,7 @@ func TestPolicyFetch(t *testing.T) {
 
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    []string{"policy", "fetch", "--owner-id", testOwnerID},
+		Args:    []string{"policy", "fetch", "--org", testOwnerID},
 		Env:     env.Environ(),
 		WorkDir: t.TempDir(),
 	})
@@ -177,7 +177,7 @@ func TestPolicyFetch_JSON(t *testing.T) {
 
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    []string{"policy", "fetch", "--owner-id", testOwnerID, "--json"},
+		Args:    []string{"policy", "fetch", "--org", testOwnerID, "--json"},
 		Env:     env.Environ(),
 		WorkDir: t.TempDir(),
 	})
@@ -200,7 +200,7 @@ func TestPolicyFetch_ByName(t *testing.T) {
 
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    []string{"policy", "fetch", "my_policy", "--owner-id", testOwnerID},
+		Args:    []string{"policy", "fetch", "my_policy", "--org", testOwnerID},
 		Env:     env.Environ(),
 		WorkDir: t.TempDir(),
 	})
@@ -224,7 +224,7 @@ func TestPolicyLogs(t *testing.T) {
 
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    []string{"policy", "logs", "--owner-id", testOwnerID},
+		Args:    []string{"policy", "logs", "--org", testOwnerID},
 		Env:     env.Environ(),
 		WorkDir: t.TempDir(),
 	})
@@ -247,7 +247,7 @@ func TestPolicyLogs_ByDecisionID(t *testing.T) {
 
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    []string{"policy", "logs", testDecisionID, "--owner-id", testOwnerID},
+		Args:    []string{"policy", "logs", testDecisionID, "--org", testOwnerID},
 		Env:     env.Environ(),
 		WorkDir: t.TempDir(),
 	})
@@ -276,7 +276,7 @@ func TestPolicyDecide(t *testing.T) {
 
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    []string{"policy", "decide", "--owner-id", testOwnerID, "--input", configFile},
+		Args:    []string{"policy", "decide", "--org", testOwnerID, "--input", configFile},
 		Env:     env.Environ(),
 		WorkDir: dir,
 	})
@@ -315,7 +315,7 @@ func TestPolicyDecide_Strict(t *testing.T) {
 
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    []string{"policy", "decide", "--owner-id", testOwnerID, "--input", configFile, "--strict"},
+		Args:    []string{"policy", "decide", "--org", testOwnerID, "--input", configFile, "--strict"},
 		Env:     env.Environ(),
 		WorkDir: dir,
 	})
@@ -336,7 +336,7 @@ func TestPolicySettingsGet(t *testing.T) {
 
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    []string{"policy", "settings", "get", "--owner-id", testOwnerID},
+		Args:    []string{"policy", "settings", "get", "--org", testOwnerID},
 		Env:     env.Environ(),
 		WorkDir: t.TempDir(),
 	})
@@ -355,7 +355,7 @@ func TestPolicySettingsGet_JSON(t *testing.T) {
 
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    []string{"policy", "settings", "get", "--owner-id", testOwnerID, "--json"},
+		Args:    []string{"policy", "settings", "get", "--org", testOwnerID, "--json"},
 		Env:     env.Environ(),
 		WorkDir: t.TempDir(),
 	})
@@ -375,7 +375,7 @@ func TestPolicySettingsSet(t *testing.T) {
 
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    []string{"policy", "settings", "set", "--owner-id", testOwnerID, "--enabled"},
+		Args:    []string{"policy", "settings", "set", "--org", testOwnerID, "--enabled"},
 		Env:     env.Environ(),
 		WorkDir: t.TempDir(),
 	})
@@ -405,7 +405,7 @@ func TestPolicySettingsSet_JSON(t *testing.T) {
 
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    []string{"policy", "settings", "set", "--owner-id", testOwnerID, "--enabled", "--json"},
+		Args:    []string{"policy", "settings", "set", "--org", testOwnerID, "--enabled", "--json"},
 		Env:     env.Environ(),
 		WorkDir: t.TempDir(),
 	})
@@ -423,10 +423,29 @@ func TestPolicy_NoToken(t *testing.T) {
 
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    []string{"policy", "fetch", "--owner-id", testOwnerID},
+		Args:    []string{"policy", "fetch", "--org", testOwnerID},
 		Env:     env.Environ(),
 		WorkDir: t.TempDir(),
 	})
 
 	assert.Equal(t, result.ExitCode, 3) // ExitAuthError
+}
+
+// --- removed flag ---
+
+// TestPolicy_RemovedOwnerIDFlag pins the clean break from --owner-id: every
+// policy command now takes --org, and the old name must no longer be accepted.
+func TestPolicy_RemovedOwnerIDFlag(t *testing.T) {
+	env := testenv.New(t)
+	env.Token = testToken
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"policy", "fetch", "--owner-id", testOwnerID},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Check(t, result.ExitCode != 0)
+	assert.Check(t, cmp.Contains(result.Stderr, "unknown flag: --owner-id"))
 }

--- a/acceptance/signing_config_test.go
+++ b/acceptance/signing_config_test.go
@@ -52,7 +52,7 @@ func TestSigningConfigCreate(t *testing.T) {
 		Binary: binaryPath,
 		Args: []string{
 			"signing-config", "create",
-			"--org-id", testIOSOrgID,
+			"--org", testIOSOrgID,
 			"--name", "production-signing",
 			"--cert-id", "cert-abc",
 			"--profile", profilePath,
@@ -89,7 +89,7 @@ func TestSigningConfigCreate_JSON(t *testing.T) {
 		Binary: binaryPath,
 		Args: []string{
 			"signing-config", "create",
-			"--org-id", testIOSOrgID,
+			"--org", testIOSOrgID,
 			"--name", "production-signing",
 			"--cert-id", "cert-abc",
 			"--profile", profilePath,
@@ -111,7 +111,7 @@ func TestSigningConfigCreate_MissingProfile(t *testing.T) {
 		Binary: binaryPath,
 		Args: []string{
 			"signing-config", "create",
-			"--org-id", testIOSOrgID,
+			"--org", testIOSOrgID,
 			"--name", "x",
 			"--cert-id", "cert-abc",
 		},
@@ -134,7 +134,7 @@ func TestSigningConfigCreate_UnknownCertID(t *testing.T) {
 		Binary: binaryPath,
 		Args: []string{
 			"signing-config", "create",
-			"--org-id", testIOSOrgID,
+			"--org", testIOSOrgID,
 			"--name", "production-signing",
 			"--cert-id", "cert-does-not-exist",
 			"--profile", profilePath,
@@ -161,7 +161,7 @@ func TestSigningConfigCreate_DuplicateName(t *testing.T) {
 		Binary: binaryPath,
 		Args: []string{
 			"signing-config", "create",
-			"--org-id", testIOSOrgID,
+			"--org", testIOSOrgID,
 			"--name", "production-signing",
 			"--cert-id", "cert-abc",
 			"--profile", profilePath,
@@ -187,7 +187,7 @@ func TestSigningConfigList(t *testing.T) {
 
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    []string{"signing-config", "list", "--org-id", testIOSOrgID},
+		Args:    []string{"signing-config", "list", "--org", testIOSOrgID},
 		Env:     env.Environ(),
 		WorkDir: t.TempDir(),
 	})
@@ -207,7 +207,7 @@ func TestSigningConfigList_Color(t *testing.T) {
 
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    []string{"signing-config", "list", "--org-id", testIOSOrgID},
+		Args:    []string{"signing-config", "list", "--org", testIOSOrgID},
 		Env:     env.Environ(),
 		WorkDir: t.TempDir(),
 		TTY:     true,
@@ -228,7 +228,7 @@ func TestSigningConfigList_JSON(t *testing.T) {
 
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    []string{"signing-config", "list", "--org-id", testIOSOrgID, "--json"},
+		Args:    []string{"signing-config", "list", "--org", testIOSOrgID, "--json"},
 		Env:     env.Environ(),
 		WorkDir: t.TempDir(),
 	})
@@ -243,7 +243,7 @@ func TestSigningConfigList_Empty(t *testing.T) {
 
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    []string{"signing-config", "list", "--org-id", testIOSOrgID},
+		Args:    []string{"signing-config", "list", "--org", testIOSOrgID},
 		Env:     env.Environ(),
 		WorkDir: t.TempDir(),
 	})

--- a/acceptance/testdata/TestCertificateDelete_InUse.stderr.txt
+++ b/acceptance/testdata/TestCertificateDelete_InUse.stderr.txt
@@ -1,5 +1,5 @@
 error: Certificate "cert-zzzz" is referenced by one or more signing configs.
 
 Suggestions:
-  • Run: circleci signing-config list --org-id <org-uuid>
+  • Run: circleci signing-config list --org <org>
   • Delete the signing configs that reference this certificate, then retry

--- a/acceptance/testdata/TestCertificateDelete_NotFound.stderr.txt
+++ b/acceptance/testdata/TestCertificateDelete_NotFound.stderr.txt
@@ -4,4 +4,4 @@ API: {"message":"not found"}
 
 Suggestions:
   • Check the certificate ID and try again
-  • Run: circleci certificate list --org-id <org-uuid>
+  • Run: circleci certificate list --org <org>

--- a/acceptance/testdata/TestNamespaceCreate_MissingOrgID.stderr.txt
+++ b/acceptance/testdata/TestNamespaceCreate_MissingOrgID.stderr.txt
@@ -1,1 +1,1 @@
-required flag(s) "org-id" not set
+required flag(s) "org" not set

--- a/acceptance/testdata/TestSigningConfigDelete_NotFound.stderr.txt
+++ b/acceptance/testdata/TestSigningConfigDelete_NotFound.stderr.txt
@@ -4,4 +4,4 @@ API: {"message":"not found"}
 
 Suggestions:
   • Check the signing config ID and try again
-  • Run: circleci signing-config list --org-id <org-uuid>
+  • Run: circleci signing-config list --org <org>

--- a/internal/cmd/certificate/certificate.go
+++ b/internal/cmd/certificate/certificate.go
@@ -72,14 +72,14 @@ func apiErr(err error, subject string) *clierrors.CLIError {
 	return cmdutil.APIErr(err, subject,
 		"certificate.not_found", "No iOS certificate found for %q.",
 		"Check the certificate ID and try again",
-		"Run: circleci certificate list --org-id <org-uuid>")
+		"Run: circleci certificate list --org <org>")
 }
 
 // --- certificate upload ---
 
 func newUploadCmd() *cobra.Command {
 	var (
-		orgID    string
+		org      string
 		certPath string
 		password string
 		jsonOut  bool
@@ -93,7 +93,7 @@ func newUploadCmd() *cobra.Command {
 			organization's secure storage.
 
 			The organization is inferred from the current git repository's remote
-			unless overridden with --org-id.
+			unless overridden with --org (a slug or UUID).
 
 			The certificate file is read from disk and base64-encoded locally
 			before being sent. In a terminal, --password may be omitted and you
@@ -112,7 +112,7 @@ func newUploadCmd() *cobra.Command {
 			$ echo "$P12_PASSWORD" | circleci certificate upload --cert-file ./Certificates.p12 --password -
 
 			# Explicit org and capture the new cert id for scripting
-			$ echo "$P12_PASSWORD" | circleci certificate upload --org-id <org-uuid> --cert-file ./Certificates.p12 --password - --json --jq -r '.id'
+			$ echo "$P12_PASSWORD" | circleci certificate upload --org gh/acme --cert-file ./Certificates.p12 --password - --json --jq -r '.id'
 		`),
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -160,11 +160,11 @@ func newUploadCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			resolvedOrgID, err := cmdutil.ResolveOrgID(ctx, client, orgID, "circleci certificate upload")
+			resolvedOrgID, err := cmdutil.ResolveOrgSlugOrID(ctx, client, org, "circleci certificate upload")
 			if err != nil {
 				return err
 			}
-			certID, err := client.UploadIOSCertificate(ctx, resolvedOrgID, fileName, blob, password)
+			certID, err := client.UploadIOSCertificate(ctx, resolvedOrgID.String(), fileName, blob, password)
 			if err != nil {
 				return apiErr(err, fileName)
 			}
@@ -180,7 +180,7 @@ func newUploadCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&orgID, "org-id", "", "CircleCI organization UUID; defaults to the org of the current git project")
+	cmdutil.AddOrgFlag(cmd, &org, cmdutil.OrgFlag{DefaultsToGitRemote: true})
 	cmd.Flags().StringVar(&certPath, "cert-file", "", "Path to the .p12 certificate file")
 	cmd.Flags().StringVar(&password, "password", "", "Password for the .p12 file. Pass - to read from stdin. Prompted if omitted in a terminal.")
 	cmdutil.AddJSONFlag(cmd, &jsonOut)
@@ -199,7 +199,7 @@ type listEntry struct {
 
 func newListCmd() *cobra.Command {
 	var (
-		orgID   string
+		org     string
 		jsonOut bool
 	)
 
@@ -212,7 +212,7 @@ func newListCmd() *cobra.Command {
 			secure storage.
 
 			The organization is inferred from the current git repository's remote
-			unless overridden with --org-id.
+			unless overridden with --org (a slug or UUID).
 
 			JSON fields: id, file_name, org_id, created_at
 		`),
@@ -221,7 +221,7 @@ func newListCmd() *cobra.Command {
 			$ circleci certificate list
 
 			# List for a specific org
-			$ circleci certificate list --org-id <org-uuid>
+			$ circleci certificate list --org gh/acme
 
 			# Output as JSON
 			$ circleci certificate list --json
@@ -236,15 +236,15 @@ func newListCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			resolvedOrgID, err := cmdutil.ResolveOrgID(ctx, client, orgID, "circleci certificate list")
+			resolvedOrgID, err := cmdutil.ResolveOrgSlugOrID(ctx, client, org, "circleci certificate list")
 			if err != nil {
 				return err
 			}
-			return runList(ctx, client, resolvedOrgID, jsonOut)
+			return runList(ctx, client, resolvedOrgID.String(), jsonOut)
 		},
 	}
 
-	cmd.Flags().StringVar(&orgID, "org-id", "", "CircleCI organization UUID; defaults to the org of the current git project")
+	cmdutil.AddOrgFlag(cmd, &org, cmdutil.OrgFlag{DefaultsToGitRemote: true})
 	cmdutil.AddJSONFlag(cmd, &jsonOut)
 	cmdutil.AddJQFlag(cmd)
 
@@ -344,7 +344,7 @@ func newDeleteCmd() *cobra.Command {
 					return clierrors.New("certificate.in_use", "Cannot delete certificate",
 						fmt.Sprintf("Certificate %q is referenced by one or more signing configs.", certID)).
 						WithSuggestions(
-							"Run: circleci signing-config list --org-id <org-uuid>",
+							"Run: circleci signing-config list --org <org>",
 							"Delete the signing configs that reference this certificate, then retry",
 						).
 						WithExitCode(clierrors.ExitAPIError)

--- a/internal/cmd/config/config.go
+++ b/internal/cmd/config/config.go
@@ -95,23 +95,22 @@ func readConfigInput(ctx context.Context, path string) (string, error) {
 	return string(b), nil
 }
 
-// resolveOrgID returns the org UUID to use for compilation.
-// --org-id takes precedence. --org-slug triggers a direct org lookup.
-// If the lookup fails, a warning is printed and "" is returned
-// (private orb resolution will be skipped, but the compile call still proceeds).
-func resolveOrgID(ctx context.Context, client *apiclient.Client, orgSlug, orgID string) string {
-	if orgID != "" {
-		return orgID
+// resolveOrgID returns the org UUID to use for private orb resolution during
+// compilation. When --org is empty it returns "" and private orb resolution is
+// skipped (the compile call still proceeds). When set, the slug or UUID is
+// resolved to a UUID via the API; an unresolvable value is a hard error so a
+// typo isn't silently ignored.
+//
+// cmdName is used only in the suggestion text of any resulting error.
+func resolveOrgID(ctx context.Context, client *apiclient.Client, org, cmdName string) (string, error) {
+	if org == "" {
+		return "", nil
 	}
-	if orgSlug == "" {
-		return ""
-	}
-	org, err := client.GetOrg(ctx, orgSlug)
+	id, err := cmdutil.ResolveOrgSlugOrID(ctx, client, org, cmdName)
 	if err != nil {
-		iostream.ErrPrintf(ctx, "warning: could not resolve org %q: %s\n", orgSlug, err)
-		return ""
+		return "", err
 	}
-	return org.ID
+	return id.String(), nil
 }
 
 func configAPIErr(err error) *clierrors.CLIError {

--- a/internal/cmd/config/process.go
+++ b/internal/cmd/config/process.go
@@ -39,8 +39,7 @@ import (
 
 func newProcessCmd() *cobra.Command {
 	var (
-		orgID          string
-		orgSlug        string
+		org            string
 		previewNext    bool
 		pipelineParams string
 	)
@@ -72,7 +71,7 @@ func newProcessCmd() *cobra.Command {
 			$ circleci config process .circleci/config.yml --pipeline-parameters 'env: staging'
 
 			# Process with private orb resolution
-			$ circleci config process .circleci/config.yml --org-slug gh/myorg
+			$ circleci config process .circleci/config.yml --org gh/myorg
 
 			# Read from stdin
 			$ cat .circleci/config.yml | circleci config process -
@@ -98,7 +97,10 @@ func newProcessCmd() *cobra.Command {
 					WithExitCode(clierrors.ExitBadArguments)
 			}
 
-			orgID = resolveOrgID(ctx, client, orgSlug, orgID)
+			orgID, err := resolveOrgID(ctx, client, org, "circleci config process")
+			if err != nil {
+				return err
+			}
 
 			result, err := configcmd.Process(ctx, client, configYAML, orgID, previewNext, params)
 			if err != nil {
@@ -119,8 +121,7 @@ func newProcessCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&orgID, "org-id", "", "Organization UUID for private orb resolution")
-	cmd.Flags().StringVarP(&orgSlug, "org-slug", "o", "", "Organization slug for private orb resolution (e.g. gh/myorg)")
+	cmdutil.AddOrgFlag(cmd, &org, cmdutil.OrgFlag{Purpose: "for private orb resolution"})
 	cmd.Flags().BoolVarP(&previewNext, "next", "n", false, "Enable config next which previews upcoming potentially breaking config changes")
 	cmd.Flags().StringVar(&pipelineParams, "pipeline-parameters", "", "Pipeline parameters as a YAML map or path to a YAML file")
 

--- a/internal/cmd/config/validate.go
+++ b/internal/cmd/config/validate.go
@@ -37,8 +37,7 @@ import (
 func newValidateCmd() *cobra.Command {
 	var (
 		configPath  string
-		orgID       string
-		orgSlug     string
+		org         string
 		previewNext bool
 		jsonOut     bool
 	)
@@ -65,7 +64,7 @@ func newValidateCmd() *cobra.Command {
 			$ circleci config validate --config path/to/config.yml
 
 			# Validate with private orb resolution for your org
-			$ circleci config validate --org-slug gh/myorg
+			$ circleci config validate --org gh/myorg
 
 			# Validate and output as JSON
 			$ circleci config validate --json
@@ -83,7 +82,10 @@ func newValidateCmd() *cobra.Command {
 				return err
 			}
 
-			orgID = resolveOrgID(ctx, client, orgSlug, orgID)
+			orgID, err := resolveOrgID(ctx, client, org, "circleci config validate")
+			if err != nil {
+				return err
+			}
 
 			result, err := configcmd.Validate(ctx, client, yaml, orgID, previewNext)
 			if err != nil {
@@ -117,9 +119,8 @@ func newValidateCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&configPath, "config", "c", ".circleci/config.yml", "Path to config file (use \"-\" for stdin)")
-	cmd.Flags().StringVar(&orgID, "org-id", "", "Organization UUID for private orb resolution")
+	cmdutil.AddOrgFlag(cmd, &org, cmdutil.OrgFlag{Purpose: "for private orb resolution"})
 	cmd.Flags().BoolVarP(&previewNext, "next", "n", false, "Enable config next which previews upcoming potentially breaking config changes")
-	cmd.Flags().StringVarP(&orgSlug, "org-slug", "o", "", "Organization slug for private orb resolution (e.g. gh/myorg)")
 	cmdutil.AddJSONFlag(cmd, &jsonOut)
 
 	return cmd

--- a/internal/cmd/namespace/create.go
+++ b/internal/cmd/namespace/create.go
@@ -35,12 +35,12 @@ import (
 
 func newCreateCmd() *cobra.Command {
 	var (
-		orgID   string
+		org     string
 		jsonOut bool
 	)
 
 	cmd := &cobra.Command{
-		Use:   "create <name> --org-id <uuid>",
+		Use:   "create <name> --org <org>",
 		Short: "Create a namespace",
 		Annotations: map[string]string{
 			"help:arguments": heredoc.Doc(`
@@ -59,13 +59,13 @@ func newCreateCmd() *cobra.Command {
 		`),
 		Example: heredoc.Doc(`
 			# Create a namespace for an organization
-			$ circleci namespace create myorg --org-id 00000000-0000-0000-0000-000000000001
+			$ circleci namespace create myorg --org gh/acme
 
 			# Create a namespace and output JSON
-			$ circleci namespace create myorg --org-id 00000000-0000-0000-0000-000000000001 --json
+			$ circleci namespace create myorg --org gh/acme --json
 
 			# Capture just the namespace ID
-			$ circleci namespace create myorg --org-id 00000000-0000-0000-0000-000000000001 --json --jq '.id'
+			$ circleci namespace create myorg --org gh/acme --json --jq '.id'
 		`),
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -77,12 +77,15 @@ func newCreateCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return runCreate(ctx, client, args[0], orgID, jsonOut)
+			orgID, err := cmdutil.ResolveOrgSlugOrID(ctx, client, org, "circleci namespace create")
+			if err != nil {
+				return err
+			}
+			return runCreate(ctx, client, args[0], orgID.String(), jsonOut)
 		},
 	}
 
-	cmd.Flags().StringVar(&orgID, "org-id", "", "organization UUID to claim the namespace for (required)")
-	_ = cmd.MarkFlagRequired("org-id")
+	cmdutil.AddOrgFlag(cmd, &org, cmdutil.OrgFlag{Purpose: "to claim the namespace for", Required: true})
 	cmdutil.AddJSONFlag(cmd, &jsonOut)
 	cmdutil.AddJQFlag(cmd)
 

--- a/internal/cmd/orb/orb.go
+++ b/internal/cmd/orb/orb.go
@@ -24,6 +24,7 @@
 package orb
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -110,4 +111,21 @@ func orbAPIErr(err error, subject string) *clierrors.CLIError {
 			WithExitCode(clierrors.ExitNotFound)
 	}
 	return cmdutil.APIErr(err, subject, "orb.api_error", "Orb API request failed for %q.")
+}
+
+// resolveOrgID returns the org UUID to use for private orb dependency
+// resolution. When --org is empty it returns "" and resolution is skipped;
+// validation/processing still proceeds for public orbs. When set, the slug or
+// UUID is resolved to a UUID via the API.
+//
+// cmdName is used only in the suggestion text of any resulting error.
+func resolveOrgID(ctx context.Context, client *apiclient.Client, org, cmdName string) (string, error) {
+	if org == "" {
+		return "", nil
+	}
+	id, err := cmdutil.ResolveOrgSlugOrID(ctx, client, org, cmdName)
+	if err != nil {
+		return "", err
+	}
+	return id.String(), nil
 }

--- a/internal/cmd/orb/process.go
+++ b/internal/cmd/orb/process.go
@@ -36,7 +36,7 @@ import (
 )
 
 func newProcessCmd() *cobra.Command {
-	var orgID string
+	var org string
 
 	cmd := &cobra.Command{
 		Use:   "process <path>",
@@ -63,7 +63,7 @@ func newProcessCmd() *cobra.Command {
 			$ cat orb.yml | circleci orb process -
 
 			# Process with a specific org for private deps
-			$ circleci orb process orb.yml --org-id 00000000-0000-0000-0000-000000000001
+			$ circleci orb process orb.yml --org gh/acme
 		`),
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -75,11 +75,15 @@ func newProcessCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			orgID, err := resolveOrgID(ctx, client, org, "circleci orb process")
+			if err != nil {
+				return err
+			}
 			return runOrbProcess(ctx, client, args[0], orgID)
 		},
 	}
 
-	cmd.Flags().StringVar(&orgID, "org-id", "", "organization UUID for private orb dependencies")
+	cmdutil.AddOrgFlag(cmd, &org, cmdutil.OrgFlag{Purpose: "for private orb dependencies"})
 
 	return cmd
 }

--- a/internal/cmd/orb/validate.go
+++ b/internal/cmd/orb/validate.go
@@ -38,7 +38,7 @@ import (
 )
 
 func newValidateCmd() *cobra.Command {
-	var orgID string
+	var org string
 
 	cmd := &cobra.Command{
 		Use:   "validate <path>",
@@ -53,8 +53,8 @@ func newValidateCmd() *cobra.Command {
 
 			Pass '-' as the path to read from stdin.
 
-			Use --org-id to validate against a specific organization's private
-			orb dependencies.
+			Use --org (a slug or UUID) to validate against a specific
+			organization's private orb dependencies.
 
 			Exit code 7 if the orb is invalid.
 		`),
@@ -66,7 +66,7 @@ func newValidateCmd() *cobra.Command {
 			$ cat orb.yml | circleci orb validate -
 
 			# Validate with a specific org for private deps
-			$ circleci orb validate orb.yml --org-id 00000000-0000-0000-0000-000000000001
+			$ circleci orb validate orb.yml --org gh/acme
 		`),
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -78,11 +78,15 @@ func newValidateCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			orgID, err := resolveOrgID(ctx, client, org, "circleci orb validate")
+			if err != nil {
+				return err
+			}
 			return runOrbValidate(ctx, client, args[0], orgID)
 		},
 	}
 
-	cmd.Flags().StringVar(&orgID, "org-id", "", "organization UUID for private orb dependencies")
+	cmdutil.AddOrgFlag(cmd, &org, cmdutil.OrgFlag{Purpose: "for private orb dependencies"})
 
 	return cmd
 }

--- a/internal/cmd/policy/decide.go
+++ b/internal/cmd/policy/decide.go
@@ -40,7 +40,7 @@ import (
 
 func newDecideCmd() *cobra.Command {
 	var (
-		ownerID   string
+		org       string
 		policyCtx string
 		inputFile string
 		meta      string
@@ -64,16 +64,16 @@ func newDecideCmd() *cobra.Command {
 		`),
 		Example: heredoc.Doc(`
 			# Evaluate a config against remote policies
-			$ circleci policy decide --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --input .circleci/config.yml
+			$ circleci policy decide --org gh/acme --input .circleci/config.yml
 
 			# Exit non-zero on hard failures
-			$ circleci policy decide --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --input .circleci/config.yml --strict
+			$ circleci policy decide --org gh/acme --input .circleci/config.yml --strict
 
 			# Pass metadata alongside the decision
-			$ circleci policy decide --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --input .circleci/config.yml --meta '{"project_id":"abc"}'
+			$ circleci policy decide --org gh/acme --input .circleci/config.yml --meta '{"project_id":"abc"}'
 
 			# Output decision as JSON
-			$ circleci policy decide --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --input .circleci/config.yml --json
+			$ circleci policy decide --org gh/acme --input .circleci/config.yml --json
 		`),
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -82,11 +82,15 @@ func newDecideCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return runDecide(ctx, client, ownerID, policyCtx, inputFile, meta, metaFile, strict, jsonOut)
+			orgID, err := cmdutil.ResolveOrgSlugOrID(ctx, client, org, "circleci policy decide")
+			if err != nil {
+				return err
+			}
+			return runDecide(ctx, client, orgID.String(), policyCtx, inputFile, meta, metaFile, strict, jsonOut)
 		},
 	}
 
-	cmd.Flags().StringVar(&ownerID, "owner-id", "", "Organization UUID (required)")
+	cmdutil.AddOrgFlag(cmd, &org, cmdutil.OrgFlag{Required: true})
 	cmd.Flags().StringVar(&policyCtx, "policy-context", "config", "Policy context")
 	cmd.Flags().StringVar(&inputFile, "input", "", "Path to input file (e.g. .circleci/config.yml) (required)")
 	cmd.Flags().StringVar(&meta, "meta", "", "Decision metadata as a JSON string")
@@ -94,7 +98,6 @@ func newDecideCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&strict, "strict", false, "Exit non-zero for HARD_FAIL or ERROR decisions")
 	cmdutil.AddJSONFlag(cmd, &jsonOut)
 	cmdutil.AddJQFlag(cmd)
-	_ = cmd.MarkFlagRequired("owner-id")
 	_ = cmd.MarkFlagRequired("input")
 
 	return cmd

--- a/internal/cmd/policy/diff.go
+++ b/internal/cmd/policy/diff.go
@@ -35,7 +35,7 @@ import (
 
 func newDiffCmd() *cobra.Command {
 	var (
-		ownerID   string
+		org       string
 		policyCtx string
 		jsonOut   bool
 	)
@@ -58,13 +58,13 @@ func newDiffCmd() *cobra.Command {
 		`),
 		Example: heredoc.Doc(`
 			# Diff policies in ./policies against the remote bundle
-			$ circleci policy diff ./policies --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f
+			$ circleci policy diff ./policies --org gh/acme
 
 			# Diff against a custom policy context
-			$ circleci policy diff ./policies --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --policy-context config
+			$ circleci policy diff ./policies --org gh/acme --policy-context config
 
 			# Output diff as JSON for scripting
-			$ circleci policy diff ./policies --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --json
+			$ circleci policy diff ./policies --org gh/acme --json
 		`),
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -73,15 +73,18 @@ func newDiffCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return runDiff(ctx, client, args[0], ownerID, policyCtx, jsonOut)
+			orgID, err := cmdutil.ResolveOrgSlugOrID(ctx, client, org, "circleci policy diff")
+			if err != nil {
+				return err
+			}
+			return runDiff(ctx, client, args[0], orgID.String(), policyCtx, jsonOut)
 		},
 	}
 
-	cmd.Flags().StringVar(&ownerID, "owner-id", "", "Organization UUID (required)")
+	cmdutil.AddOrgFlag(cmd, &org, cmdutil.OrgFlag{Required: true})
 	cmd.Flags().StringVar(&policyCtx, "policy-context", "config", "Policy context")
 	cmdutil.AddJSONFlag(cmd, &jsonOut)
 	cmdutil.AddJQFlag(cmd)
-	_ = cmd.MarkFlagRequired("owner-id")
 
 	return cmd
 }

--- a/internal/cmd/policy/fetch.go
+++ b/internal/cmd/policy/fetch.go
@@ -35,7 +35,7 @@ import (
 
 func newFetchCmd() *cobra.Command {
 	var (
-		ownerID   string
+		org       string
 		policyCtx string
 		jsonOut   bool
 	)
@@ -53,13 +53,13 @@ func newFetchCmd() *cobra.Command {
 		`),
 		Example: heredoc.Doc(`
 			# Fetch the full policy bundle
-			$ circleci policy fetch --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f
+			$ circleci policy fetch --org gh/acme
 
 			# Fetch a single policy by name
-			$ circleci policy fetch my-policy --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f
+			$ circleci policy fetch my-policy --org gh/acme
 
 			# Output as JSON with jq filtering
-			$ circleci policy fetch --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --json --jq 'keys'
+			$ circleci policy fetch --org gh/acme --json --jq 'keys'
 		`),
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -72,15 +72,18 @@ func newFetchCmd() *cobra.Command {
 			if len(args) == 1 {
 				policyName = args[0]
 			}
-			return runFetch(ctx, client, ownerID, policyCtx, policyName, jsonOut)
+			orgID, err := cmdutil.ResolveOrgSlugOrID(ctx, client, org, "circleci policy fetch")
+			if err != nil {
+				return err
+			}
+			return runFetch(ctx, client, orgID.String(), policyCtx, policyName, jsonOut)
 		},
 	}
 
-	cmd.Flags().StringVar(&ownerID, "owner-id", "", "Organization UUID (required)")
+	cmdutil.AddOrgFlag(cmd, &org, cmdutil.OrgFlag{Required: true})
 	cmd.Flags().StringVar(&policyCtx, "policy-context", "config", "Policy context")
 	cmdutil.AddJSONFlag(cmd, &jsonOut)
 	cmdutil.AddJQFlag(cmd)
-	_ = cmd.MarkFlagRequired("owner-id")
 
 	return cmd
 }

--- a/internal/cmd/policy/logs.go
+++ b/internal/cmd/policy/logs.go
@@ -39,7 +39,7 @@ import (
 
 func newLogsCmd() *cobra.Command {
 	var (
-		ownerID      string
+		org          string
 		policyCtx    string
 		after        string
 		before       string
@@ -69,16 +69,16 @@ func newLogsCmd() *cobra.Command {
 		`),
 		Example: heredoc.Doc(`
 			# Get all decision logs
-			$ circleci policy logs --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f
+			$ circleci policy logs --org gh/acme
 
 			# Get a specific decision log
-			$ circleci policy logs abc123 --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f
+			$ circleci policy logs abc123 --org gh/acme
 
 			# Filter by status and branch
-			$ circleci policy logs --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --status HARD_FAIL --branch main
+			$ circleci policy logs --org gh/acme --status HARD_FAIL --branch main
 
 			# Write output to a file
-			$ circleci policy logs --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --out logs.json
+			$ circleci policy logs --org gh/acme --out logs.json
 		`),
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -114,11 +114,15 @@ func newLogsCmd() *cobra.Command {
 				}
 				req.Before = &t
 			}
-			return runLogs(ctx, client, ownerID, policyCtx, decisionID, outputFile, policyBundle, jsonOut, req)
+			orgID, err := cmdutil.ResolveOrgSlugOrID(ctx, client, org, "circleci policy logs")
+			if err != nil {
+				return err
+			}
+			return runLogs(ctx, client, orgID.String(), policyCtx, decisionID, outputFile, policyBundle, jsonOut, req)
 		},
 	}
 
-	cmd.Flags().StringVar(&ownerID, "owner-id", "", "Organization UUID (required)")
+	cmdutil.AddOrgFlag(cmd, &org, cmdutil.OrgFlag{Required: true})
 	cmd.Flags().StringVar(&policyCtx, "policy-context", "config", "Policy context")
 	cmd.Flags().StringVar(&after, "after", "", "Return logs created after this time (RFC3339 or YYYY-MM-DD)")
 	cmd.Flags().StringVar(&before, "before", "", "Return logs created before this time (RFC3339 or YYYY-MM-DD)")
@@ -129,7 +133,6 @@ func newLogsCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&policyBundle, "policy-bundle", false, "Retrieve the policy bundle snapshot for the given decision ID")
 	cmdutil.AddJSONFlag(cmd, &jsonOut)
 	cmdutil.AddJQFlag(cmd)
-	_ = cmd.MarkFlagRequired("owner-id")
 
 	return cmd
 }

--- a/internal/cmd/policy/policy.go
+++ b/internal/cmd/policy/policy.go
@@ -44,7 +44,8 @@ func NewPolicyCmd() *cobra.Command {
 			to enforce organizational security rules. Use these commands to push,
 			inspect, and test policy bundles, and to query decision logs.
 
-			Most commands require --owner-id, which is your organization's UUID.
+			Most commands require --org, which is your organization's slug
+			(e.g. gh/acme) or UUID.
 			Find it at: https://app.circleci.com/settings/organization
 		`),
 		RunE:               cmdutil.GroupRunE,
@@ -70,6 +71,6 @@ func NewPolicyCmd() *cobra.Command {
 func policyAPIErr(err error, subject string) *clierrors.CLIError {
 	return cmdutil.APIErr(err, subject,
 		"policy.not_found", "No policy found for %q.",
-		"Check the owner ID and policy context",
-		"Run: circleci policy fetch --owner-id <id>")
+		"Check the organization and policy context",
+		"Run: circleci policy fetch --org <org>")
 }

--- a/internal/cmd/policy/push.go
+++ b/internal/cmd/policy/push.go
@@ -36,7 +36,7 @@ import (
 
 func newPushCmd() *cobra.Command {
 	var (
-		ownerID   string
+		org       string
 		policyCtx string
 		noPrompt  bool
 		jsonOut   bool
@@ -65,16 +65,16 @@ func newPushCmd() *cobra.Command {
 		`),
 		Example: heredoc.Doc(`
 			# Push policies in the ./policies directory
-			$ circleci policy push ./policies --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f
+			$ circleci policy push ./policies --org gh/acme
 
 			# Push without confirmation prompt
-			$ circleci policy push ./policies --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --no-prompt
+			$ circleci policy push ./policies --org gh/acme --no-prompt
 
 			# Push to a custom policy context
-			$ circleci policy push ./policies --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --policy-context config
+			$ circleci policy push ./policies --org gh/acme --policy-context config
 
 			# Output the diff as JSON
-			$ circleci policy push ./policies --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --no-prompt --json
+			$ circleci policy push ./policies --org gh/acme --no-prompt --json
 		`),
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -83,16 +83,19 @@ func newPushCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return runPush(ctx, client, args[0], ownerID, policyCtx, noPrompt, jsonOut)
+			orgID, err := cmdutil.ResolveOrgSlugOrID(ctx, client, org, "circleci policy push")
+			if err != nil {
+				return err
+			}
+			return runPush(ctx, client, args[0], orgID.String(), policyCtx, noPrompt, jsonOut)
 		},
 	}
 
-	cmd.Flags().StringVar(&ownerID, "owner-id", "", "Organization UUID (required)")
+	cmdutil.AddOrgFlag(cmd, &org, cmdutil.OrgFlag{Required: true})
 	cmd.Flags().StringVar(&policyCtx, "policy-context", "config", "Policy context")
 	cmd.Flags().BoolVar(&noPrompt, "no-prompt", false, "Skip confirmation prompt")
 	cmdutil.AddJSONFlag(cmd, &jsonOut)
 	cmdutil.AddJQFlag(cmd)
-	_ = cmd.MarkFlagRequired("owner-id")
 
 	return cmd
 }

--- a/internal/cmd/policy/settings.go
+++ b/internal/cmd/policy/settings.go
@@ -57,7 +57,7 @@ func newSettingsCmd() *cobra.Command {
 
 func newSettingsGetCmd() *cobra.Command {
 	var (
-		ownerID   string
+		org       string
 		policyCtx string
 		jsonOut   bool
 	)
@@ -72,13 +72,13 @@ func newSettingsGetCmd() *cobra.Command {
 		`),
 		Example: heredoc.Doc(`
 			# Get policy enforcement settings
-			$ circleci policy settings get --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f
+			$ circleci policy settings get --org gh/acme
 
 			# Output as JSON
-			$ circleci policy settings get --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --json
+			$ circleci policy settings get --org gh/acme --json
 
 			# Use with jq to extract the enabled field
-			$ circleci policy settings get --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --json --jq '.enabled'
+			$ circleci policy settings get --org gh/acme --json --jq '.enabled'
 		`),
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -87,22 +87,25 @@ func newSettingsGetCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return runSettingsGet(ctx, client, ownerID, policyCtx, jsonOut)
+			orgID, err := cmdutil.ResolveOrgSlugOrID(ctx, client, org, "circleci policy settings get")
+			if err != nil {
+				return err
+			}
+			return runSettingsGet(ctx, client, orgID.String(), policyCtx, jsonOut)
 		},
 	}
 
-	cmd.Flags().StringVar(&ownerID, "owner-id", "", "Organization UUID (required)")
+	cmdutil.AddOrgFlag(cmd, &org, cmdutil.OrgFlag{Required: true})
 	cmd.Flags().StringVar(&policyCtx, "policy-context", "config", "Policy context")
 	cmdutil.AddJSONFlag(cmd, &jsonOut)
 	cmdutil.AddJQFlag(cmd)
-	_ = cmd.MarkFlagRequired("owner-id")
 
 	return cmd
 }
 
 func newSettingsSetCmd() *cobra.Command {
 	var (
-		ownerID   string
+		org       string
 		policyCtx string
 		enabled   bool
 		jsonOut   bool
@@ -121,13 +124,13 @@ func newSettingsSetCmd() *cobra.Command {
 		`),
 		Example: heredoc.Doc(`
 			# Enable policy enforcement
-			$ circleci policy settings set --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --enabled
+			$ circleci policy settings set --org gh/acme --enabled
 
 			# Disable policy enforcement
-			$ circleci policy settings set --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --enabled=false
+			$ circleci policy settings set --org gh/acme --enabled=false
 
 			# Output result as JSON
-			$ circleci policy settings set --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --enabled --json
+			$ circleci policy settings set --org gh/acme --enabled --json
 		`),
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -136,16 +139,19 @@ func newSettingsSetCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return runSettingsSet(ctx, client, ownerID, policyCtx, enabled, jsonOut)
+			orgID, err := cmdutil.ResolveOrgSlugOrID(ctx, client, org, "circleci policy settings set")
+			if err != nil {
+				return err
+			}
+			return runSettingsSet(ctx, client, orgID.String(), policyCtx, enabled, jsonOut)
 		},
 	}
 
-	cmd.Flags().StringVar(&ownerID, "owner-id", "", "Organization UUID (required)")
+	cmdutil.AddOrgFlag(cmd, &org, cmdutil.OrgFlag{Required: true})
 	cmd.Flags().StringVar(&policyCtx, "policy-context", "config", "Policy context")
 	cmd.Flags().BoolVar(&enabled, "enabled", false, "Enable policy enforcement")
 	cmdutil.AddJSONFlag(cmd, &jsonOut)
 	cmdutil.AddJQFlag(cmd)
-	_ = cmd.MarkFlagRequired("owner-id")
 	_ = cmd.MarkFlagRequired("enabled")
 
 	return cmd

--- a/internal/cmd/root/testdata/help/circleci/certificate/list.txt
+++ b/internal/cmd/root/testdata/help/circleci/certificate/list.txt
@@ -4,7 +4,7 @@ List Apple .p12 certificates currently stored in your organization's
 secure storage.
 
 The organization is inferred from the current git repository's remote
-unless overridden with --org-id.
+unless overridden with --org (a slug or UUID).
 
 JSON fields: id, file_name, org_id, created_at
 
@@ -20,11 +20,11 @@ For more information about output formatting flags, see `circleci help formattin
 
 ## Flags
 
-| Flag              | Description                                                                |
-| ----------------- | -------------------------------------------------------------------------- |
-| `--jq string`     | Process values from the response using jq syntax                           |
-| `--json`          | Output as JSON                                                             |
-| `--org-id string` | CircleCI organization UUID; defaults to the org of the current git project |
+| Flag           | Description                                                       |
+| -------------- | ----------------------------------------------------------------- |
+| `--jq string`  | Process values from the response using jq syntax                  |
+| `--json`       | Output as JSON                                                    |
+| `--org string` | Organization slug (e.g. gh/myorg) or UUID; defaults to git remote |
 
 ## Inherited Flags
 
@@ -39,7 +39,7 @@ For more information about output formatting flags, see `circleci help formattin
 - List certificates (org inferred from git remote): 
   `circleci certificate list`
 - List for a specific org: 
-  `circleci certificate list --org-id <org-uuid>`
+  `circleci certificate list --org gh/acme`
 - Output as JSON: 
   `circleci certificate list --json`
 - Get cert IDs only: 

--- a/internal/cmd/root/testdata/help/circleci/certificate/upload.txt
+++ b/internal/cmd/root/testdata/help/circleci/certificate/upload.txt
@@ -4,7 +4,7 @@ Upload an Apple .p12 code signing certificate to your CircleCI
 organization's secure storage.
 
 The organization is inferred from the current git repository's remote
-unless overridden with --org-id.
+unless overridden with --org (a slug or UUID).
 
 The certificate file is read from disk and base64-encoded locally
 before being sent. In a terminal, --password may be omitted and you
@@ -28,7 +28,7 @@ For more information about output formatting flags, see `circleci help formattin
 | `--cert-file string` | Path to the .p12 certificate file                                                         |
 | `--jq string`        | Process values from the response using jq syntax                                          |
 | `--json`             | Output as JSON                                                                            |
-| `--org-id string`    | CircleCI organization UUID; defaults to the org of the current git project                |
+| `--org string`       | Organization slug (e.g. gh/myorg) or UUID; defaults to git remote                         |
 | `--password string`  | Password for the .p12 file. Pass - to read from stdin. Prompted if omitted in a terminal. |
 
 ## Inherited Flags
@@ -46,7 +46,7 @@ For more information about output formatting flags, see `circleci help formattin
 - Read the password from stdin (no shell history exposure): 
   `echo "$P12_PASSWORD" | circleci certificate upload --cert-file ./Certificates.p12 --password -`
 - Explicit org and capture the new cert id for scripting: 
-  `echo "$P12_PASSWORD" | circleci certificate upload --org-id <org-uuid> --cert-file ./Certificates.p12 --password - --json --jq -r '.id'`
+  `echo "$P12_PASSWORD" | circleci certificate upload --org gh/acme --cert-file ./Certificates.p12 --password - --json --jq -r '.id'`
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/config/process.txt
+++ b/internal/cmd/root/testdata/help/circleci/config/process.txt
@@ -17,8 +17,7 @@ Pass a file path or "-" to read from stdin.
 | Flag                           | Description                                                                    |
 | ------------------------------ | ------------------------------------------------------------------------------ |
 | `-n, --next`                   | Enable config next which previews upcoming potentially breaking config changes |
-| `--org-id string`              | Organization UUID for private orb resolution                                   |
-| `-o, --org-slug string`        | Organization slug for private orb resolution (e.g. gh/myorg)                   |
+| `--org string`                 | Organization slug (e.g. gh/myorg) or UUID for private orb resolution           |
 | `--pipeline-parameters string` | Pipeline parameters as a YAML map or path to a YAML file                       |
 
 ## Inherited Flags
@@ -42,7 +41,7 @@ from stdin.
 - Process with pipeline parameters: 
   `circleci config process .circleci/config.yml --pipeline-parameters 'env: staging'`
 - Process with private orb resolution: 
-  `circleci config process .circleci/config.yml --org-slug gh/myorg`
+  `circleci config process .circleci/config.yml --org gh/myorg`
 - Read from stdin: 
   `cat .circleci/config.yml | circleci config process -`
 

--- a/internal/cmd/root/testdata/help/circleci/config/validate.txt
+++ b/internal/cmd/root/testdata/help/circleci/config/validate.txt
@@ -16,13 +16,12 @@ JSON fields (--json):
 
 ## Flags
 
-| Flag                    | Description                                                                    |
-| ----------------------- | ------------------------------------------------------------------------------ |
-| `-c, --config string`   | Path to config file (use "-" for stdin) (default ".circleci/config.yml")       |
-| `--json`                | Output as JSON                                                                 |
-| `-n, --next`            | Enable config next which previews upcoming potentially breaking config changes |
-| `--org-id string`       | Organization UUID for private orb resolution                                   |
-| `-o, --org-slug string` | Organization slug for private orb resolution (e.g. gh/myorg)                   |
+| Flag                  | Description                                                                    |
+| --------------------- | ------------------------------------------------------------------------------ |
+| `-c, --config string` | Path to config file (use "-" for stdin) (default ".circleci/config.yml")       |
+| `--json`              | Output as JSON                                                                 |
+| `-n, --next`          | Enable config next which previews upcoming potentially breaking config changes |
+| `--org string`        | Organization slug (e.g. gh/myorg) or UUID for private orb resolution           |
 
 ## Inherited Flags
 
@@ -38,7 +37,7 @@ JSON fields (--json):
 - Validate a specific file: 
   `circleci config validate --config path/to/config.yml`
 - Validate with private orb resolution for your org: 
-  `circleci config validate --org-slug gh/myorg`
+  `circleci config validate --org gh/myorg`
 - Validate and output as JSON: 
   `circleci config validate --json`
 

--- a/internal/cmd/root/testdata/help/circleci/namespace/create.txt
+++ b/internal/cmd/root/testdata/help/circleci/namespace/create.txt
@@ -12,15 +12,15 @@ For more information about output formatting flags, see `circleci help formattin
 
 ## Usage
 
-`circleci namespace create <name> --org-id <uuid> [flags]`
+`circleci namespace create <name> --org <org> [flags]`
 
 ## Flags
 
-| Flag              | Description                                             |
-| ----------------- | ------------------------------------------------------- |
-| `--jq string`     | Process values from the response using jq syntax        |
-| `--json`          | Output as JSON                                          |
-| `--org-id string` | organization UUID to claim the namespace for (required) |
+| Flag           | Description                                                                     |
+| -------------- | ------------------------------------------------------------------------------- |
+| `--jq string`  | Process values from the response using jq syntax                                |
+| `--json`       | Output as JSON                                                                  |
+| `--org string` | Organization slug (e.g. gh/myorg) or UUID to claim the namespace for (required) |
 
 ## Inherited Flags
 
@@ -38,11 +38,11 @@ across CircleCI, e.g. "myorg".
 ## Examples
 
 - Create a namespace for an organization: 
-  `circleci namespace create myorg --org-id 00000000-0000-0000-0000-000000000001`
+  `circleci namespace create myorg --org gh/acme`
 - Create a namespace and output JSON: 
-  `circleci namespace create myorg --org-id 00000000-0000-0000-0000-000000000001 --json`
+  `circleci namespace create myorg --org gh/acme --json`
 - Capture just the namespace ID: 
-  `circleci namespace create myorg --org-id 00000000-0000-0000-0000-000000000001 --json --jq '.id'`
+  `circleci namespace create myorg --org gh/acme --json --jq '.id'`
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/orb/process.txt
+++ b/internal/cmd/root/testdata/help/circleci/orb/process.txt
@@ -14,9 +14,9 @@ Pass '-' as the path to read from stdin.
 
 ## Flags
 
-| Flag              | Description                                    |
-| ----------------- | ---------------------------------------------- |
-| `--org-id string` | organization UUID for private orb dependencies |
+| Flag           | Description                                                            |
+| -------------- | ---------------------------------------------------------------------- |
+| `--org string` | Organization slug (e.g. gh/myorg) or UUID for private orb dependencies |
 
 ## Inherited Flags
 
@@ -37,7 +37,7 @@ Pass '-' as the path to read from stdin.
 - Process from stdin: 
   `cat orb.yml | circleci orb process -`
 - Process with a specific org for private deps: 
-  `circleci orb process orb.yml --org-id 00000000-0000-0000-0000-000000000001`
+  `circleci orb process orb.yml --org gh/acme`
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/orb/validate.txt
+++ b/internal/cmd/root/testdata/help/circleci/orb/validate.txt
@@ -4,8 +4,8 @@ Validate an orb YAML file against the CircleCI API.
 
 Pass '-' as the path to read from stdin.
 
-Use --org-id to validate against a specific organization's private
-orb dependencies.
+Use --org (a slug or UUID) to validate against a specific
+organization's private orb dependencies.
 
 Exit code 7 if the orb is invalid.
 
@@ -15,9 +15,9 @@ Exit code 7 if the orb is invalid.
 
 ## Flags
 
-| Flag              | Description                                    |
-| ----------------- | ---------------------------------------------- |
-| `--org-id string` | organization UUID for private orb dependencies |
+| Flag           | Description                                                            |
+| -------------- | ---------------------------------------------------------------------- |
+| `--org string` | Organization slug (e.g. gh/myorg) or UUID for private orb dependencies |
 
 ## Inherited Flags
 
@@ -38,7 +38,7 @@ Exit code 7 if the orb is invalid.
 - Validate from stdin: 
   `cat orb.yml | circleci orb validate -`
 - Validate with a specific org for private deps: 
-  `circleci orb validate orb.yml --org-id 00000000-0000-0000-0000-000000000001`
+  `circleci orb validate orb.yml --org gh/acme`
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/policy.txt
+++ b/internal/cmd/root/testdata/help/circleci/policy.txt
@@ -6,7 +6,8 @@ Policies are written in Rego and evaluated against pipeline configs
 to enforce organizational security rules. Use these commands to push,
 inspect, and test policy bundles, and to query decision logs.
 
-Most commands require --owner-id, which is your organization's UUID.
+Most commands require --org, which is your organization's slug
+(e.g. gh/acme) or UUID.
 Find it at: https://app.circleci.com/settings/organization
 
 ## Usage

--- a/internal/cmd/root/testdata/help/circleci/policy/decide.txt
+++ b/internal/cmd/root/testdata/help/circleci/policy/decide.txt
@@ -24,7 +24,7 @@ For more information about output formatting flags, see `circleci help formattin
 | `--json`                  | Output as JSON                                            |
 | `--meta string`           | Decision metadata as a JSON string                        |
 | `--metafile string`       | Path to decision metadata file (YAML or JSON)             |
-| `--owner-id string`       | Organization UUID (required)                              |
+| `--org string`            | Organization slug (e.g. gh/myorg) or UUID (required)      |
 | `--policy-context string` | Policy context (default "config")                         |
 | `--strict`                | Exit non-zero for HARD_FAIL or ERROR decisions            |
 
@@ -39,13 +39,13 @@ For more information about output formatting flags, see `circleci help formattin
 ## Examples
 
 - Evaluate a config against remote policies: 
-  `circleci policy decide --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --input .circleci/config.yml`
+  `circleci policy decide --org gh/acme --input .circleci/config.yml`
 - Exit non-zero on hard failures: 
-  `circleci policy decide --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --input .circleci/config.yml --strict`
+  `circleci policy decide --org gh/acme --input .circleci/config.yml --strict`
 - Pass metadata alongside the decision: 
-  `circleci policy decide --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --input .circleci/config.yml --meta '{"project_id":"abc"}'`
+  `circleci policy decide --org gh/acme --input .circleci/config.yml --meta '{"project_id":"abc"}'`
 - Output decision as JSON: 
-  `circleci policy decide --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --input .circleci/config.yml --json`
+  `circleci policy decide --org gh/acme --input .circleci/config.yml --json`
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/policy/diff.txt
+++ b/internal/cmd/root/testdata/help/circleci/policy/diff.txt
@@ -13,12 +13,12 @@ For more information about output formatting flags, see `circleci help formattin
 
 ## Flags
 
-| Flag                      | Description                                      |
-| ------------------------- | ------------------------------------------------ |
-| `--jq string`             | Process values from the response using jq syntax |
-| `--json`                  | Output as JSON                                   |
-| `--owner-id string`       | Organization UUID (required)                     |
-| `--policy-context string` | Policy context (default "config")                |
+| Flag                      | Description                                          |
+| ------------------------- | ---------------------------------------------------- |
+| `--jq string`             | Process values from the response using jq syntax     |
+| `--json`                  | Output as JSON                                       |
+| `--org string`            | Organization slug (e.g. gh/myorg) or UUID (required) |
+| `--policy-context string` | Policy context (default "config")                    |
 
 ## Inherited Flags
 
@@ -37,11 +37,11 @@ policy bundle.
 ## Examples
 
 - Diff policies in ./policies against the remote bundle: 
-  `circleci policy diff ./policies --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f`
+  `circleci policy diff ./policies --org gh/acme`
 - Diff against a custom policy context: 
-  `circleci policy diff ./policies --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --policy-context config`
+  `circleci policy diff ./policies --org gh/acme --policy-context config`
 - Output diff as JSON for scripting: 
-  `circleci policy diff ./policies --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --json`
+  `circleci policy diff ./policies --org gh/acme --json`
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/policy/fetch.txt
+++ b/internal/cmd/root/testdata/help/circleci/policy/fetch.txt
@@ -15,12 +15,12 @@ For more information about output formatting flags, see `circleci help formattin
 
 ## Flags
 
-| Flag                      | Description                                      |
-| ------------------------- | ------------------------------------------------ |
-| `--jq string`             | Process values from the response using jq syntax |
-| `--json`                  | Output as JSON                                   |
-| `--owner-id string`       | Organization UUID (required)                     |
-| `--policy-context string` | Policy context (default "config")                |
+| Flag                      | Description                                          |
+| ------------------------- | ---------------------------------------------------- |
+| `--jq string`             | Process values from the response using jq syntax     |
+| `--json`                  | Output as JSON                                       |
+| `--org string`            | Organization slug (e.g. gh/myorg) or UUID (required) |
+| `--policy-context string` | Policy context (default "config")                    |
 
 ## Inherited Flags
 
@@ -33,11 +33,11 @@ For more information about output formatting flags, see `circleci help formattin
 ## Examples
 
 - Fetch the full policy bundle: 
-  `circleci policy fetch --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f`
+  `circleci policy fetch --org gh/acme`
 - Fetch a single policy by name: 
-  `circleci policy fetch my-policy --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f`
+  `circleci policy fetch my-policy --org gh/acme`
 - Output as JSON with jq filtering: 
-  `circleci policy fetch --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --json --jq 'keys'`
+  `circleci policy fetch --org gh/acme --json --jq 'keys'`
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/policy/logs.txt
+++ b/internal/cmd/root/testdata/help/circleci/policy/logs.txt
@@ -27,8 +27,8 @@ For more information about output formatting flags, see `circleci help formattin
 | `--branch string`         | Filter by branch name                                         |
 | `--jq string`             | Process values from the response using jq syntax              |
 | `--json`                  | Output as JSON                                                |
+| `--org string`            | Organization slug (e.g. gh/myorg) or UUID (required)          |
 | `--out string`            | Write output to this file instead of stdout                   |
-| `--owner-id string`       | Organization UUID (required)                                  |
 | `--policy-bundle`         | Retrieve the policy bundle snapshot for the given decision ID |
 | `--policy-context string` | Policy context (default "config")                             |
 | `--project-id string`     | Filter by project ID                                          |
@@ -45,13 +45,13 @@ For more information about output formatting flags, see `circleci help formattin
 ## Examples
 
 - Get all decision logs: 
-  `circleci policy logs --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f`
+  `circleci policy logs --org gh/acme`
 - Get a specific decision log: 
-  `circleci policy logs abc123 --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f`
+  `circleci policy logs abc123 --org gh/acme`
 - Filter by status and branch: 
-  `circleci policy logs --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --status HARD_FAIL --branch main`
+  `circleci policy logs --org gh/acme --status HARD_FAIL --branch main`
 - Write output to a file: 
-  `circleci policy logs --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --out logs.json`
+  `circleci policy logs --org gh/acme --out logs.json`
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/policy/push.txt
+++ b/internal/cmd/root/testdata/help/circleci/policy/push.txt
@@ -18,13 +18,13 @@ For more information about output formatting flags, see `circleci help formattin
 
 ## Flags
 
-| Flag                      | Description                                      |
-| ------------------------- | ------------------------------------------------ |
-| `--jq string`             | Process values from the response using jq syntax |
-| `--json`                  | Output as JSON                                   |
-| `--no-prompt`             | Skip confirmation prompt                         |
-| `--owner-id string`       | Organization UUID (required)                     |
-| `--policy-context string` | Policy context (default "config")                |
+| Flag                      | Description                                          |
+| ------------------------- | ---------------------------------------------------- |
+| `--jq string`             | Process values from the response using jq syntax     |
+| `--json`                  | Output as JSON                                       |
+| `--no-prompt`             | Skip confirmation prompt                             |
+| `--org string`            | Organization slug (e.g. gh/myorg) or UUID (required) |
+| `--policy-context string` | Policy context (default "config")                    |
 
 ## Inherited Flags
 
@@ -43,13 +43,13 @@ bundle, replacing the existing bundle.
 ## Examples
 
 - Push policies in the ./policies directory: 
-  `circleci policy push ./policies --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f`
+  `circleci policy push ./policies --org gh/acme`
 - Push without confirmation prompt: 
-  `circleci policy push ./policies --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --no-prompt`
+  `circleci policy push ./policies --org gh/acme --no-prompt`
 - Push to a custom policy context: 
-  `circleci policy push ./policies --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --policy-context config`
+  `circleci policy push ./policies --org gh/acme --policy-context config`
 - Output the diff as JSON: 
-  `circleci policy push ./policies --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --no-prompt --json`
+  `circleci policy push ./policies --org gh/acme --no-prompt --json`
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/policy/settings/get.txt
+++ b/internal/cmd/root/testdata/help/circleci/policy/settings/get.txt
@@ -12,12 +12,12 @@ For more information about output formatting flags, see `circleci help formattin
 
 ## Flags
 
-| Flag                      | Description                                      |
-| ------------------------- | ------------------------------------------------ |
-| `--jq string`             | Process values from the response using jq syntax |
-| `--json`                  | Output as JSON                                   |
-| `--owner-id string`       | Organization UUID (required)                     |
-| `--policy-context string` | Policy context (default "config")                |
+| Flag                      | Description                                          |
+| ------------------------- | ---------------------------------------------------- |
+| `--jq string`             | Process values from the response using jq syntax     |
+| `--json`                  | Output as JSON                                       |
+| `--org string`            | Organization slug (e.g. gh/myorg) or UUID (required) |
+| `--policy-context string` | Policy context (default "config")                    |
 
 ## Inherited Flags
 
@@ -30,11 +30,11 @@ For more information about output formatting flags, see `circleci help formattin
 ## Examples
 
 - Get policy enforcement settings: 
-  `circleci policy settings get --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f`
+  `circleci policy settings get --org gh/acme`
 - Output as JSON: 
-  `circleci policy settings get --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --json`
+  `circleci policy settings get --org gh/acme --json`
 - Use with jq to extract the enabled field: 
-  `circleci policy settings get --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --json --jq '.enabled'`
+  `circleci policy settings get --org gh/acme --json --jq '.enabled'`
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/policy/settings/set.txt
+++ b/internal/cmd/root/testdata/help/circleci/policy/settings/set.txt
@@ -15,13 +15,13 @@ For more information about output formatting flags, see `circleci help formattin
 
 ## Flags
 
-| Flag                      | Description                                      |
-| ------------------------- | ------------------------------------------------ |
-| `--enabled`               | Enable policy enforcement                        |
-| `--jq string`             | Process values from the response using jq syntax |
-| `--json`                  | Output as JSON                                   |
-| `--owner-id string`       | Organization UUID (required)                     |
-| `--policy-context string` | Policy context (default "config")                |
+| Flag                      | Description                                          |
+| ------------------------- | ---------------------------------------------------- |
+| `--enabled`               | Enable policy enforcement                            |
+| `--jq string`             | Process values from the response using jq syntax     |
+| `--json`                  | Output as JSON                                       |
+| `--org string`            | Organization slug (e.g. gh/myorg) or UUID (required) |
+| `--policy-context string` | Policy context (default "config")                    |
 
 ## Inherited Flags
 
@@ -34,11 +34,11 @@ For more information about output formatting flags, see `circleci help formattin
 ## Examples
 
 - Enable policy enforcement: 
-  `circleci policy settings set --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --enabled`
+  `circleci policy settings set --org gh/acme --enabled`
 - Disable policy enforcement: 
-  `circleci policy settings set --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --enabled=false`
+  `circleci policy settings set --org gh/acme --enabled=false`
 - Output result as JSON: 
-  `circleci policy settings set --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --enabled --json`
+  `circleci policy settings set --org gh/acme --enabled --json`
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/reference.txt
+++ b/internal/cmd/root/testdata/help/circleci/reference.txt
@@ -54,8 +54,7 @@ Compile and expand a pipeline config file
 | Flag                           | Description                                                                    |
 | ------------------------------ | ------------------------------------------------------------------------------ |
 | `-n, --next`                   | Enable config next which previews upcoming potentially breaking config changes |
-| `--org-id string`              | Organization UUID for private orb resolution                                   |
-| `-o, --org-slug string`        | Organization slug for private orb resolution (e.g. gh/myorg)                   |
+| `--org string`                 | Organization slug (e.g. gh/myorg) or UUID for private orb resolution           |
 | `--pipeline-parameters string` | Pipeline parameters as a YAML map or path to a YAML file                       |
 
 
@@ -69,13 +68,12 @@ from stdin.
 
 Validate a pipeline config file
 
-| Flag                    | Description                                                                    |
-| ----------------------- | ------------------------------------------------------------------------------ |
-| `-c, --config string`   | Path to config file (use "-" for stdin) (default ".circleci/config.yml")       |
-| `--json`                | Output as JSON                                                                 |
-| `-n, --next`            | Enable config next which previews upcoming potentially breaking config changes |
-| `--org-id string`       | Organization UUID for private orb resolution                                   |
-| `-o, --org-slug string` | Organization slug for private orb resolution (e.g. gh/myorg)                   |
+| Flag                  | Description                                                                    |
+| --------------------- | ------------------------------------------------------------------------------ |
+| `-c, --config string` | Path to config file (use "-" for stdin) (default ".circleci/config.yml")       |
+| `--json`              | Output as JSON                                                                 |
+| `-n, --next`          | Enable config next which previews upcoming potentially breaking config changes |
+| `--org string`        | Organization slug (e.g. gh/myorg) or UUID for private orb resolution           |
 
 
 ### `circleci job <command>`
@@ -416,11 +414,11 @@ Delete an iOS certificate
 
 List uploaded iOS certificates
 
-| Flag              | Description                                                                |
-| ----------------- | -------------------------------------------------------------------------- |
-| `--jq string`     | Process values from the response using jq syntax                           |
-| `--json`          | Output as JSON                                                             |
-| `--org-id string` | CircleCI organization UUID; defaults to the org of the current git project |
+| Flag           | Description                                                       |
+| -------------- | ----------------------------------------------------------------- |
+| `--jq string`  | Process values from the response using jq syntax                  |
+| `--json`       | Output as JSON                                                    |
+| `--org string` | Organization slug (e.g. gh/myorg) or UUID; defaults to git remote |
 
 
 **Aliases:**
@@ -437,7 +435,7 @@ Upload a .p12 certificate
 | `--cert-file string` | Path to the .p12 certificate file                                                         |
 | `--jq string`        | Process values from the response using jq syntax                                          |
 | `--json`             | Output as JSON                                                                            |
-| `--org-id string`    | CircleCI organization UUID; defaults to the org of the current git project                |
+| `--org string`       | Organization slug (e.g. gh/myorg) or UUID; defaults to git remote                         |
 | `--password string`  | Password for the .p12 file. Pass - to read from stdin. Prompted if omitted in a terminal. |
 
 
@@ -747,15 +745,15 @@ after being set and is masked in all subsequent list output.
 
 Manage the org namespace orbs publish under
 
-#### `circleci namespace create <name> --org-id <uuid> [flags]`
+#### `circleci namespace create <name> --org <org> [flags]`
 
 Create a namespace
 
-| Flag              | Description                                             |
-| ----------------- | ------------------------------------------------------- |
-| `--jq string`     | Process values from the response using jq syntax        |
-| `--json`          | Output as JSON                                          |
-| `--org-id string` | organization UUID to claim the namespace for (required) |
+| Flag           | Description                                                                     |
+| -------------- | ------------------------------------------------------------------------------- |
+| `--jq string`  | Process values from the response using jq syntax                                |
+| `--json`       | Output as JSON                                                                  |
+| `--org string` | Organization slug (e.g. gh/myorg) or UUID to claim the namespace for (required) |
 
 
 **Arguments:**
@@ -914,9 +912,9 @@ Pack a multi-file orb directory into a single YAML
 
 Validate and print expanded orb YAML
 
-| Flag              | Description                                    |
-| ----------------- | ---------------------------------------------- |
-| `--org-id string` | organization UUID for private orb dependencies |
+| Flag           | Description                                                            |
+| -------------- | ---------------------------------------------------------------------- |
+| `--org string` | Organization slug (e.g. gh/myorg) or UUID for private orb dependencies |
 
 
 **Arguments:**
@@ -990,9 +988,9 @@ Hide or restore an orb in the registry
 
 Validate an orb YAML file
 
-| Flag              | Description                                    |
-| ----------------- | ---------------------------------------------- |
-| `--org-id string` | organization UUID for private orb dependencies |
+| Flag           | Description                                                            |
+| -------------- | ---------------------------------------------------------------------- |
+| `--org string` | Organization slug (e.g. gh/myorg) or UUID for private orb dependencies |
 
 
 **Arguments:**
@@ -1014,7 +1012,7 @@ Evaluate a config against remote policies
 | `--json`                  | Output as JSON                                            |
 | `--meta string`           | Decision metadata as a JSON string                        |
 | `--metafile string`       | Path to decision metadata file (YAML or JSON)             |
-| `--owner-id string`       | Organization UUID (required)                              |
+| `--org string`            | Organization slug (e.g. gh/myorg) or UUID (required)      |
 | `--policy-context string` | Policy context (default "config")                         |
 | `--strict`                | Exit non-zero for HARD_FAIL or ERROR decisions            |
 
@@ -1023,12 +1021,12 @@ Evaluate a config against remote policies
 
 Show diff between local and remote policy bundles
 
-| Flag                      | Description                                      |
-| ------------------------- | ------------------------------------------------ |
-| `--jq string`             | Process values from the response using jq syntax |
-| `--json`                  | Output as JSON                                   |
-| `--owner-id string`       | Organization UUID (required)                     |
-| `--policy-context string` | Policy context (default "config")                |
+| Flag                      | Description                                          |
+| ------------------------- | ---------------------------------------------------- |
+| `--jq string`             | Process values from the response using jq syntax     |
+| `--json`                  | Output as JSON                                       |
+| `--org string`            | Organization slug (e.g. gh/myorg) or UUID (required) |
+| `--policy-context string` | Policy context (default "config")                    |
 
 
 **Arguments:**
@@ -1041,12 +1039,12 @@ policy bundle.
 
 Download the remote policy bundle
 
-| Flag                      | Description                                      |
-| ------------------------- | ------------------------------------------------ |
-| `--jq string`             | Process values from the response using jq syntax |
-| `--json`                  | Output as JSON                                   |
-| `--owner-id string`       | Organization UUID (required)                     |
-| `--policy-context string` | Policy context (default "config")                |
+| Flag                      | Description                                          |
+| ------------------------- | ---------------------------------------------------- |
+| `--jq string`             | Process values from the response using jq syntax     |
+| `--json`                  | Output as JSON                                       |
+| `--org string`            | Organization slug (e.g. gh/myorg) or UUID (required) |
+| `--policy-context string` | Policy context (default "config")                    |
 
 
 #### `circleci policy logs [decision-id] [flags]`
@@ -1060,8 +1058,8 @@ Get policy decision logs
 | `--branch string`         | Filter by branch name                                         |
 | `--jq string`             | Process values from the response using jq syntax              |
 | `--json`                  | Output as JSON                                                |
+| `--org string`            | Organization slug (e.g. gh/myorg) or UUID (required)          |
 | `--out string`            | Write output to this file instead of stdout                   |
-| `--owner-id string`       | Organization UUID (required)                                  |
 | `--policy-bundle`         | Retrieve the policy bundle snapshot for the given decision ID |
 | `--policy-context string` | Policy context (default "config")                             |
 | `--project-id string`     | Filter by project ID                                          |
@@ -1072,13 +1070,13 @@ Get policy decision logs
 
 Push a policy bundle to CircleCI
 
-| Flag                      | Description                                      |
-| ------------------------- | ------------------------------------------------ |
-| `--jq string`             | Process values from the response using jq syntax |
-| `--json`                  | Output as JSON                                   |
-| `--no-prompt`             | Skip confirmation prompt                         |
-| `--owner-id string`       | Organization UUID (required)                     |
-| `--policy-context string` | Policy context (default "config")                |
+| Flag                      | Description                                          |
+| ------------------------- | ---------------------------------------------------- |
+| `--jq string`             | Process values from the response using jq syntax     |
+| `--json`                  | Output as JSON                                       |
+| `--no-prompt`             | Skip confirmation prompt                             |
+| `--org string`            | Organization slug (e.g. gh/myorg) or UUID (required) |
+| `--policy-context string` | Policy context (default "config")                    |
 
 
 **Arguments:**
@@ -1095,25 +1093,25 @@ Manage policy enforcement settings
 
 Get policy enforcement settings
 
-| Flag                      | Description                                      |
-| ------------------------- | ------------------------------------------------ |
-| `--jq string`             | Process values from the response using jq syntax |
-| `--json`                  | Output as JSON                                   |
-| `--owner-id string`       | Organization UUID (required)                     |
-| `--policy-context string` | Policy context (default "config")                |
+| Flag                      | Description                                          |
+| ------------------------- | ---------------------------------------------------- |
+| `--jq string`             | Process values from the response using jq syntax     |
+| `--json`                  | Output as JSON                                       |
+| `--org string`            | Organization slug (e.g. gh/myorg) or UUID (required) |
+| `--policy-context string` | Policy context (default "config")                    |
 
 
 ##### `circleci policy settings set [flags]`
 
 Update policy enforcement settings
 
-| Flag                      | Description                                      |
-| ------------------------- | ------------------------------------------------ |
-| `--enabled`               | Enable policy enforcement                        |
-| `--jq string`             | Process values from the response using jq syntax |
-| `--json`                  | Output as JSON                                   |
-| `--owner-id string`       | Organization UUID (required)                     |
-| `--policy-context string` | Policy context (default "config")                |
+| Flag                      | Description                                          |
+| ------------------------- | ---------------------------------------------------- |
+| `--enabled`               | Enable policy enforcement                            |
+| `--jq string`             | Process values from the response using jq syntax     |
+| `--json`                  | Output as JSON                                       |
+| `--org string`            | Organization slug (e.g. gh/myorg) or UUID (required) |
+| `--policy-context string` | Policy context (default "config")                    |
 
 
 ### `circleci project <command>`
@@ -1480,14 +1478,14 @@ Manage iOS signing configs
 
 Create an iOS signing config
 
-| Flag                    | Description                                                                |
-| ----------------------- | -------------------------------------------------------------------------- |
-| `--cert-id string`      | ID of an uploaded certificate (see: circleci certificate list)             |
-| `--jq string`           | Process values from the response using jq syntax                           |
-| `--json`                | Output as JSON                                                             |
-| `--name string`         | Name for the signing config (referenced in pipeline config)                |
-| `--org-id string`       | CircleCI organization UUID; defaults to the org of the current git project |
-| `--profile stringArray` | Path to a provisioning profile file (repeatable)                           |
+| Flag                    | Description                                                       |
+| ----------------------- | ----------------------------------------------------------------- |
+| `--cert-id string`      | ID of an uploaded certificate (see: circleci certificate list)    |
+| `--jq string`           | Process values from the response using jq syntax                  |
+| `--json`                | Output as JSON                                                    |
+| `--name string`         | Name for the signing config (referenced in pipeline config)       |
+| `--org string`          | Organization slug (e.g. gh/myorg) or UUID; defaults to git remote |
+| `--profile stringArray` | Path to a provisioning profile file (repeatable)                  |
 
 
 #### `circleci signing-config delete <signing-config-id> [flags]`
@@ -1513,11 +1511,11 @@ Delete an iOS signing config
 
 List iOS signing configs
 
-| Flag              | Description                                                                |
-| ----------------- | -------------------------------------------------------------------------- |
-| `--jq string`     | Process values from the response using jq syntax                           |
-| `--json`          | Output as JSON                                                             |
-| `--org-id string` | CircleCI organization UUID; defaults to the org of the current git project |
+| Flag           | Description                                                       |
+| -------------- | ----------------------------------------------------------------- |
+| `--jq string`  | Process values from the response using jq syntax                  |
+| `--json`       | Output as JSON                                                    |
+| `--org string` | Organization slug (e.g. gh/myorg) or UUID; defaults to git remote |
 
 
 **Aliases:**

--- a/internal/cmd/root/testdata/help/circleci/signing-config/create.txt
+++ b/internal/cmd/root/testdata/help/circleci/signing-config/create.txt
@@ -5,7 +5,7 @@ with one or more provisioning profiles. The signing config name is what
 you reference in your pipeline config under 'code_signing'.
 
 The organization is inferred from the current git repository's remote
-unless overridden with --org-id.
+unless overridden with --org (a slug or UUID).
 
 Each --profile flag points to a single provisioning profile file on
 disk. The file is read and base64-encoded locally. Repeat the flag to
@@ -21,14 +21,14 @@ For more information about output formatting flags, see `circleci help formattin
 
 ## Flags
 
-| Flag                    | Description                                                                |
-| ----------------------- | -------------------------------------------------------------------------- |
-| `--cert-id string`      | ID of an uploaded certificate (see: circleci certificate list)             |
-| `--jq string`           | Process values from the response using jq syntax                           |
-| `--json`                | Output as JSON                                                             |
-| `--name string`         | Name for the signing config (referenced in pipeline config)                |
-| `--org-id string`       | CircleCI organization UUID; defaults to the org of the current git project |
-| `--profile stringArray` | Path to a provisioning profile file (repeatable)                           |
+| Flag                    | Description                                                       |
+| ----------------------- | ----------------------------------------------------------------- |
+| `--cert-id string`      | ID of an uploaded certificate (see: circleci certificate list)    |
+| `--jq string`           | Process values from the response using jq syntax                  |
+| `--json`                | Output as JSON                                                    |
+| `--name string`         | Name for the signing config (referenced in pipeline config)       |
+| `--org string`          | Organization slug (e.g. gh/myorg) or UUID; defaults to git remote |
+| `--profile stringArray` | Path to a provisioning profile file (repeatable)                  |
 
 ## Inherited Flags
 
@@ -52,7 +52,7 @@ For more information about output formatting flags, see `circleci help formattin
 - --profile ./MyApp.mobileprovision \
 - --profile ./MyAppExtension.mobileprovision
 - Explicit org and capture the id for scripting: 
-  `circleci signing-config create --org-id <org-uuid> --name prod --cert-id <cert-id> --profile ./p.mobileprovision --json --jq -r '.id'`
+  `circleci signing-config create --org gh/acme --name prod --cert-id <cert-id> --profile ./p.mobileprovision --json --jq -r '.id'`
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/signing-config/list.txt
+++ b/internal/cmd/root/testdata/help/circleci/signing-config/list.txt
@@ -3,7 +3,7 @@
 List the iOS signing configs defined for your organization.
 
 The organization is inferred from the current git repository's remote
-unless overridden with --org-id.
+unless overridden with --org (a slug or UUID).
 
 JSON fields: id, name, certificate, provisioning_profiles
 
@@ -19,11 +19,11 @@ For more information about output formatting flags, see `circleci help formattin
 
 ## Flags
 
-| Flag              | Description                                                                |
-| ----------------- | -------------------------------------------------------------------------- |
-| `--jq string`     | Process values from the response using jq syntax                           |
-| `--json`          | Output as JSON                                                             |
-| `--org-id string` | CircleCI organization UUID; defaults to the org of the current git project |
+| Flag           | Description                                                       |
+| -------------- | ----------------------------------------------------------------- |
+| `--jq string`  | Process values from the response using jq syntax                  |
+| `--json`       | Output as JSON                                                    |
+| `--org string` | Organization slug (e.g. gh/myorg) or UUID; defaults to git remote |
 
 ## Inherited Flags
 
@@ -38,7 +38,7 @@ For more information about output formatting flags, see `circleci help formattin
 - List signing configs (org inferred from git remote): 
   `circleci signing-config list`
 - List for a specific org: 
-  `circleci signing-config list --org-id <org-uuid>`
+  `circleci signing-config list --org gh/acme`
 - Output as JSON: 
   `circleci signing-config list --json`
 - Get signing config names only: 

--- a/internal/cmd/root/testdata/usage/circleci/certificate/list.txt
+++ b/internal/cmd/root/testdata/usage/circleci/certificate/list.txt
@@ -1,7 +1,7 @@
 Usage:  circleci certificate list [flags]
 
 Flags:
-  --jq string       Process values from the response using jq syntax
-  --json            Output as JSON
-  --org-id string   CircleCI organization UUID; defaults to the org of the current git project
+  --jq string    Process values from the response using jq syntax
+  --json         Output as JSON
+  --org string   Organization slug (e.g. gh/myorg) or UUID; defaults to git remote
   

--- a/internal/cmd/root/testdata/usage/circleci/certificate/upload.txt
+++ b/internal/cmd/root/testdata/usage/circleci/certificate/upload.txt
@@ -4,6 +4,6 @@ Flags:
   --cert-file string   Path to the .p12 certificate file
   --jq string          Process values from the response using jq syntax
   --json               Output as JSON
-  --org-id string      CircleCI organization UUID; defaults to the org of the current git project
+  --org string         Organization slug (e.g. gh/myorg) or UUID; defaults to git remote
   --password string    Password for the .p12 file. Pass - to read from stdin. Prompted if omitted in a terminal.
   

--- a/internal/cmd/root/testdata/usage/circleci/config/process.txt
+++ b/internal/cmd/root/testdata/usage/circleci/config/process.txt
@@ -2,7 +2,6 @@ Usage:  circleci config process <path> [flags]
 
 Flags:
   -n, --next                         Enable config next which previews upcoming potentially breaking config changes
-      --org-id string                Organization UUID for private orb resolution
-  -o, --org-slug string              Organization slug for private orb resolution (e.g. gh/myorg)
+      --org string                   Organization slug (e.g. gh/myorg) or UUID for private orb resolution
       --pipeline-parameters string   Pipeline parameters as a YAML map or path to a YAML file
   

--- a/internal/cmd/root/testdata/usage/circleci/config/validate.txt
+++ b/internal/cmd/root/testdata/usage/circleci/config/validate.txt
@@ -1,9 +1,8 @@
 Usage:  circleci config validate [flags]
 
 Flags:
-  -c, --config string     Path to config file (use "-" for stdin) (default ".circleci/config.yml")
-      --json              Output as JSON
-  -n, --next              Enable config next which previews upcoming potentially breaking config changes
-      --org-id string     Organization UUID for private orb resolution
-  -o, --org-slug string   Organization slug for private orb resolution (e.g. gh/myorg)
+  -c, --config string   Path to config file (use "-" for stdin) (default ".circleci/config.yml")
+      --json            Output as JSON
+  -n, --next            Enable config next which previews upcoming potentially breaking config changes
+      --org string      Organization slug (e.g. gh/myorg) or UUID for private orb resolution
   

--- a/internal/cmd/root/testdata/usage/circleci/namespace/create.txt
+++ b/internal/cmd/root/testdata/usage/circleci/namespace/create.txt
@@ -1,7 +1,7 @@
-Usage:  circleci namespace create <name> --org-id <uuid> [flags]
+Usage:  circleci namespace create <name> --org <org> [flags]
 
 Flags:
-  --jq string       Process values from the response using jq syntax
-  --json            Output as JSON
-  --org-id string   organization UUID to claim the namespace for (required)
+  --jq string    Process values from the response using jq syntax
+  --json         Output as JSON
+  --org string   Organization slug (e.g. gh/myorg) or UUID to claim the namespace for (required)
   

--- a/internal/cmd/root/testdata/usage/circleci/orb/process.txt
+++ b/internal/cmd/root/testdata/usage/circleci/orb/process.txt
@@ -1,5 +1,5 @@
 Usage:  circleci orb process <path> [flags]
 
 Flags:
-  --org-id string   organization UUID for private orb dependencies
+  --org string   Organization slug (e.g. gh/myorg) or UUID for private orb dependencies
   

--- a/internal/cmd/root/testdata/usage/circleci/orb/validate.txt
+++ b/internal/cmd/root/testdata/usage/circleci/orb/validate.txt
@@ -1,5 +1,5 @@
 Usage:  circleci orb validate <path> [flags]
 
 Flags:
-  --org-id string   organization UUID for private orb dependencies
+  --org string   Organization slug (e.g. gh/myorg) or UUID for private orb dependencies
   

--- a/internal/cmd/root/testdata/usage/circleci/policy/decide.txt
+++ b/internal/cmd/root/testdata/usage/circleci/policy/decide.txt
@@ -6,7 +6,7 @@ Flags:
   --json                    Output as JSON
   --meta string             Decision metadata as a JSON string
   --metafile string         Path to decision metadata file (YAML or JSON)
-  --owner-id string         Organization UUID (required)
+  --org string              Organization slug (e.g. gh/myorg) or UUID (required)
   --policy-context string   Policy context (default "config")
   --strict                  Exit non-zero for HARD_FAIL or ERROR decisions
   

--- a/internal/cmd/root/testdata/usage/circleci/policy/diff.txt
+++ b/internal/cmd/root/testdata/usage/circleci/policy/diff.txt
@@ -3,6 +3,6 @@ Usage:  circleci policy diff <path> [flags]
 Flags:
   --jq string               Process values from the response using jq syntax
   --json                    Output as JSON
-  --owner-id string         Organization UUID (required)
+  --org string              Organization slug (e.g. gh/myorg) or UUID (required)
   --policy-context string   Policy context (default "config")
   

--- a/internal/cmd/root/testdata/usage/circleci/policy/fetch.txt
+++ b/internal/cmd/root/testdata/usage/circleci/policy/fetch.txt
@@ -3,6 +3,6 @@ Usage:  circleci policy fetch [policy-name] [flags]
 Flags:
   --jq string               Process values from the response using jq syntax
   --json                    Output as JSON
-  --owner-id string         Organization UUID (required)
+  --org string              Organization slug (e.g. gh/myorg) or UUID (required)
   --policy-context string   Policy context (default "config")
   

--- a/internal/cmd/root/testdata/usage/circleci/policy/logs.txt
+++ b/internal/cmd/root/testdata/usage/circleci/policy/logs.txt
@@ -6,8 +6,8 @@ Flags:
   --branch string           Filter by branch name
   --jq string               Process values from the response using jq syntax
   --json                    Output as JSON
+  --org string              Organization slug (e.g. gh/myorg) or UUID (required)
   --out string              Write output to this file instead of stdout
-  --owner-id string         Organization UUID (required)
   --policy-bundle           Retrieve the policy bundle snapshot for the given decision ID
   --policy-context string   Policy context (default "config")
   --project-id string       Filter by project ID

--- a/internal/cmd/root/testdata/usage/circleci/policy/push.txt
+++ b/internal/cmd/root/testdata/usage/circleci/policy/push.txt
@@ -4,6 +4,6 @@ Flags:
   --jq string               Process values from the response using jq syntax
   --json                    Output as JSON
   --no-prompt               Skip confirmation prompt
-  --owner-id string         Organization UUID (required)
+  --org string              Organization slug (e.g. gh/myorg) or UUID (required)
   --policy-context string   Policy context (default "config")
   

--- a/internal/cmd/root/testdata/usage/circleci/policy/settings/get.txt
+++ b/internal/cmd/root/testdata/usage/circleci/policy/settings/get.txt
@@ -3,6 +3,6 @@ Usage:  circleci policy settings get [flags]
 Flags:
   --jq string               Process values from the response using jq syntax
   --json                    Output as JSON
-  --owner-id string         Organization UUID (required)
+  --org string              Organization slug (e.g. gh/myorg) or UUID (required)
   --policy-context string   Policy context (default "config")
   

--- a/internal/cmd/root/testdata/usage/circleci/policy/settings/set.txt
+++ b/internal/cmd/root/testdata/usage/circleci/policy/settings/set.txt
@@ -4,6 +4,6 @@ Flags:
   --enabled                 Enable policy enforcement
   --jq string               Process values from the response using jq syntax
   --json                    Output as JSON
-  --owner-id string         Organization UUID (required)
+  --org string              Organization slug (e.g. gh/myorg) or UUID (required)
   --policy-context string   Policy context (default "config")
   

--- a/internal/cmd/root/testdata/usage/circleci/signing-config/create.txt
+++ b/internal/cmd/root/testdata/usage/circleci/signing-config/create.txt
@@ -5,6 +5,6 @@ Flags:
   --jq string             Process values from the response using jq syntax
   --json                  Output as JSON
   --name string           Name for the signing config (referenced in pipeline config)
-  --org-id string         CircleCI organization UUID; defaults to the org of the current git project
+  --org string            Organization slug (e.g. gh/myorg) or UUID; defaults to git remote
   --profile stringArray   Path to a provisioning profile file (repeatable)
   

--- a/internal/cmd/root/testdata/usage/circleci/signing-config/list.txt
+++ b/internal/cmd/root/testdata/usage/circleci/signing-config/list.txt
@@ -1,7 +1,7 @@
 Usage:  circleci signing-config list [flags]
 
 Flags:
-  --jq string       Process values from the response using jq syntax
-  --json            Output as JSON
-  --org-id string   CircleCI organization UUID; defaults to the org of the current git project
+  --jq string    Process values from the response using jq syntax
+  --json         Output as JSON
+  --org string   Organization slug (e.g. gh/myorg) or UUID; defaults to git remote
   

--- a/internal/cmd/runner/instance.go
+++ b/internal/cmd/runner/instance.go
@@ -105,7 +105,7 @@ func newInstanceListCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&org, "org", "", "Organization slug (e.g. gh/myorg) or UUID; defaults to git remote")
+	cmdutil.AddOrgFlag(cmd, &org, cmdutil.OrgFlag{DefaultsToGitRemote: true})
 	cmd.Flags().StringVar(&resourceClass, "resource-class", "", "Filter by resource class (namespace/name)")
 	cmd.Flags().StringVar(&namespace, "namespace", "", "Filter by namespace (organization)")
 	cmdutil.AddJSONFlag(cmd, &jsonOut)

--- a/internal/cmd/runner/resource_class.go
+++ b/internal/cmd/runner/resource_class.go
@@ -106,7 +106,7 @@ func newResourceClassListCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&org, "org", "", "Organization slug (e.g. gh/myorg) or UUID; defaults to git remote")
+	cmdutil.AddOrgFlag(cmd, &org, cmdutil.OrgFlag{DefaultsToGitRemote: true})
 	cmd.Flags().StringVar(&namespace, "namespace", "", "Filter by namespace (organization)")
 	cmdutil.AddJSONFlag(cmd, &jsonOut)
 	cmdutil.AddJQFlag(cmd)

--- a/internal/cmd/signingconfig/signingconfig.go
+++ b/internal/cmd/signingconfig/signingconfig.go
@@ -74,7 +74,7 @@ func apiErr(err error, subject string) *clierrors.CLIError {
 	return cmdutil.APIErr(err, subject,
 		"signing_config.not_found", "No iOS signing config found for %q.",
 		"Check the signing config ID and try again",
-		"Run: circleci signing-config list --org-id <org-uuid>")
+		"Run: circleci signing-config list --org <org>")
 }
 
 // createAPIErr translates errors from POST /signing-configs into structured
@@ -108,7 +108,7 @@ func createAPIErr(err error, name, certID string) *clierrors.CLIError {
 
 func newCreateCmd() *cobra.Command {
 	var (
-		orgID       string
+		org         string
 		name        string
 		certID      string
 		profilePath []string
@@ -124,7 +124,7 @@ func newCreateCmd() *cobra.Command {
 			you reference in your pipeline config under 'code_signing'.
 
 			The organization is inferred from the current git repository's remote
-			unless overridden with --org-id.
+			unless overridden with --org (a slug or UUID).
 
 			Each --profile flag points to a single provisioning profile file on
 			disk. The file is read and base64-encoded locally. Repeat the flag to
@@ -147,7 +147,7 @@ func newCreateCmd() *cobra.Command {
 			    --profile ./MyAppExtension.mobileprovision
 
 			# Explicit org and capture the id for scripting
-			$ circleci signing-config create --org-id <org-uuid> --name prod --cert-id <cert-id> --profile ./p.mobileprovision --json --jq -r '.id'
+			$ circleci signing-config create --org gh/acme --name prod --cert-id <cert-id> --profile ./p.mobileprovision --json --jq -r '.id'
 		`),
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -176,11 +176,11 @@ func newCreateCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			resolvedOrgID, err := cmdutil.ResolveOrgID(ctx, client, orgID, "circleci signing-config create")
+			resolvedOrgID, err := cmdutil.ResolveOrgSlugOrID(ctx, client, org, "circleci signing-config create")
 			if err != nil {
 				return err
 			}
-			id, err := client.CreateIOSSigningConfig(ctx, resolvedOrgID, name, certID, profiles)
+			id, err := client.CreateIOSSigningConfig(ctx, resolvedOrgID.String(), name, certID, profiles)
 			if err != nil {
 				return createAPIErr(err, name, certID)
 			}
@@ -197,7 +197,7 @@ func newCreateCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&orgID, "org-id", "", "CircleCI organization UUID; defaults to the org of the current git project")
+	cmdutil.AddOrgFlag(cmd, &org, cmdutil.OrgFlag{DefaultsToGitRemote: true})
 	cmd.Flags().StringVar(&name, "name", "", "Name for the signing config (referenced in pipeline config)")
 	cmd.Flags().StringVar(&certID, "cert-id", "", "ID of an uploaded certificate (see: circleci certificate list)")
 	cmd.Flags().StringArrayVar(&profilePath, "profile", nil, "Path to a provisioning profile file (repeatable)")
@@ -218,7 +218,7 @@ type listEntry struct {
 
 func newListCmd() *cobra.Command {
 	var (
-		orgID   string
+		org     string
 		jsonOut bool
 	)
 
@@ -230,7 +230,7 @@ func newListCmd() *cobra.Command {
 			List the iOS signing configs defined for your organization.
 
 			The organization is inferred from the current git repository's remote
-			unless overridden with --org-id.
+			unless overridden with --org (a slug or UUID).
 
 			JSON fields: id, name, certificate, provisioning_profiles
 		`),
@@ -239,7 +239,7 @@ func newListCmd() *cobra.Command {
 			$ circleci signing-config list
 
 			# List for a specific org
-			$ circleci signing-config list --org-id <org-uuid>
+			$ circleci signing-config list --org gh/acme
 
 			# Output as JSON
 			$ circleci signing-config list --json
@@ -254,15 +254,15 @@ func newListCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			resolvedOrgID, err := cmdutil.ResolveOrgID(ctx, client, orgID, "circleci signing-config list")
+			resolvedOrgID, err := cmdutil.ResolveOrgSlugOrID(ctx, client, org, "circleci signing-config list")
 			if err != nil {
 				return err
 			}
-			return runList(ctx, client, resolvedOrgID, jsonOut)
+			return runList(ctx, client, resolvedOrgID.String(), jsonOut)
 		},
 	}
 
-	cmd.Flags().StringVar(&orgID, "org-id", "", "CircleCI organization UUID; defaults to the org of the current git project")
+	cmdutil.AddOrgFlag(cmd, &org, cmdutil.OrgFlag{DefaultsToGitRemote: true})
 	cmdutil.AddJSONFlag(cmd, &jsonOut)
 	cmdutil.AddJQFlag(cmd)
 

--- a/internal/cmdutil/helpers.go
+++ b/internal/cmdutil/helpers.go
@@ -46,6 +46,45 @@ func AddJQFlag(cmd *cobra.Command) {
 	cmd.Flags().StringP("jq", "", "", "Process values from the response using jq syntax")
 }
 
+// OrgFlag configures the canonical --org flag added by AddOrgFlag. The flag
+// always accepts an organization slug (e.g. gh/myorg) or a UUID; resolve its
+// value to a UUID with ResolveOrgSlugOrID.
+type OrgFlag struct {
+	// Purpose, when set, is appended to describe what the organization scopes,
+	// e.g. "for private orb resolution" or "to claim the namespace for". Omit
+	// the leading space.
+	Purpose string
+	// Required marks --org required and appends "(required)" to its
+	// description. Use it for commands with no git-remote fallback. It is
+	// mutually exclusive with DefaultsToGitRemote.
+	Required bool
+	// DefaultsToGitRemote appends "; defaults to git remote" to the description.
+	// Set it for commands that infer the org from the current repository when
+	// --org is omitted. Ignored when Required is true.
+	DefaultsToGitRemote bool
+}
+
+// AddOrgFlag registers the canonical --org flag on cmd, binding it to org and
+// marking it required when opts.Required is set. It is the single source of the
+// flag name and help wording shared by every org-scoped command; pair it with
+// ResolveOrgSlugOrID to turn the value into an org UUID.
+func AddOrgFlag(cmd *cobra.Command, org *string, opts OrgFlag) {
+	desc := "Organization slug (e.g. gh/myorg) or UUID"
+	if opts.Purpose != "" {
+		desc += " " + opts.Purpose
+	}
+	switch {
+	case opts.Required:
+		desc += " (required)"
+	case opts.DefaultsToGitRemote:
+		desc += "; defaults to git remote"
+	}
+	cmd.Flags().StringVar(org, "org", "", desc)
+	if opts.Required {
+		_ = cmd.MarkFlagRequired("org")
+	}
+}
+
 // AddOutputFlag registers --output/-o on cmd, binding it to out. The what
 // argument names the content being written, e.g. "the manpage", and is used in
 // the flag description: "Write <what> to this file instead of stdout".

--- a/internal/cmdutil/orgid.go
+++ b/internal/cmdutil/orgid.go
@@ -37,7 +37,7 @@ import (
 // ResolveOrgSlug returns orgSlug as-is when non-empty. Otherwise it derives the
 // organization slug (vcs/org, e.g. gh/myorg) from the current git remote. It
 // makes no API call — use this for endpoints keyed on an owner slug rather than
-// an org UUID (see ResolveOrgID / ResolveOrgSlugOrID for the UUID case).
+// an org UUID (see ResolveOrgSlugOrID for the UUID case).
 //
 // cmdName is included in the GitDetectErr suggestion text so users see the
 // exact override flag for the command they invoked, e.g. "circleci context list".
@@ -60,22 +60,6 @@ func orgSlugFromProjectSlug(projectSlug string) string {
 		return parts[0] + "/" + parts[1]
 	}
 	return projectSlug
-}
-
-// ResolveOrgID returns orgID as-is when non-empty. Otherwise it detects the
-// project from the current git remote and resolves it through the API to
-// recover the org UUID.
-//
-// cmdName is included in the GitDetectErr suggestion text so users see the
-// exact override flag for the command they invoked, e.g.
-// "circleci certificate list".
-func ResolveOrgID(ctx context.Context, client *apiclient.Client, orgID, cmdName string) (string, error) {
-	if orgID != "" {
-		return orgID, nil
-	}
-	return orgIDFromGitRemote(ctx, client,
-		"Or specify the organization: "+cmdName+" --org-id <org-uuid>",
-		"Pass --org-id <org-uuid> explicitly")
 }
 
 // ResolveOrgSlugOrID resolves an organization reference to its UUID. The
@@ -121,7 +105,7 @@ func ResolveOrgSlugOrID(ctx context.Context, client *apiclient.Client, ref, cmdN
 // resolves it through the API to recover the org UUID (as the raw string the
 // API returns). detectHint is passed to GitDetectErr and projectFailSuggestion
 // is used when the project lookup fails, so callers can phrase the override in
-// terms of their own flag (--org-id vs --org).
+// terms of their own flag.
 func orgIDFromGitRemote(ctx context.Context, client *apiclient.Client, detectHint, projectFailSuggestion string) (string, error) {
 	info, err := gitremote.Detect()
 	if err != nil {

--- a/internal/testing/fakes/circleci.go
+++ b/internal/testing/fakes/circleci.go
@@ -157,9 +157,10 @@ type CircleCI struct {
 	// DLC state.
 	dlcPurgeStatus map[string]int // projectID → HTTP status to return (default 204)
 	// Config compile state.
-	compileValid      bool
-	compileOutputYAML string
-	compileErrors     []string
+	compileValid       bool
+	compileOutputYAML  string
+	compileErrors      []string
+	lastCompileOwnerID string
 
 	// Org state.
 	orgs map[string]map[string]any
@@ -3273,6 +3274,15 @@ func (f *CircleCI) SetCompileResponse(valid bool, outputYAML string, errors ...s
 	f.compileErrors = errors
 }
 
+// LastCompileOwnerID returns the owner_id sent on the most recent
+// POST /compile-config-with-defaults request (empty if none yet). Tests use it
+// to assert that --org resolved to the expected organization UUID.
+func (f *CircleCI) LastCompileOwnerID() string {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return f.lastCompileOwnerID
+}
+
 // AddOrg registers an org returned by GET /api/v2/organization/{slug}.
 func (f *CircleCI) AddOrg(id, slug, name, vcsType string) {
 	f.mu.Lock()
@@ -3286,11 +3296,21 @@ func (f *CircleCI) AddOrg(id, slug, name, vcsType string) {
 }
 
 func (f *CircleCI) handleCompileConfig(w http.ResponseWriter, r *http.Request) {
-	f.mu.RLock()
+	// Capture the resolved owner_id so tests can assert that --org (slug or UUID)
+	// resolved to the expected organization UUID before the compile call.
+	var body struct {
+		Options struct {
+			OwnerID string `json:"owner_id"`
+		} `json:"options"`
+	}
+	_ = json.NewDecoder(r.Body).Decode(&body)
+
+	f.mu.Lock()
+	f.lastCompileOwnerID = body.Options.OwnerID
 	valid := f.compileValid
 	outputYAML := f.compileOutputYAML
 	errs := f.compileErrors
-	f.mu.RUnlock()
+	f.mu.Unlock()
 
 	apiErrors := make([]map[string]any, len(errs))
 	for i, e := range errs {

--- a/org-flag-standardization-plan.md
+++ b/org-flag-standardization-plan.md
@@ -1,0 +1,171 @@
+# Plan: standardize the organization flag
+
+> Addresses review feedback item #2 — "The organization flag has four names."
+
+## Problem
+
+The same concept — the organization — is exposed under **four different flag
+names** depending on the command:
+
+| Flag         | Value     | Where it's used today                                                                                 |
+| ------------ | --------- | ----------------------------------------------------------------------------------------------------- |
+| `--org`      | slug      | `context *`, `project create`, `runner open`                                                          |
+| `--org`      | slug-or-UUID | `runner instance list`, `runner resource-class list` (already does the right thing)                |
+| `--org-id`   | UUID      | `config validate`, `config process`, `certificate list/upload`, `signing-config create/list`, `namespace create`, `orb process`, `orb validate` |
+| `--org-slug` | slug      | `config validate`, `config process` (**alongside** `--org-id` on the same command)                    |
+| `--owner-id` | UUID      | every `policy` command (`decide`, `diff`, `fetch`, `logs`, `push`, `settings get/set`)                |
+
+Users have to relearn the flag per command. The worst case is `config
+validate`/`config process`, which carry **two** flags for one concept
+(`--org-id` *and* `--org-slug`), and `policy`, which invents a third name
+(`--owner-id`).
+
+## Target state — one rule
+
+**`--org` is the single, canonical organization flag on every org-scoped
+command.** It accepts **either a slug (`gh/myorg`) or a UUID**, and where a Git
+remote is present it defaults to that remote's org. `--org-id`, `--org-slug`,
+and `--owner-id` are all **deleted outright** — the CLI is unreleased, so there
+is no back-compat to preserve and no deprecation/alias period. One name, no
+leftovers.
+
+This is achievable today with zero new resolution logic: `internal/cmdutil/orgid.go`
+already provides the resolver the `runner` commands use —
+
+```go
+// ResolveOrgSlugOrID resolves an organization reference to its UUID. The
+// reference may be a UUID (used as-is), a slug (looked up via the API), or
+// empty (inferred from the current git remote).
+func ResolveOrgSlugOrID(ctx, client, ref, cmdName string) (uuid.UUID, error)
+```
+
+`runner instance list` / `runner resource-class list` are the reference
+implementation — every other command should converge on the same helper and the
+same `--org` flag string.
+
+### Why not keep `--org-id` as a visible flag where "UUID is strictly required"?
+
+The feedback proposed keeping `--org-id` where a UUID is strictly required. In
+practice **no command strictly requires the literal UUID**: `ResolveOrgSlugOrID`
+already accepts a UUID verbatim *and* resolves a slug to one via the API, so a
+single `--org` covers both the human (slug) and machine (UUID) callers. Keeping a
+second flag would re-introduce the "two names for one concept" problem we are
+removing. We therefore delete `--org-id` entirely rather than keep it as a parallel
+public flag. (See "Alternative considered" if we'd rather keep `--org-id` visible
+on the pure-UUID commands.)
+
+## Per-command migration
+
+| Command(s)                                            | Today                         | After                                  | Resolver                          |
+| ----------------------------------------------------- | ----------------------------- | -------------------------------------- | --------------------------------- |
+| `runner instance list`, `runner resource-class list`  | `--org` (slug-or-UUID)        | **no change** (reference impl)         | `ResolveOrgSlugOrID`              |
+| `context *` (10 subcommands), `project create`, `runner open` | `--org` (slug only)   | `--org` now also accepts a UUID        | `ResolveOrgSlugOrID`¹             |
+| `config validate`, `config process`                   | `--org-id` **and** `--org-slug` (`-o`) | single `--org`; delete both old flags; free `-o` | `ResolveOrgSlugOrID` (replaces config's bespoke `resolveOrgID`) |
+| `certificate list`, `certificate upload`              | `--org-id`                    | `--org` (delete `--org-id`)            | `ResolveOrgSlugOrID`              |
+| `signing-config create`, `signing-config list`        | `--org-id`                    | `--org` (delete `--org-id`)            | `ResolveOrgSlugOrID`              |
+| `namespace create`                                    | `--org-id` (required)         | `--org` (required; delete `--org-id`)  | `ResolveOrgSlugOrID`              |
+| `orb process`, `orb validate`                         | `--org-id`                    | `--org` (delete `--org-id`)            | `ResolveOrgSlugOrID`              |
+| `policy decide/diff/fetch/logs/push/settings get/set` | `--owner-id` (required)       | `--org` (required; delete `--owner-id`) | `ResolveOrgSlugOrID`             |
+
+¹ The `context` and `project create` endpoints are keyed on the org **slug**, not
+the UUID. For those, accepting a UUID means the new code path must resolve
+UUID→slug (or call a UUID-keyed endpoint). If that reverse lookup isn't readily
+available, keep these on `ResolveOrgSlug` (slug-only) for now — the **flag name is
+already `--org`, so they already satisfy the feedback**; broadening them to accept
+a UUID is a nice-to-have, not a blocker. Confirm the endpoint contract before
+changing behavior here.
+
+### Notable cleanups bundled in
+
+- **`config` has a private duplicate resolver.** `internal/cmd/config/config.go`
+  defines its own `resolveOrgID` (org-id takes precedence; org-slug triggers a
+  `GetOrg`; logs a *warning* instead of erroring on failure). Delete it and route
+  through `cmdutil.ResolveOrgSlugOrID` so config behaves like every other command
+  (structured error on failure, not a silent warning).
+- **`-o` short form.** `config validate`/`process` bind `-o` to `--org-slug`,
+  which collides with the `-o, --output` convention used by `artifact`,
+  `job artifact`, and `runner config`. Removing `--org-slug` frees `-o`. **Do not
+  reassign `-o` to `--org`** — no other `--org` has a short form; keep it
+  consistent. (Note: `process.go` may already have dropped the `-o` short; verify
+  against `validate.go`, which still has it.)
+
+## Back-compat / deprecation strategy
+
+**None — clean break.** The CLI is unreleased, so the old flag names
+(`--org-id`, `--org-slug`, `--owner-id`) are simply deleted, not aliased or
+deprecated. No hidden flags, no transition period, no changelog "breaking" note
+beyond the normal pre-release churn. The only callers are inside this repo
+(commands, acceptance tests, golden help files), and they're updated in the same
+change.
+
+## Implementation steps
+
+Ordered to keep each commit self-contained and green.
+
+1. **Audit the resolvers** (`internal/cmdutil/orgid.go`). Confirm `ResolveOrgSlugOrID`
+   covers required-vs-defaulted cases. `namespace create` and `policy` have **no**
+   git-remote default and are `required` — ensure the "empty ref" branch surfaces a
+   clean "required" error there rather than attempting Git detection. Add a
+   `required: true` variant or have callers `MarkFlagRequired("org")`.
+2. **policy** (7 command files + `policy.go`): rename `ownerID`→`org`, flag
+   `owner-id`→`org`, update `MarkFlagRequired`, the `Long`/`Example` heredocs
+   (currently say "Most commands require --owner-id"), and the
+   `policyAPIErr`/suggestion text in `policy.go` ("Run: circleci policy fetch
+   --owner-id <id>"). Route through `ResolveOrgSlugOrID`. Delete `--owner-id`.
+3. **config** (`validate.go`, `process.go`, `config.go`): collapse `--org-id` +
+   `--org-slug` into `--org`; delete the bespoke `resolveOrgID`; call
+   `ResolveOrgSlugOrID`; fix the `--org-slug` example at `process.go:75`; remove the
+   `-o` short. Delete `--org-id` and `--org-slug`.
+4. **certificate**, **signing-config**, **namespace**, **orb**: `--org-id`→`--org`,
+   route through `ResolveOrgSlugOrID`.
+5. **context** / **project create** / **runner open**: rename stays `--org`; decide
+   per footnote ¹ whether to broaden to slug-or-UUID. Update help text from
+   "Organization slug (e.g. gh/myorg)" to "Organization slug or UUID (e.g.
+   gh/myorg)" only if behavior actually changes.
+6. **Consistent help string.** Standardize every `--org` usage line on one
+   wording, e.g.:
+   `"Organization slug (e.g. gh/myorg) or UUID; defaults to the current git remote"`
+   (drop "defaults to…" on the required ones).
+
+## Testing
+
+- **Acceptance tests** that reference the old names must be updated:
+  `acceptance/policy_test.go` (`--owner-id`) and `acceptance/config_test.go`
+  (`--org-id`/`--org-slug`). Add cases that pass `--org` with **both** a slug and a
+  UUID and assert the same resolved request hits the fake API.
+- Add a test asserting the **old names are gone** — `--owner-id`/`--org-slug`/
+  `--org-id` should now exit `ExitBadArguments` with "unknown flag".
+- Per CLAUDE.md rule #1/#6, every touched command keeps `--json` and 3+ examples;
+  update the examples to use `--org`.
+
+## Docs & golden files
+
+- Regenerate the help golden files — at minimum
+  `internal/cmd/root/testdata/help/circleci/reference.txt` plus the per-command
+  `.txt` files under `internal/cmd/root/testdata/help/circleci/{config,policy,certificate,namespace,orb,signing-config,...}`.
+  These are snapshot-tested, so they must be refreshed in the same change.
+- `circleci help environment` / `docs/build-plan.md`: check for prose referencing
+  `--owner-id`/`--org-slug`.
+- **MCP surface:** the MCP server does **not** define these as flags
+  (grep of `internal/cmd/mcp` / `internal/mcp` is clean), so no tool-schema change
+  is expected — but verify any tool that shells the CLI with `--owner-id`/`--org-id`.
+
+## Alternative considered (feedback's literal reading)
+
+Keep `--org-id` as a **visible** flag (not just an alias) on the commands where the
+value is inherently a UUID and there is no Git default — `policy`, `namespace
+create`, `orb process/validate`, `config` orb resolution — and rename
+`--owner-id`→`--org-id` there as the feedback literally states; use `--org`
+(slug-or-UUID) everywhere else. This still collapses four names to two
+(`--org` + `--org-id`) and is less churn, but leaves two flags for one concept,
+which is the smell we're removing. Recommended only if the UUID-keyed endpoints
+genuinely cannot resolve a slug.
+
+## Decision needed
+
+1. **Broaden `context`/`project create` to accept a UUID**, or leave slug-only
+   (already named `--org`, so already compliant — see footnote ¹)?
+2. **One name (`--org`) or two (`--org` + `--org-id`)** — recommended vs. the
+   alternative below.
+
+(Back-compat is settled: clean break, no aliases — the CLI is unreleased.)


### PR DESCRIPTION
The same concept — the organization — is addressed as --org (slug), --org-id (UUID), --org-slug, and --owner-id (in the policy commands). Users have to relearn the flag per command. Fix: standardize on --org (accepting either slug or UUID) plus --org-id only where a UUID is strictly required, and rename policy's --owner-id to --org-id.

<!--
  Thank you for contributing to CircleCI CLI!
  For PRs adding new features, please raise an issue first.
-->
