### PR TITLE
Follow classic projects during onboard instead of creating

### DIFF
--- a/acceptance/onboard_test.go
+++ b/acceptance/onboard_test.go
@@ -289,7 +289,7 @@ func TestOnboard_PostSignup_ProjectCreated(t *testing.T) {
 	copyFixture(t, "testdata/test-run/dotnet", dir)
 	initGitRepoWithRemote(t, dir, "https://github.com/myorg/my-repo.git")
 
-	_, env := onboardAuthenticatedEnv(t, "testuser")
+	_, env := onboardStandaloneEnv(t, "testuser")
 	addFakeDotnet(t, env, false)
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
@@ -302,6 +302,29 @@ func TestOnboard_PostSignup_ProjectCreated(t *testing.T) {
 	assert.Check(t, strings.Contains(result.Stdout, "Project created: my-repo"))
 	assert.Check(t, strings.Contains(result.Stdout, "Organization: myorg"))
 	assert.Check(t, strings.Contains(result.Stdout, "Commit .circleci/config.yml"))
+}
+
+func TestOnboard_PostSignup_ClassicOrg_FollowsProject(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test runner uses sh -c")
+	}
+	dir := t.TempDir()
+	copyFixture(t, "testdata/test-run/dotnet", dir)
+	initGitRepoWithRemote(t, dir, "https://github.com/myorg/my-repo.git")
+
+	_, env := onboardAuthenticatedEnv(t, "testuser")
+	addFakeDotnet(t, env, false)
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"onboard", "--scan"},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Check(t, strings.Contains(result.Stdout, "Project followed: my-repo"))
+	assert.Check(t, strings.Contains(result.Stdout, "Organization: myorg"))
+	assert.Check(t, strings.Contains(result.Stdout, "Commit and push .circleci/config.yml"))
 }
 
 func TestOnboard_PostSignup_NoOrgs(t *testing.T) {
@@ -334,7 +357,7 @@ func TestOnboard_PostSignup_CreateFails(t *testing.T) {
 	copyFixture(t, "testdata/test-run/dotnet", dir)
 	initGitRepoWithRemote(t, dir, "https://github.com/myorg/my-repo.git")
 
-	fake, env := onboardAuthenticatedEnv(t, "testuser")
+	fake, env := onboardStandaloneEnv(t, "testuser")
 	fake.SetCreateProjectResponse(nil)
 	addFakeDotnet(t, env, false)
 	result := binary.RunCLI(t, binary.RunOpts{
@@ -347,6 +370,35 @@ func TestOnboard_PostSignup_CreateFails(t *testing.T) {
 	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
 	assert.Check(t, strings.Contains(result.Stderr, "Could not create project"))
 	assert.Check(t, strings.Contains(result.Stdout, "circleci project create"))
+}
+
+func onboardStandaloneEnv(t *testing.T, login string) (*fakes.CircleCI, *testenv.TestEnv) {
+	t.Helper()
+
+	fake := fakes.NewCircleCI(t)
+	fake.SetMe(map[string]any{
+		"id": "e4a72497-7c55-400d-a72d-dadc4b92255d",
+		"attributes": map[string]any{
+			"name":  "Test User",
+			"login": login,
+		},
+	})
+	fake.SetCollaborations([]any{
+		map[string]any{"id": "org-uuid-1234", "name": "myorg", "slug": "circleci/myorg", "vcs_type": "circleci"},
+	})
+	fake.SetCreateProjectResponse(map[string]any{
+		"id":                "proj-uuid-5678",
+		"slug":              "circleci/myorg/my-repo",
+		"name":              "my-repo",
+		"organization_name": "myorg",
+		"organization_slug": "circleci/myorg",
+		"organization_id":   "org-uuid-1234",
+	})
+
+	env := testenv.New(t)
+	env.CircleCIURL = fake.URL()
+	env.Token = "test-token"
+	return fake, env
 }
 
 func onboardAuthenticatedEnv(t *testing.T, login string) (*fakes.CircleCI, *testenv.TestEnv) {

--- a/acceptance/onboard_test.go
+++ b/acceptance/onboard_test.go
@@ -322,7 +322,7 @@ func TestOnboard_PostSignup_ClassicOrg_FollowsProject(t *testing.T) {
 	})
 
 	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
-	assert.Check(t, strings.Contains(result.Stdout, "Project followed: my-repo"))
+	assert.Check(t, strings.Contains(result.Stdout, "Project connected: my-repo"))
 	assert.Check(t, strings.Contains(result.Stdout, "Organization: myorg"))
 	assert.Check(t, strings.Contains(result.Stdout, "Commit and push .circleci/config.yml"))
 }

--- a/internal/onboarder/onboarder.go
+++ b/internal/onboarder/onboarder.go
@@ -243,13 +243,13 @@ func postSignupGuidance(ctx context.Context) error {
 
 func followClassicProject(ctx context.Context, client *apiclient.Client, appURL, vcs, orgName, repoName string) error {
 	if err := client.FollowProject(ctx, vcs, orgName, repoName); err != nil {
-		iostream.ErrPrintf(ctx, "%s Could not follow project: %s\n", iostream.SymbolWarn(ctx), err)
+		iostream.ErrPrintf(ctx, "%s Could not connect project: %s\n", iostream.SymbolWarn(ctx), err)
 		printManualGuidance(ctx)
 		return nil
 	}
 
 	slug := fmt.Sprintf("%s/%s/%s", vcs, orgName, repoName)
-	iostream.Printf(ctx, "%s Project followed: %s\n", iostream.SymbolOK(ctx), repoName)
+	iostream.Printf(ctx, "%s Project connected: %s\n", iostream.SymbolOK(ctx), repoName)
 	iostream.Printf(ctx, "  Organization: %s\n", orgName)
 	if pipelinesURL, err := cmdutil.RunSlugURL(appURL, slug); err == nil {
 		iostream.Printf(ctx, "  Pipelines: %s\n", pipelinesURL)

--- a/internal/onboarder/onboarder.go
+++ b/internal/onboarder/onboarder.go
@@ -31,6 +31,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/CircleCI-Public/circleci-cli/internal/apiclient"
 	"github.com/CircleCI-Public/circleci-cli/internal/cmd/cmdauth"
 	"github.com/CircleCI-Public/circleci-cli/internal/cmdutil"
 	"github.com/CircleCI-Public/circleci-cli/internal/configgen"
@@ -165,11 +166,11 @@ func postSignupGuidance(ctx context.Context) error {
 		return nil
 	}
 
-	var orgSlug string
+	var selectedOrg apiclient.Collaboration
 	switch {
 	case len(orgs) == 1:
-		orgSlug = orgs[0].Slug
-		iostream.Printf(ctx, "%s Using organization %s\n", iostream.SymbolOK(ctx), orgSlug)
+		selectedOrg = orgs[0]
+		iostream.Printf(ctx, "%s Using organization %s\n", iostream.SymbolOK(ctx), selectedOrg.Slug)
 	case iostream.IsInteractive(ctx):
 		iostream.ErrPrintf(ctx, "\nLet's create your CircleCI project.\n\n")
 		labels := make([]string, len(orgs))
@@ -185,13 +186,13 @@ func postSignupGuidance(ctx context.Context) error {
 			printManualGuidance(ctx)
 			return nil
 		}
-		orgSlug = orgs[idx].Slug
+		selectedOrg = orgs[idx]
 	default:
 		printManualGuidance(ctx)
 		return nil
 	}
 
-	vcs, orgName, err := org.ParseSlug(orgSlug)
+	vcs, orgName, err := org.ParseSlug(selectedOrg.Slug)
 	if err != nil {
 		printManualGuidance(ctx)
 		return nil
@@ -220,6 +221,10 @@ func postSignupGuidance(ctx context.Context) error {
 		}
 	}
 
+	if selectedOrg.VCSType != "circleci" {
+		return followClassicProject(ctx, client, appURL, vcs, orgName, name)
+	}
+
 	proj, err := client.CreateProject(ctx, vcs, orgName, name)
 	if err != nil {
 		iostream.ErrPrintf(ctx, "%s Could not create project: %s\n", iostream.SymbolWarn(ctx), err)
@@ -233,6 +238,23 @@ func postSignupGuidance(ctx context.Context) error {
 		iostream.Printf(ctx, "  Pipelines: %s\n", pipelinesURL)
 	}
 	iostream.Printf(ctx, "\nCommit .circleci/config.yml. After your project is connected in CircleCI, pushing will start your first pipeline.\n")
+	return nil
+}
+
+func followClassicProject(ctx context.Context, client *apiclient.Client, appURL, vcs, orgName, repoName string) error {
+	if err := client.FollowProject(ctx, vcs, orgName, repoName); err != nil {
+		iostream.ErrPrintf(ctx, "%s Could not follow project: %s\n", iostream.SymbolWarn(ctx), err)
+		printManualGuidance(ctx)
+		return nil
+	}
+
+	slug := fmt.Sprintf("%s/%s/%s", vcs, orgName, repoName)
+	iostream.Printf(ctx, "%s Project followed: %s\n", iostream.SymbolOK(ctx), repoName)
+	iostream.Printf(ctx, "  Organization: %s\n", orgName)
+	if pipelinesURL, err := cmdutil.RunSlugURL(appURL, slug); err == nil {
+		iostream.Printf(ctx, "  Pipelines: %s\n", pipelinesURL)
+	}
+	iostream.Printf(ctx, "\nCommit and push .circleci/config.yml to start your first pipeline.\n")
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- When a user selects a VCS-connected (classic) org during `circleci onboard`, use `FollowProject` (v1.1 API) instead of `CreateProject`
- Classic follows automatically set up webhooks, so no separate pipeline definition or trigger creation is needed
- Standalone (`circleci` type) orgs continue to use `CreateProject` as before

## Before (classic org)

```
$ circleci onboard --scan
...
✓ Using organization gh/myorg
✓ Project created: my-repo
  Organization: myorg
  Pipelines: https://app.circleci.com/pipelines/gh/myorg/my-repo

Commit .circleci/config.yml. After your project is connected in CircleCI, pushing will start your first pipeline.
```

## After (classic org)

```
$ circleci onboard --scan
...
✓ Using organization gh/myorg
✓ Project connected: my-repo
  Organization: myorg
  Pipelines: https://app.circleci.com/pipelines/gh/myorg/my-repo

Commit and push .circleci/config.yml to start your first pipeline.
```

Standalone orgs (`circleci/myorg`) continue to use `CreateProject` and show the same output as before.

## Test plan

- [ ] `TestOnboard_PostSignup_ClassicOrg_FollowsProject` covers the new classic follow path
- [ ] `TestOnboard_PostSignup_ProjectCreated` confirms standalone orgs still use `CreateProject`
- [ ] `TestOnboard_PostSignup_CreateFails` confirms standalone create-failure fallback still works