### PR TITLE
Offer scan-repo vs signup choice in circleci onboard

### DIFF
--- a/acceptance/onboard_test.go
+++ b/acceptance/onboard_test.go
@@ -194,6 +194,92 @@ func TestOnboard_HappyPath_AlreadyAuthenticated(t *testing.T) {
 	assert.Check(t, golden.String(stdout, t.Name()+".txt"))
 }
 
+func TestOnboard_ScanAndSignupMutuallyExclusive(t *testing.T) {
+	dir := t.TempDir()
+	initGitDir(t, dir)
+
+	env := testenv.New(t)
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"onboard", "--scan", "--signup", dir},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 2, "expected ExitBadArguments, stderr: %s", result.Stderr)
+	assert.Check(t, golden.String(result.Stderr, t.Name()+".stderr.txt"))
+}
+
+func TestOnboard_SignupFlag_AlreadyAuthenticated(t *testing.T) {
+	dir := t.TempDir()
+
+	env := onboardAuthenticatedEnv(t, "testuser")
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"onboard", "--signup"},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Check(t, golden.String(result.Stdout, t.Name()+".txt"))
+}
+
+func TestOnboard_SignupFlag_NotInGitRepo(t *testing.T) {
+	dir := t.TempDir()
+
+	env := onboardAuthenticatedEnv(t, "testuser")
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"onboard", "--signup"},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Check(t, strings.Contains(result.Stdout, "Already signed in"), "expected signup confirmation")
+}
+
+func TestOnboard_ScanFlag_NotAGitRepo(t *testing.T) {
+	dir := t.TempDir()
+
+	env := testenv.New(t)
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"onboard", "--scan", dir},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 2, "expected ExitBadArguments, stderr: %s", result.Stderr)
+
+	stderr := strings.ReplaceAll(result.Stderr, strconv.Quote(dir), `"<DIR>"`)
+	assert.Check(t, golden.String(stderr, "TestOnboard_NotAGitRepo.stderr.txt"))
+}
+
+func TestOnboard_ScanFlag_ExplicitSameAsDefault(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test runner uses sh -c")
+	}
+	dir := t.TempDir()
+	copyFixture(t, "testdata/test-run/dotnet", dir)
+	initGitDir(t, dir)
+
+	env := onboardAuthenticatedEnv(t, "testuser")
+	addFakeDotnet(t, env, false)
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"onboard", "--scan", dir},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+
+	stdout := normalizeOnboardOutput(result.Stdout, dir)
+	assert.Check(t, golden.String(stdout, "TestOnboard_HappyPath_AlreadyAuthenticated.txt"))
+}
+
 func onboardAuthenticatedEnv(t *testing.T, login string) *testenv.TestEnv {
 	t.Helper()
 

--- a/acceptance/testdata/TestOnboard_ScanAndSignupMutuallyExclusive.stderr.txt
+++ b/acceptance/testdata/TestOnboard_ScanAndSignupMutuallyExclusive.stderr.txt
@@ -1,0 +1,1 @@
+error: --scan and --signup are mutually exclusive

--- a/acceptance/testdata/TestOnboard_SignupFlag_AlreadyAuthenticated.txt
+++ b/acceptance/testdata/TestOnboard_SignupFlag_AlreadyAuthenticated.txt
@@ -1,0 +1,1 @@
+✓ Already signed in as testuser

--- a/internal/cmd/onboard/onboard.go
+++ b/internal/cmd/onboard/onboard.go
@@ -28,35 +28,54 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/CircleCI-Public/circleci-cli/internal/cmdutil"
+	clierrors "github.com/CircleCI-Public/circleci-cli/internal/errors"
 	"github.com/CircleCI-Public/circleci-cli/internal/onboarder"
 )
 
 // NewOnboardCmd returns the "circleci onboard" command.
 func NewOnboardCmd() *cobra.Command {
-	var noBrowser bool
+	var (
+		noBrowser bool
+		scan      bool
+		signup    bool
+	)
 
 	cmd := &cobra.Command{
 		Use:     "onboard [path]",
 		GroupID: "user",
 		Short:   "Guided onboarding: scan, test, generate config, sign up",
 		Long: heredoc.Doc(`
-			Scan a local repository, run its detected tests, generate a starter
-			.circleci/config.yml when one does not already exist, and sign up for
-			CircleCI through the browser-based auth flow.
+			Guided onboarding: scan a local repository, run its detected tests,
+			generate a starter .circleci/config.yml, and sign up for CircleCI.
+
+			When run interactively without --scan or --signup, a prompt lets you
+			choose between scanning the current repo or signing up directly.
 		`),
 		Example: heredoc.Doc(`
-			# Onboard the current directory
+			# Interactive mode: choose scan or signup
 			$ circleci onboard
 
+			# Scan the current directory (skip the choice prompt)
+			$ circleci onboard --scan
+
+			# Sign up for CircleCI (no repo needed)
+			$ circleci onboard --signup
+
 			# Onboard a specific project path
-			$ circleci onboard ./my-app
+			$ circleci onboard --scan ./my-app
 
 			# Print the signup URL instead of opening a browser
-			$ circleci onboard --no-browser
+			$ circleci onboard --signup --no-browser
 		`),
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+
+			if scan && signup {
+				return clierrors.New("onboard.invalid_args", "Invalid arguments",
+					"--scan and --signup are mutually exclusive").
+					WithExitCode(clierrors.ExitBadArguments)
+			}
 
 			dir := "."
 			if len(args) == 1 {
@@ -68,10 +87,14 @@ func NewOnboardCmd() *cobra.Command {
 				NoBrowser:     noBrowser,
 				SecureStorage: cmdutil.IsSecureStorage(cmd),
 				ConfigPath:    configPath,
+				Scan:          scan,
+				Signup:        signup,
 			})
 		},
 	}
 
 	cmd.Flags().BoolVar(&noBrowser, "no-browser", false, "Print the signup URL instead of opening a browser")
+	cmd.Flags().BoolVar(&scan, "scan", false, "Skip prompt: scan the repo and generate config")
+	cmd.Flags().BoolVar(&signup, "signup", false, "Skip prompt: sign up for CircleCI")
 	return cmd
 }

--- a/internal/cmd/root/testdata/help/circleci/onboard.txt
+++ b/internal/cmd/root/testdata/help/circleci/onboard.txt
@@ -1,8 +1,10 @@
 # CircleCI CLI
 
-Scan a local repository, run its detected tests, generate a starter
-.circleci/config.yml when one does not already exist, and sign up for
-CircleCI through the browser-based auth flow.
+Guided onboarding: scan a local repository, run its detected tests,
+generate a starter .circleci/config.yml, and sign up for CircleCI.
+
+When run interactively without --scan or --signup, a prompt lets you
+choose between scanning the current repo or signing up directly.
 
 ## Usage
 
@@ -13,6 +15,8 @@ CircleCI through the browser-based auth flow.
 | Flag           | Description                                       |
 | -------------- | ------------------------------------------------- |
 | `--no-browser` | Print the signup URL instead of opening a browser |
+| `--scan`       | Skip prompt: scan the repo and generate config    |
+| `--signup`     | Skip prompt: sign up for CircleCI                 |
 
 ## Inherited Flags
 
@@ -24,12 +28,16 @@ CircleCI through the browser-based auth flow.
 
 ## Examples
 
-- Onboard the current directory: 
+- Interactive mode: choose scan or signup: 
   `circleci onboard`
+- Scan the current directory (skip the choice prompt): 
+  `circleci onboard --scan`
+- Sign up for CircleCI (no repo needed): 
+  `circleci onboard --signup`
 - Onboard a specific project path: 
-  `circleci onboard ./my-app`
+  `circleci onboard --scan ./my-app`
 - Print the signup URL instead of opening a browser: 
-  `circleci onboard --no-browser`
+  `circleci onboard --signup --no-browser`
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/reference.txt
+++ b/internal/cmd/root/testdata/help/circleci/reference.txt
@@ -1759,6 +1759,8 @@ Guided onboarding: scan, test, generate config, sign up
 | Flag           | Description                                       |
 | -------------- | ------------------------------------------------- |
 | `--no-browser` | Print the signup URL instead of opening a browser |
+| `--scan`       | Skip prompt: scan the repo and generate config    |
+| `--signup`     | Skip prompt: sign up for CircleCI                 |
 
 
 ### `circleci setting <command>`

--- a/internal/cmd/root/testdata/usage/circleci/onboard.txt
+++ b/internal/cmd/root/testdata/usage/circleci/onboard.txt
@@ -2,4 +2,6 @@ Usage:  circleci onboard [path] [flags]
 
 Flags:
   --no-browser   Print the signup URL instead of opening a browser
+  --scan         Skip prompt: scan the repo and generate config
+  --signup       Skip prompt: sign up for CircleCI
   

--- a/internal/onboarder/onboarder.go
+++ b/internal/onboarder/onboarder.go
@@ -40,16 +40,34 @@ import (
 	"github.com/CircleCI-Public/circleci-cli/internal/ui"
 )
 
+type mode int
+
+const (
+	modeScan   mode = iota // scan repo, run tests, generate config, then sign up
+	modeSignup             // sign up only — no repo required
+)
+
 // Options configures the onboarding flow.
 type Options struct {
 	ConfigPath    string
 	NoBrowser     bool
 	SecureStorage bool
+	Scan          bool
+	Signup        bool
 }
 
 // Run scans a repository, verifies its tests, generates a starter config when
 // needed, and ensures the CLI has an authenticated CircleCI session.
 func Run(ctx context.Context, dir string, opts Options) error {
+	m, err := resolveMode(ctx, opts)
+	if err != nil {
+		return err
+	}
+
+	if m == modeSignup {
+		return cmdauth.SignupIfNeeded(ctx, opts.NoBrowser, opts.SecureStorage, opts.ConfigPath)
+	}
+
 	info, err := os.Stat(dir)
 	if err != nil || !info.IsDir() {
 		return clierrors.New(
@@ -112,6 +130,43 @@ func Run(ctx context.Context, dir string, opts Options) error {
 	iostream.Printf(ctx, "%s Onboarded\n", iostream.SymbolOK(ctx))
 	iostream.Printf(ctx, "Commit .circleci/config.yml. After your project is connected in CircleCI, pushing will start your first pipeline.\n")
 	return nil
+}
+
+func resolveMode(ctx context.Context, opts Options) (mode, error) {
+	if opts.Scan {
+		return modeScan, nil
+	}
+	if opts.Signup {
+		return modeSignup, nil
+	}
+
+	if !iostream.IsInteractive(ctx) {
+		return modeScan, nil
+	}
+
+	idx, err := iostream.PromptSelect(ctx, "What would you like to do?", []string{
+		"Scan this repo and generate config",
+		"Sign up for CircleCI",
+	})
+	if err != nil {
+		return 0, clierrors.New(
+			"onboard.mode_prompt_failed",
+			"Mode selection failed",
+			err.Error(),
+		).WithExitCode(clierrors.ExitGeneralError)
+	}
+	if idx == -1 {
+		return 0, clierrors.New(
+			"onboard.cancelled",
+			"Onboarding cancelled",
+			"No mode selected.",
+		).WithExitCode(clierrors.ExitCancelled)
+	}
+
+	if idx == 1 {
+		return modeSignup, nil
+	}
+	return modeScan, nil
 }
 
 // displayPreamble shows a confirmation gate before any work begins. The prompt


### PR DESCRIPTION
## Summary

- `circleci onboard` now presents an interactive picker ("Scan this repo and generate config" / "Sign up for CircleCI") instead of hard-failing when not in a git repo
- Added `--scan` and `--signup` flags to skip the prompt for non-interactive use
- Non-interactive sessions (CI, no TTY) default to the scan path for backward compatibility
- The two flags are mutually exclusive, validated at runtime with a structured error

https://github.com/user-attachments/assets/562791a5-4d16-47ed-8950-e4c701da6622

## Test plan

- [x] `--scan --signup` together returns exit 2 with clear error message
- [x] `--signup` from a non-git directory succeeds (the key use case)
- [x] `--signup` with existing auth prints "Already signed in"
- [x] `--scan` from a non-git directory still returns the "Not a git repository" error
- [x] `--scan` produces identical output to the no-flag default path
- [x] All 6 existing onboard acceptance tests pass unchanged