### PR TITLE
Add circleci my runs command

### DIFF
--- a/acceptance/my_test.go
+++ b/acceptance/my_test.go
@@ -1,0 +1,174 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package acceptance_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+	"gotest.tools/v3/golden"
+
+	"github.com/CircleCI-Public/circleci-cli/internal/testing/binary"
+	testenv "github.com/CircleCI-Public/circleci-cli/internal/testing/env"
+	"github.com/CircleCI-Public/circleci-cli/internal/testing/fakes"
+)
+
+// fakeMyRunV3 builds a V3 run payload with a repository_url and an explicit
+// created_at, as returned by GET /api/v3/runs?filter[user_id]=me. Output groups
+// these by repository, most recent run first.
+func fakeMyRunV3(id, projectID, phase, outcome, repoURL, branch, revision, createdAt string) map[string]any {
+	run := fakeRunV3(id, projectID, phase, outcome, branch, revision)
+	attrs := run["attributes"].(map[string]any)
+	attrs["vcs"].(map[string]any)["repository_url"] = repoURL
+	attrs["created_at"] = createdAt
+	return run
+}
+
+func TestMyRuns(t *testing.T) {
+	fake := fakes.NewCircleCI(t)
+	// web has two runs (newest and oldest overall); api has one in between.
+	// Expected grouping: acme/web (run-1, run-3) then acme/api (run-2).
+	fake.SetUserRuns(
+		fakeMyRunV3("run-3", "proj-a", "ended", "succeeded", "https://github.com/acme/web", "main", "1111111122222222", "2026-06-19T08:00:00Z"),
+		fakeMyRunV3("run-1", "proj-a", "ended", "succeeded", "https://github.com/acme/web", "main", "abc1234def5678", "2026-06-19T10:00:00Z"),
+		fakeMyRunV3("run-2", "proj-b", "ended", "failed", "https://github.com/acme/api", "feature", "deadbeef12345678", "2026-06-19T09:00:00Z"),
+	)
+
+	env := testenv.New(t)
+	env.Token = testToken
+	env.CircleCIURL = fake.URL()
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"my", "runs"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Check(t, strings.Contains(result.Stdout, "## acme/web"))
+	assert.Check(t, strings.Contains(result.Stdout, "## acme/api"))
+	// web (carrying the most recent run) groups before api.
+	assert.Check(t, strings.Index(result.Stdout, "acme/web") < strings.Index(result.Stdout, "acme/api"))
+	assert.Check(t, golden.String(result.Stdout, t.Name()+".txt"))
+}
+
+func TestMyRuns_Empty(t *testing.T) {
+	fake := fakes.NewCircleCI(t)
+	// No runs registered.
+
+	env := testenv.New(t)
+	env.Token = testToken
+	env.CircleCIURL = fake.URL()
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"my", "runs"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Check(t, strings.Contains(result.Stderr, "No runs found."))
+}
+
+func TestMyRuns_Limit(t *testing.T) {
+	fake := fakes.NewCircleCI(t)
+	fake.SetUserRuns(
+		fakeMyRunV3("run-1", "proj-a", "ended", "succeeded", "https://github.com/acme/web", "main", "abc1234def5678", "2026-06-19T10:00:00Z"),
+		fakeMyRunV3("run-2", "proj-b", "ended", "failed", "https://github.com/acme/api", "feature", "deadbeef12345678", "2026-06-19T09:00:00Z"),
+		fakeMyRunV3("run-3", "proj-c", "ended", "succeeded", "https://github.com/acme/cli", "main", "1111111122222222", "2026-06-19T08:00:00Z"),
+	)
+
+	env := testenv.New(t)
+	env.Token = testToken
+	env.CircleCIURL = fake.URL()
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"my", "runs", "--limit", "2"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Check(t, strings.Contains(result.Stdout, "acme/web"))
+	assert.Check(t, strings.Contains(result.Stdout, "acme/api"))
+	assert.Check(t, !strings.Contains(result.Stdout, "acme/cli"))
+}
+
+func TestMyRuns_JSON(t *testing.T) {
+	fake := fakes.NewCircleCI(t)
+	fake.SetUserRuns(
+		fakeMyRunV3("run-3", "proj-a", "ended", "succeeded", "https://github.com/acme/web", "main", "1111111122222222", "2026-06-19T08:00:00Z"),
+		fakeMyRunV3("run-1", "proj-a", "ended", "succeeded", "https://github.com/acme/web", "main", "abc1234def5678", "2026-06-19T10:00:00Z"),
+		fakeMyRunV3("run-2", "proj-b", "ended", "failed", "https://github.com/acme/api", "feature", "deadbeef12345678", "2026-06-19T09:00:00Z"),
+	)
+
+	env := testenv.New(t)
+	env.Token = testToken
+	env.CircleCIURL = fake.URL()
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"my", "runs", "--json"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+
+	var out []map[string]any
+	err := json.Unmarshal([]byte(result.Stdout), &out)
+	assert.NilError(t, err)
+	assert.Check(t, cmp.Len(out, 2))
+
+	// First group: acme/web with its two runs, newest first.
+	assert.Check(t, cmp.Equal(out[0]["repository"], "acme/web"))
+	webRuns := out[0]["runs"].([]any)
+	assert.Check(t, cmp.Len(webRuns, 2))
+	assert.Check(t, cmp.Equal(webRuns[0].(map[string]any)["id"], "run-1"))
+	assert.Check(t, cmp.Equal(webRuns[1].(map[string]any)["id"], "run-3"))
+
+	// Second group: acme/api with one run.
+	assert.Check(t, cmp.Equal(out[1]["repository"], "acme/api"))
+	apiRuns := out[1]["runs"].([]any)
+	assert.Check(t, cmp.Len(apiRuns, 1))
+	assert.Check(t, cmp.Equal(apiRuns[0].(map[string]any)["current_outcome"], "failed"))
+}
+
+func TestMyRuns_NoToken(t *testing.T) {
+	env := testenv.New(t)
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"my", "runs"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 3, "stderr: %s", result.Stderr) // ExitAuthError
+}

--- a/acceptance/testdata/TestMyRuns.txt
+++ b/acceptance/testdata/TestMyRuns.txt
@@ -1,0 +1,12 @@
+# My runs
+
+## acme/web
+| Ref  | Revision | ID      | Created              | Status    |
+| ---- | -------- | ------- | -------------------- | --------- |
+| main | abc1234  | `run-1` | 2026-06-19 10:00 UTC | succeeded |
+| main | 1111111  | `run-3` | 2026-06-19 08:00 UTC | succeeded |
+
+## acme/api
+| Ref     | Revision | ID      | Created              | Status |
+| ------- | -------- | ------- | -------------------- | ------ |
+| feature | deadbee  | `run-2` | 2026-06-19 09:00 UTC | failed |

--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -164,8 +164,6 @@ type v3List[T any] struct {
 
 // pageSize returns a request option that sets page[size].
 // A size of 0 is ignored (server default is used).
-//
-//nolint:unused // this will likely become used
 func pageSize(n int) func(*httpcl.Request) {
 	if n <= 0 {
 		return func(*httpcl.Request) {}

--- a/internal/apiclient/run.go
+++ b/internal/apiclient/run.go
@@ -46,9 +46,10 @@ type runErrorWire struct {
 }
 
 type runVCSWire struct {
-	Branch   string `json:"branch"`
-	Tag      string `json:"tag"`
-	Revision string `json:"revision"`
+	Branch        string `json:"branch"`
+	Tag           string `json:"tag"`
+	Revision      string `json:"revision"`
+	RepositoryURL string `json:"repository_url"`
 }
 
 type runReferencesWire struct {
@@ -103,6 +104,7 @@ type RunV3 struct {
 	Branch         string     `json:"branch,omitempty"`
 	Tag            string     `json:"tag,omitempty"`
 	Revision       string     `json:"revision,omitempty"`
+	RepositoryURL  string     `json:"repository_url,omitempty"`
 	CreatedAt      time.Time  `json:"created_at"`
 	ProjectID      string     `json:"project_id"`
 	Errors         []RunError `json:"errors,omitempty"`
@@ -133,6 +135,11 @@ func (w runWire) toRunV3() *RunV3 {
 	} else if a.VCS != nil {
 		r.Branch = a.VCS.Branch
 		r.Revision = a.VCS.Revision
+	}
+	// repository_url is only carried by the top-level attributes.vcs, not the
+	// event reference — set it independently of the branch/tag source above.
+	if a.VCS != nil {
+		r.RepositoryURL = a.VCS.RepositoryURL
 	}
 	for _, e := range a.Errors {
 		r.Errors = append(r.Errors, RunError(e))
@@ -200,6 +207,23 @@ func (c *Client) SearchRunsV3(ctx context.Context, params RunSearchParams) ([]Ru
 
 	var resp v3List[runWire]
 	if err := c.postV3(ctx, "/runs/search", body, &resp); err != nil {
+		return nil, err
+	}
+
+	runs := make([]RunV3, len(resp.Data))
+	for i, w := range resp.Data {
+		runs[i] = *w.toRunV3()
+	}
+	return runs, nil
+}
+
+// ListMyRunsV3 lists runs triggered by the authenticated user across all
+// projects, via GET /api/v3/runs?filter[user_id]=me. limit caps the page size;
+// a value <= 0 uses the server default.
+func (c *Client) ListMyRunsV3(ctx context.Context, limit int) ([]RunV3, error) {
+	var resp v3List[runWire]
+	if err := c.getV3(ctx, "/runs", &resp,
+		filterParam("user_id", "me"), pageSize(limit)); err != nil {
 		return nil, err
 	}
 

--- a/internal/cmd/my/my.go
+++ b/internal/cmd/my/my.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package my
+
+import (
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+
+	"github.com/CircleCI-Public/circleci-cli/internal/cmdutil"
+)
+
+// NewMyCmd returns the "circleci my" command group: resources scoped to the
+// authenticated user.
+func NewMyCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "my <command>",
+		GroupID: "user",
+		Short:   "Show resources for the authenticated user",
+		Long: heredoc.Doc(`
+			Show CircleCI resources scoped to you, the authenticated user.
+
+			These commands answer "what's mine?" across every project you have
+			access to, rather than a single project inferred from the current
+			git repository.
+		`),
+		RunE:               cmdutil.GroupRunE,
+		FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
+	}
+
+	cmdutil.AddGroup(cmd, "General commands",
+		newRunsCmd(),
+	)
+
+	return cmd
+}

--- a/internal/cmd/my/runs.go
+++ b/internal/cmd/my/runs.go
@@ -1,0 +1,214 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package my
+
+import (
+	"context"
+	"net/url"
+	"sort"
+	"strings"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+
+	"github.com/CircleCI-Public/circleci-cli/internal/apiclient"
+	"github.com/CircleCI-Public/circleci-cli/internal/cmdutil"
+	"github.com/CircleCI-Public/circleci-cli/internal/iostream"
+	"github.com/CircleCI-Public/circleci-cli/internal/mdtable"
+)
+
+func newRunsCmd() *cobra.Command {
+	var (
+		limit   int
+		jsonOut bool
+	)
+
+	cmd := &cobra.Command{
+		Use:     "runs",
+		Aliases: []string{"run"},
+		Short:   "List your recent runs grouped by project",
+		Long: heredoc.Doc(`
+			List recent runs you triggered, grouped by project.
+
+			This is the personal counterpart to "circleci run list": rather than
+			a single project, it shows your runs across everywhere you have access,
+			grouped by project with the most recent run first.
+
+			JSON: an array of projects, each { repository, runs: [...] }.
+			Run fields: id, phase, outcome, current_outcome, branch, tag, revision, created_at
+		`),
+		Example: heredoc.Doc(`
+			# List your recent runs grouped by project
+			$ circleci my runs
+
+			# Show more results
+			$ circleci my runs --limit 50
+
+			# Output as JSON for scripting
+			$ circleci my runs --json
+
+			# Pull out just the run IDs with jq
+			$ circleci my runs --json --jq '.[].runs[].id'
+		`),
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			ctx := cmd.Context()
+			client, err := cmdutil.LoadClient(ctx)
+			if err != nil {
+				return err
+			}
+			return runMyRuns(ctx, client, limit, jsonOut)
+		},
+	}
+
+	cmd.Flags().IntVar(&limit, "limit", 20, "Maximum number of runs to fetch [default: 20]")
+	cmdutil.AddJSONFlag(cmd, &jsonOut)
+	cmdutil.AddJQFlag(cmd)
+
+	return cmd
+}
+
+type projectRuns struct {
+	Repository string     `json:"repository"`
+	Runs       []runEntry `json:"runs"`
+}
+
+type runEntry struct {
+	ID             string `json:"id"`
+	Phase          string `json:"phase"`
+	Outcome        string `json:"outcome,omitempty"`
+	CurrentOutcome string `json:"current_outcome,omitempty"`
+	Branch         string `json:"branch,omitempty"`
+	Tag            string `json:"tag,omitempty"`
+	Revision       string `json:"revision,omitempty"`
+	CreatedAt      string `json:"created_at"`
+}
+
+func runMyRuns(ctx context.Context, client *apiclient.Client, limit int, jsonOut bool) error {
+	runs, err := client.ListMyRunsV3(ctx, limit)
+	if err != nil {
+		return cmdutil.APIErr(err, "your runs",
+			"my.runs_failed", "Could not list your runs.")
+	}
+
+	groups := groupByProject(runs)
+
+	if jsonOut {
+		return iostream.PrintJSON(ctx, groups)
+	}
+
+	if len(groups) == 0 {
+		iostream.ErrPrintln(ctx, "No runs found.")
+		return nil
+	}
+
+	printRuns(ctx, groups)
+	return nil
+}
+
+// groupByProject sorts runs newest-first, then groups them by repository.
+// Group order follows each project's most recent run, and runs within a group
+// stay newest-first.
+func groupByProject(runs []apiclient.RunV3) []projectRuns {
+	sort.SliceStable(runs, func(i, j int) bool {
+		return runs[i].CreatedAt.After(runs[j].CreatedAt)
+	})
+
+	index := map[string]int{}
+	var groups []projectRuns
+	for i := range runs {
+		repo := repoName(runs[i].RepositoryURL)
+		gi, ok := index[repo]
+		if !ok {
+			gi = len(groups)
+			index[repo] = gi
+			groups = append(groups, projectRuns{Repository: repo})
+		}
+		groups[gi].Runs = append(groups[gi].Runs, toEntry(&runs[i]))
+	}
+	return groups
+}
+
+func toEntry(r *apiclient.RunV3) runEntry {
+	rev := r.Revision
+	if len(rev) > 7 {
+		rev = rev[:7]
+	}
+	return runEntry{
+		ID:             r.ID,
+		Phase:          r.Phase,
+		Outcome:        r.Outcome,
+		CurrentOutcome: r.CurrentOutcome,
+		Branch:         r.Branch,
+		Tag:            r.Tag,
+		Revision:       rev,
+		CreatedAt:      r.CreatedAt.Format("2006-01-02 15:04 UTC"),
+	}
+}
+
+func printRuns(ctx context.Context, groups []projectRuns) {
+	var b strings.Builder
+	b.WriteString("# My runs\n")
+	for _, g := range groups {
+		repo := g.Repository
+		if repo == "" {
+			repo = "(unknown repository)"
+		}
+		b.WriteString("\n## " + repo + "\n")
+		table := mdtable.New("Ref", "Revision", "ID", "Created", "Status")
+		for _, e := range g.Runs {
+			table.Row(
+				refDisplay(e.Branch, e.Tag),
+				e.Revision,
+				"`"+e.ID+"`",
+				e.CreatedAt,
+				apiclient.PhaseOutcomeStatus(e.Phase, e.Outcome, e.CurrentOutcome),
+			)
+		}
+		b.WriteString(table.Render())
+	}
+	iostream.PrintMarkdown(ctx, b.String())
+}
+
+// repoName reduces a repository URL to its "org/repo" form for display,
+// e.g. "https://github.com/circleci/foo" -> "circleci/foo". It returns the
+// input unchanged if it cannot be parsed.
+func repoName(repoURL string) string {
+	if repoURL == "" {
+		return ""
+	}
+	u, err := url.Parse(repoURL)
+	if err != nil || u.Path == "" {
+		return repoURL
+	}
+	return strings.TrimSuffix(strings.TrimPrefix(u.Path, "/"), ".git")
+}
+
+// refDisplay renders the git ref for a run: the branch, or the tag (marked
+// with 🏷) for runs triggered by a tag rather than a branch.
+func refDisplay(branch, tag string) string {
+	if branch == "" && tag != "" {
+		return "🏷 " + tag
+	}
+	return branch
+}

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -42,6 +42,7 @@ import (
 	cmddlc "github.com/CircleCI-Public/circleci-cli/internal/cmd/dlc"
 	"github.com/CircleCI-Public/circleci-cli/internal/cmd/envvar"
 	"github.com/CircleCI-Public/circleci-cli/internal/cmd/job"
+	"github.com/CircleCI-Public/circleci-cli/internal/cmd/my"
 	cmdnamespace "github.com/CircleCI-Public/circleci-cli/internal/cmd/namespace"
 	cmdonboard "github.com/CircleCI-Public/circleci-cli/internal/cmd/onboard"
 	cmdorb "github.com/CircleCI-Public/circleci-cli/internal/cmd/orb"
@@ -213,6 +214,7 @@ func NewRootCmd(version string) *cobra.Command {
 	cmd.AddCommand(deploy.NewDeployCmd())
 	cmd.AddCommand(envvar.NewEnvVarCmd())
 	cmd.AddCommand(job.NewJobCmd())
+	cmd.AddCommand(my.NewMyCmd())
 	cmd.AddCommand(pipeline.NewPipelineCmd())
 	cmd.AddCommand(project.NewProjectCmd())
 	cmd.AddCommand(receivetelemetry.NewReceiveTelemetryCmd())

--- a/internal/cmd/root/testdata/help/circleci.txt
+++ b/internal/cmd/root/testdata/help/circleci.txt
@@ -40,6 +40,7 @@ Work with CircleCI from the command line.
 | `auth`       | Log in, sign up and check your CircleCI identity        |
 | `completion` | Install, remove or print shell completions              |
 | `mcp`        | Run the CLI as an MCP server for AI tools               |
+| `my`         | Show resources for the authenticated user               |
 | `onboard`    | Guided onboarding: scan, test, generate config, sign up |
 | `setting`    | Configure the CLI itself (token, host, defaults)        |
 

--- a/internal/cmd/root/testdata/help/circleci/my.txt
+++ b/internal/cmd/root/testdata/help/circleci/my.txt
@@ -1,0 +1,32 @@
+# CircleCI CLI
+
+Show CircleCI resources scoped to you, the authenticated user.
+
+These commands answer "what's mine?" across every project you have
+access to, rather than a single project inferred from the current
+git repository.
+
+## Usage
+
+`circleci my <command> [flags]`
+
+## General Commands
+
+| Command | Description                              |
+| ------- | ---------------------------------------- |
+| `runs`  | List your recent runs grouped by project |
+
+## Inherited Flags
+
+| Flag                  | Description                                                  |
+| --------------------- | ------------------------------------------------------------ |
+| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | enable debug logging                                         |
+| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+
+## Learn More
+
+- Use `circleci <command> <subcommand> --help` for more information about a command.
+- Read the manual at <https://circleci-public.github.io/circleci-cli>
+- Support at <https://github.com/CircleCI-Public/circleci-cli/issues>
+

--- a/internal/cmd/root/testdata/help/circleci/my/runs.txt
+++ b/internal/cmd/root/testdata/help/circleci/my/runs.txt
@@ -1,0 +1,54 @@
+# CircleCI CLI
+
+List recent runs you triggered, grouped by project.
+
+This is the personal counterpart to "circleci run list": rather than
+a single project, it shows your runs across everywhere you have access,
+grouped by project with the most recent run first.
+
+JSON: an array of projects, each { repository, runs: [...] }.
+Run fields: id, phase, outcome, current_outcome, branch, tag, revision, created_at
+
+For more information about output formatting flags, see `circleci help formatting`.
+
+## Usage
+
+`circleci my runs [flags]`
+
+## Aliases
+
+`circleci my run`
+
+## Flags
+
+| Flag          | Description                                                |
+| ------------- | ---------------------------------------------------------- |
+| `--jq string` | Process values from the response using jq syntax           |
+| `--json`      | Output as JSON                                             |
+| `--limit int` | Maximum number of runs to fetch [default: 20] (default 20) |
+
+## Inherited Flags
+
+| Flag                  | Description                                                  |
+| --------------------- | ------------------------------------------------------------ |
+| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | enable debug logging                                         |
+| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+
+## Examples
+
+- List your recent runs grouped by project: 
+  `circleci my runs`
+- Show more results: 
+  `circleci my runs --limit 50`
+- Output as JSON for scripting: 
+  `circleci my runs --json`
+- Pull out just the run IDs with jq: 
+  `circleci my runs --json --jq '.[].runs[].id'`
+
+## Learn More
+
+- Use `circleci <command> <subcommand> --help` for more information about a command.
+- Read the manual at <https://circleci-public.github.io/circleci-cli>
+- Support at <https://github.com/CircleCI-Public/circleci-cli/issues>
+

--- a/internal/cmd/root/testdata/help/circleci/reference.txt
+++ b/internal/cmd/root/testdata/help/circleci/reference.txt
@@ -1732,6 +1732,26 @@ Show VSCode MCP servers
 | `--workspace`          | List from workspace settings (.vscode/mcp.json) instead of user settings |
 
 
+### `circleci my <command>`
+
+Show resources for the authenticated user
+
+#### `circleci my runs [flags]`
+
+List your recent runs grouped by project
+
+| Flag          | Description                                                |
+| ------------- | ---------------------------------------------------------- |
+| `--jq string` | Process values from the response using jq syntax           |
+| `--json`      | Output as JSON                                             |
+| `--limit int` | Maximum number of runs to fetch [default: 20] (default 20) |
+
+
+**Aliases:**
+
+
+`circleci my run`
+
 ### `circleci onboard [path] [flags]`
 
 Guided onboarding: scan, test, generate config, sign up

--- a/internal/cmd/root/testdata/usage/circleci.txt
+++ b/internal/cmd/root/testdata/usage/circleci.txt
@@ -13,6 +13,7 @@ Available commands:
   envvar
   job
   mcp
+  my
   namespace
   onboard
   orb

--- a/internal/cmd/root/testdata/usage/circleci/my.txt
+++ b/internal/cmd/root/testdata/usage/circleci/my.txt
@@ -1,0 +1,4 @@
+Usage:  circleci my <command>
+
+Available commands:
+  runs

--- a/internal/cmd/root/testdata/usage/circleci/my/runs.txt
+++ b/internal/cmd/root/testdata/usage/circleci/my/runs.txt
@@ -1,0 +1,7 @@
+Usage:  circleci my runs [flags]
+
+Flags:
+  --jq string   Process values from the response using jq syntax
+  --json        Output as JSON
+  --limit int   Maximum number of runs to fetch [default: 20] (default 20)
+  

--- a/internal/testing/fakes/circleci.go
+++ b/internal/testing/fakes/circleci.go
@@ -80,6 +80,7 @@ type CircleCI struct {
 	// Run (v3) state.
 	runsV3          map[string]any   // run UUID → V3 response data (inner, not wrapped)
 	runsV3ByProject map[string][]any // project UUID → ordered V3 run data items
+	userRunsV3      []any            // ordered V3 run data items for GET /runs?filter[user_id]=me
 
 	// Workflow (v3) state.
 	workflowsV3         map[string]any   // workflow UUID → V3 workflow data (inner, not wrapped)
@@ -327,6 +328,7 @@ func NewCircleCI(t *testing.T) *CircleCI {
 	r.Get("/api/v3/workflows/{id}", f.handleGetWorkflowV3ByID)
 	r.Get("/api/v3/workflows", f.handleGetWorkflowsV3)
 	// Run (v3) routes.
+	r.Get("/api/v3/runs", f.handleListMyRunsV3)
 	r.Get("/api/v3/runs/{id}", f.handleGetRunV3)
 	r.Post("/api/v3/runs/search", f.handleSearchRunsV3)
 	// Runner (v3) routes. GET /runner lists instances (scoped by ?org-id= and/or
@@ -890,6 +892,35 @@ func (f *CircleCI) AddRunV3(id, projectID string, run any) {
 	defer f.mu.Unlock()
 	f.runsV3[id] = run
 	f.runsV3ByProject[projectID] = append(f.runsV3ByProject[projectID], run)
+}
+
+// SetUserRuns registers the V3 run data items returned by
+// GET /api/v3/runs?filter[user_id]=me (i.e. "circleci my runs").
+func (f *CircleCI) SetUserRuns(runs ...any) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.userRunsV3 = runs
+}
+
+func (f *CircleCI) handleListMyRunsV3(w http.ResponseWriter, r *http.Request) {
+	if got := r.URL.Query().Get("filter[user_id]"); got != "me" {
+		render.Status(r, http.StatusBadRequest)
+		render.JSON(w, r, map[string]any{"message": "expected filter[user_id]=me, got " + got})
+		return
+	}
+
+	f.mu.RLock()
+	results := append([]any(nil), f.userRunsV3...)
+	f.mu.RUnlock()
+
+	if size, err := strconv.Atoi(r.URL.Query().Get("page[size]")); err == nil && size > 0 && len(results) > size {
+		results = results[:size]
+	}
+
+	render.JSON(w, r, map[string]any{
+		"data": results,
+		"page": map[string]any{"next": nil, "prev": nil},
+	})
 }
 
 func (f *CircleCI) handleGetRunV3(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- Adds a new top-level `circleci my` command group (resources scoped to the authenticated user)
- `circleci my runs` lists your runs across all projects via `GET /api/v3/runs?filter[user_id]=me`, grouped by project with the most recent run first (default `--limit 20`)
- `--json` returns an array of `{ repository, runs: [...] }`; `--jq` supported
- Reuses the existing v3 `runWire`/`toRunV3` decode path and the `getV3`/`filterParam`/`pageSize` client helpers; adds `repository_url` to the run wire/domain types

🤖 Generated with [Claude Code](https://claude.com/claude-code)