### PR TITLE
Add programmatic org creation from the CLI

### DIFF
--- a/acceptance/onboard_test.go
+++ b/acceptance/onboard_test.go
@@ -323,7 +323,6 @@ func TestOnboard_PostSignup_NoOrgs(t *testing.T) {
 	})
 
 	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
-	assert.Check(t, strings.Contains(result.Stdout, "isn't part of a CircleCI organization"))
 	assert.Check(t, strings.Contains(result.Stdout, "circleci project create"))
 }
 

--- a/acceptance/project_test.go
+++ b/acceptance/project_test.go
@@ -1085,7 +1085,7 @@ func TestProjectCreate_NoOrgs_Interactive_CreatesOrg(t *testing.T) {
 	})
 
 	assert.Assert(t, t.Run("prompts for org name", func(t *testing.T) {
-		_, err := console.ExpectString("Organization name")
+		_, err := console.ExpectString("New organization name")
 		assert.NilError(t, err)
 		_, err = console.Send("my-new-org\r")
 		assert.NilError(t, err)

--- a/acceptance/project_test.go
+++ b/acceptance/project_test.go
@@ -1067,6 +1067,38 @@ func TestProjectCreate_NoOrgs_NoOrgFlag(t *testing.T) {
 	assert.Check(t, strings.Contains(result.Stderr, "not a member of any CircleCI organizations"))
 }
 
+func TestProjectCreate_NoOrgs_Interactive_CreatesOrg(t *testing.T) {
+	fake, env := setupCreateProjectFake(t)
+	fake.SetCollaborations(nil)
+	fake.SetCreateOrgResponse(map[string]any{
+		"id":       "org-new-uuid",
+		"name":     "my-new-org",
+		"slug":     "circleci/my-new-org",
+		"vcs_type": "circleci",
+	})
+
+	console := binary.RunCLIInteractive(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"project", "create", "my-new-repo"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Assert(t, t.Run("prompts for org name", func(t *testing.T) {
+		_, err := console.ExpectString("Organization name")
+		assert.NilError(t, err)
+		_, err = console.Send("my-new-org\r")
+		assert.NilError(t, err)
+	}))
+
+	assert.Assert(t, t.Run("creates org and project", func(t *testing.T) {
+		_, err := console.ExpectString("Created organization")
+		assert.NilError(t, err)
+		_, err = console.ExpectString("my-new-repo")
+		assert.NilError(t, err)
+	}))
+}
+
 func TestProjectCreate_WrongOrg(t *testing.T) {
 	_, env := setupCreateProjectFake(t)
 

--- a/internal/apiclient/org.go
+++ b/internal/apiclient/org.go
@@ -40,3 +40,14 @@ func (c *Client) GetOrg(ctx context.Context, slugOrID string) (*OrgInfo, error) 
 	}
 	return &org, nil
 }
+
+// CreateOrg creates a new organization. vcsType must be one of "github",
+// "bitbucket", or "circleci".
+func (c *Client) CreateOrg(ctx context.Context, name, vcsType string) (*OrgInfo, error) {
+	body := map[string]string{"name": name, "vcs_type": vcsType}
+	var org OrgInfo
+	if err := c.post(ctx, "/organization", body, &org); err != nil {
+		return nil, err
+	}
+	return &org, nil
+}

--- a/internal/onboarder/onboarder.go
+++ b/internal/onboarder/onboarder.go
@@ -159,14 +159,9 @@ func postSignupGuidance(ctx context.Context) error {
 
 	appURL, _ := cmdutil.AppURL(ctx)
 
-	orgs, err := org.List(ctx, client)
+	orgs, err := org.Require(ctx, client)
 	if err != nil {
 		printManualGuidance(ctx)
-		return nil
-	}
-
-	if len(orgs) == 0 {
-		printNoOrgGuidance(ctx, appURL)
 		return nil
 	}
 
@@ -243,25 +238,6 @@ func postSignupGuidance(ctx context.Context) error {
 
 func printManualGuidance(ctx context.Context) {
 	iostream.Printf(ctx, "\nRun 'circleci project create' to connect this repo to CircleCI.\n")
-}
-
-func printNoOrgGuidance(ctx context.Context, appURL string) {
-	if appURL != "" {
-		iostream.Printf(ctx, `
-Your account isn't part of a CircleCI organization yet.
-Create or join one at: %s
-
-Then run:
-  circleci project create
-`, appURL)
-	} else {
-		iostream.Printf(ctx, `
-Your account isn't part of a CircleCI organization yet.
-
-Then run:
-  circleci project create
-`)
-	}
 }
 
 func resolveMode(ctx context.Context, opts Options) (mode, error) {

--- a/internal/org/org.go
+++ b/internal/org/org.go
@@ -46,14 +46,17 @@ func List(ctx context.Context, client *apiclient.Client) ([]apiclient.Collaborat
 }
 
 // Require fetches the user's organizations and returns an actionable error
-// when the account has none. Callers that need to ensure at least one org
-// exists before proceeding should use this instead of List.
+// when the account has none. In interactive mode, offers to create a new
+// CircleCI organization on the spot.
 func Require(ctx context.Context, client *apiclient.Client) ([]apiclient.Collaboration, error) {
 	collabs, err := List(ctx, client)
 	if err != nil {
 		return nil, err
 	}
 	if len(collabs) == 0 {
+		if iostream.IsInteractive(ctx) {
+			return promptCreateOrg(ctx, client)
+		}
 		suggestions := []string{
 			"Ask an admin to invite you to an existing organization",
 		}
@@ -69,6 +72,28 @@ func Require(ctx context.Context, client *apiclient.Client) ([]apiclient.Collabo
 			WithExitCode(clierrors.ExitNotFound)
 	}
 	return collabs, nil
+}
+
+func promptCreateOrg(ctx context.Context, client *apiclient.Client) ([]apiclient.Collaboration, error) {
+	iostream.ErrPrintf(ctx, "You don't belong to any CircleCI organizations yet.\n\n")
+
+	name, err := iostream.PromptText(ctx, "Organization name", "")
+	if err != nil || name == "" {
+		return nil, clierrors.New("org.create_cancelled", "Cancelled",
+			"No organization name entered.").
+			WithExitCode(clierrors.ExitCancelled)
+	}
+
+	created, err := client.CreateOrg(ctx, name, "circleci")
+	if err != nil {
+		return nil, cmdutil.APIErr(err, name, "org.create_failed", "Could not create organization %q.")
+	}
+
+	iostream.Printf(ctx, "%s Created organization %s\n", iostream.SymbolOK(ctx), created.Slug)
+
+	return []apiclient.Collaboration{
+		{ID: created.ID, Name: created.Name, Slug: created.Slug, VCSType: created.VCSType},
+	}, nil
 }
 
 // Select fetches the user's organizations and presents an interactive picker.

--- a/internal/org/org.go
+++ b/internal/org/org.go
@@ -75,9 +75,9 @@ func Require(ctx context.Context, client *apiclient.Client) ([]apiclient.Collabo
 }
 
 func promptCreateOrg(ctx context.Context, client *apiclient.Client) ([]apiclient.Collaboration, error) {
-	iostream.ErrPrintf(ctx, "You don't belong to any CircleCI organizations yet.\n\n")
+	iostream.ErrPrintf(ctx, "You don't belong to any CircleCI organizations yet.\nLet's create one.\n\n")
 
-	name, err := iostream.PromptText(ctx, "Organization name", "")
+	name, err := iostream.PromptText(ctx, "New organization name", "")
 	if err != nil || name == "" {
 		return nil, clierrors.New("org.create_cancelled", "Cancelled",
 			"No organization name entered.").

--- a/internal/testing/fakes/circleci.go
+++ b/internal/testing/fakes/circleci.go
@@ -102,6 +102,7 @@ type CircleCI struct {
 	projectInfos      map[string]any   // project slug → project info response
 	projectsByID      map[string]any   // project UUID → V3 project response (GET /api/v3/projects/{id})
 	createProjectResp any              // preset response for POST /organization/{vcs}/{org}/project
+	createOrgResp     any              // preset response for POST /organization
 
 	// Context state.
 	contexts                   map[string]any   // context id → context object
@@ -274,6 +275,7 @@ func NewCircleCI(t *testing.T) *CircleCI {
 	// project slug, so we match three separate path segments rather than {slug}.
 	r.Get("/api/v1.1/projects", f.handleListProjects)
 	r.Post("/api/v1.1/project/{vcs}/{org}/{repo}/follow", f.handleFollowProject)
+	r.Post("/api/v2/organization", f.handleCreateOrg)
 	r.Post("/api/v2/organization/{vcs}/{org}/project", f.handleCreateProject)
 	r.Get("/api/v3/users", f.handleGetMe)
 	r.Get("/api/v2/me/collaborations", f.handleGetCollaborations)
@@ -1443,6 +1445,14 @@ func (f *CircleCI) AddFollowedProject(proj any) {
 	f.followedProjects = append(f.followedProjects, proj)
 }
 
+// SetCreateOrgResponse registers the response body returned when
+// POST /api/v2/organization is called. Pass nil to simulate a 422 error.
+func (f *CircleCI) SetCreateOrgResponse(resp any) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.createOrgResp = resp
+}
+
 // SetCreateProjectResponse registers the response body returned when
 // POST /api/v2/organization/{vcs}/{org}/project is called.
 // Pass nil to simulate a 422 error.
@@ -1496,6 +1506,20 @@ func (f *CircleCI) handleFollowProject(w http.ResponseWriter, r *http.Request) {
 	f.mu.Unlock()
 
 	render.JSON(w, r, map[string]any{"following": true})
+}
+
+func (f *CircleCI) handleCreateOrg(w http.ResponseWriter, r *http.Request) {
+	f.mu.RLock()
+	resp := f.createOrgResp
+	f.mu.RUnlock()
+
+	if resp == nil {
+		render.Status(r, http.StatusUnprocessableEntity)
+		render.JSON(w, r, map[string]any{"message": "org creation not configured"})
+		return
+	}
+	render.Status(r, http.StatusCreated)
+	render.JSON(w, r, resp)
 }
 
 func (f *CircleCI) handleCreateProject(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

- Add `CreateOrg(ctx, name, vcsType)` to the API client, wiring `POST /api/v2/organization`
- When a user has no organizations and is in interactive mode, `org.Require` now prompts to create a CircleCI-native org on the spot instead of erroring
- The onboard flow uses the same path, so freshly signed-up users can create an org and project in one session without leaving the terminal

Part B of [WEBXP-1396](https://linear.app/circleci/issue/WEBXP-1396)

## Before / After

### `project create` (interactive, no orgs)

**Before:**
```
$ circleci project create my-repo
error: No organizations found

Your account is not a member of any CircleCI organizations.

Suggestions:
  • Create or join an organization at https://app.circleci.com
  • Ask an admin to invite you to an existing organization
```

**After:**
```
$ circleci project create my-repo
You don't belong to any CircleCI organizations yet.
Let's create one.

New organization name: my-new-org
✓ Created organization circleci/my-new-org

 Project Created
  • Name: my-repo
  • Slug: circleci/my-new-org/my-repo
  ...
```

### `onboard` (interactive, freshly signed up, no orgs)

**Before:**
```
$ circleci onboard --scan
...
✓ Already signed in as newuser

Your account isn't part of a CircleCI organization yet.
Create or join one at: https://app.circleci.com

Then run:
  circleci project create
```

**After:**
```
$ circleci onboard --scan
...
✓ Already signed in as newuser
You don't belong to any CircleCI organizations yet.
Let's create one.

New organization name: my-new-org
✓ Created organization circleci/my-new-org
✓ Project created: my-repo
  Organization: my-new-org
  Pipelines: https://app.circleci.com/pipelines/circleci/my-new-org/my-repo

Commit .circleci/config.yml. After your project is connected in CircleCI, pushing will start your first pipeline.
```

**Non-interactive mode is unchanged** — still returns the structured error with suggestions.

## Test plan

- [ ] `TestProjectCreate_NoOrgs_Interactive_CreatesOrg` — interactive flow: no orgs → prompt for name → org created → project created
- [ ] `TestProjectCreate_NoOrgs` / `TestProjectCreate_NoOrgs_NoOrgFlag` — non-interactive still returns exit 5 with no-org error
- [ ] `TestOnboard_PostSignup_NoOrgs` — onboard with no orgs gracefully falls back to guidance
- [ ] `TestOnboard_PostSignup_ProjectCreated` / `TestOnboard_PostSignup_CreateFails` — existing onboard tests still pass
- [ ] `task check` passes