### PR TITLE
WIP: add right-align support to mdtable

### DIFF
--- a/internal/mdtable/mdtable.go
+++ b/internal/mdtable/mdtable.go
@@ -40,6 +40,7 @@ type Table struct {
 	headers []string
 	rows    [][]string
 	widths  []int
+	right   []bool
 }
 
 // New creates a Table with the given column headers.
@@ -48,7 +49,16 @@ func New(headers ...string) *Table {
 	for i, h := range headers {
 		widths[i] = len(h)
 	}
-	return &Table{headers: headers, widths: widths}
+	return &Table{headers: headers, widths: widths, right: make([]bool, len(headers))}
+}
+
+// RightAlign marks a column (0-indexed) as right-aligned. The separator row
+// renders a trailing colon so GFM renderers right-align the column.
+// WIP: separator marker not yet emitted.
+func (t *Table) RightAlign(col int) {
+	if col >= 0 && col < len(t.right) {
+		t.right[col] = true
+	}
 }
 
 // Row appends a data row. Values beyond the header count are ignored;

--- a/internal/mdtable/mdtable_test.go
+++ b/internal/mdtable/mdtable_test.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// SPDX-License-Identifier: MIT
+
+package mdtable
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+)
+
+func TestRender(t *testing.T) {
+	tbl := New("Name", "Value")
+	tbl.Row("FOO", "bar")
+
+	want := "| Name | Value |\n| ---- | ----- |\n| FOO  | bar   |\n"
+	assert.Check(t, cmp.Equal(tbl.Render(), want))
+}
+
+func TestRightAlignSeparator(t *testing.T) {
+	tbl := New("Name", "Value")
+	tbl.RightAlign(1)
+	tbl.Row("FOO", "bar")
+
+	// A right-aligned column should render a trailing colon in the separator
+	// row so GFM renderers right-align it.
+	want := "| Name | Value |\n| ---- | ----: |\n| FOO  |   bar |\n"
+	assert.Check(t, cmp.Equal(tbl.Render(), want))
+}


### PR DESCRIPTION
Add RightAlign(col) to mark columns for right alignment. Render still needs to emit the trailing-colon separator marker and right-pad cells.

<!--
  Thank you for contributing to CircleCI CLI!
  For PRs adding new features, please raise an issue first.
-->
