### PR TITLE
Fix snapcraft publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,15 +180,6 @@ jobs:
             sudo apt install snapd --yes
             sudo snap install snapcraft --classic
       - run:
-          name: Configure snapcraft
-          # Credentials are read from the SNAPCRAFT_LOGIN_FILE env var (base64-encoded).
-          # To refresh: run `snapcraft login` and `snapcraft export-login creds`
-          # inside cibuilds/snapcraft:stable, then `cat creds | base64 | tr -d '\n'`
-          # and store the output as SNAPCRAFT_LOGIN_FILE in CircleCI project settings.
-          command: |
-            mkdir -p .snapcraft
-            echo -n "$SNAPCRAFT_LOGIN_FILE" | base64 --decode > .snapcraft/snapcraft.cfg
-      - run:
           name: Install choco
           command: |
             sudo cp tools/choco.sh /usr/local/bin/choco

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -145,6 +145,10 @@ winget:
           name: winget-pkgs
           branch: master
 
+# To refresh the snapcraft credentials, run:
+# $ snapcraft export-login --snaps circleci --channels stable,candidate,edge,beta --acls package_push,package_release snapcraft-credentials.txt
+# Then paste the contents of snapcraft-credentials.txt into:
+# $ circleci context secret set devex-release --name SNAPCRAFT_STORE_CREDENTIALS
 snapcrafts:
   - id: circleci
     name: circleci

--- a/README.md
+++ b/README.md
@@ -56,15 +56,12 @@ A ground-up rewrite of the CircleCI CLI is available for preview.
 Install the preview (v2) CLI via one of the following package managers:
 
 Homebrew:
-```shell
-brew tap circleci-public/homebrew-circleci
-brew trust circleci-public/homebrew-circleci
-brew install circleci@next
-```
-
 **If you have the stable CLI installed:**
 ```shell
 brew uninstall circleci
+```
+
+```shell
 brew tap circleci-public/homebrew-circleci
 brew trust circleci-public/homebrew-circleci # for brew greater than v6
 brew install circleci@next


### PR DESCRIPTION
- The snapcraft credentials file hasn't been used for some time, and was a red-herring.
- We actually just need the correct env var set in a context, and have added instructions for that.