### PR TITLE
Resolve project slug to UUID via v3 endpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,6 +104,9 @@ internal/
 │
 ├── apiclient/            CircleCI REST API client. Injected via constructor; tests pass
 │                         a custom http.RoundTripper to intercept requests.
+│                         v3 endpoints type id fields (format: uuid in the spec) as
+│                         uuid.UUID, not string — e.g. RunV3.ID, ProjectRef.ID/OrgID.
+│                         Stringify with .String() at call sites that need a string.
 │
 ├── gitremote/            Detect project slug + branch from git remote URL.
 │

--- a/acceptance/api_test.go
+++ b/acceptance/api_test.go
@@ -39,8 +39,8 @@ import (
 
 // IDs used by the {project-id}/{org-id} substitution tests.
 const (
-	apiProjectID = "proj-uuid-api-001"
-	apiOrgID     = "org-uuid-api-001"
+	apiProjectID = "a0000000-0000-4000-8000-0000000a0001"
+	apiOrgID     = "a0000000-0000-4000-8000-0000000a0002"
 )
 
 // writeInfoYML writes .circleci/info.yml into dir so that gitremote.Detect
@@ -318,11 +318,7 @@ func TestAPI_PathDefaultsToV3(t *testing.T) {
 func TestAPI_ProjectIDSubstitution(t *testing.T) {
 	fake := fakes.NewCircleCI(t)
 	// Slug → UUID resolution (the CLI's internal lookup).
-	fake.AddProjectInfo(testSlug, map[string]any{
-		"id":              apiProjectID,
-		"slug":            testSlug,
-		"organization_id": apiOrgID,
-	})
+	fake.AddProjectBySlug(testSlug, apiProjectID, "testrepo", apiOrgID)
 	// The V3 project the substituted path actually targets.
 	fake.AddProjectV3(apiProjectID, map[string]any{
 		"id":         apiProjectID,

--- a/acceptance/deploy_test.go
+++ b/acceptance/deploy_test.go
@@ -40,18 +40,11 @@ func setupDeployFake(t *testing.T) (*fakes.CircleCI, *testenv.TestEnv) {
 	fake := fakes.NewCircleCI(t)
 
 	// Register a project so --project can resolve to IDs.
-	fake.AddProjectInfo("gh/myorg/alpha", map[string]any{
-		"id":                "proj-uuid-1234",
-		"slug":              "gh/myorg/alpha",
-		"name":              "alpha",
-		"organization_name": "myorg",
-		"organization_slug": "gh/myorg",
-		"organization_id":   "org-uuid-5678",
-	})
+	fake.AddProjectBySlug("gh/myorg/alpha", "a0000000-0000-4000-8000-0000000f0001", "alpha", "a0000000-0000-4000-8000-0000000f0002")
 
-	fake.AddDeploy("proj-uuid-1234", map[string]any{
+	fake.AddDeploy("a0000000-0000-4000-8000-0000000f0001", map[string]any{
 		"id":               "rel-uuid-0001",
-		"project_id":       "proj-uuid-1234",
+		"project_id":       "a0000000-0000-4000-8000-0000000f0001",
 		"component_id":     "comp-uuid-1111",
 		"component_name":   "web-frontend",
 		"type":             "DEPLOYMENT",
@@ -63,9 +56,9 @@ func setupDeployFake(t *testing.T) (*fakes.CircleCI, *testenv.TestEnv) {
 		"created_at":       "2026-04-28T14:30:00Z",
 		"ended_at":         "2026-04-28T14:35:00Z",
 	})
-	fake.AddDeploy("proj-uuid-1234", map[string]any{
+	fake.AddDeploy("a0000000-0000-4000-8000-0000000f0001", map[string]any{
 		"id":               "rel-uuid-0002",
-		"project_id":       "proj-uuid-1234",
+		"project_id":       "a0000000-0000-4000-8000-0000000f0001",
 		"component_id":     "comp-uuid-2222",
 		"component_name":   "api-server",
 		"type":             "DEPLOYMENT",
@@ -78,9 +71,9 @@ func setupDeployFake(t *testing.T) (*fakes.CircleCI, *testenv.TestEnv) {
 		"created_at":       "2026-04-27T09:15:00Z",
 		"ended_at":         "2026-04-27T09:25:00Z",
 	})
-	fake.AddDeploy("proj-uuid-1234", map[string]any{
+	fake.AddDeploy("a0000000-0000-4000-8000-0000000f0001", map[string]any{
 		"id":               "rel-uuid-0003",
-		"project_id":       "proj-uuid-1234",
+		"project_id":       "a0000000-0000-4000-8000-0000000f0001",
 		"component_id":     "comp-uuid-1111",
 		"component_name":   "web-frontend",
 		"type":             "ROLLBACK",
@@ -137,14 +130,7 @@ func TestDeployList_JSON(t *testing.T) {
 
 func TestDeployList_Empty(t *testing.T) {
 	fake := fakes.NewCircleCI(t)
-	fake.AddProjectInfo("gh/myorg/empty", map[string]any{
-		"id":                "proj-uuid-empty",
-		"slug":              "gh/myorg/empty",
-		"name":              "empty",
-		"organization_name": "myorg",
-		"organization_slug": "gh/myorg",
-		"organization_id":   "org-uuid-5678",
-	})
+	fake.AddProjectBySlug("gh/myorg/empty", "a0000000-0000-4000-8000-0000000f0003", "empty", "a0000000-0000-4000-8000-0000000f0002")
 	env := testenv.New(t)
 	env.Token = "testtoken"
 	env.CircleCIURL = fake.URL()

--- a/acceptance/dlc_test.go
+++ b/acceptance/dlc_test.go
@@ -43,14 +43,7 @@ import (
 func setupDLCFake(t *testing.T) (*fakes.CircleCI, *testenv.TestEnv) {
 	t.Helper()
 	fake := fakes.NewCircleCI(t)
-	fake.AddProjectInfo("gh/myorg/myrepo", map[string]any{
-		"id":                "proj-dlc-uuid",
-		"slug":              "gh/myorg/myrepo",
-		"name":              "myrepo",
-		"organization_name": "myorg",
-		"organization_slug": "gh/myorg",
-		"organization_id":   "org-uuid-1234",
-	})
+	fake.AddProjectBySlug("gh/myorg/myrepo", "a0000000-0000-4000-8000-0000000e0001", "myrepo", "a0000000-0000-4000-8000-0000000e0002")
 	// Default DLC purge status is 204 (success); no override needed.
 	env := testenv.New(t)
 	env.Token = testToken
@@ -76,7 +69,7 @@ func TestDLCPurge(t *testing.T) {
 	t.Run("check request", func(t *testing.T) {
 		assert.Check(t, cmp.DeepEqual(fake.LastRequest(), &httprecorder.Request{
 			Method: http.MethodDelete,
-			URL:    url.URL{Path: "/api/v3/projects/proj-dlc-uuid/dlc"},
+			URL:    url.URL{Path: "/api/v3/projects/a0000000-0000-4000-8000-0000000e0001/dlc"},
 			Header: http.Header{
 				"Authorization": {"Bearer test-token"},
 				"User-Agent":    {apiclient.UserAgent(runtime.GOOS, runtime.GOARCH, "dev", "")},
@@ -101,7 +94,7 @@ func TestDLCPurge_JSON(t *testing.T) {
 	var out map[string]any
 	err := json.Unmarshal([]byte(result.Stdout), &out)
 	assert.NilError(t, err)
-	assert.Equal(t, out["project_id"], "proj-dlc-uuid")
+	assert.Equal(t, out["project_id"], "a0000000-0000-4000-8000-0000000e0001")
 	assert.Equal(t, out["project_slug"], "gh/myorg/myrepo")
 }
 
@@ -136,7 +129,7 @@ func TestDLCPurge_ProjectSlug(t *testing.T) {
 
 func TestDLCPurge_Gone(t *testing.T) {
 	fake, env := setupDLCFake(t)
-	fake.SetDLCPurgeStatus("proj-dlc-uuid", http.StatusGone)
+	fake.SetDLCPurgeStatus("a0000000-0000-4000-8000-0000000e0001", http.StatusGone)
 
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,

--- a/acceptance/pipeline_test.go
+++ b/acceptance/pipeline_test.go
@@ -44,7 +44,7 @@ import (
 // keyDown is defined in login_test.go (same package).
 
 const (
-	pipelineProjectID = "proj-uuid-pipeline"
+	pipelineProjectID = "a0000000-0000-4000-8000-0000000b0001"
 	pipelineDefID     = "pdef-uuid-0001"
 	pipelineRepoID    = "987654321"
 )
@@ -76,11 +76,7 @@ func fakePipelineDefPayload(id, name, configProvider, configRepoID, configFile, 
 func setupPipelineFake(t *testing.T) (*fakes.CircleCI, *testenv.TestEnv) {
 	t.Helper()
 	fake := fakes.NewCircleCI(t)
-	fake.AddProjectInfo("gh/myorg/myrepo", map[string]any{
-		"id":   pipelineProjectID,
-		"slug": "gh/myorg/myrepo",
-		"name": "myrepo",
-	})
+	fake.AddProjectBySlug("gh/myorg/myrepo", pipelineProjectID, "myrepo", "a0000000-0000-4000-8000-0000000b0003")
 	fake.SetCreatePipelineDefinitionResponse(pipelineProjectID,
 		fakePipelineDefPayload(pipelineDefID, "my-pipeline", "github_app", pipelineRepoID, ".circleci/config.yml", "github_app", pipelineRepoID),
 	)
@@ -412,11 +408,7 @@ func TestPipelineList_BySlug(t *testing.T) {
 
 func TestPipelineList_Empty(t *testing.T) {
 	fake := fakes.NewCircleCI(t)
-	fake.AddProjectInfo("gh/myorg/empty", map[string]any{
-		"id":   "proj-empty",
-		"slug": "gh/myorg/empty",
-		"name": "empty",
-	})
+	fake.AddProjectBySlug("gh/myorg/empty", "a0000000-0000-4000-8000-0000000b0002", "empty", "a0000000-0000-4000-8000-0000000b0004")
 	env := testenv.New(t)
 	env.Token = testToken
 	env.CircleCIURL = fake.URL()

--- a/acceptance/project_test.go
+++ b/acceptance/project_test.go
@@ -47,7 +47,7 @@ func setupProjectFake(t *testing.T) (*fakes.CircleCI, *testenv.TestEnv) {
 	fake := fakes.NewCircleCI(t)
 
 	fake.SetCollaborations([]any{
-		map[string]any{"id": "org-uuid-5678", "name": "myorg", "slug": "gh/myorg", "vcs_type": "github"},
+		map[string]any{"id": "a0000000-0000-4000-8000-0000000c0002", "name": "myorg", "slug": "gh/myorg", "vcs_type": "github"},
 	})
 
 	fake.AddFollowedProject(map[string]any{
@@ -65,18 +65,20 @@ func setupProjectFake(t *testing.T) (*fakes.CircleCI, *testenv.TestEnv) {
 		"name":     "beta",
 	})
 	fake.AddProjectInfo("gh/myorg/alpha", map[string]any{
-		"id":                "proj-uuid-1234",
+		"id":                "a0000000-0000-4000-8000-0000000c0001",
 		"slug":              "gh/myorg/alpha",
 		"name":              "alpha",
 		"organization_name": "myorg",
 		"organization_slug": "gh/myorg",
-		"organization_id":   "org-uuid-5678",
+		"organization_id":   "a0000000-0000-4000-8000-0000000c0002",
 		"vcs_info": map[string]any{
 			"provider":       "GitHub",
 			"default_branch": "main",
 			"vcs_url":        "https://github.com/myorg/alpha",
 		},
 	})
+	// v3 slug → UUID resolution, used by `project trigger`.
+	fake.AddProjectBySlug("gh/myorg/alpha", "a0000000-0000-4000-8000-0000000c0001", "alpha", "a0000000-0000-4000-8000-0000000c0002")
 
 	fake.AddEnvVar("gh/myorg/alpha", "DATABASE_URL", "xxxx", nil)
 	fake.AddEnvVar("gh/myorg/alpha", "SECRET_KEY", "xxxx",
@@ -573,8 +575,8 @@ func TestProjectGet_JSON(t *testing.T) {
 	var out map[string]any
 	err := json.Unmarshal([]byte(result.Stdout), &out)
 	assert.NilError(t, err)
-	assert.Check(t, cmp.Equal(out["id"], "proj-uuid-1234"))
-	assert.Check(t, cmp.Equal(out["organization_id"], "org-uuid-5678"))
+	assert.Check(t, cmp.Equal(out["id"], "a0000000-0000-4000-8000-0000000c0001"))
+	assert.Check(t, cmp.Equal(out["organization_id"], "a0000000-0000-4000-8000-0000000c0002"))
 
 	assert.Check(t, golden.String(result.Stdout, t.Name()+".json"))
 }
@@ -596,7 +598,7 @@ func TestProjectGet_NotFound(t *testing.T) {
 // --- project trigger create ---
 
 const (
-	triggerProjectID     = "proj-uuid-1234"
+	triggerProjectID     = "a0000000-0000-4000-8000-0000000c0001"
 	triggerPipelineDefID = "pdef-uuid-5678"
 	triggerRepoID        = "987654321"
 	triggerID            = "trig-uuid-abcd"
@@ -887,7 +889,7 @@ func setupCreateProjectFake(t *testing.T) (*fakes.CircleCI, *testenv.TestEnv) {
 		"name":              "my-new-repo",
 		"organization_name": "myorg",
 		"organization_slug": "gh/myorg",
-		"organization_id":   "org-uuid-5678",
+		"organization_id":   "a0000000-0000-4000-8000-0000000c0002",
 		"vcs_info": map[string]any{
 			"provider":       "GitHub",
 			"default_branch": "main",
@@ -895,7 +897,7 @@ func setupCreateProjectFake(t *testing.T) (*fakes.CircleCI, *testenv.TestEnv) {
 		},
 	})
 	fake.SetCollaborations([]any{
-		map[string]any{"id": "org-uuid-5678", "name": "myorg", "slug": "gh/myorg", "vcs_type": "github"},
+		map[string]any{"id": "a0000000-0000-4000-8000-0000000c0002", "name": "myorg", "slug": "gh/myorg", "vcs_type": "github"},
 		map[string]any{"id": "org-uuid-9999", "name": "other-org", "slug": "gh/other-org", "vcs_type": "github"},
 	})
 	return fake, env

--- a/acceptance/run_test.go
+++ b/acceptance/run_test.go
@@ -176,14 +176,8 @@ func fakeJobV3(id, name, workflowID, projectID string) map[string]any {
 	}
 }
 
-func addProjectInfo(fake *fakes.CircleCI, slug, projectID string) {
-	fake.AddProjectInfo(slug, map[string]any{
-		"id":                projectID,
-		"slug":              slug,
-		"name":              "testrepo",
-		"organization_name": "testorg",
-		"organization_slug": "gh/testorg",
-	})
+func addProjectBySlug(fake *fakes.CircleCI, slug, projectID string) {
+	fake.AddProjectBySlug(slug, projectID, "testrepo", "a0000000-0000-4000-8000-0000000d0001")
 }
 
 // --- run get (V3) ---
@@ -441,7 +435,7 @@ func TestRunGet_NoToken(t *testing.T) {
 func TestRunList(t *testing.T) {
 	fake := fakes.NewCircleCI(t)
 	slug := watchSlug
-	addProjectInfo(fake, slug, runTestProjectID)
+	addProjectBySlug(fake, slug, runTestProjectID)
 	fake.AddRunV3("e0000000-0000-4000-8000-000000000001", runTestProjectID, fakeRunV3("e0000000-0000-4000-8000-000000000001", runTestProjectID, "ended", "succeeded", "main", "abc1234def5678"))
 	fake.AddRunV3("e0000000-0000-4000-8000-000000000002", runTestProjectID, fakeRunV3("e0000000-0000-4000-8000-000000000002", runTestProjectID, "ended", "failed", "feature", "deadbeef12345678"))
 	fake.AddRunV3("e0000000-0000-4000-8000-000000000003", runTestProjectID, fakeRunV3("e0000000-0000-4000-8000-000000000003", runTestProjectID, "ended", "succeeded", "main", "1111111122222222"))
@@ -464,7 +458,7 @@ func TestRunList(t *testing.T) {
 func TestRunList_Tag(t *testing.T) {
 	fake := fakes.NewCircleCI(t)
 	slug := watchSlug
-	addProjectInfo(fake, slug, runTestProjectID)
+	addProjectBySlug(fake, slug, runTestProjectID)
 	fake.AddRunV3("e0000000-0000-4000-8000-000000000001", runTestProjectID, fakeRunV3("e0000000-0000-4000-8000-000000000001", runTestProjectID, "ended", "succeeded", "main", "abc1234def5678"))
 	fake.AddRunV3("e0000000-0000-4000-8000-000000000002", runTestProjectID, fakeRunV3Tag("e0000000-0000-4000-8000-000000000002", runTestProjectID, "ended", "succeeded", "v1.2.3", "deadbeef12345678"))
 
@@ -487,7 +481,7 @@ func TestRunList_Tag(t *testing.T) {
 func TestRunList_Tag_JSON(t *testing.T) {
 	fake := fakes.NewCircleCI(t)
 	slug := watchSlug
-	addProjectInfo(fake, slug, runTestProjectID)
+	addProjectBySlug(fake, slug, runTestProjectID)
 	fake.AddRunV3("e0000000-0000-4000-8000-000000000002", runTestProjectID, fakeRunV3Tag("e0000000-0000-4000-8000-000000000002", runTestProjectID, "ended", "succeeded", "v1.2.3", "deadbeef12345678"))
 
 	env := testenv.New(t)
@@ -515,7 +509,7 @@ func TestRunList_Tag_JSON(t *testing.T) {
 func TestRunList_Color(t *testing.T) {
 	fake := fakes.NewCircleCI(t)
 	slug := watchSlug
-	addProjectInfo(fake, slug, runTestProjectID)
+	addProjectBySlug(fake, slug, runTestProjectID)
 	fake.AddRunV3("e0000000-0000-4000-8000-000000000001", runTestProjectID, fakeRunV3("e0000000-0000-4000-8000-000000000001", runTestProjectID, "ended", "succeeded", "main", "abc1234def5678"))
 	fake.AddRunV3("e0000000-0000-4000-8000-000000000002", runTestProjectID, fakeRunV3("e0000000-0000-4000-8000-000000000002", runTestProjectID, "ended", "failed", "feature", "deadbeef12345678"))
 	fake.AddRunV3("e0000000-0000-4000-8000-000000000003", runTestProjectID, fakeRunV3("e0000000-0000-4000-8000-000000000003", runTestProjectID, "ended", "succeeded", "main", "1111111122222222"))
@@ -539,7 +533,7 @@ func TestRunList_Color(t *testing.T) {
 func TestRunList_Limit(t *testing.T) {
 	fake := fakes.NewCircleCI(t)
 	slug := watchSlug
-	addProjectInfo(fake, slug, runTestProjectID)
+	addProjectBySlug(fake, slug, runTestProjectID)
 	fake.AddRunV3("e0000000-0000-4000-8000-000000000001", runTestProjectID, fakeRunV3("e0000000-0000-4000-8000-000000000001", runTestProjectID, "ended", "succeeded", "main", "abc1234def5678"))
 	fake.AddRunV3("e0000000-0000-4000-8000-000000000002", runTestProjectID, fakeRunV3("e0000000-0000-4000-8000-000000000002", runTestProjectID, "ended", "succeeded", "main", "deadbeef12345678"))
 	fake.AddRunV3("e0000000-0000-4000-8000-000000000003", runTestProjectID, fakeRunV3("e0000000-0000-4000-8000-000000000003", runTestProjectID, "ended", "succeeded", "main", "1111111122222222"))
@@ -562,7 +556,7 @@ func TestRunList_Limit(t *testing.T) {
 func TestRunList_Limit_Color(t *testing.T) {
 	fake := fakes.NewCircleCI(t)
 	slug := watchSlug
-	addProjectInfo(fake, slug, runTestProjectID)
+	addProjectBySlug(fake, slug, runTestProjectID)
 	fake.AddRunV3("e0000000-0000-4000-8000-000000000001", runTestProjectID, fakeRunV3("e0000000-0000-4000-8000-000000000001", runTestProjectID, "ended", "succeeded", "main", "abc1234def5678"))
 	fake.AddRunV3("e0000000-0000-4000-8000-000000000002", runTestProjectID, fakeRunV3("e0000000-0000-4000-8000-000000000002", runTestProjectID, "ended", "succeeded", "main", "deadbeef12345678"))
 	fake.AddRunV3("e0000000-0000-4000-8000-000000000003", runTestProjectID, fakeRunV3("e0000000-0000-4000-8000-000000000003", runTestProjectID, "ended", "succeeded", "main", "1111111122222222"))
@@ -586,7 +580,7 @@ func TestRunList_Limit_Color(t *testing.T) {
 func TestRunList_JSON(t *testing.T) {
 	fake := fakes.NewCircleCI(t)
 	slug := watchSlug
-	addProjectInfo(fake, slug, runTestProjectID)
+	addProjectBySlug(fake, slug, runTestProjectID)
 	fake.AddRunV3("e0000000-0000-4000-8000-000000000001", runTestProjectID, fakeRunV3("e0000000-0000-4000-8000-000000000001", runTestProjectID, "ended", "succeeded", "main", "abc1234def5678"))
 	fake.AddRunV3("e0000000-0000-4000-8000-000000000002", runTestProjectID, fakeRunV3("e0000000-0000-4000-8000-000000000002", runTestProjectID, "ended", "failed", "feature", "deadbeef12345678"))
 
@@ -618,7 +612,7 @@ func TestRunList_JSON(t *testing.T) {
 func TestRunList_JSON_Color(t *testing.T) {
 	fake := fakes.NewCircleCI(t)
 	slug := watchSlug
-	addProjectInfo(fake, slug, runTestProjectID)
+	addProjectBySlug(fake, slug, runTestProjectID)
 	fake.AddRunV3("e0000000-0000-4000-8000-000000000001", runTestProjectID, fakeRunV3("e0000000-0000-4000-8000-000000000001", runTestProjectID, "ended", "succeeded", "main", "abc1234def5678"))
 	fake.AddRunV3("e0000000-0000-4000-8000-000000000002", runTestProjectID, fakeRunV3("e0000000-0000-4000-8000-000000000002", runTestProjectID, "ended", "failed", "feature", "deadbeef12345678"))
 

--- a/acceptance/testdata/TestAPI_ProjectIDSubstitution.txt
+++ b/acceptance/testdata/TestAPI_ProjectIDSubstitution.txt
@@ -1,1 +1,1 @@
-{"data":{"attributes":{"name":"testrepo","slug":"gh/testorg/testrepo"},"id":"proj-uuid-api-001"}}
+{"data":{"attributes":{"name":"testrepo","slug":"gh/testorg/testrepo"},"id":"a0000000-0000-4000-8000-0000000a0001"}}

--- a/acceptance/testdata/TestAPI_ProjectIDSubstitution_LookupFails.stderr.txt
+++ b/acceptance/testdata/TestAPI_ProjectIDSubstitution_LookupFails.stderr.txt
@@ -1,1 +1,1 @@
-error: Failed to look up project "gh/testorg/testrepo": GET /api/v2/project/gh%2Ftestorg%2Ftestrepo: 404 Not Found
+error: Failed to look up project "gh/testorg/testrepo": project not found: "gh/testorg/testrepo"

--- a/acceptance/testdata/TestProjectCreate_JSON.json
+++ b/acceptance/testdata/TestProjectCreate_JSON.json
@@ -4,7 +4,7 @@
   "name": "my-new-repo",
   "organization_name": "myorg",
   "organization_slug": "gh/myorg",
-  "organization_id": "org-uuid-5678",
+  "organization_id": "a0000000-0000-4000-8000-0000000c0002",
   "vcs_provider": "GitHub",
   "vcs_default_branch": "main",
   "vcs_url": "https://github.com/myorg/my-new-repo"

--- a/acceptance/testdata/TestProjectGet.txt
+++ b/acceptance/testdata/TestProjectGet.txt
@@ -1,9 +1,9 @@
 # Project
 - Name: alpha
 - Slug: gh/myorg/alpha
-- Project ID: `proj-uuid-1234`
+- Project ID: `a0000000-0000-4000-8000-0000000c0001`
 - Organization: myorg
-- Organization ID: `org-uuid-5678`
+- Organization ID: `a0000000-0000-4000-8000-0000000c0002`
 
 ## VCS
 - Provider: GitHub

--- a/acceptance/testdata/TestProjectGet_JSON.json
+++ b/acceptance/testdata/TestProjectGet_JSON.json
@@ -1,10 +1,10 @@
 {
-  "id": "proj-uuid-1234",
+  "id": "a0000000-0000-4000-8000-0000000c0001",
   "slug": "gh/myorg/alpha",
   "name": "alpha",
   "organization_name": "myorg",
   "organization_slug": "gh/myorg",
-  "organization_id": "org-uuid-5678",
+  "organization_id": "a0000000-0000-4000-8000-0000000c0002",
   "vcs_provider": "GitHub",
   "vcs_default_branch": "main",
   "vcs_url": "https://github.com/myorg/alpha"

--- a/acceptance/watch_test.go
+++ b/acceptance/watch_test.go
@@ -61,7 +61,7 @@ func setupWatchFake(t *testing.T, runID, wfID, wfStatus string) (*fakes.CircleCI
 	v3Run := fakeRunV3(runID, watchProjectID, "ended", v3Outcome, "main", "abc1234def5678abcdef")
 
 	fake := fakes.NewCircleCI(t)
-	addProjectInfo(fake, watchSlug, watchProjectID)
+	addProjectBySlug(fake, watchSlug, watchProjectID)
 	fake.AddRunV3(runID, watchProjectID, v3Run)
 	fake.AddRun(runID, v2Run)
 	fake.AddProjectRuns(watchSlug, v2Run)
@@ -123,7 +123,7 @@ func TestRunWatch_Latest(t *testing.T) {
 	wfID := "b0000000-0000-4000-8000-0000000f0002"
 
 	fake := fakes.NewCircleCI(t)
-	addProjectInfo(fake, watchSlug, watchProjectID)
+	addProjectBySlug(fake, watchSlug, watchProjectID)
 	fake.AddRunV3(runID, watchProjectID, fakeRunV3(runID, watchProjectID, "ended", "succeeded", "main", "abc1234def5678"))
 	fake.AddRunWorkflowsV3(runID, fakeWorkflowV3(wfID, "build", runID, watchProjectID, "ended", "succeeded"))
 	fake.AddWorkflowJobsV3(wfID, fakeJobV3("d0000000-0000-4000-8000-00000000f001", "test", wfID, watchProjectID))
@@ -171,7 +171,7 @@ func TestRunWatch_Failed_SuggestsJobLogs(t *testing.T) {
 	failedJob["attributes"].(map[string]any)["outcome"] = "failed"
 
 	fake := fakes.NewCircleCI(t)
-	addProjectInfo(fake, watchSlug, watchProjectID)
+	addProjectBySlug(fake, watchSlug, watchProjectID)
 	fake.AddRunV3(runID, watchProjectID, fakeRunV3(runID, watchProjectID, "ended", "failed", "main", "abc1234def5678"))
 	fake.AddRun(runID, fakeRun(runID, 75, "created", watchSlug, "main"))
 	fake.AddProjectRuns(watchSlug, fakeRun(runID, 75, "created", watchSlug, "main"))
@@ -235,7 +235,7 @@ func TestRunWatch_SHA(t *testing.T) {
 
 func TestRunWatch_SHA_NotFound(t *testing.T) {
 	fake := fakes.NewCircleCI(t)
-	addProjectInfo(fake, watchSlug, watchProjectID)
+	addProjectBySlug(fake, watchSlug, watchProjectID)
 
 	env := testenv.New(t)
 	env.Token = testToken
@@ -265,7 +265,7 @@ func TestRunWatch_FailFast(t *testing.T) {
 	failedJob["attributes"].(map[string]any)["outcome"] = "failed"
 
 	fake := fakes.NewCircleCI(t)
-	addProjectInfo(fake, watchSlug, watchProjectID)
+	addProjectBySlug(fake, watchSlug, watchProjectID)
 	fake.AddRunV3(runID, watchProjectID, fakeRunV3(runID, watchProjectID, "started", "", "main", "abc1234def5678"))
 	fake.AddRun(runID, fakeRun(runID, 79, "created", watchSlug, "main"))
 	fake.AddProjectRuns(watchSlug, fakeRun(runID, 79, "created", watchSlug, "main"))
@@ -298,7 +298,7 @@ func TestRunWatch_Timeout(t *testing.T) {
 	wfID := "b0000000-0000-4000-8000-0000000f0006"
 
 	fake := fakes.NewCircleCI(t)
-	addProjectInfo(fake, watchSlug, watchProjectID)
+	addProjectBySlug(fake, watchSlug, watchProjectID)
 	fake.AddRunV3(runID, watchProjectID, fakeRunV3(runID, watchProjectID, "started", "", "main", "abc1234def5678"))
 	fake.AddRun(runID, fakeRun(runID, 77, "created", watchSlug, "main"))
 	fake.AddProjectRuns(watchSlug, fakeRun(runID, 77, "created", watchSlug, "main"))
@@ -328,7 +328,7 @@ func TestRunWatch_InterruptDuringPolling(t *testing.T) {
 	wfID := "b0000000-0000-4000-8000-0000000ff033"
 
 	fake := fakes.NewCircleCI(t)
-	addProjectInfo(fake, watchSlug, watchProjectID)
+	addProjectBySlug(fake, watchSlug, watchProjectID)
 	fake.AddRunV3(runID, watchProjectID, fakeRunV3(runID, watchProjectID, "started", "", "main", "abc1234def5678"))
 	fake.AddRun(runID, fakeRun(runID, 78, "created", watchSlug, "main"))
 	fake.AddProjectRuns(watchSlug, fakeRun(runID, 78, "created", watchSlug, "main"))

--- a/acceptance/workflow_test.go
+++ b/acceptance/workflow_test.go
@@ -375,7 +375,7 @@ const wfListProjectID = "a0000000-0000-4000-8000-00000000f100"
 
 func setupRecentRuns(t *testing.T, fake *fakes.CircleCI) {
 	t.Helper()
-	addProjectInfo(fake, testSlug, wfListProjectID)
+	addProjectBySlug(fake, testSlug, wfListProjectID)
 	fake.AddRunV3(testRunRecent1, wfListProjectID,
 		fakeRunV3(testRunRecent1, wfListProjectID, "ended", "failed", "main", "abc1234567890"))
 	fake.AddRunV3(testRunRecent2, wfListProjectID,
@@ -430,7 +430,7 @@ func TestWorkflowList_NoArg_Color(t *testing.T) {
 
 func TestWorkflowList_NoArg_JSON(t *testing.T) {
 	fake := fakes.NewCircleCI(t)
-	addProjectInfo(fake, testSlug, wfListProjectID)
+	addProjectBySlug(fake, testSlug, wfListProjectID)
 	fake.AddRunV3(testRunRecent1, wfListProjectID,
 		fakeRunV3(testRunRecent1, wfListProjectID, "ended", "succeeded", "main", "abc1234567890"))
 	fake.AddRunWorkflowsV3(testRunRecent1,
@@ -464,7 +464,7 @@ func TestWorkflowList_NoArg_JSON(t *testing.T) {
 
 func TestWorkflowList_NoArg_JSON_Color(t *testing.T) {
 	fake := fakes.NewCircleCI(t)
-	addProjectInfo(fake, testSlug, wfListProjectID)
+	addProjectBySlug(fake, testSlug, wfListProjectID)
 	fake.AddRunV3(testRunRecent1, wfListProjectID,
 		fakeRunV3(testRunRecent1, wfListProjectID, "ended", "succeeded", "main", "abc1234567890"))
 	fake.AddRunWorkflowsV3(testRunRecent1,
@@ -489,7 +489,7 @@ func TestWorkflowList_NoArg_JSON_Color(t *testing.T) {
 
 func TestWorkflowList_NoArg_NoRuns(t *testing.T) {
 	fake := fakes.NewCircleCI(t)
-	addProjectInfo(fake, testSlug, wfListProjectID)
+	addProjectBySlug(fake, testSlug, wfListProjectID)
 
 	env := testenv.New(t)
 	env.Token = testToken

--- a/internal/apiclient/project.go
+++ b/internal/apiclient/project.go
@@ -24,8 +24,23 @@ package apiclient
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"time"
+
+	"github.com/google/uuid"
 )
+
+// ErrProjectNotFound is returned by GetProjectBySlug when no project matches the slug.
+var ErrProjectNotFound = errors.New("project not found")
+
+// ProjectRef is a project resolved from its slug, carrying the UUIDs that the
+// v3 API needs. Returned by GetProjectBySlug.
+type ProjectRef struct {
+	ID    uuid.UUID
+	Name  string
+	OrgID uuid.UUID
+}
 
 // Project is a followed CircleCI project.
 type Project struct {
@@ -116,6 +131,44 @@ type VCSInfo struct {
 	Provider      string `json:"provider"`
 	DefaultBranch string `json:"default_branch"`
 	VCSURL        string `json:"vcs_url"`
+}
+
+// projectEntity is the v3 response envelope for GET /api/v3/projects.
+type projectEntity struct {
+	ID         uuid.UUID `json:"id"`
+	Attributes struct {
+		Name string `json:"name"`
+	} `json:"attributes"`
+	References struct {
+		Org struct {
+			ID uuid.UUID `json:"id"`
+		} `json:"org"`
+	} `json:"references"`
+}
+
+// GetProjectBySlug resolves a project slug (vcs/org/repo) to its UUID, name, and
+// owning org UUID via GET /api/v3/projects?filter[slug]=. Use this for the
+// slug-to-UUID lookup; GetProjectInfo (v2) returns the fuller settings payload.
+//
+// The endpoint is a collection: a slug matching no project returns an empty list
+// (not a 404), which is surfaced as ErrProjectNotFound.
+func (c *Client) GetProjectBySlug(ctx context.Context, slug string) (*ProjectRef, error) {
+	var env v3List[projectEntity]
+	err := c.getV3(ctx, "/projects", &env,
+		filterParam("slug", slug),
+	)
+	if err != nil {
+		return nil, err
+	}
+	if len(env.Data) == 0 {
+		return nil, fmt.Errorf("%w: %q", ErrProjectNotFound, slug)
+	}
+	p := env.Data[0]
+	return &ProjectRef{
+		ID:    p.ID,
+		Name:  p.Attributes.Name,
+		OrgID: p.References.Org.ID,
+	}, nil
 }
 
 // GetProjectInfo returns detailed information about a project by slug.

--- a/internal/cmd/api/api.go
+++ b/internal/cmd/api/api.go
@@ -183,15 +183,15 @@ func run(ctx context.Context, client *apiclient.Client, thepath, method string, 
 		if err != nil {
 			return cmdutil.GitDetectErr(err, "Or pass the IDs explicitly in the path instead of {project-id}/{org-id}.")
 		}
-		proj, err := client.GetProjectInfo(ctx, info.Slug)
+		proj, err := client.GetProjectBySlug(ctx, info.Slug)
 		if err != nil {
 			return clierrors.New("api.project_lookup_failed", "Could not resolve project",
 				fmt.Sprintf("Failed to look up project %q: %v", info.Slug, err)).
 				WithExitCode(clierrors.ExitAPIError)
 		}
 		r := strings.NewReplacer(
-			"{project-id}", proj.ID,
-			"{org-id}", proj.OrganizationID,
+			"{project-id}", proj.ID.String(),
+			"{org-id}", proj.OrgID.String(),
 		)
 		thepath = r.Replace(thepath)
 	}

--- a/internal/cmd/deploy/list.go
+++ b/internal/cmd/deploy/list.go
@@ -106,7 +106,7 @@ func runList(ctx context.Context, client *apiclient.Client, projectSlug string, 
 		projectSlug = info.Slug
 	}
 
-	proj, err := client.GetProjectInfo(ctx, projectSlug)
+	proj, err := client.GetProjectBySlug(ctx, projectSlug)
 	if err != nil {
 		return cmdutil.APIErr(err, projectSlug,
 			"project.not_found", "No project found for %q.",
@@ -115,7 +115,7 @@ func runList(ctx context.Context, client *apiclient.Client, projectSlug string, 
 			"Use 'circleci project list' to see followed projects")
 	}
 
-	deploys, err := client.ListDeploys(ctx, proj.ID, proj.OrganizationID, 10)
+	deploys, err := client.ListDeploys(ctx, proj.ID.String(), proj.OrgID.String(), 10)
 	if err != nil {
 		return apiErr(err, projectSlug)
 	}

--- a/internal/cmd/dlc/purge.go
+++ b/internal/cmd/dlc/purge.go
@@ -98,14 +98,14 @@ func NewPurgeCmd() *cobra.Command {
 				return err
 			}
 
-			proj, err := client.GetProjectInfo(ctx, projectSlug)
+			proj, err := client.GetProjectBySlug(ctx, projectSlug)
 			if err != nil {
 				return cmdutil.APIErr(err, projectSlug, "project.not_found", "No project found for %q.",
 					"Check the project slug and try again",
 					"Use 'circleci project list' to see followed projects")
 			}
 
-			if err := client.PurgeDLC(ctx, proj.ID); err != nil {
+			if err := client.PurgeDLC(ctx, proj.ID.String()); err != nil {
 				if errors.Is(err, apiclient.ErrDLCGone) {
 					return clierrors.New("dlc.gone", "DLC purge unavailable",
 						"This DLC feature is no longer supported by this version of the CLI. Please upgrade.").
@@ -121,7 +121,7 @@ func NewPurgeCmd() *cobra.Command {
 			}
 
 			out := purgeOutput{
-				ProjectID:   proj.ID,
+				ProjectID:   proj.ID.String(),
 				ProjectSlug: projectSlug,
 			}
 

--- a/internal/cmd/project/trigger.go
+++ b/internal/cmd/project/trigger.go
@@ -104,14 +104,14 @@ func resolveProjectID(ctx context.Context, client *apiclient.Client, projectSlug
 		}
 		projectSlug = info.Slug
 	}
-	proj, err := client.GetProjectInfo(ctx, projectSlug)
+	proj, err := client.GetProjectBySlug(ctx, projectSlug)
 	if err != nil {
 		return "", cmdutil.APIErr(err, projectSlug, "project.not_found", "No project found for %q.",
 			"Run 'circleci project link' to bind this repository to a CircleCI project",
 			"Check the project slug and try again",
 			"Use 'circleci project list' to see followed projects")
 	}
-	return proj.ID, nil
+	return proj.ID.String(), nil
 }
 
 // selectPipelineDefinition fetches the list of pipeline definitions for the project

--- a/internal/cmd/run/get.go
+++ b/internal/cmd/run/get.go
@@ -172,7 +172,7 @@ func runGet(ctx context.Context, client *apiclient.Client, args []string, projec
 			effectiveBranch = info.Branch
 		}
 
-		proj, err := client.GetProjectInfo(ctx, projectSlug)
+		proj, err := client.GetProjectBySlug(ctx, projectSlug)
 		if err != nil {
 			return apiErr(err, projectSlug)
 		}
@@ -180,7 +180,7 @@ func runGet(ctx context.Context, client *apiclient.Client, args []string, projec
 		sp := iostream.Spinner(ctx, !jsonOut, fmt.Sprintf("Fetching latest run for %s on branch %s", projectSlug, effectiveBranch))
 		now := time.Now().UTC()
 		runs, searchErr := client.SearchRunsV3(ctx, apiclient.RunSearchParams{
-			ProjectIDs: []string{proj.ID},
+			ProjectIDs: []string{proj.ID.String()},
 			From:       now.AddDate(0, 0, -90),
 			To:         now,
 			Filter:     apiclient.BuildRunFilter(effectiveBranch, ""),

--- a/internal/cmd/run/list.go
+++ b/internal/cmd/run/list.go
@@ -127,14 +127,14 @@ func runList(ctx context.Context, client *apiclient.Client, projectSlug, branch 
 		projectSlug = info.Slug
 	}
 
-	proj, err := client.GetProjectInfo(ctx, projectSlug)
+	proj, err := client.GetProjectBySlug(ctx, projectSlug)
 	if err != nil {
 		return apiErr(err, projectSlug)
 	}
 
 	now := time.Now().UTC()
 	runs, err := client.SearchRunsV3(ctx, apiclient.RunSearchParams{
-		ProjectIDs: []string{proj.ID},
+		ProjectIDs: []string{proj.ID.String()},
 		From:       now.AddDate(0, 0, -90),
 		To:         now,
 		Filter:     apiclient.BuildRunFilter(branch, ""),

--- a/internal/cmd/run/open.go
+++ b/internal/cmd/run/open.go
@@ -115,7 +115,7 @@ func runOpen(ctx context.Context, client *apiclient.Client, args []string, proje
 			effectiveBranch = info.Branch
 		}
 
-		proj, err := client.GetProjectInfo(ctx, projectSlug)
+		proj, err := client.GetProjectBySlug(ctx, projectSlug)
 		if err != nil {
 			return apiErr(err, projectSlug)
 		}
@@ -123,7 +123,7 @@ func runOpen(ctx context.Context, client *apiclient.Client, args []string, proje
 		sp := iostream.Spinner(ctx, true, fmt.Sprintf("Fetching latest run for %s on branch %s", projectSlug, effectiveBranch))
 		now := time.Now().UTC()
 		runs, searchErr := client.SearchRunsV3(ctx, apiclient.RunSearchParams{
-			ProjectIDs: []string{proj.ID},
+			ProjectIDs: []string{proj.ID.String()},
 			From:       now.AddDate(0, 0, -90),
 			To:         now,
 			Filter:     apiclient.BuildRunFilter(effectiveBranch, ""),

--- a/internal/cmd/run/watch.go
+++ b/internal/cmd/run/watch.go
@@ -189,13 +189,13 @@ func runWatch(ctx context.Context, client *apiclient.Client, args []string, proj
 		}
 
 	default:
-		proj, pErr := client.GetProjectInfo(ctx, projectSlug)
+		proj, pErr := client.GetProjectBySlug(ctx, projectSlug)
 		if pErr != nil {
 			return apiErr(pErr, projectSlug)
 		}
 		now := time.Now().UTC()
 		runs, sErr := client.SearchRunsV3(ctx, apiclient.RunSearchParams{
-			ProjectIDs: []string{proj.ID},
+			ProjectIDs: []string{proj.ID.String()},
 			From:       now.AddDate(0, 0, -90),
 			To:         now,
 			Filter:     apiclient.BuildRunFilter(branch, ""),
@@ -223,7 +223,7 @@ func runWatch(ctx context.Context, client *apiclient.Client, args []string, proj
 // waitForRunBySHA searches for a run matching the given commit SHA via V3 search,
 // polling every 5 seconds for up to shaWaitDuration() if not immediately found.
 func waitForRunBySHA(ctx context.Context, client *apiclient.Client, projectSlug, branch, sha string) (*apiclient.RunV3, error) {
-	proj, err := client.GetProjectInfo(ctx, projectSlug)
+	proj, err := client.GetProjectBySlug(ctx, projectSlug)
 	if err != nil {
 		return nil, apiErr(err, projectSlug)
 	}
@@ -241,7 +241,7 @@ func waitForRunBySHA(ctx context.Context, client *apiclient.Client, projectSlug,
 	for {
 		now := time.Now().UTC()
 		runs, searchErr := client.SearchRunsV3(ctx, apiclient.RunSearchParams{
-			ProjectIDs: []string{proj.ID},
+			ProjectIDs: []string{proj.ID.String()},
 			From:       now.AddDate(0, 0, -1),
 			To:         now,
 			Filter:     filter,

--- a/internal/cmd/workflow/list.go
+++ b/internal/cmd/workflow/list.go
@@ -188,14 +188,14 @@ func runListRecent(ctx context.Context, client *apiclient.Client, projectSlug, b
 		projectSlug = info.Slug
 	}
 
-	proj, err := client.GetProjectInfo(ctx, projectSlug)
+	proj, err := client.GetProjectBySlug(ctx, projectSlug)
 	if err != nil {
 		return apiErr(err, projectSlug)
 	}
 
 	now := time.Now().UTC()
 	runs, err := client.SearchRunsV3(ctx, apiclient.RunSearchParams{
-		ProjectIDs: []string{proj.ID},
+		ProjectIDs: []string{proj.ID.String()},
 		From:       now.AddDate(0, 0, -90),
 		To:         now,
 		Filter:     apiclient.BuildRunFilter(branch, ""),

--- a/internal/cmdutil/client.go
+++ b/internal/cmdutil/client.go
@@ -206,7 +206,7 @@ func APIErr(err error, subject, notFoundCode, notFoundMsg string, notFoundSugges
 			WithRef("https://app.circleci.com/settings/user/oauth-clients").
 			WithExitCode(clierrors.ExitAuthError)
 	}
-	if httpcl.HasStatusCode(err, http.StatusNotFound) {
+	if httpcl.HasStatusCode(err, http.StatusNotFound) || errors.Is(err, apiclient.ErrProjectNotFound) {
 		msg := fmt.Sprintf(notFoundMsg, subject)
 		if apiErr, ok := apiclient.ParseError(err); ok {
 			// The API detail just restates "not found" — keep only the error id.

--- a/internal/cmdutil/orgid.go
+++ b/internal/cmdutil/orgid.go
@@ -111,14 +111,14 @@ func orgIDFromGitRemote(ctx context.Context, client *apiclient.Client, detectHin
 	if err != nil {
 		return "", GitDetectErr(err, detectHint)
 	}
-	proj, err := client.GetProjectInfo(ctx, info.Slug)
+	proj, err := client.GetProjectBySlug(ctx, info.Slug)
 	if err != nil {
 		return "", clierrors.New("org.resolve_failed", "Could not resolve organization",
 			fmt.Sprintf("Failed to look up project %q to recover its organization: %s", info.Slug, err.Error())).
 			WithSuggestions(projectFailSuggestion).
 			WithExitCode(clierrors.ExitBadArguments)
 	}
-	return proj.OrganizationID, nil
+	return proj.OrgID.String(), nil
 }
 
 // parseOrgID converts an organization ID string returned by the API into a

--- a/internal/cmdutil/project.go
+++ b/internal/cmdutil/project.go
@@ -57,12 +57,12 @@ func ResolveProjectID(ctx context.Context, client *apiclient.Client, projectSlug
 		}
 		projectSlug = info.Slug
 	}
-	proj, err := client.GetProjectInfo(ctx, projectSlug)
+	proj, err := client.GetProjectBySlug(ctx, projectSlug)
 	if err != nil {
 		return "", APIErr(err, projectSlug, "project.not_found", "No project found for %q.",
 			"Run 'circleci project link' to bind this repository to a CircleCI project",
 			"Check the project slug and try again",
 			"Use 'circleci project list' to see followed projects")
 	}
-	return proj.ID, nil
+	return proj.ID.String(), nil
 }

--- a/internal/extension/extension.go
+++ b/internal/extension/extension.go
@@ -287,12 +287,12 @@ func resolveProjectID(ctx context.Context, client *apiclient.Client, cfg *config
 		return ""
 	}
 
-	info, err := client.GetProjectInfo(ctx, slug)
+	info, err := client.GetProjectBySlug(ctx, slug)
 	if err != nil {
 		return ""
 	}
 
-	return info.ID
+	return info.ID.String()
 }
 
 func vcsLong(short string) string {

--- a/internal/testing/fakes/circleci.go
+++ b/internal/testing/fakes/circleci.go
@@ -101,6 +101,7 @@ type CircleCI struct {
 	deletedEnvVars    map[string]bool  // "slug/name" → deleted
 	projectInfos      map[string]any   // project slug → project info response
 	projectsByID      map[string]any   // project UUID → V3 project response (GET /api/v3/projects/{id})
+	projectsBySlug    map[string]any   // project slug → V3 project entity (GET /api/v3/projects?filter[slug]=)
 	createProjectResp any              // preset response for POST /organization/{vcs}/{org}/project
 
 	// Context state.
@@ -229,6 +230,7 @@ func NewCircleCI(t *testing.T) *CircleCI {
 		deletedContextRestrictions:        map[string]bool{},
 		projectInfos:                      map[string]any{},
 		projectsByID:                      map[string]any{},
+		projectsBySlug:                    map[string]any{},
 		deploys:                           map[string][]any{},
 		policyBundles:                     make(map[string]map[string]string),
 		decisionLogs:                      make(map[string][]any),
@@ -330,6 +332,7 @@ func NewCircleCI(t *testing.T) *CircleCI {
 	r.Get("/api/v3/workflows/{id}", f.handleGetWorkflowV3ByID)
 	r.Get("/api/v3/workflows", f.handleGetWorkflowsV3)
 	// Project (v3) routes.
+	r.Get("/api/v3/projects", f.handleResolveProjectBySlug)
 	r.Get("/api/v3/projects/{id}", f.handleGetProjectV3)
 	// Run (v3) routes.
 	r.Get("/api/v3/runs", f.handleListMyRunsV3)
@@ -1398,6 +1401,37 @@ func (f *CircleCI) handleGetProjectV3(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	render.JSON(w, r, map[string]any{"data": project})
+}
+
+// AddProjectBySlug registers a project resolved by GET
+// /api/v3/projects?filter[slug]=<slug>, returning its UUID, name, and org UUID.
+func (f *CircleCI) AddProjectBySlug(slug, id, name, orgID string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.projectsBySlug[slug] = map[string]any{
+		"id":         id,
+		"attributes": map[string]any{"name": name},
+		"references": map[string]any{"org": map[string]any{"id": orgID}},
+	}
+}
+
+func (f *CircleCI) handleResolveProjectBySlug(w http.ResponseWriter, r *http.Request) {
+	slug := r.URL.Query().Get("filter[slug]")
+	if slug == "" {
+		render.Status(r, http.StatusBadRequest)
+		render.JSON(w, r, map[string]any{"error": map[string]any{"title": "Bad Request", "detail": "filter[slug] is required"}})
+		return
+	}
+	f.mu.RLock()
+	project, ok := f.projectsBySlug[slug]
+	f.mu.RUnlock()
+
+	// The endpoint is a collection: an unmatched slug is an empty list, not a 404.
+	data := []any{}
+	if ok {
+		data = append(data, project)
+	}
+	render.JSON(w, r, map[string]any{"data": data, "page": map[string]any{"next": nil, "prev": nil}})
 }
 
 // AddPipelineDefinition registers a pipeline definition for a project, returned by


### PR DESCRIPTION
## Summary
- Add `GetProjectBySlug` hitting `GET /api/v3/projects?filter[slug]=`, returning the project UUID, name, and org UUID in one call (mirrors the `namespaces?filter[name]` pattern, backed by [public-api-service#1081](https://github.com/circleci/public-api-service/pull/1081)).
- Route **every** slug→UUID lookup through it instead of the v2 `GetProjectInfo`: `ResolveProjectID`, the `api` command's `{project-id}`/`{org-id}` placeholders, `project trigger`, `run list`/`get`/`open`/`watch`, `workflow list`, `deploy list`, `dlc purge`, the git-remote org resolver (`cmdutil/orgid`), and extension project detection.
- `GetProjectInfo` (v2) stays where the fuller settings payload is needed: `project get`/`link`, `deploy open` (needs VCS provider + org name), and the `pipeline run` prompt.
- Fake server: add `AddProjectBySlug` helper + `GET /api/v3/projects` route; update affected acceptance fakes and one golden.

> Note: depends on the v3 endpoint being deployed to the target hosts — slug-based lookups will 404 until it's live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)