### PR TITLE
Fix artifact docs referring to incorrect output flag

### DIFF
--- a/internal/cmd/artifacts/artifacts.go
+++ b/internal/cmd/artifacts/artifacts.go
@@ -56,7 +56,7 @@ func NewArtifactCmd() *cobra.Command {
 		Long: heredoc.Doc(`
 			List or download artifacts produced by a CircleCI job.
 
-			Pass the job UUID to list its artifacts. Use --download to save
+			Pass the job UUID to list its artifacts. Use --output to save
 			them to a local directory.
 
 			JSON fields: path, url, node_index
@@ -66,7 +66,7 @@ func NewArtifactCmd() *cobra.Command {
 			$ circleci artifact 5034460f-c7c4-4c43-9457-de07e2029e7b
 
 			# Download all artifacts into ./artifacts
-			$ circleci artifact 5034460f-c7c4-4c43-9457-de07e2029e7b --download ./artifacts
+			$ circleci artifact 5034460f-c7c4-4c43-9457-de07e2029e7b --output ./artifacts
 
 			# Output as JSON for scripting
 			$ circleci artifact 5034460f-c7c4-4c43-9457-de07e2029e7b --json

--- a/internal/cmd/job/artifacts.go
+++ b/internal/cmd/job/artifacts.go
@@ -53,7 +53,7 @@ func newArtifactCmd() *cobra.Command {
 		Long: heredoc.Doc(`
 			List or download artifacts produced by a specific job.
 
-			Pass the job UUID to list its artifacts. Use --download to save
+			Pass the job UUID to list its artifacts. Use --output to save
 			them to a local directory.
 
 			JSON fields: path, url, node_index
@@ -63,7 +63,7 @@ func newArtifactCmd() *cobra.Command {
 			$ circleci job artifact 5034460f-c7c4-4c43-9457-de07e2029e7b
 
 			# Download artifacts into ./artifacts
-			$ circleci job artifact 5034460f-c7c4-4c43-9457-de07e2029e7b --download ./artifacts
+			$ circleci job artifact 5034460f-c7c4-4c43-9457-de07e2029e7b --output ./artifacts
 
 			# Output as JSON
 			$ circleci job artifact 5034460f-c7c4-4c43-9457-de07e2029e7b --json

--- a/internal/cmd/root/testdata/help/circleci/artifact.txt
+++ b/internal/cmd/root/testdata/help/circleci/artifact.txt
@@ -2,7 +2,7 @@
 
 List or download artifacts produced by a CircleCI job.
 
-Pass the job UUID to list its artifacts. Use --download to save
+Pass the job UUID to list its artifacts. Use --output to save
 them to a local directory.
 
 JSON fields: path, url, node_index
@@ -40,7 +40,7 @@ e.g. 5034460f-c7c4-4c43-9457-de07e2029e7b.
 - List artifacts for a job: 
   `circleci artifact 5034460f-c7c4-4c43-9457-de07e2029e7b`
 - Download all artifacts into ./artifacts: 
-  `circleci artifact 5034460f-c7c4-4c43-9457-de07e2029e7b --download ./artifacts`
+  `circleci artifact 5034460f-c7c4-4c43-9457-de07e2029e7b --output ./artifacts`
 - Output as JSON for scripting: 
   `circleci artifact 5034460f-c7c4-4c43-9457-de07e2029e7b --json`
 

--- a/internal/cmd/root/testdata/help/circleci/job/artifact.txt
+++ b/internal/cmd/root/testdata/help/circleci/job/artifact.txt
@@ -2,7 +2,7 @@
 
 List or download artifacts produced by a specific job.
 
-Pass the job UUID to list its artifacts. Use --download to save
+Pass the job UUID to list its artifacts. Use --output to save
 them to a local directory.
 
 JSON fields: path, url, node_index
@@ -40,7 +40,7 @@ Job UUIDs are shown in the output of "circleci workflow get" and
 - List artifacts for a job: 
   `circleci job artifact 5034460f-c7c4-4c43-9457-de07e2029e7b`
 - Download artifacts into ./artifacts: 
-  `circleci job artifact 5034460f-c7c4-4c43-9457-de07e2029e7b --download ./artifacts`
+  `circleci job artifact 5034460f-c7c4-4c43-9457-de07e2029e7b --output ./artifacts`
 - Output as JSON: 
   `circleci job artifact 5034460f-c7c4-4c43-9457-de07e2029e7b --json`
 


### PR DESCRIPTION
The flag to download artifacts was renamed from `--download` to `--output`.

This change replaces the references `--download` with `--output`.
