### PR TITLE
Rename test command to testresult

### DIFF
--- a/acceptance/test_get_test.go
+++ b/acceptance/test_get_test.go
@@ -52,12 +52,12 @@ func setupTestGetFake(t *testing.T) *testenv.TestEnv {
 	return env
 }
 
-// runTestGet runs "circleci test get <job-id> <extra...>" against the fixture.
+// runTestGet runs "circleci testresult get <job-id> <extra...>" against the fixture.
 func runTestGet(t *testing.T, env *testenv.TestEnv, extra ...string) binary.CLIResult {
 	t.Helper()
 	return binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    append([]string{"test", "get", testTestsJobID}, extra...),
+		Args:    append([]string{"testresult", "get", testTestsJobID}, extra...),
 		Env:     env.Environ(),
 		WorkDir: t.TempDir(),
 	})

--- a/acceptance/test_list_test.go
+++ b/acceptance/test_list_test.go
@@ -67,13 +67,13 @@ func setupTestListFake(t *testing.T) (*fakes.CircleCI, *testenv.TestEnv) {
 	return fake, env
 }
 
-// runTestList runs "circleci test list" with the given extra args against the
+// runTestList runs "circleci testresult list" with the given extra args against the
 // standard fixture and returns the CLI result.
 func runTestList(t *testing.T, env *testenv.TestEnv, extra ...string) binary.CLIResult {
 	t.Helper()
 	return binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    append([]string{"test", "list", testTestsJobID}, extra...),
+		Args:    append([]string{"testresult", "list", testTestsJobID}, extra...),
 		Env:     env.Environ(),
 		WorkDir: t.TempDir(),
 	})
@@ -289,7 +289,7 @@ func TestTestList_MissingArg(t *testing.T) {
 
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    []string{"test", "list"},
+		Args:    []string{"testresult", "list"},
 		Env:     env.Environ(),
 		WorkDir: t.TempDir(),
 	})

--- a/acceptance/testdata/TestTestGet_Ambiguous.stderr.txt
+++ b/acceptance/testdata/TestTestGet_Ambiguous.stderr.txt
@@ -1,5 +1,5 @@
 error: 2 tests are named "TestDup"; add --filter classname=<value> to select one.
 
 Suggestions:
-  • circleci test get 8e50c384-0083-43d0-bc8f-93f0db589d6b "TestDup" --filter classname=pkg/foo
-  • circleci test get 8e50c384-0083-43d0-bc8f-93f0db589d6b "TestDup" --filter classname=pkg/bar
+  • circleci testresult get 8e50c384-0083-43d0-bc8f-93f0db589d6b "TestDup" --filter classname=pkg/foo
+  • circleci testresult get 8e50c384-0083-43d0-bc8f-93f0db589d6b "TestDup" --filter classname=pkg/bar

--- a/acceptance/testdata/TestTestGet_NotFound.stderr.txt
+++ b/acceptance/testdata/TestTestGet_NotFound.stderr.txt
@@ -1,4 +1,4 @@
 error: No test named "TestMissing" was found in job 8e50c384-0083-43d0-bc8f-93f0db589d6b.
 
 Suggestions:
-  • List the job's tests with: circleci test list 8e50c384-0083-43d0-bc8f-93f0db589d6b --all
+  • List the job's tests with: circleci testresult list 8e50c384-0083-43d0-bc8f-93f0db589d6b --all

--- a/acceptance/testdata/TestTestGet_UnknownFilterKey.stderr.txt
+++ b/acceptance/testdata/TestTestGet_UnknownFilterKey.stderr.txt
@@ -1,4 +1,4 @@
 error: test get only supports the classname filter; got "result"
 
 Suggestions:
-  • Use "circleci test list" to filter by result or name
+  • Use "circleci testresult list" to filter by result or name

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -56,7 +56,7 @@ import (
 	"github.com/CircleCI-Public/circleci-cli/internal/cmd/setup"
 	"github.com/CircleCI-Public/circleci-cli/internal/cmd/signingconfig"
 	"github.com/CircleCI-Public/circleci-cli/internal/cmd/step"
-	cmdtest "github.com/CircleCI-Public/circleci-cli/internal/cmd/test"
+	cmdtestresult "github.com/CircleCI-Public/circleci-cli/internal/cmd/testresult"
 	cmdversion "github.com/CircleCI-Public/circleci-cli/internal/cmd/version"
 	"github.com/CircleCI-Public/circleci-cli/internal/cmd/workflow"
 	"github.com/CircleCI-Public/circleci-cli/internal/cmdutil"
@@ -239,7 +239,7 @@ func NewRootCmd(version string) *cobra.Command {
 	cmd.AddCommand(setup.NewSetupCmd())
 	cmd.AddCommand(signingconfig.NewSigningConfigCmd())
 	cmd.AddCommand(step.NewStepCmd())
-	cmd.AddCommand(cmdtest.NewTestCmd())
+	cmd.AddCommand(cmdtestresult.NewTestResultCmd())
 	cmd.AddCommand(workflow.NewWorkflowCmd())
 
 	// Wire in MCP commands. ophis sets its own terse Short; override it so the

--- a/internal/cmd/root/testdata/help/circleci.txt
+++ b/internal/cmd/root/testdata/help/circleci.txt
@@ -8,15 +8,15 @@ Work with CircleCI from the command line.
 
 ## CI Commands
 
-| Command    | Description                                      |
-| ---------- | ------------------------------------------------ |
-| `artifact` | List and download a job's artifact files         |
-| `config`   | Generate, validate, process and pack config YAML |
-| `job`      | Inspect a job's details, output and artifacts    |
-| `pipeline` | Define what will happen in a run                 |
-| `run`      | Trigger, watch and cancel CI runs                |
-| `test`     | Inspect test results for a job                   |
-| `workflow` | Inspect, rerun and cancel workflows (job graphs) |
+| Command      | Description                                      |
+| ------------ | ------------------------------------------------ |
+| `artifact`   | List and download a job's artifact files         |
+| `config`     | Generate, validate, process and pack config YAML |
+| `job`        | Inspect a job's details, output and artifacts    |
+| `pipeline`   | Define what will happen in a run                 |
+| `run`        | Trigger, watch and cancel CI runs                |
+| `testresult` | Inspect test results for a job                   |
+| `workflow`   | Inspect, rerun and cancel workflows (job graphs) |
 
 ## Management Commands
 

--- a/internal/cmd/root/testdata/help/circleci/reference.txt
+++ b/internal/cmd/root/testdata/help/circleci/reference.txt
@@ -321,11 +321,11 @@ Watch a run until it completes
 When omitted, the latest run for the current branch is watched
 (override the branch with --branch, or match a commit with --sha).
 
-### `circleci test <command>`
+### `circleci testresult <command>`
 
 Inspect test results for a job
 
-#### `circleci test get <job-id> <name> [flags]`
+#### `circleci testresult get <job-id> <name> [flags]`
 
 Get a single test result by name
 
@@ -345,7 +345,7 @@ UUIDs are shown in "circleci job get" and "circleci run get --json".
 <name> is the exact test name to look up. If more than one test
 shares that name, use --filter classname=<value> to disambiguate.
 
-#### `circleci test list <job-id> [flags]`
+#### `circleci testresult list <job-id> [flags]`
 
 List test results for a job
 
@@ -367,7 +367,7 @@ UUIDs are shown in "circleci job get" and "circleci run get --json".
 **Aliases:**
 
 
-`circleci test ls`
+`circleci testresult ls`
 
 ### `circleci workflow <command>`
 

--- a/internal/cmd/root/testdata/help/circleci/testresult.txt
+++ b/internal/cmd/root/testdata/help/circleci/testresult.txt
@@ -9,7 +9,7 @@ web UI.
 
 ## Usage
 
-`circleci test <command> [flags]`
+`circleci testresult <command> [flags]`
 
 ## General Commands
 

--- a/internal/cmd/root/testdata/help/circleci/testresult/get.txt
+++ b/internal/cmd/root/testdata/help/circleci/testresult/get.txt
@@ -9,7 +9,7 @@ classname is matched as a case-insensitive substring and may be
 repeated to accept any of several suites.
 
 To browse or filter across all of a job's tests, use
-'circleci test list'.
+'circleci testresult list'.
 
 By default the message is replayed through a virtual terminal and
 embedded in the output. Pass --plain to print only the message exactly
@@ -22,7 +22,7 @@ For more information about output formatting flags, see `circleci help formattin
 
 ## Usage
 
-`circleci test get <job-id> <name> [flags]`
+`circleci testresult get <job-id> <name> [flags]`
 
 ## Flags
 
@@ -53,13 +53,13 @@ shares that name, use --filter classname=<value> to disambiguate.
 ## Examples
 
 - Get a test by name: 
-  `circleci test get 8e50c384-0083-43d0-bc8f-93f0db589d6b TestLogin`
+  `circleci testresult get 8e50c384-0083-43d0-bc8f-93f0db589d6b TestLogin`
 - Disambiguate when the name appears in multiple suites: 
-  `circleci test get <job-id> TestLogin --filter classname=api`
+  `circleci testresult get <job-id> TestLogin --filter classname=api`
 - Print only the raw test message: 
-  `circleci test get <job-id> TestLogin --plain`
+  `circleci testresult get <job-id> TestLogin --plain`
 - Output as JSON: 
-  `circleci test get <job-id> TestLogin --json`
+  `circleci testresult get <job-id> TestLogin --json`
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/testresult/list.txt
+++ b/internal/cmd/root/testdata/help/circleci/testresult/list.txt
@@ -31,11 +31,11 @@ For more information about output formatting flags, see `circleci help formattin
 
 ## Usage
 
-`circleci test list <job-id> [flags]`
+`circleci testresult list <job-id> [flags]`
 
 ## Aliases
 
-`circleci test ls`
+`circleci testresult ls`
 
 ## Flags
 
@@ -65,19 +65,19 @@ UUIDs are shown in "circleci job get" and "circleci run get --json".
 ## Examples
 
 - List failed tests for a job (the default): 
-  `circleci test list 8e50c384-0083-43d0-bc8f-93f0db589d6b`
+  `circleci testresult list 8e50c384-0083-43d0-bc8f-93f0db589d6b`
 - Show every result: passing, failed and skipped: 
-  `circleci test list 8e50c384-0083-43d0-bc8f-93f0db589d6b --all`
+  `circleci testresult list 8e50c384-0083-43d0-bc8f-93f0db589d6b --all`
 - Show skipped tests instead: 
-  `circleci test list 8e50c384-0083-43d0-bc8f-93f0db589d6b --filter result=skipped`
+  `circleci testresult list 8e50c384-0083-43d0-bc8f-93f0db589d6b --filter result=skipped`
 - Failed tests in a specific suite, slowest last (sorted by run_time): 
-  `circleci test list <job-id> --filter result=failure --filter classname=api --sort run_time`
+  `circleci testresult list <job-id> --filter result=failure --filter classname=api --sort run_time`
 - Every result for tests whose name matches "login": 
-  `circleci test list <job-id> --all --filter name=login`
+  `circleci testresult list <job-id> --all --filter name=login`
 - Limit output and emit JSON for scripting: 
-  `circleci test list <job-id> --limit 20 --json`
+  `circleci testresult list <job-id> --limit 20 --json`
 - Count failed tests by aggregating the JSONL stream with jq: 
-  `circleci test list <job-id> --json --jq '[.,inputs] | length'`
+  `circleci testresult list <job-id> --json --jq '[.,inputs] | length'`
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/usage/circleci.txt
+++ b/internal/cmd/root/testdata/usage/circleci.txt
@@ -24,6 +24,6 @@ Available commands:
   runner
   setting
   signing-config
-  test
+  testresult
   version
   workflow

--- a/internal/cmd/root/testdata/usage/circleci/test.txt
+++ b/internal/cmd/root/testdata/usage/circleci/test.txt
@@ -1,5 +1,0 @@
-Usage:  circleci test <command>
-
-Available commands:
-  get
-  list

--- a/internal/cmd/root/testdata/usage/circleci/testresult.txt
+++ b/internal/cmd/root/testdata/usage/circleci/testresult.txt
@@ -1,0 +1,5 @@
+Usage:  circleci testresult <command>
+
+Available commands:
+  get
+  list

--- a/internal/cmd/root/testdata/usage/circleci/testresult/get.txt
+++ b/internal/cmd/root/testdata/usage/circleci/testresult/get.txt
@@ -1,4 +1,4 @@
-Usage:  circleci test get <job-id> <name> [flags]
+Usage:  circleci testresult get <job-id> <name> [flags]
 
 Flags:
   --filter stringArray   Disambiguate by classname=<value> when a name is shared; repeatable

--- a/internal/cmd/root/testdata/usage/circleci/testresult/list.txt
+++ b/internal/cmd/root/testdata/usage/circleci/testresult/list.txt
@@ -1,4 +1,4 @@
-Usage:  circleci test list <job-id> [flags]
+Usage:  circleci testresult list <job-id> [flags]
 
 Flags:
   --all                  Show all results (passing, failed and skipped), not just failures

--- a/internal/cmd/testresult/get.go
+++ b/internal/cmd/testresult/get.go
@@ -20,7 +20,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-package test
+package testresult
 
 import (
 	"context"
@@ -67,7 +67,7 @@ func newGetCmd() *cobra.Command {
 			repeated to accept any of several suites.
 
 			To browse or filter across all of a job's tests, use
-			'circleci test list'.
+			'circleci testresult list'.
 
 			By default the message is replayed through a virtual terminal and
 			embedded in the output. Pass --plain to print only the message exactly
@@ -78,16 +78,16 @@ func newGetCmd() *cobra.Command {
 		`),
 		Example: heredoc.Doc(`
 			# Get a test by name
-			$ circleci test get 8e50c384-0083-43d0-bc8f-93f0db589d6b TestLogin
+			$ circleci testresult get 8e50c384-0083-43d0-bc8f-93f0db589d6b TestLogin
 
 			# Disambiguate when the name appears in multiple suites
-			$ circleci test get <job-id> TestLogin --filter classname=api
+			$ circleci testresult get <job-id> TestLogin --filter classname=api
 
 			# Print only the raw test message
-			$ circleci test get <job-id> TestLogin --plain
+			$ circleci testresult get <job-id> TestLogin --plain
 
 			# Output as JSON
-			$ circleci test get <job-id> TestLogin --json
+			$ circleci testresult get <job-id> TestLogin --json
 		`),
 		Args: cobra.MaximumNArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -184,7 +184,7 @@ func parseClassnameFilter(filters []string) ([]string, error) {
 		if strings.TrimSpace(key) != "classname" {
 			return nil, badArg("args.invalid_filter", "Invalid filter key",
 				fmt.Sprintf("test get only supports the classname filter; got %q", key)).
-				WithSuggestions(`Use "circleci test list" to filter by result or name`)
+				WithSuggestions(`Use "circleci testresult list" to filter by result or name`)
 		}
 		classnames = append(classnames, strings.ToLower(val))
 	}
@@ -234,7 +234,7 @@ func testNotFound(jobID, name string, filtered bool) error {
 		msg = fmt.Sprintf("No test named %q with a matching classname was found in job %s.", name, jobID)
 	}
 	return clierrors.New("test.not_found", "Test not found", msg).
-		WithSuggestions(fmt.Sprintf("List the job's tests with: circleci test list %s --all", jobID)).
+		WithSuggestions(fmt.Sprintf("List the job's tests with: circleci testresult list %s --all", jobID)).
 		WithExitCode(clierrors.ExitNotFound)
 }
 
@@ -249,7 +249,7 @@ func ambiguousTest(jobID, name string, matches []apiclient.TestResult) error {
 		}
 		seen[m.Classname] = true
 		suggestions = append(suggestions,
-			fmt.Sprintf("circleci test get %s %q --filter classname=%s", jobID, name, m.Classname))
+			fmt.Sprintf("circleci testresult get %s %q --filter classname=%s", jobID, name, m.Classname))
 	}
 	return badArg("test.ambiguous", "Ambiguous test name",
 		fmt.Sprintf("%d tests are named %q; add --filter classname=<value> to select one.", len(matches), name)).

--- a/internal/cmd/testresult/list.go
+++ b/internal/cmd/testresult/list.go
@@ -20,7 +20,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-package test
+package testresult
 
 import (
 	"context"
@@ -97,25 +97,25 @@ func newListCmd() *cobra.Command {
 		`),
 		Example: heredoc.Doc(`
 			# List failed tests for a job (the default)
-			$ circleci test list 8e50c384-0083-43d0-bc8f-93f0db589d6b
+			$ circleci testresult list 8e50c384-0083-43d0-bc8f-93f0db589d6b
 
 			# Show every result: passing, failed and skipped
-			$ circleci test list 8e50c384-0083-43d0-bc8f-93f0db589d6b --all
+			$ circleci testresult list 8e50c384-0083-43d0-bc8f-93f0db589d6b --all
 
 			# Show skipped tests instead
-			$ circleci test list 8e50c384-0083-43d0-bc8f-93f0db589d6b --filter result=skipped
+			$ circleci testresult list 8e50c384-0083-43d0-bc8f-93f0db589d6b --filter result=skipped
 
 			# Failed tests in a specific suite, slowest last (sorted by run_time)
-			$ circleci test list <job-id> --filter result=failure --filter classname=api --sort run_time
+			$ circleci testresult list <job-id> --filter result=failure --filter classname=api --sort run_time
 
 			# Every result for tests whose name matches "login"
-			$ circleci test list <job-id> --all --filter name=login
+			$ circleci testresult list <job-id> --all --filter name=login
 
 			# Limit output and emit JSON for scripting
-			$ circleci test list <job-id> --limit 20 --json
+			$ circleci testresult list <job-id> --limit 20 --json
 
 			# Count failed tests by aggregating the JSONL stream with jq
-			$ circleci test list <job-id> --json --jq '[.,inputs] | length'
+			$ circleci testresult list <job-id> --json --jq '[.,inputs] | length'
 		`),
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/testresult/testresult.go
+++ b/internal/cmd/testresult/testresult.go
@@ -20,8 +20,8 @@
 //
 // SPDX-License-Identifier: MIT
 
-// Package test implements the "circleci test" command group.
-package test
+// Package testresult implements the "circleci testresult" command group.
+package testresult
 
 import (
 	"github.com/MakeNowJust/heredoc"
@@ -31,10 +31,10 @@ import (
 	clierrors "github.com/CircleCI-Public/circleci-cli/internal/errors"
 )
 
-// NewTestCmd returns the "circleci test" command group.
-func NewTestCmd() *cobra.Command {
+// NewTestResultCmd returns the "circleci testresult" command group.
+func NewTestResultCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "test <command>",
+		Use:     "testresult <command>",
 		GroupID: "ci",
 		Short:   "Inspect test results for a job",
 		Long: heredoc.Doc(`


### PR DESCRIPTION
To avoid conflicts and confusion with the new `circleci testsuite` command for running tests, and its predecessor `circleci tests run`.

This change renames `circleci test` to `circleci testresult`.

<!--
  Thank you for contributing to CircleCI CLI!
  For PRs adding new features, please raise an issue first.
-->
