### PR TITLE
Fix onboard preamble showing '.' instead of absolute path

### DIFF
--- a/internal/onboarder/onboarder.go
+++ b/internal/onboarder/onboarder.go
@@ -68,6 +68,15 @@ func Run(ctx context.Context, dir string, opts Options) error {
 		return cmdauth.SignupIfNeeded(ctx, opts.NoBrowser, opts.SecureStorage, opts.ConfigPath)
 	}
 
+	dir, err = filepath.Abs(dir)
+	if err != nil {
+		return clierrors.New(
+			"onboard.resolve_path",
+			"Cannot resolve directory",
+			fmt.Sprintf("Could not resolve %q to an absolute path: %s.", dir, err),
+		).WithExitCode(clierrors.ExitGeneralError)
+	}
+
 	info, err := os.Stat(dir)
 	if err != nil || !info.IsDir() {
 		return clierrors.New(

--- a/internal/ui/preamble.go
+++ b/internal/ui/preamble.go
@@ -78,7 +78,7 @@ func (m PreambleModel) View() tea.View {
 		sb.WriteString("  • " + b + "\n")
 	}
 	if m.dir != "" {
-		sb.WriteString("\nThis will run in: " + m.dir + "\n")
+		sb.WriteString("\nThis will run in your current directory: " + m.dir + "\n")
 	}
 	if !m.done {
 		sb.WriteString("\nPress Enter to continue · Esc to cancel\n")

--- a/internal/ui/preamble.go
+++ b/internal/ui/preamble.go
@@ -78,7 +78,7 @@ func (m PreambleModel) View() tea.View {
 		sb.WriteString("  • " + b + "\n")
 	}
 	if m.dir != "" {
-		sb.WriteString("\nThis will run in your current directory: " + m.dir + "\n")
+		sb.WriteString("\nThis will run in: " + m.dir + "\n")
 	}
 	if !m.done {
 		sb.WriteString("\nPress Enter to continue · Esc to cancel\n")


### PR DESCRIPTION
## Summary
- Resolve `dir` to an absolute path via `filepath.Abs` in `onboarder.Run` before it reaches the preamble display
- Fixes `circleci onboard` showing `This will run in: .` instead of the actual directory path

Closes WEBXP-1393

## Test plan
- [x] Run `circleci onboard` with no path argument — preamble shows the absolute cwd
- [x] Run `circleci onboard ./some-repo` — preamble shows the resolved absolute path
- [x] `go test ./internal/ui/... ./internal/onboarder/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)