### PR TITLE
Add packagecloud uploads

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -204,15 +204,18 @@ jobs:
     executor: linux
     steps:
       - setup
-      - run:
-          name: Install docs toolchain (Hugo + htmltest)
-          command: task docs:install
-      - run:
-          name: Generate reference and build the site
-          command: task docs:build
-      - run:
-          name: Check internal links
-          command: task docs:test
+      - go/with-cache:
+          checksum: *checksum
+          steps:
+            - run:
+                name: Install docs toolchain (Hugo + htmltest)
+                command: task docs:install
+            - run:
+                name: Generate reference and build the site
+                command: task docs:build
+            - run:
+                name: Check internal links
+                command: task docs:test
       - store_artifacts:
           path: website/public
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -345,13 +345,30 @@ tasks:
       - git tag -a '{{.VERSION}}' -m 'Release {{.VERSION}}'
       - git push origin '{{.VERSION}}'
       - go tool -modfile tools/go.mod goreleaser release --clean
+      - task: ci:packagecloud
+
+  ci:packagecloud:
+    desc: Publish the Linux nfpm packages (rpm + deb) from dist/ to packagecloud
+    # PACKAGECLOUD_TOKEN must be set in the environment (not needed when DRY_RUN is
+    # set). Override REPO to target a different packagecloud repository
+    # (<user>/<repo>); set DRY_RUN to validate without uploading.
+    vars:
+      REPO: '{{default "circleci/circleci" .REPO}}'
+      DRY_RUN: '{{default "" .DRY_RUN}}'
+    cmds:
+      # goreleaser only pushes to packagecloud under a Pro licence, so cmd/packagecloud
+      # uploads the nfpm output to the public REST API instead — no Ruby CLI needed.
+      - go run ./cmd/packagecloud {{if .DRY_RUN}}--dry-run {{end}}--repo '{{.REPO}}' dist/*.rpm dist/*.deb
 
   ci:build:
-    desc: Build a release
+    desc: Dry-run a release — build a snapshot (incl. nfpms) and dry-run the packagecloud publish
     vars:
       VERSION: 'v1.0.{{env "CIRCLE_BUILD_NUM" | default "0"}}-pre'
     cmds:
       - git config --global user.email $GH_EMAIL
       - git config --global user.name $GH_NAME
       - git tag -a '{{.VERSION}}' -m 'Release {{.VERSION}}'
-      - go tool -modfile tools/go.mod goreleaser build --clean
+      - go tool -modfile tools/go.mod goreleaser release --snapshot --skip=snapcraft --skip=chocolatey --clean
+      - task: ci:packagecloud
+        vars:
+          DRY_RUN: "true"

--- a/cmd/packagecloud/main.go
+++ b/cmd/packagecloud/main.go
@@ -1,0 +1,264 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+// Command packagecloud uploads Linux nfpm packages (.rpm/.deb) to packagecloud.io.
+//
+// goreleaser only pushes to packagecloud under a Pro licence, so this small
+// release-time tool does it against the public REST API instead. Each package is
+// published to the generic "rpm_any"/"deb_any" distribution so a single upload
+// serves every distro version.
+//
+// Usage:
+//
+//	PACKAGECLOUD_TOKEN=... go run ./cmd/packagecloud --repo circleci/circleci dist/*.rpm dist/*.deb
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/CircleCI-Public/circleci-cli/internal/httpcl"
+	"github.com/CircleCI-Public/circleci-cli/internal/iostream"
+)
+
+func main() {
+	if err := rootCmd().Execute(); err != nil {
+		os.Exit(1)
+	}
+}
+
+func rootCmd() *cobra.Command {
+	var repo string
+	var dryRun bool
+	cmd := &cobra.Command{
+		Use:          "packagecloud [flags] <package>...",
+		Short:        "Upload Linux nfpm packages (.rpm/.deb) to packagecloud.io",
+		Args:         cobra.MinimumNArgs(1),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// FromCmd installs Streams into the context so httpcl's
+			// iostream.DebugContext logging works; --debug enables it.
+			ctx := iostream.FromCmd(cmd.Context(), cmd, "")
+			return run(ctx, repo, args, dryRun)
+		},
+	}
+	cmd.Flags().StringVar(&repo, "repo", "circleci/circleci", "packagecloud repository as <user>/<repo>")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "validate the packages and print what would be uploaded, without contacting packagecloud")
+	cmd.Flags().Bool("debug", false, "log HTTP requests to stderr")
+	return cmd
+}
+
+func run(ctx context.Context, repo string, files []string, dryRun bool) error {
+	user, name, ok := strings.Cut(repo, "/")
+	if !ok || user == "" || name == "" {
+		return fmt.Errorf("--repo must be <user>/<repo>, got %q", repo)
+	}
+
+	// Validate package type and existence up front, so --dry-run surfaces bad
+	// inputs without contacting packagecloud.
+	for _, f := range files {
+		if ext := pkgExt(f); ext != "rpm" && ext != "deb" {
+			return fmt.Errorf("%s: unsupported package type %q", f, ext)
+		}
+		if _, err := os.Stat(f); err != nil {
+			return err
+		}
+	}
+
+	if dryRun {
+		for _, f := range files {
+			iostream.InfoContext(ctx, "would publish",
+				"package", filepath.Base(f),
+				"repo", repo,
+				"distro", pkgExt(f)+"_any",
+			)
+		}
+		return nil
+	}
+
+	token := os.Getenv("PACKAGECLOUD_TOKEN")
+	if token == "" {
+		return errors.New("PACKAGECLOUD_TOKEN must be set")
+	}
+
+	pc := newClient(token)
+
+	// The upload API keys packages by a numeric distro_version_id, so resolve the
+	// ids for the generic "any" distributions once up front.
+	ids, err := pc.resolveAnyDistroIDs(ctx)
+	if err != nil {
+		return err
+	}
+
+	iostream.InfoContext(ctx, "publishing packages",
+		"count", len(files),
+		"repo", repo,
+	)
+	for _, f := range files {
+		if err := pc.push(ctx, user, name, f, ids[pkgExt(f)]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// pkgExt returns the package type ("rpm"/"deb") from a file's extension.
+func pkgExt(path string) string {
+	return strings.TrimPrefix(filepath.Ext(path), ".")
+}
+
+// client is a thin packagecloud REST API client over httpcl.
+type client struct {
+	http *httpcl.Client
+}
+
+func newClient(token string) *client {
+	return &client{
+		http: httpcl.New(httpcl.Config{
+			BaseURL: "https://packagecloud.io",
+			// packagecloud authenticates with HTTP Basic: token as username, blank password.
+			AuthHeader: "Authorization",
+			AuthToken:  "Basic " + base64.StdEncoding.EncodeToString([]byte(token+":")),
+			UserAgent:  "circleci-cli-release",
+			Timeout:    2 * time.Minute,
+		}),
+	}
+}
+
+// push uploads a single package as multipart/form-data. An "already published"
+// 422 is treated as success so re-running a release is idempotent.
+func (c *client) push(ctx context.Context, user, repo, path string, distroVersionID int) error {
+	body, contentType, err := multipartBody(path, distroVersionID)
+	if err != nil {
+		return err
+	}
+
+	status, err := c.http.Call(ctx, httpcl.NewRequest("POST", "/api/v1/repos/%s/%s/packages.json",
+		httpcl.RouteParams(user, repo),
+		httpcl.RawBody(body, contentType),
+	))
+	switch {
+	case err == nil:
+		iostream.InfoContext(ctx, "pushed",
+			"package", filepath.Base(path),
+			"status", status,
+		)
+		return nil
+	case status == 422 && alreadyPublished(err):
+		iostream.InfoContext(ctx, "skipped, already published",
+			"package", filepath.Base(path),
+			"status", status,
+		)
+		return nil
+	default:
+		return fmt.Errorf("uploading %s: %w", filepath.Base(path), err)
+	}
+}
+
+func multipartBody(path string, distroVersionID int) (body []byte, contentType string, err error) {
+	file, err := os.Open(path) //nolint:gosec // path is an operator-supplied package file
+	if err != nil {
+		return nil, "", err
+	}
+	defer func() { _ = file.Close() }()
+
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+	if err := w.WriteField("package[distro_version_id]", strconv.Itoa(distroVersionID)); err != nil {
+		return nil, "", err
+	}
+	fw, err := w.CreateFormFile("package[package_file]", filepath.Base(path))
+	if err != nil {
+		return nil, "", err
+	}
+	if _, err := io.Copy(fw, file); err != nil {
+		return nil, "", err
+	}
+	if err := w.Close(); err != nil {
+		return nil, "", err
+	}
+	return buf.Bytes(), w.FormDataContentType(), nil
+}
+
+func alreadyPublished(err error) bool {
+	var httpErr *httpcl.HTTPError
+	return errors.As(err, &httpErr) && bytes.Contains(httpErr.Body, []byte("already been taken"))
+}
+
+// resolveAnyDistroIDs returns the distro_version_id of the generic "rpm_any" and
+// "deb_any" distributions, keyed by package extension ("rpm"/"deb").
+func (c *client) resolveAnyDistroIDs(ctx context.Context) (map[string]int, error) {
+	var dists struct {
+		Deb []distro `json:"deb"`
+		Rpm []distro `json:"rpm"`
+	}
+	if _, err := c.http.Call(ctx, httpcl.NewRequest("GET", "/api/v1/distributions.json",
+		httpcl.JSONDecoder(&dists),
+	)); err != nil {
+		return nil, fmt.Errorf("listing distributions: %w", err)
+	}
+
+	ids := map[string]int{}
+	for ext, list := range map[string][]distro{"rpm": dists.Rpm, "deb": dists.Deb} {
+		name := ext + "_any"
+		id, ok := findDistroVersion(list, name)
+		if !ok {
+			return nil, fmt.Errorf("distribution %q not found in packagecloud distributions", name)
+		}
+		ids[ext] = id
+	}
+	return ids, nil
+}
+
+func findDistroVersion(list []distro, name string) (int, bool) {
+	for _, d := range list {
+		if d.IndexName != name {
+			continue
+		}
+		for _, v := range d.Versions {
+			if v.IndexName == name {
+				return v.ID, true
+			}
+		}
+	}
+	return 0, false
+}
+
+type distro struct {
+	IndexName string `json:"index_name"`
+	Versions  []struct {
+		ID        int    `json:"id"`
+		IndexName string `json:"index_name"`
+	} `json:"versions"`
+}

--- a/internal/httpcl/client.go
+++ b/internal/httpcl/client.go
@@ -142,7 +142,12 @@ func (c *Client) Call(ctx context.Context, r Request) (status int, err error) {
 	}()
 
 	var bodyReader io.Reader
-	if r.body != nil {
+	contentType := jsonContentType
+	switch {
+	case r.rawBody != nil:
+		bodyReader = bytes.NewReader(r.rawBody)
+		contentType = r.contentType
+	case r.body != nil:
 		b, err := json.Marshal(r.body)
 		if err != nil {
 			return 0, fmt.Errorf("httpcl: marshal body: %w", err)
@@ -158,8 +163,8 @@ func (c *Client) Call(ctx context.Context, r Request) (status int, err error) {
 		return 0, fmt.Errorf("httpcl: new request: %w", err)
 	}
 
-	if r.body != nil {
-		req.Header.Set("Content-Type", jsonContentType)
+	if bodyReader != nil {
+		req.Header.Set("Content-Type", contentType)
 	}
 	req.Header.Set("Accept", "application/json")
 

--- a/internal/httpcl/request.go
+++ b/internal/httpcl/request.go
@@ -35,6 +35,8 @@ type Request struct {
 	method      string
 	route       string
 	body        any
+	rawBody     []byte
+	contentType string
 	decoder     func(io.Reader) error
 	headers     http.Header
 	query       url.Values
@@ -58,6 +60,16 @@ func NewRequest(method, route string, opts ...func(*Request)) Request {
 // Body sets a value that will be JSON-encoded as the request body.
 func Body(v any) func(*Request) {
 	return func(r *Request) { r.body = v }
+}
+
+// RawBody sets a pre-encoded request body sent verbatim with the given
+// Content-Type, bypassing JSON marshaling (e.g. multipart/form-data uploads).
+// Takes precedence over Body.
+func RawBody(body []byte, contentType string) func(*Request) {
+	return func(r *Request) {
+		r.rawBody = body
+		r.contentType = contentType
+	}
 }
 
 // JSONDecoder decodes a 2xx response body as JSON into v.

--- a/internal/iostream/streams.go
+++ b/internal/iostream/streams.go
@@ -236,6 +236,10 @@ func DebugContext(ctx context.Context, msg string, args ...any) {
 	fromContext(ctx).DebugContext(ctx, msg, args...)
 }
 
+func InfoContext(ctx context.Context, msg string, args ...any) {
+	fromContext(ctx).InfoContext(ctx, msg, args...)
+}
+
 func PrintJSON(ctx context.Context, v any) error {
 	return fromContext(ctx).PrintJSON(ctx, v)
 }
@@ -609,6 +613,10 @@ func (s Streams) PromptSecret(ctx context.Context, header string) (string, error
 
 func (s Streams) DebugContext(ctx context.Context, msg string, args ...any) {
 	s.slog.DebugContext(ctx, msg, args...)
+}
+
+func (s Streams) InfoContext(ctx context.Context, msg string, args ...any) {
+	s.slog.InfoContext(ctx, msg, args...)
 }
 
 func (s Streams) PrintJSON(ctx context.Context, v any) error {


### PR DESCRIPTION
<!--
  Thank you for contributing to CircleCI CLI!
  For PRs adding new features, please raise an issue first.
-->
- Avoid using packagecloud CLI, and use their API directly (they have also archived all their SDKs)
- package will be in the `circleci` repo, with package name `circleci`
