### PR TITLE
Fix `winget` install instruction on marketing site

### DIFF
--- a/docs/website/assets/css/main.css
+++ b/docs/website/assets/css/main.css
@@ -218,6 +218,17 @@ a:hover {
   text-decoration: none;
 }
 
+.navbar-link--icon {
+  display: flex;
+  align-items: center;
+  color: var(--color-site-muted);
+}
+
+.navbar-icon {
+  height: 1.25rem;
+  width: auto;
+}
+
 @media (hover: hover) {
   .navbar-link:hover { color: var(--color-site-heading); }
 }

--- a/docs/website/layouts/index.html
+++ b/docs/website/layouts/index.html
@@ -45,7 +45,7 @@
             <ul class="install-menu" id="install-menu" role="listbox" aria-label="Installation method" hidden>
               <li role="option" tabindex="-1" data-cmd="brew install circleci" aria-selected="true">macOS — Homebrew</li>
               <li class="picker-divider" aria-hidden="true"></li>
-              <li role="option" tabindex="-1" data-cmd="winget install CircleCI.CLI" aria-selected="false">Windows — WinGet</li>
+              <li role="option" tabindex="-1" data-cmd="winget install --id CircleCI.CLI" aria-selected="false">Windows — WinGet</li>
               <li role="option" tabindex="-1" data-cmd="choco install circleci-cli -y" aria-selected="false">Windows — Chocolatey</li>
               <li class="picker-divider" aria-hidden="true"></li>
               <li role="option" tabindex="-1" data-cmd="brew install circleci" aria-selected="false">Linux — Homebrew</li>

--- a/docs/website/layouts/partials/navbar.html
+++ b/docs/website/layouts/partials/navbar.html
@@ -19,6 +19,11 @@
     <div class="navbar-links">
       <a class="navbar-link" href="{{ $root }}reference/">Reference</a>
       <a class="navbar-link" href="https://github.com/CircleCI-Public/circleci-cli/releases">Release notes</a>
+      <a class="navbar-link navbar-link--icon" href="https://github.com/CircleCI-Public/circleci-cli" aria-label="View the project on GitHub" title="View the project on GitHub">
+        <svg class="navbar-icon" viewBox="0 0 16 16" width="20" height="20" fill="currentColor" aria-hidden="true">
+          <path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"></path>
+        </svg>
+      </a>
     </div>
   </nav>
 </header>


### PR DESCRIPTION
<img width="1340" height="786" alt="Screenshot 2026-06-29 at 13 17 44" src="https://github.com/user-attachments/assets/880589ae-cd8a-4585-8942-84f60d4883e8" />

I also added a GH project link to the top bar