### PR TITLE
Use page[limit] for V3 pagination

### DIFF
--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -162,13 +162,13 @@ type v3List[T any] struct {
 	} `json:"page"`
 }
 
-// pageSize returns a request option that sets page[size].
-// A size of 0 is ignored (server default is used).
-func pageSize(n int) func(*httpcl.Request) {
+// pageLimit returns a request option that sets page[limit].
+// A limit of 0 is ignored (server default is used).
+func pageLimit(n int) func(*httpcl.Request) {
 	if n <= 0 {
 		return func(*httpcl.Request) {}
 	}
-	return queryParam("page[size]", fmt.Sprintf("%d", n))
+	return queryParam("page[limit]", fmt.Sprintf("%d", n))
 }
 
 // pageCursor returns a request option that sets page[cursor].

--- a/internal/apiclient/run.go
+++ b/internal/apiclient/run.go
@@ -223,7 +223,7 @@ func (c *Client) SearchRunsV3(ctx context.Context, params RunSearchParams) ([]Ru
 func (c *Client) ListMyRunsV3(ctx context.Context, limit int) ([]RunV3, error) {
 	var resp v3List[runWire]
 	if err := c.getV3(ctx, "/runs", &resp,
-		filterParam("user_id", "me"), pageSize(limit)); err != nil {
+		filterParam("user_id", "me"), pageLimit(limit)); err != nil {
 		return nil, err
 	}
 

--- a/internal/testing/fakes/circleci.go
+++ b/internal/testing/fakes/circleci.go
@@ -917,7 +917,7 @@ func (f *CircleCI) handleListMyRunsV3(w http.ResponseWriter, r *http.Request) {
 	results := append([]any(nil), f.userRunsV3...)
 	f.mu.RUnlock()
 
-	if size, err := strconv.Atoi(r.URL.Query().Get("page[size]")); err == nil && size > 0 && len(results) > size {
+	if size, err := strconv.Atoi(r.URL.Query().Get("page[limit]")); err == nil && size > 0 && len(results) > size {
 		results = results[:size]
 	}
 
@@ -2842,7 +2842,7 @@ func (f *CircleCI) handleOrbListVersions(w http.ResponseWriter, r *http.Request)
 
 	orbID := r.URL.Query().Get("filter[orb_id]")
 	channel := r.URL.Query().Get("filter[channel]")
-	pageSizeStr := r.URL.Query().Get("page[size]")
+	pageSizeStr := r.URL.Query().Get("page[limit]")
 
 	f.mu.RLock()
 	versionIDs := f.orbVersionsByOrbID[orbID]


### PR DESCRIPTION
backplane-go dropped the `page[size]` query-param alias from its V3 pagination helper (`request.Page`). In v0.50 it read `page[limit]` *or* fell back to `page[size]`; from v0.52 it honours only `page[limit]`. Servers that bump backplane-go now silently ignore `page[size]` and fall back to the default page size, so the CLI's requested page size / `--limit` stops being honoured.

This swaps the CLI to send `page[limit]` (the surviving param). It works against both old and new servers, since v0.50 already accepted `page[limit]`.

- `pageSize` helper renamed to `pageLimit`, sends `page[limit]`
- `ListMyRunsV3` call site updated
- Fake server handlers (`my runs`, orb versions) read `page[limit]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)