### PR TITLE
Remove flag hint to make consistent with other commands in navigation

### DIFF
--- a/internal/cmd/dlc/purge.go
+++ b/internal/cmd/dlc/purge.go
@@ -44,7 +44,7 @@ func NewPurgeCmd() *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:   "purge --project <slug>",
+		Use:   "purge",
 		Short: "Purge the Docker Layer Cache for a project",
 		Long: heredoc.Doc(`
 			Purge the docker layer cache (DLC) for a project.

--- a/internal/cmd/root/testdata/help/circleci/dlc/purge.txt
+++ b/internal/cmd/root/testdata/help/circleci/dlc/purge.txt
@@ -15,7 +15,7 @@ JSON fields (--json): project_id, project_slug
 
 ## Usage
 
-`circleci dlc purge --project <slug> [flags]`
+`circleci dlc purge [flags]`
 
 ## Flags
 

--- a/internal/cmd/root/testdata/help/circleci/project/dlc/purge.txt
+++ b/internal/cmd/root/testdata/help/circleci/project/dlc/purge.txt
@@ -15,7 +15,7 @@ JSON fields (--json): project_id, project_slug
 
 ## Usage
 
-`circleci project dlc purge --project <slug> [flags]`
+`circleci project dlc purge [flags]`
 
 ## Flags
 

--- a/internal/cmd/root/testdata/help/circleci/reference.txt
+++ b/internal/cmd/root/testdata/help/circleci/reference.txt
@@ -744,7 +744,7 @@ Open the deploys page in the browser
 
 Purge a project's Docker layer cache (DLC)
 
-#### `circleci dlc purge --project <slug> [flags]`
+#### `circleci dlc purge [flags]`
 
 Purge the Docker Layer Cache for a project
 
@@ -1207,7 +1207,7 @@ non-interactive mode it is used automatically.
 
 Purge a project's Docker layer cache (DLC)
 
-##### `circleci project dlc purge --project <slug> [flags]`
+##### `circleci project dlc purge [flags]`
 
 Purge the Docker Layer Cache for a project
 

--- a/internal/cmd/root/testdata/usage/circleci/dlc/purge.txt
+++ b/internal/cmd/root/testdata/usage/circleci/dlc/purge.txt
@@ -1,4 +1,4 @@
-Usage:  circleci dlc purge --project <slug> [flags]
+Usage:  circleci dlc purge [flags]
 
 Flags:
   --json             Output as JSON

--- a/internal/cmd/root/testdata/usage/circleci/project/dlc/purge.txt
+++ b/internal/cmd/root/testdata/usage/circleci/project/dlc/purge.txt
@@ -1,4 +1,4 @@
-Usage:  circleci project dlc purge --project <slug> [flags]
+Usage:  circleci project dlc purge [flags]
 
 Flags:
   --json             Output as JSON


### PR DESCRIPTION
DLC purge command was showing a flag in the navigation label. This should remove it and make the `Use` string consistent with other commands.