### PR TITLE
TEST-198 Add default branch to extensions environment variables

### DIFF
--- a/internal/extension/extension.go
+++ b/internal/extension/extension.go
@@ -243,6 +243,9 @@ func buildEnv(ctx context.Context, client *apiclient.Client) []string {
 		if info.Branch != "" {
 			overlays = append(overlays, kv{"CIRCLE_BRANCH", info.Branch})
 		}
+		if info.DefaultBranch != "" {
+			overlays = append(overlays, kv{"CIRCLE_DEFAULT_BRANCH", info.DefaultBranch})
+		}
 
 		if id := resolveProjectID(ctx, client, cfg, info.Slug); id != "" {
 			overlays = append(overlays, kv{"CIRCLE_PROJECT_ID", id})

--- a/internal/gitremote/detect.go
+++ b/internal/gitremote/detect.go
@@ -43,6 +43,8 @@ type ProjectInfo struct {
 	Slug string
 	// Branch is the current git branch name.
 	Branch string
+	// DefaultBranch is the default branch name.
+	DefaultBranch string
 }
 
 var (
@@ -83,7 +85,12 @@ func Detect() (*ProjectInfo, error) {
 	if cwd, err := os.Getwd(); err == nil {
 		if ref, err := projectref.Read(cwd); err == nil {
 			branch, _ := gitOutput("rev-parse", "--abbrev-ref", "HEAD")
-			return &ProjectInfo{Slug: ref.EffectiveSlug(), Branch: branch}, nil
+			defaultBranch, _ := gitOutput("rev-parse", "--abbrev-ref", "origin/HEAD")
+			return &ProjectInfo{
+				Slug:          ref.EffectiveSlug(),
+				Branch:        branch,
+				DefaultBranch: strings.TrimPrefix(defaultBranch, "origin/"),
+			}, nil
 		}
 	}
 	return DetectFromRemote()
@@ -109,7 +116,16 @@ func DetectFromRemote() (*ProjectInfo, error) {
 		return nil, fmt.Errorf("could not determine current branch: %w", err)
 	}
 
-	return &ProjectInfo{Slug: slug, Branch: branch}, nil
+	defaultBranch, err := gitOutput("rev-parse", "--abbrev-ref", "origin/HEAD")
+	if err != nil {
+		return nil, fmt.Errorf("could not determine default branch: %w", err)
+	}
+
+	return &ProjectInfo{
+		Slug:          slug,
+		Branch:        branch,
+		DefaultBranch: strings.TrimPrefix(defaultBranch, "origin/"),
+	}, nil
 }
 
 // SlugFromRemote is exported for testing.


### PR DESCRIPTION
The testsuite extension will use the default branch to change the way tests are run and analyzed. This change adds `CIRCLE_DEFAULT_BRANCH` to the extension environment variables.
