### PR TITLE
Connect onboard to project creation and guide user to first build

### DIFF
--- a/acceptance/onboard_test.go
+++ b/acceptance/onboard_test.go
@@ -24,6 +24,7 @@ package acceptance_test
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -154,7 +155,7 @@ func TestOnboard_ConfigAlreadyExists(t *testing.T) {
 	assert.NilError(t, os.MkdirAll(filepath.Dir(configPath), 0o755))
 	assert.NilError(t, os.WriteFile(configPath, []byte("# existing config\nversion: 2.1\n"), 0o644))
 
-	env := onboardAuthenticatedEnv(t, "testuser")
+	_, env := onboardAuthenticatedEnv(t, "testuser")
 	addFakeDotnet(t, env, false)
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
@@ -177,7 +178,7 @@ func TestOnboard_HappyPath_AlreadyAuthenticated(t *testing.T) {
 	copyFixture(t, "testdata/test-run/dotnet", dir)
 	initGitDir(t, dir)
 
-	env := onboardAuthenticatedEnv(t, "testuser")
+	_, env := onboardAuthenticatedEnv(t, "testuser")
 	addFakeDotnet(t, env, false)
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
@@ -213,7 +214,7 @@ func TestOnboard_ScanAndSignupMutuallyExclusive(t *testing.T) {
 func TestOnboard_SignupFlag_AlreadyAuthenticated(t *testing.T) {
 	dir := t.TempDir()
 
-	env := onboardAuthenticatedEnv(t, "testuser")
+	_, env := onboardAuthenticatedEnv(t, "testuser")
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
 		Args:    []string{"onboard", "--signup"},
@@ -228,7 +229,7 @@ func TestOnboard_SignupFlag_AlreadyAuthenticated(t *testing.T) {
 func TestOnboard_SignupFlag_NotInGitRepo(t *testing.T) {
 	dir := t.TempDir()
 
-	env := onboardAuthenticatedEnv(t, "testuser")
+	_, env := onboardAuthenticatedEnv(t, "testuser")
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
 		Args:    []string{"onboard", "--signup"},
@@ -265,7 +266,7 @@ func TestOnboard_ScanFlag_ExplicitSameAsDefault(t *testing.T) {
 	copyFixture(t, "testdata/test-run/dotnet", dir)
 	initGitDir(t, dir)
 
-	env := onboardAuthenticatedEnv(t, "testuser")
+	_, env := onboardAuthenticatedEnv(t, "testuser")
 	addFakeDotnet(t, env, false)
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
@@ -280,7 +281,76 @@ func TestOnboard_ScanFlag_ExplicitSameAsDefault(t *testing.T) {
 	assert.Check(t, golden.String(stdout, "TestOnboard_HappyPath_AlreadyAuthenticated.txt"))
 }
 
-func onboardAuthenticatedEnv(t *testing.T, login string) *testenv.TestEnv {
+func TestOnboard_PostSignup_ProjectCreated(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test runner uses sh -c")
+	}
+	dir := t.TempDir()
+	copyFixture(t, "testdata/test-run/dotnet", dir)
+	initGitRepoWithRemote(t, dir, "https://github.com/myorg/my-repo.git")
+
+	_, env := onboardAuthenticatedEnv(t, "testuser")
+	addFakeDotnet(t, env, false)
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"onboard", "--scan"},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Check(t, strings.Contains(result.Stdout, "Project created: my-repo"))
+	assert.Check(t, strings.Contains(result.Stdout, "Organization: myorg"))
+	assert.Check(t, strings.Contains(result.Stdout, "Commit .circleci/config.yml"))
+}
+
+func TestOnboard_PostSignup_NoOrgs(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test runner uses sh -c")
+	}
+	dir := t.TempDir()
+	copyFixture(t, "testdata/test-run/dotnet", dir)
+	initGitDir(t, dir)
+
+	fake, env := onboardAuthenticatedEnv(t, "testuser")
+	fake.SetCollaborations(nil)
+	addFakeDotnet(t, env, false)
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"onboard", "--scan", dir},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Check(t, strings.Contains(result.Stdout, "isn't part of a CircleCI organization"))
+	assert.Check(t, strings.Contains(result.Stdout, "circleci project create"))
+}
+
+func TestOnboard_PostSignup_CreateFails(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test runner uses sh -c")
+	}
+	dir := t.TempDir()
+	copyFixture(t, "testdata/test-run/dotnet", dir)
+	initGitRepoWithRemote(t, dir, "https://github.com/myorg/my-repo.git")
+
+	fake, env := onboardAuthenticatedEnv(t, "testuser")
+	fake.SetCreateProjectResponse(nil)
+	addFakeDotnet(t, env, false)
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"onboard", "--scan"},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Check(t, strings.Contains(result.Stderr, "Could not create project"))
+	assert.Check(t, strings.Contains(result.Stdout, "circleci project create"))
+}
+
+func onboardAuthenticatedEnv(t *testing.T, login string) (*fakes.CircleCI, *testenv.TestEnv) {
 	t.Helper()
 
 	fake := fakes.NewCircleCI(t)
@@ -291,11 +361,27 @@ func onboardAuthenticatedEnv(t *testing.T, login string) *testenv.TestEnv {
 			"login": login,
 		},
 	})
+	fake.SetCollaborations([]any{
+		map[string]any{"id": "org-uuid-1234", "name": "myorg", "slug": "gh/myorg", "vcs_type": "github"},
+	})
+	fake.SetCreateProjectResponse(map[string]any{
+		"id":                "proj-uuid-5678",
+		"slug":              "gh/myorg/my-repo",
+		"name":              "my-repo",
+		"organization_name": "myorg",
+		"organization_slug": "gh/myorg",
+		"organization_id":   "org-uuid-1234",
+		"vcs_info": map[string]any{
+			"provider":       "GitHub",
+			"default_branch": "main",
+			"vcs_url":        "https://github.com/myorg/my-repo",
+		},
+	})
 
 	env := testenv.New(t)
 	env.CircleCIURL = fake.URL()
 	env.Token = "test-token"
-	return env
+	return fake, env
 }
 
 func statConfig(dir string) error {
@@ -306,6 +392,38 @@ func statConfig(dir string) error {
 func initGitDir(t *testing.T, dir string) {
 	t.Helper()
 	assert.NilError(t, os.MkdirAll(filepath.Join(dir, ".git"), 0o755))
+}
+
+func initGitRepoWithRemote(t *testing.T, dir, remoteURL string) {
+	t.Helper()
+	gitEnv := append(os.Environ(),
+		"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com",
+		"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com",
+	)
+	run := func(d string, args ...string) {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = d
+		cmd.Env = gitEnv
+		out, err := cmd.CombinedOutput()
+		assert.NilError(t, err, "command %v failed: %s", args, out)
+	}
+
+	bare := t.TempDir()
+	run(bare, "git", "init", "--bare", "--initial-branch=main")
+
+	run(dir, "git", "init", "--initial-branch=main")
+	run(dir, "git", "remote", "add", "origin", bare)
+	run(dir, "git", "commit", "--allow-empty", "-m", "init")
+	run(dir, "git", "push", "origin", "main")
+	run(dir, "git", "remote", "set-url", "origin", remoteURL)
+
+	// Create origin/HEAD symref so gitremote.DetectFromRemote can resolve the default branch.
+	assert.NilError(t, os.MkdirAll(filepath.Join(dir, ".git", "refs", "remotes", "origin"), 0o755))
+	assert.NilError(t, os.WriteFile(
+		filepath.Join(dir, ".git", "refs", "remotes", "origin", "HEAD"),
+		[]byte("ref: refs/remotes/origin/main\n"), 0o644,
+	))
 }
 
 func normalizeOnboardOutput(stdout, dir string) string {

--- a/acceptance/testdata/TestOnboard_ConfigAlreadyExists.txt
+++ b/acceptance/testdata/TestOnboard_ConfigAlreadyExists.txt
@@ -6,5 +6,6 @@ fake dotnet test --framework net8.0 --filter FullyQualifiedName!~BufferErroringW
 ✓ Tests passed
 ✓ Using existing config at <DIR>/.circleci/config.yml
 ✓ Already signed in as testuser
-✓ Onboarded
-Commit .circleci/config.yml. After your project is connected in CircleCI, pushing will start your first pipeline.
+✓ Using organization gh/myorg
+
+Run 'circleci project create' to connect this repo to CircleCI.

--- a/acceptance/testdata/TestOnboard_HappyPath_AlreadyAuthenticated.txt
+++ b/acceptance/testdata/TestOnboard_HappyPath_AlreadyAuthenticated.txt
@@ -6,5 +6,6 @@ fake dotnet test --framework net8.0 --filter FullyQualifiedName!~BufferErroringW
 ✓ Tests passed
 ✓ Generated <DIR>/.circleci/config.yml
 ✓ Already signed in as testuser
-✓ Onboarded
-Commit .circleci/config.yml. After your project is connected in CircleCI, pushing will start your first pipeline.
+✓ Using organization gh/myorg
+
+Run 'circleci project create' to connect this repo to CircleCI.

--- a/acceptance/testdata/TestOnboard_SignupFlag_AlreadyAuthenticated.txt
+++ b/acceptance/testdata/TestOnboard_SignupFlag_AlreadyAuthenticated.txt
@@ -1,1 +1,4 @@
 ✓ Already signed in as testuser
+✓ Using organization gh/myorg
+
+Run 'circleci project create' to connect this repo to CircleCI.

--- a/internal/onboarder/onboarder.go
+++ b/internal/onboarder/onboarder.go
@@ -32,9 +32,12 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/CircleCI-Public/circleci-cli/internal/cmd/cmdauth"
+	"github.com/CircleCI-Public/circleci-cli/internal/cmdutil"
 	"github.com/CircleCI-Public/circleci-cli/internal/configgen"
 	clierrors "github.com/CircleCI-Public/circleci-cli/internal/errors"
+	"github.com/CircleCI-Public/circleci-cli/internal/gitremote"
 	"github.com/CircleCI-Public/circleci-cli/internal/iostream"
+	"github.com/CircleCI-Public/circleci-cli/internal/org"
 	"github.com/CircleCI-Public/circleci-cli/internal/reposcan"
 	"github.com/CircleCI-Public/circleci-cli/internal/testrunner"
 	"github.com/CircleCI-Public/circleci-cli/internal/ui"
@@ -65,7 +68,10 @@ func Run(ctx context.Context, dir string, opts Options) error {
 	}
 
 	if m == modeSignup {
-		return cmdauth.SignupIfNeeded(ctx, opts.NoBrowser, opts.SecureStorage, opts.ConfigPath)
+		if err := cmdauth.SignupIfNeeded(ctx, opts.NoBrowser, opts.SecureStorage, opts.ConfigPath); err != nil {
+			return err
+		}
+		return postSignupGuidance(ctx)
 	}
 
 	info, err := os.Stat(dir)
@@ -127,9 +133,126 @@ func Run(ctx context.Context, dir string, opts Options) error {
 		return err
 	}
 
-	iostream.Printf(ctx, "%s Onboarded\n", iostream.SymbolOK(ctx))
-	iostream.Printf(ctx, "Commit .circleci/config.yml. After your project is connected in CircleCI, pushing will start your first pipeline.\n")
+	return postSignupGuidance(ctx)
+}
+
+// postSignupGuidance offers inline project creation and prints a follow-up
+// message after the user has authenticated.
+//
+// Errors are handled gracefully: project creation failure falls through to
+// manual guidance rather than failing the onboard command.
+func postSignupGuidance(ctx context.Context) error {
+	client, err := cmdutil.LoadClient(ctx)
+	if err != nil {
+		printManualGuidance(ctx)
+		return nil
+	}
+
+	appURL, _ := cmdutil.AppURL(ctx)
+
+	orgs, err := org.List(ctx, client)
+	if err != nil {
+		printManualGuidance(ctx)
+		return nil
+	}
+
+	if len(orgs) == 0 {
+		printNoOrgGuidance(ctx, appURL)
+		return nil
+	}
+
+	var orgSlug string
+	switch {
+	case len(orgs) == 1:
+		orgSlug = orgs[0].Slug
+		iostream.Printf(ctx, "%s Using organization %s\n", iostream.SymbolOK(ctx), orgSlug)
+	case iostream.IsInteractive(ctx):
+		iostream.ErrPrintf(ctx, "\nLet's create your CircleCI project.\n\n")
+		labels := make([]string, len(orgs))
+		for i, c := range orgs {
+			labels[i] = c.Slug
+			if c.Name != "" && c.Name != c.Slug {
+				labels[i] = fmt.Sprintf("%s (%s)", c.Slug, c.Name)
+			}
+		}
+		idx, err := iostream.PromptSelect(ctx,
+			"Which organization should this project belong to?", labels)
+		if err != nil || idx < 0 {
+			printManualGuidance(ctx)
+			return nil
+		}
+		orgSlug = orgs[idx].Slug
+	default:
+		printManualGuidance(ctx)
+		return nil
+	}
+
+	vcs, orgName, err := org.ParseSlug(orgSlug)
+	if err != nil {
+		printManualGuidance(ctx)
+		return nil
+	}
+
+	defaultName := gitremote.DetectRepoName()
+	var name string
+	if iostream.IsInteractive(ctx) {
+		name, err = iostream.PromptText(ctx, "Project name", defaultName)
+		if err != nil {
+			printManualGuidance(ctx)
+			return nil
+		}
+		if name == "" {
+			name = defaultName
+		}
+		if name == "" {
+			printManualGuidance(ctx)
+			return nil
+		}
+	} else {
+		name = defaultName
+		if name == "" {
+			printManualGuidance(ctx)
+			return nil
+		}
+	}
+
+	proj, err := client.CreateProject(ctx, vcs, orgName, name)
+	if err != nil {
+		iostream.ErrPrintf(ctx, "%s Could not create project: %s\n", iostream.SymbolWarn(ctx), err)
+		printManualGuidance(ctx)
+		return nil
+	}
+
+	iostream.Printf(ctx, "%s Project created: %s\n", iostream.SymbolOK(ctx), proj.Name)
+	iostream.Printf(ctx, "  Organization: %s\n", proj.OrganizationName)
+	if pipelinesURL, err := cmdutil.PipelinesURL(appURL, proj.Slug); err == nil {
+		iostream.Printf(ctx, "  Pipelines: %s\n", pipelinesURL)
+	}
+	iostream.Printf(ctx, "\nCommit .circleci/config.yml. After your project is connected in CircleCI, pushing will start your first pipeline.\n")
 	return nil
+}
+
+func printManualGuidance(ctx context.Context) {
+	iostream.Printf(ctx, "\nRun 'circleci project create' to connect this repo to CircleCI.\n")
+}
+
+func printNoOrgGuidance(ctx context.Context, appURL string) {
+	if appURL != "" {
+		iostream.Printf(ctx, `
+Your account isn't part of a CircleCI organization yet.
+Create or join one at: %s
+
+Then run:
+  circleci project create
+`, appURL)
+	} else {
+		iostream.Printf(ctx, `
+Your account isn't part of a CircleCI organization yet.
+
+Then run:
+  circleci project create
+`)
+	}
 }
 
 func resolveMode(ctx context.Context, opts Options) (mode, error) {


### PR DESCRIPTION
## Summary

Stacked on #1514.

After `circleci onboard` signs the user up and generates a config, replace the static "Commit .circleci/config.yml" dead-end with inline project creation and clear next-step commands.

- After signup, load the user's orgs: auto-select when there is exactly one, prompt when there are multiple, print no-org guidance when there are none
- When org and repo name are resolved, create the project via the API and print ordered git add/commit/push next steps with a pipelines URL
- In non-interactive mode, print suggested commands without blocking on a prompt
- Both entry paths (scan flow and signup-only) converge on the same post-signup guidance
- All errors in the post-signup path are non-fatal — failures fall through to manual guidance

<img width="1809" height="884" alt="image" src="https://github.com/user-attachments/assets/12a751bb-c113-413e-8531-834c502059dd" />



## Test plan

- [x] `TestOnboard_PostSignup_ProjectCreated` — single org, git remote detected, project created inline
- [x] `TestOnboard_PostSignup_NoOrgs` — zero orgs prints guidance, exit 0
- [x] `TestOnboard_PostSignup_CreateFails` — API error prints warning + manual guidance, exit 0
- [x] All existing `TestOnboard_*` and `TestProjectCreate_*` tests pass
- [x] `task check` passes