### PR TITLE
Add org pre-check before project creation

### DIFF
--- a/acceptance/project_test.go
+++ b/acceptance/project_test.go
@@ -46,6 +46,10 @@ func setupProjectFake(t *testing.T) (*fakes.CircleCI, *testenv.TestEnv) {
 	t.Helper()
 	fake := fakes.NewCircleCI(t)
 
+	fake.SetCollaborations([]any{
+		map[string]any{"id": "org-uuid-5678", "name": "myorg", "slug": "gh/myorg", "vcs_type": "github"},
+	})
+
 	fake.AddFollowedProject(map[string]any{
 		"slug":     "gh/myorg/alpha",
 		"username": "myorg",
@@ -1031,4 +1035,49 @@ func TestProjectCreate_NoArgs_NoGitRepo(t *testing.T) {
 
 	assert.Equal(t, result.ExitCode, 2, "stderr: %s", result.Stderr)
 	assert.Check(t, strings.Contains(result.Stderr, "project name"))
+}
+
+func TestProjectCreate_NoOrgs(t *testing.T) {
+	fake, env := setupCreateProjectFake(t)
+	fake.SetCollaborations(nil)
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"project", "create", "my-new-repo", "--org", "gh/myorg"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 5, "stderr: %s", result.Stderr)
+	assert.Check(t, strings.Contains(result.Stderr, "not a member of any CircleCI organizations"))
+}
+
+func TestProjectCreate_NoOrgs_NoOrgFlag(t *testing.T) {
+	fake, env := setupCreateProjectFake(t)
+	fake.SetCollaborations(nil)
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"project", "create", "my-new-repo"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 5, "stderr: %s", result.Stderr)
+	assert.Check(t, strings.Contains(result.Stderr, "not a member of any CircleCI organizations"))
+}
+
+func TestProjectCreate_WrongOrg(t *testing.T) {
+	_, env := setupCreateProjectFake(t)
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"project", "create", "my-new-repo", "--org", "gh/wrong-org"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 2, "stderr: %s", result.Stderr)
+	assert.Check(t, strings.Contains(result.Stderr, "not a member of organization"))
+	assert.Check(t, strings.Contains(result.Stderr, "gh/wrong-org"))
 }

--- a/internal/cmd/project/create.go
+++ b/internal/cmd/project/create.go
@@ -134,6 +134,9 @@ func newCreateCmd() *cobra.Command {
 
 			if orgSlug == "" {
 				if !iostream.IsInteractive(ctx) {
+					if _, err := org.Require(ctx, client); err != nil {
+						return err
+					}
 					return clierrors.New("args.missing_org", "Missing required flag",
 						"--org is required to specify the target organization.").
 						WithSuggestions(
@@ -147,6 +150,14 @@ func newCreateCmd() *cobra.Command {
 					return err
 				}
 				orgSlug = selected
+			} else {
+				orgs, err := org.Require(ctx, client)
+				if err != nil {
+					return err
+				}
+				if err := org.ValidateSlug(orgs, orgSlug); err != nil {
+					return err
+				}
 			}
 
 			vcs, orgName, err := org.ParseSlug(orgSlug)

--- a/internal/org/org.go
+++ b/internal/org/org.go
@@ -45,17 +45,38 @@ func List(ctx context.Context, client *apiclient.Client) ([]apiclient.Collaborat
 	return collabs, nil
 }
 
+// Require fetches the user's organizations and returns an actionable error
+// when the account has none. Callers that need to ensure at least one org
+// exists before proceeding should use this instead of List.
+func Require(ctx context.Context, client *apiclient.Client) ([]apiclient.Collaboration, error) {
+	collabs, err := List(ctx, client)
+	if err != nil {
+		return nil, err
+	}
+	if len(collabs) == 0 {
+		suggestions := []string{
+			"Ask an admin to invite you to an existing organization",
+		}
+		if appURL, err := cmdutil.AppURL(ctx); err == nil {
+			suggestions = []string{
+				fmt.Sprintf("Create or join an organization at %s", appURL),
+				"Ask an admin to invite you to an existing organization",
+			}
+		}
+		return nil, clierrors.New("org.none_found", "No organizations found",
+			"Your account is not a member of any CircleCI organizations.").
+			WithSuggestions(suggestions...).
+			WithExitCode(clierrors.ExitNotFound)
+	}
+	return collabs, nil
+}
+
 // Select fetches the user's organizations and presents an interactive picker.
 // With exactly one org it is auto-selected; with multiple the user picks.
 func Select(ctx context.Context, client *apiclient.Client) (string, error) {
-	collabs, err := List(ctx, client)
+	collabs, err := Require(ctx, client)
 	if err != nil {
 		return "", err
-	}
-	if len(collabs) == 0 {
-		return "", clierrors.New("org.none_found", "No organizations found",
-			"Your account is not a member of any CircleCI organizations.").
-			WithExitCode(clierrors.ExitNotFound)
 	}
 
 	if len(collabs) == 1 {
@@ -72,11 +93,33 @@ func Select(ctx context.Context, client *apiclient.Client) (string, error) {
 
 	idx, err := iostream.PromptSelect(ctx, "Select an organization", labels)
 	if err != nil || idx < 0 {
-		return "", clierrors.New("project.create_cancelled", "Cancelled",
+		return "", clierrors.New("org.selection_cancelled", "Cancelled",
 			"No organization selected.").
 			WithExitCode(clierrors.ExitCancelled)
 	}
 	return collabs[idx].Slug, nil
+}
+
+// ValidateSlug checks that the given org slug is among the user's organizations.
+func ValidateSlug(collabs []apiclient.Collaboration, slug string) error {
+	for _, c := range collabs {
+		if c.Slug == slug {
+			return nil
+		}
+	}
+	suggestions := []string{"Check the --org value and try again"}
+	if len(collabs) <= 5 {
+		slugs := make([]string, len(collabs))
+		for i, c := range collabs {
+			slugs[i] = c.Slug
+		}
+		suggestions = append(suggestions,
+			fmt.Sprintf("Your organizations: %s", strings.Join(slugs, ", ")))
+	}
+	return clierrors.New("org.not_member", "Not a member of this organization",
+		fmt.Sprintf("You are not a member of organization %q.", slug)).
+		WithSuggestions(suggestions...).
+		WithExitCode(clierrors.ExitBadArguments)
 }
 
 // ParseSlug splits "gh/myorg" into its VCS and org components.

--- a/internal/org/org.go
+++ b/internal/org/org.go
@@ -107,14 +107,13 @@ func ValidateSlug(collabs []apiclient.Collaboration, slug string) error {
 			return nil
 		}
 	}
-	suggestions := []string{"Check the --org value and try again"}
-	if len(collabs) <= 5 {
-		slugs := make([]string, len(collabs))
-		for i, c := range collabs {
-			slugs[i] = c.Slug
-		}
-		suggestions = append(suggestions,
-			fmt.Sprintf("Your organizations: %s", strings.Join(slugs, ", ")))
+	slugs := make([]string, len(collabs))
+	for i, c := range collabs {
+		slugs[i] = c.Slug
+	}
+	suggestions := []string{
+		"Check the --org value and try again",
+		fmt.Sprintf("Your organizations: %s", strings.Join(slugs, ", ")),
 	}
 	return clierrors.New("org.not_member", "Not a member of this organization",
 		fmt.Sprintf("You are not a member of organization %q.", slug)).

--- a/internal/org/org.go
+++ b/internal/org/org.go
@@ -111,9 +111,13 @@ func ValidateSlug(collabs []apiclient.Collaboration, slug string) error {
 	for i, c := range collabs {
 		slugs[i] = c.Slug
 	}
+	orgList := strings.Join(slugs, ", ")
+	if len(slugs) > 10 {
+		orgList = strings.Join(slugs[:10], ", ") + fmt.Sprintf(" (and %d more)", len(slugs)-10)
+	}
 	suggestions := []string{
 		"Check the --org value and try again",
-		fmt.Sprintf("Your organizations: %s", strings.Join(slugs, ", ")),
+		fmt.Sprintf("Your organizations: %s", orgList),
 	}
 	return clierrors.New("org.not_member", "Not a member of this organization",
 		fmt.Sprintf("You are not a member of organization %q.", slug)).


### PR DESCRIPTION
## Summary

- Add `org.Require` — a shared pre-check that fetches the user's orgs and returns a structured error with actionable suggestions (including the app URL) when none exist
- Add `org.ValidateSlug` — validates a provided `--org` value against the user's actual org membership, listing their orgs in the error if it doesn't match
- Wire both into `project create` so all paths get clear errors before hitting the API:
  - **Non-interactive, no `--org`**: no-org error fires before "missing flag" error
  - **Non-interactive, `--org` provided**: validates membership and shows available orgs on mismatch
  - **Interactive**: `org.Select` now composes on `Require`, so the no-org error includes suggestions

**Before**
<img width="1075" height="68" alt="image" src="https://github.com/user-attachments/assets/64eadc30-8261-4b15-a2af-f003807f8904" />


**After**
<img width="1226" height="170" alt="image" src="https://github.com/user-attachments/assets/150df171-2251-4f33-b643-4012c7fd1b2a" />


## Test plan

- [ ] `TestProjectCreate_NoOrgs` — empty collab list with `--org` returns exit 5 with no-org message
- [ ] `TestProjectCreate_NoOrgs_NoOrgFlag` — empty collab list without `--org` returns exit 5 (not "missing flag")
- [ ] `TestProjectCreate_WrongOrg` — `--org gh/wrong-org` returns exit 2 with membership error and lists available orgs
- [ ] Existing `TestProjectCreate_MissingOrg`, `TestProjectCreate_APIError`, and all other project/onboard tests still pass
- [ ] `task check` passes (lint, license, mod tidy)