### PR TITLE
Extract shared org and git helpers for reuse by onboard

### DIFF
--- a/internal/cmd/project/create.go
+++ b/internal/cmd/project/create.go
@@ -35,6 +35,7 @@ import (
 	clierrors "github.com/CircleCI-Public/circleci-cli/internal/errors"
 	"github.com/CircleCI-Public/circleci-cli/internal/gitremote"
 	"github.com/CircleCI-Public/circleci-cli/internal/iostream"
+	"github.com/CircleCI-Public/circleci-cli/internal/org"
 )
 
 func newCreateCmd() *cobra.Command {
@@ -96,7 +97,7 @@ func newCreateCmd() *cobra.Command {
 			}
 
 			if name == "" {
-				defaultName := repoNameFromGit()
+				defaultName := gitremote.DetectRepoName()
 				if iostream.IsInteractive(ctx) {
 					val, err := iostream.PromptText(ctx, "Project name", defaultName)
 					if err != nil {
@@ -141,14 +142,14 @@ func newCreateCmd() *cobra.Command {
 						).
 						WithExitCode(clierrors.ExitBadArguments)
 				}
-				selected, err := selectOrg(ctx, client)
+				selected, err := org.Select(ctx, client)
 				if err != nil {
 					return err
 				}
 				orgSlug = selected
 			}
 
-			vcs, org, err := parseOrgSlug(orgSlug)
+			vcs, orgName, err := org.ParseSlug(orgSlug)
 			if err != nil {
 				return clierrors.New("args.invalid_org", "Invalid --org value",
 					fmt.Sprintf("%q is not a valid org slug.", orgSlug)).
@@ -159,7 +160,7 @@ func newCreateCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return runProjectCreate(ctx, client, vcs, org, name, appURL, jsonOut)
+			return runProjectCreate(ctx, client, vcs, orgName, name, appURL, jsonOut)
 		},
 	}
 
@@ -167,15 +168,6 @@ func newCreateCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output as JSON")
 
 	return cmd
-}
-
-// parseOrgSlug splits "gh/myorg" → ("gh", "myorg").
-func parseOrgSlug(slug string) (vcs, org string, err error) {
-	parts := strings.SplitN(slug, "/", 2)
-	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-		return "", "", fmt.Errorf("invalid org slug")
-	}
-	return parts[0], parts[1], nil
 }
 
 type createProjectOutput struct {
@@ -218,51 +210,6 @@ func runProjectCreate(ctx context.Context, client *apiclient.Client, vcs, org, n
 	pipelinesURL, _ := cmdutil.PipelinesURL(appURL, out.Slug)
 	printCreatedProject(ctx, out, pipelinesURL)
 	return nil
-}
-
-// selectOrg fetches the user's organizations and presents an interactive picker.
-func selectOrg(ctx context.Context, client *apiclient.Client) (string, error) {
-	collabs, err := client.ListCollaborations(ctx)
-	if err != nil {
-		return "", cmdutil.APIErr(err, "", "org.list_failed", "Could not fetch your organizations.",
-			"Check your API token and network connection",
-		)
-	}
-	if len(collabs) == 0 {
-		return "", clierrors.New("org.none_found", "No organizations found",
-			"Your account is not a member of any CircleCI organizations.").
-			WithExitCode(clierrors.ExitNotFound)
-	}
-
-	labels := make([]string, len(collabs))
-	for i, c := range collabs {
-		labels[i] = c.Slug
-		if c.Name != "" && c.Name != c.Slug {
-			labels[i] = fmt.Sprintf("%s (%s)", c.Slug, c.Name)
-		}
-	}
-
-	idx, err := iostream.PromptSelect(ctx, "Select an organization", labels)
-	if err != nil || idx < 0 {
-		return "", clierrors.New("project.create_cancelled", "Cancelled",
-			"No organization selected.").
-			WithExitCode(clierrors.ExitCancelled)
-	}
-	return collabs[idx].Slug, nil
-}
-
-// repoNameFromGit returns the repository name from the git remote, or "" if it
-// cannot be detected.
-func repoNameFromGit() string {
-	info, err := gitremote.Detect()
-	if err != nil {
-		return ""
-	}
-	parts := strings.Split(info.Slug, "/")
-	if len(parts) == 3 {
-		return parts[2]
-	}
-	return ""
 }
 
 func printCreatedProject(ctx context.Context, p createProjectOutput, pipelinesURL string) {

--- a/internal/gitremote/detect.go
+++ b/internal/gitremote/detect.go
@@ -71,6 +71,20 @@ func DetectNamespace() (string, error) {
 	return parts[1], nil
 }
 
+// DetectRepoName returns the repository name from the git remote, or "" if it
+// cannot be detected.
+func DetectRepoName() string {
+	info, err := Detect()
+	if err != nil {
+		return ""
+	}
+	parts := strings.Split(info.Slug, "/")
+	if len(parts) == 3 {
+		return parts[2]
+	}
+	return ""
+}
+
 // Detect resolves the CircleCI project for the current working directory.
 //
 // Resolution priority:

--- a/internal/org/org.go
+++ b/internal/org/org.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+// Package org provides shared logic for CircleCI organization operations.
+package org
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/CircleCI-Public/circleci-cli/internal/apiclient"
+	"github.com/CircleCI-Public/circleci-cli/internal/cmdutil"
+	clierrors "github.com/CircleCI-Public/circleci-cli/internal/errors"
+	"github.com/CircleCI-Public/circleci-cli/internal/iostream"
+)
+
+// List fetches the organizations the authenticated user belongs to.
+func List(ctx context.Context, client *apiclient.Client) ([]apiclient.Collaboration, error) {
+	collabs, err := client.ListCollaborations(ctx)
+	if err != nil {
+		return nil, cmdutil.APIErr(err, "", "org.list_failed", "Could not fetch your organizations.",
+			"Check your API token and network connection",
+		)
+	}
+	return collabs, nil
+}
+
+// Select fetches the user's organizations and presents an interactive picker.
+// With exactly one org it is auto-selected; with multiple the user picks.
+func Select(ctx context.Context, client *apiclient.Client) (string, error) {
+	collabs, err := List(ctx, client)
+	if err != nil {
+		return "", err
+	}
+	if len(collabs) == 0 {
+		return "", clierrors.New("org.none_found", "No organizations found",
+			"Your account is not a member of any CircleCI organizations.").
+			WithExitCode(clierrors.ExitNotFound)
+	}
+
+	if len(collabs) == 1 {
+		return collabs[0].Slug, nil
+	}
+
+	labels := make([]string, len(collabs))
+	for i, c := range collabs {
+		labels[i] = c.Slug
+		if c.Name != "" && c.Name != c.Slug {
+			labels[i] = fmt.Sprintf("%s (%s)", c.Slug, c.Name)
+		}
+	}
+
+	idx, err := iostream.PromptSelect(ctx, "Select an organization", labels)
+	if err != nil || idx < 0 {
+		return "", clierrors.New("project.create_cancelled", "Cancelled",
+			"No organization selected.").
+			WithExitCode(clierrors.ExitCancelled)
+	}
+	return collabs[idx].Slug, nil
+}
+
+// ParseSlug splits "gh/myorg" into its VCS and org components.
+func ParseSlug(slug string) (vcs, orgName string, err error) {
+	parts := strings.SplitN(slug, "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("invalid org slug")
+	}
+	return parts[0], parts[1], nil
+}


### PR DESCRIPTION
## Summary

- Create `internal/org/` with `List`, `Select`, and `ParseSlug` — extracted from `internal/cmd/project/create.go`
- Add `DetectRepoName` to `internal/gitremote/` alongside the existing `DetectNamespace`
- `project create` calls the exported versions — no behavior change

Splits shared logic by domain: org operations in `internal/org/`, git detection in `internal/gitremote/`. This follows the existing pattern where `DetectNamespace` already lives in `gitremote`.

## Test plan

- [x] All `TestProjectCreate_*` acceptance tests pass unchanged
- [x] `task check` passes
- [x] Pure refactor — no new behavior to test