### PR TITLE
Drop angle brackets from docs prose to fix placeholder removal

### DIFF
--- a/internal/cmd/api/api.go
+++ b/internal/cmd/api/api.go
@@ -61,7 +61,7 @@ func NewAPICmd() *cobra.Command {
 		Short: "Call the CircleCI REST API directly",
 		Annotations: map[string]string{
 			"help:arguments": heredoc.Doc(`
-				<path> is the request path. It is relative to /api/v3 by default
+				path is the request path. It is relative to /api/v3 by default
 				(e.g. "projects/{project-id}"). To target
 				a different version prefix, include it explicitly, e.g. "api/v2/me".
 			`),
@@ -70,7 +70,7 @@ func NewAPICmd() *cobra.Command {
 			Make an authenticated HTTP request to the REST APIs and print
 			the raw response body.
 
-			<path> is relative to /api/v3 (e.g. projects/{project-id}). To target
+			path is relative to /api/v3 (e.g. projects/{project-id}). To target
 			a different version prefix, include it explicitly:
 			  circleci api api/v2/me
 

--- a/internal/cmd/artifacts/artifacts.go
+++ b/internal/cmd/artifacts/artifacts.go
@@ -48,7 +48,7 @@ func NewArtifactCmd() *cobra.Command {
 		Short:   "List and download a job's artifact files",
 		Annotations: map[string]string{
 			"help:arguments": heredoc.Doc(`
-				<job-id> is the UUID of the job whose artifacts you want to
+				job-id is the UUID of the job whose artifacts you want to
 				list or download,
 				e.g. 5034460f-c7c4-4c43-9457-de07e2029e7b.
 			`),

--- a/internal/cmd/certificate/certificate.go
+++ b/internal/cmd/certificate/certificate.go
@@ -297,7 +297,7 @@ func newDeleteCmd() *cobra.Command {
 		Short:   "Delete an iOS certificate",
 		Annotations: map[string]string{
 			"help:arguments": heredoc.Doc(`
-				<cert-id> is the ID of the certificate to delete
+				cert-id is the ID of the certificate to delete
 				(see: circleci certificate list).
 			`),
 		},

--- a/internal/cmd/cmdauth/id.go
+++ b/internal/cmd/cmdauth/id.go
@@ -39,7 +39,7 @@ func newDeviceIDCmd() *cobra.Command {
 		Use:   "id",
 		Short: "Show the device ID for this CLI installation",
 		Long: heredoc.Doc(`
-			Print the device ID for this CLI installation as "<os>:<uuid>".
+			Print the device ID for this CLI installation as "os:uuid".
 
 			The UUID is generated on first use and stored in the config file.
 			The OS prefix (e.g. darwin, linux) is added at print time so you
@@ -48,7 +48,7 @@ func newDeviceIDCmd() *cobra.Command {
 			a token in the CircleCI UI back to this installation.
 
 			JSON fields:
-			  device_id  string  Stable identifier in the form <os>:<uuid>
+			  device_id  string  Stable identifier in the form os:uuid
 		`),
 		Example: heredoc.Doc(`
 			# Print the device ID

--- a/internal/cmd/config/generate.go
+++ b/internal/cmd/config/generate.go
@@ -42,7 +42,7 @@ func newGenerateCmd() *cobra.Command {
 		Short: "Generate .circleci/config.yml from a repository scan",
 		Long: heredoc.Doc(`
 			Detect the language stack, container image, and setup commands for a
-			repository, then write a starter pipeline to <path>/.circleci/config.yml.
+			repository, then write a starter pipeline to path/.circleci/config.yml.
 
 			If no supported stack is detected, a minimal cimg/base:stable template
 			with a placeholder build step is written instead so you have something

--- a/internal/cmd/config/pack.go
+++ b/internal/cmd/config/pack.go
@@ -39,7 +39,7 @@ func newPackCmd() *cobra.Command {
 		Short: "Bundle split config files into a single YAML document",
 		Annotations: map[string]string{
 			"help:arguments": heredoc.Doc(`
-				<path> is the path to a split config directory to pack,
+				path is the path to a split config directory to pack,
 				e.g. ".circleci" or "src/ci". The directory structure is
 				mapped to YAML keys in the merged document.
 			`),

--- a/internal/cmd/config/process.go
+++ b/internal/cmd/config/process.go
@@ -49,7 +49,7 @@ func newProcessCmd() *cobra.Command {
 		Short: "Compile and expand a pipeline config file",
 		Annotations: map[string]string{
 			"help:arguments": heredoc.Doc(`
-				<path> is the path to a pipeline config file to compile,
+				path is the path to a pipeline config file to compile,
 				e.g. ".circleci/config.yml". Pass "-" to read the config
 				from stdin.
 			`),

--- a/internal/cmd/envvar/env.go
+++ b/internal/cmd/envvar/env.go
@@ -50,7 +50,7 @@ func NewEnvVarCmd() *cobra.Command {
 			Environment variable values are masked in list output (shown as "xxxx").
 			The full value is never retrievable after it has been set.
 
-			Also available as: circleci project envvar <command>
+			Also available as: circleci project envvar command
 		`),
 		Example: heredoc.Doc(`
 			# List all environment variables for the current project

--- a/internal/cmd/job/artifacts.go
+++ b/internal/cmd/job/artifacts.go
@@ -45,7 +45,7 @@ func newArtifactCmd() *cobra.Command {
 		Short: "List or download artifacts for a job",
 		Annotations: map[string]string{
 			"help:arguments": heredoc.Doc(`
-				<job-id> is the UUID of the job whose artifacts to list or download.
+				job-id is the UUID of the job whose artifacts to list or download.
 				Job UUIDs are shown in the output of "circleci workflow get" and
 				"circleci run get --json".
 			`),

--- a/internal/cmd/job/get.go
+++ b/internal/cmd/job/get.go
@@ -46,7 +46,7 @@ func newGetCmd() *cobra.Command {
 		Short: "Get job details",
 		Annotations: map[string]string{
 			"help:arguments": heredoc.Doc(`
-				<job-id> is the UUID of the job to look up. Job UUIDs are shown in
+				job-id is the UUID of the job to look up. Job UUIDs are shown in
 				the output of "circleci workflow get" and "circleci run get --json".
 			`),
 		},

--- a/internal/cmd/job/open.go
+++ b/internal/cmd/job/open.go
@@ -41,7 +41,7 @@ func newOpenCmd() *cobra.Command {
 		Short: "Open job in browser",
 		Annotations: map[string]string{
 			"help:arguments": heredoc.Doc(`
-				<job-id> is the UUID of the job to look up. Job UUIDs are shown in
+				job-id is the UUID of the job to look up. Job UUIDs are shown in
 				the output of "circleci workflow get" and "circleci run get --json".
 			`),
 		},

--- a/internal/cmd/job/output_get.go
+++ b/internal/cmd/job/output_get.go
@@ -52,7 +52,7 @@ func newOutputGetCmd() *cobra.Command {
 		Short: "Get the output of a job step",
 		Annotations: map[string]string{
 			"help:arguments": heredoc.Doc(`
-				<job-id> is the UUID of the job whose step output to fetch. Job UUIDs
+				job-id is the UUID of the job whose step output to fetch. Job UUIDs
 				are shown in the output of "circleci workflow get" and "circleci job get".
 				Use --step-num to select which step's output to read.
 			`),

--- a/internal/cmd/job/output_list.go
+++ b/internal/cmd/job/output_list.go
@@ -90,7 +90,7 @@ func newOutputListCmd() *cobra.Command {
 		Short: "List a job's steps with their output",
 		Annotations: map[string]string{
 			"help:arguments": heredoc.Doc(`
-				<job-id> is the UUID of the job whose steps and output to list. Job
+				job-id is the UUID of the job whose steps and output to list. Job
 				UUIDs are shown in the output of "circleci workflow get" and
 				"circleci job get".
 			`),

--- a/internal/cmd/namespace/create.go
+++ b/internal/cmd/namespace/create.go
@@ -44,7 +44,7 @@ func newCreateCmd() *cobra.Command {
 		Short: "Create a namespace",
 		Annotations: map[string]string{
 			"help:arguments": heredoc.Doc(`
-				<name> is the namespace name to create. It must be globally unique
+				name is the namespace name to create. It must be globally unique
 				across CircleCI, e.g. "myorg".
 			`),
 		},

--- a/internal/cmd/namespace/delete.go
+++ b/internal/cmd/namespace/delete.go
@@ -45,7 +45,7 @@ func newDeleteCmd() *cobra.Command {
 		Short:   "Delete a namespace and all its orbs",
 		Annotations: map[string]string{
 			"help:arguments": heredoc.Doc(`
-				<name> is the name of the namespace to delete, e.g. "myorg".
+				name is the name of the namespace to delete, e.g. "myorg".
 			`),
 		},
 		Long: heredoc.Doc(`

--- a/internal/cmd/namespace/get.go
+++ b/internal/cmd/namespace/get.go
@@ -42,7 +42,7 @@ func newGetCmd() *cobra.Command {
 		Short: "Get details of a namespace",
 		Annotations: map[string]string{
 			"help:arguments": heredoc.Doc(`
-				<name> is the name of the namespace to look up, e.g. "myorg".
+				name is the name of the namespace to look up, e.g. "myorg".
 			`),
 		},
 		Long: heredoc.Doc(`

--- a/internal/cmd/namespace/namespace.go
+++ b/internal/cmd/namespace/namespace.go
@@ -46,7 +46,7 @@ func NewNamespaceCmd() *cobra.Command {
 
 			Namespaces are unique identifiers used to publish orbs.
 			Each organization may claim one namespace. Orbs are published
-			and referenced as <namespace>/<orb>. All published orbs are world-readable.
+			and referenced as namespace/orb. All published orbs are world-readable.
 		`),
 		RunE:               cmdutil.GroupRunE,
 		FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},

--- a/internal/cmd/namespace/rename.go
+++ b/internal/cmd/namespace/rename.go
@@ -41,8 +41,8 @@ func newRenameCmd() *cobra.Command {
 		Short: "Rename a namespace",
 		Annotations: map[string]string{
 			"help:arguments": heredoc.Doc(`
-				- <name> is the current name of the namespace, e.g. "oldname".
-				- <new-name> is the new name to assign, e.g. "newname".
+				- name is the current name of the namespace, e.g. "oldname".
+				- new-name is the new name to assign, e.g. "newname".
 			`),
 		},
 		Long: heredoc.Doc(`

--- a/internal/cmd/orb/add_to_category.go
+++ b/internal/cmd/orb/add_to_category.go
@@ -39,8 +39,8 @@ func newAddToCategoryCmd() *cobra.Command {
 		Short: "Add an orb to a registry category",
 		Annotations: map[string]string{
 			"help:arguments": heredoc.Doc(`
-				- <ns>/<orb>: the orb to add, as "namespace/orb-name"
-				- <category>: the registry category name, e.g. "Testing"
+				- ns/orb: the orb to add, as "namespace/orb-name"
+				- category: the registry category name, e.g. "Testing"
 			`),
 		},
 		Long: heredoc.Doc(`

--- a/internal/cmd/orb/create.go
+++ b/internal/cmd/orb/create.go
@@ -46,7 +46,7 @@ func newCreateCmd() *cobra.Command {
 		Short: "Reserve an orb name in a namespace",
 		Annotations: map[string]string{
 			"help:arguments": heredoc.Doc(`
-				- <namespace>/<orb>: the orb name to reserve, as "namespace/orb-name".
+				- namespace/orb: the orb name to reserve, as "namespace/orb-name".
 				  The namespace must already exist.
 			`),
 		},

--- a/internal/cmd/orb/diff.go
+++ b/internal/cmd/orb/diff.go
@@ -49,7 +49,7 @@ func newDiffCmd() *cobra.Command {
 		Short: "Show a unified diff between two orb versions",
 		Annotations: map[string]string{
 			"help:arguments": heredoc.Doc(`
-				- <ns>/<orb>: the orb to diff, as "namespace/orb-name"
+				- ns/orb: the orb to diff, as "namespace/orb-name"
 			`),
 		},
 		Long: heredoc.Doc(`

--- a/internal/cmd/orb/list.go
+++ b/internal/cmd/orb/list.go
@@ -47,7 +47,7 @@ func newListCmd() *cobra.Command {
 		Short:   "List orbs in the registry",
 		Annotations: map[string]string{
 			"help:arguments": heredoc.Doc(`
-				- <namespace>: optional. When given, lists all orbs in that namespace.
+				- namespace: optional. When given, lists all orbs in that namespace.
 				  When omitted, lists certified orbs globally.
 			`),
 		},

--- a/internal/cmd/orb/pack.go
+++ b/internal/cmd/orb/pack.go
@@ -40,7 +40,7 @@ func newPackCmd() *cobra.Command {
 		Short: "Pack a multi-file orb directory into a single YAML",
 		Annotations: map[string]string{
 			"help:arguments": heredoc.Doc(`
-				- <path>: path to an orb source directory or a single orb YAML file.
+				- path: path to an orb source directory or a single orb YAML file.
 			`),
 		},
 		Long: heredoc.Doc(`

--- a/internal/cmd/orb/process.go
+++ b/internal/cmd/orb/process.go
@@ -43,7 +43,7 @@ func newProcessCmd() *cobra.Command {
 		Short: "Validate and print expanded orb YAML",
 		Annotations: map[string]string{
 			"help:arguments": heredoc.Doc(`
-				- <path>: path to an orb YAML file. Pass '-' to read from stdin.
+				- path: path to an orb YAML file. Pass '-' to read from stdin.
 			`),
 		},
 		Long: heredoc.Doc(`

--- a/internal/cmd/orb/publish.go
+++ b/internal/cmd/orb/publish.go
@@ -45,13 +45,13 @@ func newPublishCmd() *cobra.Command {
 			Publish orb versions to the CircleCI orb registry.
 
 			To publish a specific version:
-			  circleci orb publish <path> <ns>/<orb>@<version>
+			  circleci orb publish path ns/orb@version
 
 			To promote a dev version to a stable semver:
-			  circleci orb publish promote <ns>/<orb>@dev:<label> --bump major|minor|patch
+			  circleci orb publish promote ns/orb@dev:label --bump major|minor|patch
 
 			To increment the latest stable version and publish:
-			  circleci orb publish increment <path> <ns>/<orb> --bump major|minor|patch
+			  circleci orb publish increment path ns/orb --bump major|minor|patch
 		`),
 		Example: heredoc.Doc(`
 			# Publish a specific version
@@ -100,13 +100,13 @@ func newPublishPromoteCmd() *cobra.Command {
 		Short: "Promote a dev orb version to a stable semver",
 		Annotations: map[string]string{
 			"help:arguments": heredoc.Doc(`
-				- <ns>/<orb>@dev:<label>: the dev version to promote, e.g. "namespace/orb-name@dev:my-branch"
+				- ns/orb@dev:label: the dev version to promote, e.g. "namespace/orb-name@dev:my-branch"
 			`),
 		},
 		Long: heredoc.Doc(`
 			Promote a dev orb version to a stable semver version.
 
-			The dev version ref must be in the form <ns>/<orb>@dev:<label>.
+			The dev version ref must be in the form ns/orb@dev:label.
 			The --bump flag determines how the version is incremented
 			from the latest stable release.
 		`),
@@ -152,8 +152,8 @@ func newPublishIncrementCmd() *cobra.Command {
 		Short: "Increment and publish a new orb version",
 		Annotations: map[string]string{
 			"help:arguments": heredoc.Doc(`
-				- <path>: path to the orb YAML to publish. Pass '-' to read from stdin.
-				- <ns>/<orb>: the orb to publish, as "namespace/orb-name"
+				- path: path to the orb YAML to publish. Pass '-' to read from stdin.
+				- ns/orb: the orb to publish, as "namespace/orb-name"
 			`),
 		},
 		Long: heredoc.Doc(`

--- a/internal/cmd/orb/remove_from_category.go
+++ b/internal/cmd/orb/remove_from_category.go
@@ -39,14 +39,14 @@ func newRemoveFromCategoryCmd() *cobra.Command {
 		Short: "Remove an orb from a registry category",
 		Annotations: map[string]string{
 			"help:arguments": heredoc.Doc(`
-				- <ns>/<orb>: the orb to remove, as "namespace/orb-name"
-				- <category>: the registry category name, e.g. "Testing"
+				- ns/orb: the orb to remove, as "namespace/orb-name"
+				- category: the registry category name, e.g. "Testing"
 			`),
 		},
 		Long: heredoc.Doc(`
 			Remove an orb from an orb registry category.
 
-			Use 'circleci orb get <ns>/<orb>' to see the current categories
+			Use 'circleci orb get ns/orb' to see the current categories
 			for an orb, and 'circleci orb list-categories' for all available
 			categories.
 		`),

--- a/internal/cmd/orb/source.go
+++ b/internal/cmd/orb/source.go
@@ -40,8 +40,8 @@ func newSourceCmd() *cobra.Command {
 		Short: "Print the YAML source of an orb version",
 		Annotations: map[string]string{
 			"help:arguments": heredoc.Doc(`
-				- <ns>/<orb>[@<version>]: the orb to print, as "namespace/orb-name".
-				  Optionally append @<version> (e.g. @1.2.3, @volatile, or @dev:my-branch).
+				- ns/orb[@version]: the orb to print, as "namespace/orb-name".
+				  Optionally append @version (e.g. @1.2.3, @volatile, or @dev:my-branch).
 				  When omitted, the latest published version is shown.
 			`),
 		},
@@ -49,7 +49,7 @@ func newSourceCmd() *cobra.Command {
 			Print the raw YAML source of an orb version.
 
 			If no version is specified, the latest published version is shown.
-			Specify a version with @<version> (e.g. @1.2.3 or @volatile for latest).
+			Specify a version with @version (e.g. @1.2.3 or @volatile for latest).
 		`),
 		Example: heredoc.Doc(`
 			# Print source of the latest version

--- a/internal/cmd/orb/unlist.go
+++ b/internal/cmd/orb/unlist.go
@@ -41,7 +41,7 @@ func newUnlistCmd() *cobra.Command {
 		Short: "Hide or restore an orb in the registry",
 		Annotations: map[string]string{
 			"help:arguments": heredoc.Doc(`
-				- <ns>/<orb>: the orb to update, as "namespace/orb-name"
+				- ns/orb: the orb to update, as "namespace/orb-name"
 			`),
 		},
 		Long: heredoc.Doc(`

--- a/internal/cmd/orb/validate.go
+++ b/internal/cmd/orb/validate.go
@@ -45,7 +45,7 @@ func newValidateCmd() *cobra.Command {
 		Short: "Validate an orb YAML file",
 		Annotations: map[string]string{
 			"help:arguments": heredoc.Doc(`
-				- <path>: path to an orb YAML file. Pass '-' to read from stdin.
+				- path: path to an orb YAML file. Pass '-' to read from stdin.
 			`),
 		},
 		Long: heredoc.Doc(`

--- a/internal/cmd/policy/diff.go
+++ b/internal/cmd/policy/diff.go
@@ -45,7 +45,7 @@ func newDiffCmd() *cobra.Command {
 		Short: "Show diff between local and remote policy bundles",
 		Annotations: map[string]string{
 			"help:arguments": heredoc.Doc(`
-				<path> is the path to a local directory of .rego policy files,
+				path is the path to a local directory of .rego policy files,
 				e.g. "./policies". Its contents are compared against the remote
 				policy bundle.
 			`),

--- a/internal/cmd/policy/push.go
+++ b/internal/cmd/policy/push.go
@@ -47,7 +47,7 @@ func newPushCmd() *cobra.Command {
 		Short: "Push a policy bundle to CircleCI",
 		Annotations: map[string]string{
 			"help:arguments": heredoc.Doc(`
-				<path> is the path to a local directory of .rego policy files,
+				path is the path to a local directory of .rego policy files,
 				e.g. "./policies". Its contents are uploaded as the policy
 				bundle, replacing the existing bundle.
 			`),

--- a/internal/cmd/project/env.go
+++ b/internal/cmd/project/env.go
@@ -164,8 +164,8 @@ func NewEnvSetCmd() *cobra.Command {
 		Short: "Set a project environment variable",
 		Annotations: map[string]string{
 			"help:arguments": heredoc.Doc(`
-				<name> is the name of the environment variable to create or
-				update. <value> is the value to store; it is never retrievable
+				name is the name of the environment variable to create or
+				update. value is the value to store; it is never retrievable
 				after being set and is masked in all subsequent list output.
 			`),
 		},
@@ -241,7 +241,7 @@ func NewEnvDeleteCmd() *cobra.Command {
 		Short:   "Delete a project environment variable",
 		Annotations: map[string]string{
 			"help:arguments": heredoc.Doc(`
-				<name> is the name of the environment variable to delete from
+				name is the name of the environment variable to delete from
 				the project. This action is irreversible.
 			`),
 		},

--- a/internal/cmd/project/link.go
+++ b/internal/cmd/project/link.go
@@ -56,7 +56,7 @@ func newLinkCmd() *cobra.Command {
 			re-detecting from the git remote each time.
 
 			Resolution order:
-			  1. --project <slug>, if given.
+			  1. --project slug, if given.
 			  2. The git remote (origin) of the current directory.
 			  3. An interactive prompt — used when neither of the above
 			     yields a project the API recognises.
@@ -88,7 +88,7 @@ func newLinkCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&projectSlug, "project", "", "Project slug (e.g. gh/org/repo or circleci/<orgID>/<projectID>)")
+	cmd.Flags().StringVar(&projectSlug, "project", "", "Project slug (e.g. gh/org/repo or circleci/orgID/projectID)")
 	cmd.Flags().BoolVarP(&force, "force", "f", false, "Overwrite an existing .circleci/info.yml")
 
 	return cmd

--- a/internal/cmd/root/testdata/help/circleci/api.txt
+++ b/internal/cmd/root/testdata/help/circleci/api.txt
@@ -3,7 +3,7 @@
 Make an authenticated HTTP request to the REST APIs and print
 the raw response body.
 
-<path> is relative to /api/v3 (e.g. projects/{project-id}). To target
+path is relative to /api/v3 (e.g. projects/{project-id}). To target
 a different version prefix, include it explicitly:
   circleci api api/v2/me
 
@@ -45,7 +45,7 @@ For more information about output formatting flags, see `circleci help formattin
 
 ## Arguments
 
-<path> is the request path. It is relative to /api/v3 by default
+path is the request path. It is relative to /api/v3 by default
 (e.g. "projects/{project-id}"). To target
 a different version prefix, include it explicitly, e.g. "api/v2/me".
 

--- a/internal/cmd/root/testdata/help/circleci/artifact.txt
+++ b/internal/cmd/root/testdata/help/circleci/artifact.txt
@@ -32,7 +32,7 @@ For more information about output formatting flags, see `circleci help formattin
 
 ## Arguments
 
-<job-id> is the UUID of the job whose artifacts you want to
+job-id is the UUID of the job whose artifacts you want to
 list or download,
 e.g. 5034460f-c7c4-4c43-9457-de07e2029e7b.
 

--- a/internal/cmd/root/testdata/help/circleci/auth/id.txt
+++ b/internal/cmd/root/testdata/help/circleci/auth/id.txt
@@ -1,6 +1,6 @@
 # CircleCI CLI
 
-Print the device ID for this CLI installation as "<os>:<uuid>".
+Print the device ID for this CLI installation as "os:uuid".
 
 The UUID is generated on first use and stored in the config file.
 The OS prefix (e.g. darwin, linux) is added at print time so you
@@ -9,7 +9,7 @@ is sent with every OAuth authorization request, so you can match
 a token in the CircleCI UI back to this installation.
 
 JSON fields:
-  device_id  string  Stable identifier in the form <os>:<uuid>
+  device_id  string  Stable identifier in the form os:uuid
 
 ## Usage
 

--- a/internal/cmd/root/testdata/help/circleci/certificate/delete.txt
+++ b/internal/cmd/root/testdata/help/circleci/certificate/delete.txt
@@ -34,7 +34,7 @@ Use --force (-f) to skip the prompt for scripting.
 
 ## Arguments
 
-<cert-id> is the ID of the certificate to delete
+cert-id is the ID of the certificate to delete
 (see: circleci certificate list).
 
 ## Examples

--- a/internal/cmd/root/testdata/help/circleci/config/generate.txt
+++ b/internal/cmd/root/testdata/help/circleci/config/generate.txt
@@ -1,7 +1,7 @@
 # CircleCI CLI
 
 Detect the language stack, container image, and setup commands for a
-repository, then write a starter pipeline to <path>/.circleci/config.yml.
+repository, then write a starter pipeline to path/.circleci/config.yml.
 
 If no supported stack is detected, a minimal cimg/base:stable template
 with a placeholder build step is written instead so you have something

--- a/internal/cmd/root/testdata/help/circleci/config/pack.txt
+++ b/internal/cmd/root/testdata/help/circleci/config/pack.txt
@@ -32,7 +32,7 @@ The merged YAML is printed to stdout.
 
 ## Arguments
 
-<path> is the path to a split config directory to pack,
+path is the path to a split config directory to pack,
 e.g. ".circleci" or "src/ci". The directory structure is
 mapped to YAML keys in the merged document.
 

--- a/internal/cmd/root/testdata/help/circleci/config/process.txt
+++ b/internal/cmd/root/testdata/help/circleci/config/process.txt
@@ -31,7 +31,7 @@ Pass a file path or "-" to read from stdin.
 
 ## Arguments
 
-<path> is the path to a pipeline config file to compile,
+path is the path to a pipeline config file to compile,
 e.g. ".circleci/config.yml". Pass "-" to read the config
 from stdin.
 

--- a/internal/cmd/root/testdata/help/circleci/envvar.txt
+++ b/internal/cmd/root/testdata/help/circleci/envvar.txt
@@ -8,7 +8,7 @@ unless overridden with --project.
 Environment variable values are masked in list output (shown as "xxxx").
 The full value is never retrievable after it has been set.
 
-Also available as: circleci project envvar <command>
+Also available as: circleci project envvar command
 
 ## Usage
 

--- a/internal/cmd/root/testdata/help/circleci/envvar/delete.txt
+++ b/internal/cmd/root/testdata/help/circleci/envvar/delete.txt
@@ -37,7 +37,7 @@ Use --force (-f) to skip the prompt for scripting.
 
 ## Arguments
 
-<name> is the name of the environment variable to delete from
+name is the name of the environment variable to delete from
 the project. This action is irreversible.
 
 ## Examples

--- a/internal/cmd/root/testdata/help/circleci/envvar/set.txt
+++ b/internal/cmd/root/testdata/help/circleci/envvar/set.txt
@@ -30,8 +30,8 @@ unless overridden with --project.
 
 ## Arguments
 
-<name> is the name of the environment variable to create or
-update. <value> is the value to store; it is never retrievable
+name is the name of the environment variable to create or
+update. value is the value to store; it is never retrievable
 after being set and is masked in all subsequent list output.
 
 ## Examples

--- a/internal/cmd/root/testdata/help/circleci/job/artifact.txt
+++ b/internal/cmd/root/testdata/help/circleci/job/artifact.txt
@@ -32,7 +32,7 @@ For more information about output formatting flags, see `circleci help formattin
 
 ## Arguments
 
-<job-id> is the UUID of the job whose artifacts to list or download.
+job-id is the UUID of the job whose artifacts to list or download.
 Job UUIDs are shown in the output of "circleci workflow get" and
 "circleci run get --json".
 

--- a/internal/cmd/root/testdata/help/circleci/job/get.txt
+++ b/internal/cmd/root/testdata/help/circleci/job/get.txt
@@ -33,7 +33,7 @@ For more information about output formatting flags, see `circleci help formattin
 
 ## Arguments
 
-<job-id> is the UUID of the job to look up. Job UUIDs are shown in
+job-id is the UUID of the job to look up. Job UUIDs are shown in
 the output of "circleci workflow get" and "circleci run get --json".
 
 ## Examples

--- a/internal/cmd/root/testdata/help/circleci/job/open.txt
+++ b/internal/cmd/root/testdata/help/circleci/job/open.txt
@@ -17,7 +17,7 @@ Open job in browser
 
 ## Arguments
 
-<job-id> is the UUID of the job to look up. Job UUIDs are shown in
+job-id is the UUID of the job to look up. Job UUIDs are shown in
 the output of "circleci workflow get" and "circleci run get --json".
 
 ## Examples

--- a/internal/cmd/root/testdata/help/circleci/job/output/get.txt
+++ b/internal/cmd/root/testdata/help/circleci/job/output/get.txt
@@ -45,7 +45,7 @@ Use --strip-ansi to force this rendering even on a terminal, or
 
 ## Arguments
 
-<job-id> is the UUID of the job whose step output to fetch. Job UUIDs
+job-id is the UUID of the job whose step output to fetch. Job UUIDs
 are shown in the output of "circleci workflow get" and "circleci job get".
 Use --step-num to select which step's output to read.
 

--- a/internal/cmd/root/testdata/help/circleci/job/output/list.txt
+++ b/internal/cmd/root/testdata/help/circleci/job/output/list.txt
@@ -46,7 +46,7 @@ For more information about output formatting flags, see `circleci help formattin
 
 ## Arguments
 
-<job-id> is the UUID of the job whose steps and output to list. Job
+job-id is the UUID of the job whose steps and output to list. Job
 UUIDs are shown in the output of "circleci workflow get" and
 "circleci job get".
 

--- a/internal/cmd/root/testdata/help/circleci/namespace.txt
+++ b/internal/cmd/root/testdata/help/circleci/namespace.txt
@@ -4,7 +4,7 @@ Work with CircleCI orb namespaces.
 
 Namespaces are unique identifiers used to publish orbs.
 Each organization may claim one namespace. Orbs are published
-and referenced as <namespace>/<orb>. All published orbs are world-readable.
+and referenced as namespace/orb. All published orbs are world-readable.
 
 ## Usage
 

--- a/internal/cmd/root/testdata/help/circleci/namespace/create.txt
+++ b/internal/cmd/root/testdata/help/circleci/namespace/create.txt
@@ -33,7 +33,7 @@ For more information about output formatting flags, see `circleci help formattin
 
 ## Arguments
 
-<name> is the namespace name to create. It must be globally unique
+name is the namespace name to create. It must be globally unique
 across CircleCI, e.g. "myorg".
 
 ## Examples

--- a/internal/cmd/root/testdata/help/circleci/namespace/delete.txt
+++ b/internal/cmd/root/testdata/help/circleci/namespace/delete.txt
@@ -35,7 +35,7 @@ Use --dry-run (-n) to preview what would be deleted without deleting.
 
 ## Arguments
 
-<name> is the name of the namespace to delete, e.g. "myorg".
+name is the name of the namespace to delete, e.g. "myorg".
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/namespace/get.txt
+++ b/internal/cmd/root/testdata/help/circleci/namespace/get.txt
@@ -28,7 +28,7 @@ For more information about output formatting flags, see `circleci help formattin
 
 ## Arguments
 
-<name> is the name of the namespace to look up, e.g. "myorg".
+name is the name of the namespace to look up, e.g. "myorg".
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/namespace/rename.txt
+++ b/internal/cmd/root/testdata/help/circleci/namespace/rename.txt
@@ -32,8 +32,8 @@ For more information about output formatting flags, see `circleci help formattin
 
 ## Arguments
 
-- <name> is the current name of the namespace, e.g. "oldname".
-- <new-name> is the new name to assign, e.g. "newname".
+- name is the current name of the namespace, e.g. "oldname".
+- new-name is the new name to assign, e.g. "newname".
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/orb/add-to-category.txt
+++ b/internal/cmd/root/testdata/help/circleci/orb/add-to-category.txt
@@ -20,8 +20,8 @@ to see available categories.
 
 ## Arguments
 
-- <ns>/<orb>: the orb to add, as "namespace/orb-name"
-- <category>: the registry category name, e.g. "Testing"
+- ns/orb: the orb to add, as "namespace/orb-name"
+- category: the registry category name, e.g. "Testing"
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/orb/create.txt
+++ b/internal/cmd/root/testdata/help/circleci/orb/create.txt
@@ -35,7 +35,7 @@ For more information about output formatting flags, see `circleci help formattin
 
 ## Arguments
 
-- <namespace>/<orb>: the orb name to reserve, as "namespace/orb-name".
+- namespace/orb: the orb name to reserve, as "namespace/orb-name".
   The namespace must already exist.
 
 ## Examples

--- a/internal/cmd/root/testdata/help/circleci/orb/diff.txt
+++ b/internal/cmd/root/testdata/help/circleci/orb/diff.txt
@@ -29,7 +29,7 @@ Exit code is 0 regardless of whether the versions differ.
 
 ## Arguments
 
-- <ns>/<orb>: the orb to diff, as "namespace/orb-name"
+- ns/orb: the orb to diff, as "namespace/orb-name"
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/orb/list.txt
+++ b/internal/cmd/root/testdata/help/circleci/orb/list.txt
@@ -40,7 +40,7 @@ For more information about output formatting flags, see `circleci help formattin
 
 ## Arguments
 
-- <namespace>: optional. When given, lists all orbs in that namespace.
+- namespace: optional. When given, lists all orbs in that namespace.
   When omitted, lists certified orbs globally.
 
 ## Examples

--- a/internal/cmd/root/testdata/help/circleci/orb/pack.txt
+++ b/internal/cmd/root/testdata/help/circleci/orb/pack.txt
@@ -26,7 +26,7 @@ The merged YAML is written to stdout.
 
 ## Arguments
 
-- <path>: path to an orb source directory or a single orb YAML file.
+- path: path to an orb source directory or a single orb YAML file.
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/orb/process.txt
+++ b/internal/cmd/root/testdata/help/circleci/orb/process.txt
@@ -29,7 +29,7 @@ Pass '-' as the path to read from stdin.
 
 ## Arguments
 
-- <path>: path to an orb YAML file. Pass '-' to read from stdin.
+- path: path to an orb YAML file. Pass '-' to read from stdin.
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/orb/publish.txt
+++ b/internal/cmd/root/testdata/help/circleci/orb/publish.txt
@@ -3,13 +3,13 @@
 Publish orb versions to the CircleCI orb registry.
 
 To publish a specific version:
-  circleci orb publish <path> <ns>/<orb>@<version>
+  circleci orb publish path ns/orb@version
 
 To promote a dev version to a stable semver:
-  circleci orb publish promote <ns>/<orb>@dev:<label> --bump major|minor|patch
+  circleci orb publish promote ns/orb@dev:label --bump major|minor|patch
 
 To increment the latest stable version and publish:
-  circleci orb publish increment <path> <ns>/<orb> --bump major|minor|patch
+  circleci orb publish increment path ns/orb --bump major|minor|patch
 
 ## Usage
 

--- a/internal/cmd/root/testdata/help/circleci/orb/publish/increment.txt
+++ b/internal/cmd/root/testdata/help/circleci/orb/publish/increment.txt
@@ -30,8 +30,8 @@ Pass '-' as the path to read from stdin.
 
 ## Arguments
 
-- <path>: path to the orb YAML to publish. Pass '-' to read from stdin.
-- <ns>/<orb>: the orb to publish, as "namespace/orb-name"
+- path: path to the orb YAML to publish. Pass '-' to read from stdin.
+- ns/orb: the orb to publish, as "namespace/orb-name"
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/orb/publish/promote.txt
+++ b/internal/cmd/root/testdata/help/circleci/orb/publish/promote.txt
@@ -2,7 +2,7 @@
 
 Promote a dev orb version to a stable semver version.
 
-The dev version ref must be in the form <ns>/<orb>@dev:<label>.
+The dev version ref must be in the form ns/orb@dev:label.
 The --bump flag determines how the version is incremented
 from the latest stable release.
 
@@ -27,7 +27,7 @@ from the latest stable release.
 
 ## Arguments
 
-- <ns>/<orb>@dev:<label>: the dev version to promote, e.g. "namespace/orb-name@dev:my-branch"
+- ns/orb@dev:label: the dev version to promote, e.g. "namespace/orb-name@dev:my-branch"
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/orb/remove-from-category.txt
+++ b/internal/cmd/root/testdata/help/circleci/orb/remove-from-category.txt
@@ -2,7 +2,7 @@
 
 Remove an orb from an orb registry category.
 
-Use 'circleci orb get <ns>/<orb>' to see the current categories
+Use 'circleci orb get ns/orb' to see the current categories
 for an orb, and 'circleci orb list-categories' for all available
 categories.
 
@@ -21,8 +21,8 @@ categories.
 
 ## Arguments
 
-- <ns>/<orb>: the orb to remove, as "namespace/orb-name"
-- <category>: the registry category name, e.g. "Testing"
+- ns/orb: the orb to remove, as "namespace/orb-name"
+- category: the registry category name, e.g. "Testing"
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/orb/source.txt
+++ b/internal/cmd/root/testdata/help/circleci/orb/source.txt
@@ -3,7 +3,7 @@
 Print the raw YAML source of an orb version.
 
 If no version is specified, the latest published version is shown.
-Specify a version with @<version> (e.g. @1.2.3 or @volatile for latest).
+Specify a version with @version (e.g. @1.2.3 or @volatile for latest).
 
 ## Usage
 
@@ -20,8 +20,8 @@ Specify a version with @<version> (e.g. @1.2.3 or @volatile for latest).
 
 ## Arguments
 
-- <ns>/<orb>[@<version>]: the orb to print, as "namespace/orb-name".
-  Optionally append @<version> (e.g. @1.2.3, @volatile, or @dev:my-branch).
+- ns/orb[@version]: the orb to print, as "namespace/orb-name".
+  Optionally append @version (e.g. @1.2.3, @volatile, or @dev:my-branch).
   When omitted, the latest published version is shown.
 
 ## Examples

--- a/internal/cmd/root/testdata/help/circleci/orb/unlist.txt
+++ b/internal/cmd/root/testdata/help/circleci/orb/unlist.txt
@@ -28,7 +28,7 @@ Unlisted orbs can still be used if you know the exact orb reference.
 
 ## Arguments
 
-- <ns>/<orb>: the orb to update, as "namespace/orb-name"
+- ns/orb: the orb to update, as "namespace/orb-name"
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/orb/validate.txt
+++ b/internal/cmd/root/testdata/help/circleci/orb/validate.txt
@@ -30,7 +30,7 @@ Exit code 7 if the orb is invalid.
 
 ## Arguments
 
-- <path>: path to an orb YAML file. Pass '-' to read from stdin.
+- path: path to an orb YAML file. Pass '-' to read from stdin.
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/policy/diff.txt
+++ b/internal/cmd/root/testdata/help/circleci/policy/diff.txt
@@ -31,7 +31,7 @@ For more information about output formatting flags, see `circleci help formattin
 
 ## Arguments
 
-<path> is the path to a local directory of .rego policy files,
+path is the path to a local directory of .rego policy files,
 e.g. "./policies". Its contents are compared against the remote
 policy bundle.
 

--- a/internal/cmd/root/testdata/help/circleci/policy/push.txt
+++ b/internal/cmd/root/testdata/help/circleci/policy/push.txt
@@ -37,7 +37,7 @@ For more information about output formatting flags, see `circleci help formattin
 
 ## Arguments
 
-<path> is the path to a local directory of .rego policy files,
+path is the path to a local directory of .rego policy files,
 e.g. "./policies". Its contents are uploaded as the policy
 bundle, replacing the existing bundle.
 

--- a/internal/cmd/root/testdata/help/circleci/project/envvar/delete.txt
+++ b/internal/cmd/root/testdata/help/circleci/project/envvar/delete.txt
@@ -37,7 +37,7 @@ Use --force (-f) to skip the prompt for scripting.
 
 ## Arguments
 
-<name> is the name of the environment variable to delete from
+name is the name of the environment variable to delete from
 the project. This action is irreversible.
 
 ## Examples

--- a/internal/cmd/root/testdata/help/circleci/project/envvar/set.txt
+++ b/internal/cmd/root/testdata/help/circleci/project/envvar/set.txt
@@ -30,8 +30,8 @@ unless overridden with --project.
 
 ## Arguments
 
-<name> is the name of the environment variable to create or
-update. <value> is the value to store; it is never retrievable
+name is the name of the environment variable to create or
+update. value is the value to store; it is never retrievable
 after being set and is masked in all subsequent list output.
 
 ## Examples

--- a/internal/cmd/root/testdata/help/circleci/project/link.txt
+++ b/internal/cmd/root/testdata/help/circleci/project/link.txt
@@ -5,7 +5,7 @@ Record the CircleCI project for the current checkout in
 re-detecting from the git remote each time.
 
 Resolution order:
-  1. --project <slug>, if given.
+  1. --project slug, if given.
   2. The git remote (origin) of the current directory.
   3. An interactive prompt — used when neither of the above
      yields a project the API recognises.
@@ -23,10 +23,10 @@ is passed.
 
 ## Flags
 
-| Flag               | Description                                                     |
-| ------------------ | --------------------------------------------------------------- |
-| `-f, --force`      | Overwrite an existing .circleci/info.yml                        |
-| `--project string` | Project slug (e.g. gh/org/repo or circleci/<orgID>/<projectID>) |
+| Flag               | Description                                                 |
+| ------------------ | ----------------------------------------------------------- |
+| `-f, --force`      | Overwrite an existing .circleci/info.yml                    |
+| `--project string` | Project slug (e.g. gh/org/repo or circleci/orgID/projectID) |
 
 ## Inherited Flags
 

--- a/internal/cmd/root/testdata/help/circleci/reference.txt
+++ b/internal/cmd/root/testdata/help/circleci/reference.txt
@@ -26,7 +26,7 @@ List and download a job's artifact files
 
 **Arguments:**
 
-<job-id> is the UUID of the job whose artifacts you want to
+job-id is the UUID of the job whose artifacts you want to
 list or download,
 e.g. 5034460f-c7c4-4c43-9457-de07e2029e7b.
 
@@ -44,7 +44,7 @@ Bundle split config files into a single YAML document
 
 **Arguments:**
 
-<path> is the path to a split config directory to pack,
+path is the path to a split config directory to pack,
 e.g. ".circleci" or "src/ci". The directory structure is
 mapped to YAML keys in the merged document.
 
@@ -61,7 +61,7 @@ Compile and expand a pipeline config file
 
 **Arguments:**
 
-<path> is the path to a pipeline config file to compile,
+path is the path to a pipeline config file to compile,
 e.g. ".circleci/config.yml". Pass "-" to read the config
 from stdin.
 
@@ -94,7 +94,7 @@ List or download artifacts for a job
 
 **Arguments:**
 
-<job-id> is the UUID of the job whose artifacts to list or download.
+job-id is the UUID of the job whose artifacts to list or download.
 Job UUIDs are shown in the output of "circleci workflow get" and
 "circleci run get --json".
 
@@ -110,7 +110,7 @@ Get job details
 
 **Arguments:**
 
-<job-id> is the UUID of the job to look up. Job UUIDs are shown in
+job-id is the UUID of the job to look up. Job UUIDs are shown in
 the output of "circleci workflow get" and "circleci run get --json".
 
 #### `circleci job open <job-id>`
@@ -119,7 +119,7 @@ Open job in browser
 
 **Arguments:**
 
-<job-id> is the UUID of the job to look up. Job UUIDs are shown in
+job-id is the UUID of the job to look up. Job UUIDs are shown in
 the output of "circleci workflow get" and "circleci run get --json".
 
 #### `circleci job output <command>`
@@ -139,7 +139,7 @@ Get the output of a job step
 
 **Arguments:**
 
-<job-id> is the UUID of the job whose step output to fetch. Job UUIDs
+job-id is the UUID of the job whose step output to fetch. Job UUIDs
 are shown in the output of "circleci workflow get" and "circleci job get".
 Use --step-num to select which step's output to read.
 
@@ -157,7 +157,7 @@ List a job's steps with their output
 
 **Arguments:**
 
-<job-id> is the UUID of the job whose steps and output to list. Job
+job-id is the UUID of the job whose steps and output to list. Job
 UUIDs are shown in the output of "circleci workflow get" and
 "circleci job get".
 
@@ -232,7 +232,7 @@ Cancel a run
 
 **Arguments:**
 
-<run-number-or-id> identifies the run to cancel. It can be:
+run-number-or-id identifies the run to cancel. It can be:
 - a run UUID (shown in "circleci run list --json")
 - a run number (shown in "circleci run list"); the project is
   inferred from the git remote unless overridden with --project
@@ -251,7 +251,7 @@ Get a run's status
 
 **Arguments:**
 
-<run-id> is optional and is the UUID of the run to look up. When
+run-id is optional and is the UUID of the run to look up. When
 omitted, the latest run is resolved from the project and branch
 inferred from the current git repository's remote and checked-out
 branch (override with --project and --branch).
@@ -313,7 +313,7 @@ Watch a run until it completes
 
 **Arguments:**
 
-<run-id> is optional and selects the run to watch. It can be:
+run-id is optional and selects the run to watch. It can be:
 - a run UUID (shown in "circleci run list --json")
 - a run number (shown in "circleci run list"); the project is
   inferred from the git remote unless overridden with --project
@@ -329,21 +329,21 @@ Inspect test results for a job
 
 Get a single test result by name
 
-| Flag                   | Description                                                         |
-| ---------------------- | ------------------------------------------------------------------- |
-| `--filter stringArray` | Disambiguate by classname=<value> when a name is shared; repeatable |
-| `--jq string`          | Process values from the response using jq syntax                    |
-| `--json`               | Output as JSON                                                      |
-| `--plain`              | Print only the raw test message, verbatim and unformatted           |
+| Flag                   | Description                                                       |
+| ---------------------- | ----------------------------------------------------------------- |
+| `--filter stringArray` | Disambiguate by classname=value when a name is shared; repeatable |
+| `--jq string`          | Process values from the response using jq syntax                  |
+| `--json`               | Output as JSON                                                    |
+| `--plain`              | Print only the raw test message, verbatim and unformatted         |
 
 
 **Arguments:**
 
-<job-id> is the UUID of the job whose test results to search. Job
+job-id is the UUID of the job whose test results to search. Job
 UUIDs are shown in "circleci job get" and "circleci run get --json".
 
-<name> is the exact test name to look up. If more than one test
-shares that name, use --filter classname=<value> to disambiguate.
+name is the exact test name to look up. If more than one test
+shares that name, use --filter classname=value to disambiguate.
 
 #### `circleci testresult list <job-id> [flags]`
 
@@ -361,7 +361,7 @@ List test results for a job
 
 **Arguments:**
 
-<job-id> is the UUID of the job whose test results to list. Job
+job-id is the UUID of the job whose test results to list. Job
 UUIDs are shown in "circleci job get" and "circleci run get --json".
 
 **Aliases:**
@@ -384,7 +384,7 @@ Cancel a running workflow
 
 **Arguments:**
 
-<workflow-id> is the UUID of the workflow to cancel. Workflow IDs are
+workflow-id is the UUID of the workflow to cancel. Workflow IDs are
 shown in the output of "circleci run get".
 
 #### `circleci workflow get <workflow-id> [flags]`
@@ -399,7 +399,7 @@ Get workflow details
 
 **Arguments:**
 
-<workflow-id> is the UUID of the workflow to look up. Workflow IDs are
+workflow-id is the UUID of the workflow to look up. Workflow IDs are
 shown in the output of "circleci run get".
 
 #### `circleci workflow list [<run-id>] [flags]`
@@ -417,7 +417,7 @@ List workflows for a run or recent runs
 
 **Arguments:**
 
-<run-id> is optional and selects a single run. It can be:
+run-id is optional and selects a single run. It can be:
 - a run UUID (shown in "circleci run list --json")
 - a run number (shown in "circleci run list"); the project is
   inferred from the git remote unless overridden with --project
@@ -436,7 +436,7 @@ Open workflow in browser
 
 **Arguments:**
 
-<workflow-id> is the UUID of the workflow to look up. Workflow IDs are
+workflow-id is the UUID of the workflow to look up. Workflow IDs are
 shown in the output of "circleci run get".
 
 #### `circleci workflow rerun <workflow-id> [flags]`
@@ -450,7 +450,7 @@ Rerun a workflow
 
 **Arguments:**
 
-<workflow-id> is the UUID of the workflow to rerun. Workflow IDs are
+workflow-id is the UUID of the workflow to rerun. Workflow IDs are
 shown in the output of "circleci run get".
 
 ## Management Commands
@@ -470,7 +470,7 @@ Delete an iOS certificate
 
 **Arguments:**
 
-<cert-id> is the ID of the certificate to delete
+cert-id is the ID of the certificate to delete
 (see: circleci certificate list).
 
 **Aliases:**
@@ -770,7 +770,7 @@ Delete a project environment variable
 
 **Arguments:**
 
-<name> is the name of the environment variable to delete from
+name is the name of the environment variable to delete from
 the project. This action is irreversible.
 
 **Aliases:**
@@ -805,8 +805,8 @@ Set a project environment variable
 
 **Arguments:**
 
-<name> is the name of the environment variable to create or
-update. <value> is the value to store; it is never retrievable
+name is the name of the environment variable to create or
+update. value is the value to store; it is never retrievable
 after being set and is masked in all subsequent list output.
 
 ### `circleci namespace <command>`
@@ -826,7 +826,7 @@ Create a namespace
 
 **Arguments:**
 
-<name> is the namespace name to create. It must be globally unique
+name is the namespace name to create. It must be globally unique
 across CircleCI, e.g. "myorg".
 
 #### `circleci namespace delete <name> [flags]`
@@ -841,7 +841,7 @@ Delete a namespace and all its orbs
 
 **Arguments:**
 
-<name> is the name of the namespace to delete, e.g. "myorg".
+name is the name of the namespace to delete, e.g. "myorg".
 
 **Aliases:**
 
@@ -860,7 +860,7 @@ Get details of a namespace
 
 **Arguments:**
 
-<name> is the name of the namespace to look up, e.g. "myorg".
+name is the name of the namespace to look up, e.g. "myorg".
 
 #### `circleci namespace rename <name> <new-name> [flags]`
 
@@ -874,8 +874,8 @@ Rename a namespace
 
 **Arguments:**
 
-- <name> is the current name of the namespace, e.g. "oldname".
-- <new-name> is the new name to assign, e.g. "newname".
+- name is the current name of the namespace, e.g. "oldname".
+- new-name is the new name to assign, e.g. "newname".
 
 ### `circleci orb <command>`
 
@@ -887,8 +887,8 @@ Add an orb to a registry category
 
 **Arguments:**
 
-- <ns>/<orb>: the orb to add, as "namespace/orb-name"
-- <category>: the registry category name, e.g. "Testing"
+- ns/orb: the orb to add, as "namespace/orb-name"
+- category: the registry category name, e.g. "Testing"
 
 #### `circleci orb create <namespace>/<orb> [flags]`
 
@@ -903,7 +903,7 @@ Reserve an orb name in a namespace
 
 **Arguments:**
 
-- <namespace>/<orb>: the orb name to reserve, as "namespace/orb-name".
+- namespace/orb: the orb name to reserve, as "namespace/orb-name".
   The namespace must already exist.
 
 #### `circleci orb diff <ns>/<orb> --from <v1> --to <v2> [flags]`
@@ -918,7 +918,7 @@ Show a unified diff between two orb versions
 
 **Arguments:**
 
-- <ns>/<orb>: the orb to diff, as "namespace/orb-name"
+- ns/orb: the orb to diff, as "namespace/orb-name"
 
 #### `circleci orb get <ns>/<orb>[@<version>]/<orb-id> [flags]`
 
@@ -950,7 +950,7 @@ List orbs in the registry
 
 **Arguments:**
 
-- <namespace>: optional. When given, lists all orbs in that namespace.
+- namespace: optional. When given, lists all orbs in that namespace.
   When omitted, lists certified orbs globally.
 
 **Aliases:**
@@ -974,7 +974,7 @@ Pack a multi-file orb directory into a single YAML
 
 **Arguments:**
 
-- <path>: path to an orb source directory or a single orb YAML file.
+- path: path to an orb source directory or a single orb YAML file.
 
 #### `circleci orb process <path> [flags]`
 
@@ -987,7 +987,7 @@ Validate and print expanded orb YAML
 
 **Arguments:**
 
-- <path>: path to an orb YAML file. Pass '-' to read from stdin.
+- path: path to an orb YAML file. Pass '-' to read from stdin.
 
 #### `circleci orb publish <command>`
 
@@ -1004,8 +1004,8 @@ Increment and publish a new orb version
 
 **Arguments:**
 
-- <path>: path to the orb YAML to publish. Pass '-' to read from stdin.
-- <ns>/<orb>: the orb to publish, as "namespace/orb-name"
+- path: path to the orb YAML to publish. Pass '-' to read from stdin.
+- ns/orb: the orb to publish, as "namespace/orb-name"
 
 ##### `circleci orb publish promote <ns>/<orb>@dev:<label> --bump major|minor|patch [flags]`
 
@@ -1018,7 +1018,7 @@ Promote a dev orb version to a stable semver
 
 **Arguments:**
 
-- <ns>/<orb>@dev:<label>: the dev version to promote, e.g. "namespace/orb-name@dev:my-branch"
+- ns/orb@dev:label: the dev version to promote, e.g. "namespace/orb-name@dev:my-branch"
 
 #### `circleci orb remove-from-category <ns>/<orb> <category>`
 
@@ -1026,8 +1026,8 @@ Remove an orb from a registry category
 
 **Arguments:**
 
-- <ns>/<orb>: the orb to remove, as "namespace/orb-name"
-- <category>: the registry category name, e.g. "Testing"
+- ns/orb: the orb to remove, as "namespace/orb-name"
+- category: the registry category name, e.g. "Testing"
 
 #### `circleci orb source <ns>/<orb>[@<version>]`
 
@@ -1035,8 +1035,8 @@ Print the YAML source of an orb version
 
 **Arguments:**
 
-- <ns>/<orb>[@<version>]: the orb to print, as "namespace/orb-name".
-  Optionally append @<version> (e.g. @1.2.3, @volatile, or @dev:my-branch).
+- ns/orb[@version]: the orb to print, as "namespace/orb-name".
+  Optionally append @version (e.g. @1.2.3, @volatile, or @dev:my-branch).
   When omitted, the latest published version is shown.
 
 #### `circleci orb unlist <ns>/<orb> [flags]`
@@ -1050,7 +1050,7 @@ Hide or restore an orb in the registry
 
 **Arguments:**
 
-- <ns>/<orb>: the orb to update, as "namespace/orb-name"
+- ns/orb: the orb to update, as "namespace/orb-name"
 
 #### `circleci orb validate <path> [flags]`
 
@@ -1063,7 +1063,7 @@ Validate an orb YAML file
 
 **Arguments:**
 
-- <path>: path to an orb YAML file. Pass '-' to read from stdin.
+- path: path to an orb YAML file. Pass '-' to read from stdin.
 
 ### `circleci policy <command>`
 
@@ -1099,7 +1099,7 @@ Show diff between local and remote policy bundles
 
 **Arguments:**
 
-<path> is the path to a local directory of .rego policy files,
+path is the path to a local directory of .rego policy files,
 e.g. "./policies". Its contents are compared against the remote
 policy bundle.
 
@@ -1149,7 +1149,7 @@ Push a policy bundle to CircleCI
 
 **Arguments:**
 
-<path> is the path to a local directory of .rego policy files,
+path is the path to a local directory of .rego policy files,
 e.g. "./policies". Its contents are uploaded as the policy
 bundle, replacing the existing bundle.
 
@@ -1233,7 +1233,7 @@ Delete a project environment variable
 
 **Arguments:**
 
-<name> is the name of the environment variable to delete from
+name is the name of the environment variable to delete from
 the project. This action is irreversible.
 
 **Aliases:**
@@ -1268,8 +1268,8 @@ Set a project environment variable
 
 **Arguments:**
 
-<name> is the name of the environment variable to create or
-update. <value> is the value to store; it is never retrievable
+name is the name of the environment variable to create or
+update. value is the value to store; it is never retrievable
 after being set and is masked in all subsequent list output.
 
 #### `circleci project follow [flags]`
@@ -1295,10 +1295,10 @@ Show project details
 
 Bind this checkout to a CircleCI project
 
-| Flag               | Description                                                     |
-| ------------------ | --------------------------------------------------------------- |
-| `-f, --force`      | Overwrite an existing .circleci/info.yml                        |
-| `--project string` | Project slug (e.g. gh/org/repo or circleci/<orgID>/<projectID>) |
+| Flag               | Description                                                 |
+| ------------------ | ----------------------------------------------------------- |
+| `-f, --force`      | Overwrite an existing .circleci/info.yml                    |
+| `--project string` | Project slug (e.g. gh/org/repo or circleci/orgID/projectID) |
 
 
 #### `circleci project list [flags]`
@@ -1382,7 +1382,7 @@ Generate a runner agent configuration file
 
 **Arguments:**
 
-<resource-class> is the runner resource class to generate config for,
+resource-class is the runner resource class to generate config for,
 in the form "namespace/name" (e.g. my-org/my-runner).
 
 #### `circleci runner instance <command>`
@@ -1500,7 +1500,7 @@ Create a token for a resource class
 
 **Arguments:**
 
-<resource-class> is the runner resource class to create a token for,
+resource-class is the runner resource class to create a token for,
 in the form "namespace/name" (e.g. my-org/my-runner).
 
 ##### `circleci runner token delete <token-id> [flags]`
@@ -1514,8 +1514,8 @@ Delete a runner token
 
 **Arguments:**
 
-<token-id> is the ID of the token to delete (a UUID). Find token IDs
-with: circleci runner token list --resource-class <namespace/name>
+token-id is the ID of the token to delete (a UUID). Find token IDs
+with: circleci runner token list --resource-class namespace/name
 
 **Aliases:**
 
@@ -1567,7 +1567,7 @@ Delete an iOS signing config
 
 **Arguments:**
 
-<signing-config-id> is the ID of the signing config to delete
+signing-config-id is the ID of the signing config to delete
 (see: circleci signing-config list).
 
 **Aliases:**
@@ -1856,8 +1856,8 @@ Set a CLI setting
 
 **Arguments:**
 
-- <key> is the setting to change: token, host, telemetry, or theme.
-- <value> is the value to store. Pass "-" to read it from stdin.
+- key is the setting to change: token, host, telemetry, or theme.
+- value is the value to store. Pass "-" to read it from stdin.
   May be omitted for "theme" to pick interactively.
 
 #### `circleci setting unset <key>`
@@ -1866,7 +1866,7 @@ Remove a stored CLI setting
 
 **Arguments:**
 
-<key> is the setting to remove. Currently only "token" is supported.
+key is the setting to remove. Currently only "token" is supported.
 
 ## Additional Commands
 
@@ -1885,7 +1885,7 @@ Call the CircleCI REST API directly
 
 **Arguments:**
 
-<path> is the request path. It is relative to /api/v3 by default
+path is the request path. It is relative to /api/v3 by default
 (e.g. "projects/{project-id}"). To target
 a different version prefix, include it explicitly, e.g. "api/v2/me".
 

--- a/internal/cmd/root/testdata/help/circleci/run/cancel.txt
+++ b/internal/cmd/root/testdata/help/circleci/run/cancel.txt
@@ -33,7 +33,7 @@ Use --force (-f) to skip the prompt for scripting.
 
 ## Arguments
 
-<run-number-or-id> identifies the run to cancel. It can be:
+run-number-or-id identifies the run to cancel. It can be:
 - a run UUID (shown in "circleci run list --json")
 - a run number (shown in "circleci run list"); the project is
   inferred from the git remote unless overridden with --project

--- a/internal/cmd/root/testdata/help/circleci/run/get.txt
+++ b/internal/cmd/root/testdata/help/circleci/run/get.txt
@@ -38,7 +38,7 @@ For more information about output formatting flags, see `circleci help formattin
 
 ## Arguments
 
-<run-id> is optional and is the UUID of the run to look up. When
+run-id is optional and is the UUID of the run to look up. When
 omitted, the latest run is resolved from the project and branch
 inferred from the current git repository's remote and checked-out
 branch (override with --project and --branch).

--- a/internal/cmd/root/testdata/help/circleci/run/watch.txt
+++ b/internal/cmd/root/testdata/help/circleci/run/watch.txt
@@ -43,7 +43,7 @@ without waiting for the remaining workflows to finish.
 
 ## Arguments
 
-<run-id> is optional and selects the run to watch. It can be:
+run-id is optional and selects the run to watch. It can be:
 - a run UUID (shown in "circleci run list --json")
 - a run number (shown in "circleci run list"); the project is
   inferred from the git remote unless overridden with --project

--- a/internal/cmd/root/testdata/help/circleci/runner/config.txt
+++ b/internal/cmd/root/testdata/help/circleci/runner/config.txt
@@ -36,7 +36,7 @@ launch-agent-config.yaml.
 
 ## Arguments
 
-<resource-class> is the runner resource class to generate config for,
+resource-class is the runner resource class to generate config for,
 in the form "namespace/name" (e.g. my-org/my-runner).
 
 ## Examples

--- a/internal/cmd/root/testdata/help/circleci/runner/token/create.txt
+++ b/internal/cmd/root/testdata/help/circleci/runner/token/create.txt
@@ -33,7 +33,7 @@ For more information about output formatting flags, see `circleci help formattin
 
 ## Arguments
 
-<resource-class> is the runner resource class to create a token for,
+resource-class is the runner resource class to create a token for,
 in the form "namespace/name" (e.g. my-org/my-runner).
 
 ## Examples

--- a/internal/cmd/root/testdata/help/circleci/runner/token/delete.txt
+++ b/internal/cmd/root/testdata/help/circleci/runner/token/delete.txt
@@ -5,7 +5,7 @@ Delete a CircleCI runner authentication token by its ID.
 Any runner agents using this token will immediately lose their ability
 to claim new jobs. Running jobs are not affected.
 
-Find token IDs with: circleci runner token list <resource-class>
+Find token IDs with: circleci runner token list resource-class
 
 In a terminal, you will be prompted to confirm before deleting.
 Use --force (-f) to skip the prompt for scripting.
@@ -35,8 +35,8 @@ Use --force (-f) to skip the prompt for scripting.
 
 ## Arguments
 
-<token-id> is the ID of the token to delete (a UUID). Find token IDs
-with: circleci runner token list --resource-class <namespace/name>
+token-id is the ID of the token to delete (a UUID). Find token IDs
+with: circleci runner token list --resource-class namespace/name
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/setting/set.txt
+++ b/internal/cmd/root/testdata/help/circleci/setting/set.txt
@@ -29,8 +29,8 @@ terminal to pick a theme from a list.
 
 ## Arguments
 
-- <key> is the setting to change: token, host, telemetry, or theme.
-- <value> is the value to store. Pass "-" to read it from stdin.
+- key is the setting to change: token, host, telemetry, or theme.
+- value is the value to store. Pass "-" to read it from stdin.
   May be omitted for "theme" to pick interactively.
 
 ## Examples

--- a/internal/cmd/root/testdata/help/circleci/setting/unset.txt
+++ b/internal/cmd/root/testdata/help/circleci/setting/unset.txt
@@ -20,7 +20,7 @@ Supported keys:
 
 ## Arguments
 
-<key> is the setting to remove. Currently only "token" is supported.
+key is the setting to remove. Currently only "token" is supported.
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/setup.txt
+++ b/internal/cmd/root/testdata/help/circleci/setup.txt
@@ -8,9 +8,9 @@ must pass --no-prompt, --host, and --token. The interactive setup
 flow from the legacy CLI is not reimplemented.
 
 For new usage, prefer:
-  circleci auth login                 interactive, browser-based
-  circleci setting set host <host>    store the host
-  circleci setting set token <token>  store the token
+  circleci auth login                interactive, browser-based
+  circleci setting set host host     store the host
+  circleci setting set token token   store the token
 
 ## Usage
 

--- a/internal/cmd/root/testdata/help/circleci/signing-config/create.txt
+++ b/internal/cmd/root/testdata/help/circleci/signing-config/create.txt
@@ -44,12 +44,12 @@ For more information about output formatting flags, see `circleci help formattin
 - Create a signing config (org inferred from git remote): 
   `circleci signing-config create \`
 - --name production-signing \
-- --cert-id <cert-id> \
+- --cert-id cert-id \
 - --profile ./MyApp.mobileprovision
 - Multiple profiles: 
   `circleci signing-config create \`
 - --name multi-target-signing \
-- --cert-id <cert-id> \
+- --cert-id cert-id \
 - --profile ./MyApp.mobileprovision \
 - --profile ./MyAppExtension.mobileprovision
 - Explicit org and capture the id for scripting: 

--- a/internal/cmd/root/testdata/help/circleci/signing-config/delete.txt
+++ b/internal/cmd/root/testdata/help/circleci/signing-config/delete.txt
@@ -33,7 +33,7 @@ Use --force (-f) to skip the prompt for scripting.
 
 ## Arguments
 
-<signing-config-id> is the ID of the signing config to delete
+signing-config-id is the ID of the signing config to delete
 (see: circleci signing-config list).
 
 ## Examples

--- a/internal/cmd/root/testdata/help/circleci/testresult/get.txt
+++ b/internal/cmd/root/testdata/help/circleci/testresult/get.txt
@@ -4,7 +4,7 @@ Get a single test result from a job by its exact name.
 
 The name must match exactly. When several tests share a name — for
 example the same test running under different suites — the lookup is
-ambiguous and fails; pass --filter classname=<value> to narrow to one.
+ambiguous and fails; pass --filter classname=value to narrow to one.
 classname is matched as a case-insensitive substring and may be
 repeated to accept any of several suites.
 
@@ -26,12 +26,12 @@ For more information about output formatting flags, see `circleci help formattin
 
 ## Flags
 
-| Flag                   | Description                                                         |
-| ---------------------- | ------------------------------------------------------------------- |
-| `--filter stringArray` | Disambiguate by classname=<value> when a name is shared; repeatable |
-| `--jq string`          | Process values from the response using jq syntax                    |
-| `--json`               | Output as JSON                                                      |
-| `--plain`              | Print only the raw test message, verbatim and unformatted           |
+| Flag                   | Description                                                       |
+| ---------------------- | ----------------------------------------------------------------- |
+| `--filter stringArray` | Disambiguate by classname=value when a name is shared; repeatable |
+| `--jq string`          | Process values from the response using jq syntax                  |
+| `--json`               | Output as JSON                                                    |
+| `--plain`              | Print only the raw test message, verbatim and unformatted         |
 
 ## Inherited Flags
 
@@ -44,11 +44,11 @@ For more information about output formatting flags, see `circleci help formattin
 
 ## Arguments
 
-<job-id> is the UUID of the job whose test results to search. Job
+job-id is the UUID of the job whose test results to search. Job
 UUIDs are shown in "circleci job get" and "circleci run get --json".
 
-<name> is the exact test name to look up. If more than one test
-shares that name, use --filter classname=<value> to disambiguate.
+name is the exact test name to look up. If more than one test
+shares that name, use --filter classname=value to disambiguate.
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/testresult/list.txt
+++ b/internal/cmd/root/testdata/help/circleci/testresult/list.txt
@@ -3,7 +3,7 @@
 Show the test results recorded for a CircleCI job.
 
 By default only failed tests are shown. Pass --all to show every
-result, or --filter result=<value> to select specific outcomes.
+result, or --filter result=value to select specific outcomes.
 
 --filter takes key=value and may be repeated. Repeating the same key
 matches any of its values (OR); different keys must all match (AND).
@@ -59,7 +59,7 @@ For more information about output formatting flags, see `circleci help formattin
 
 ## Arguments
 
-<job-id> is the UUID of the job whose test results to list. Job
+job-id is the UUID of the job whose test results to list. Job
 UUIDs are shown in "circleci job get" and "circleci run get --json".
 
 ## Examples

--- a/internal/cmd/root/testdata/help/circleci/workflow/cancel.txt
+++ b/internal/cmd/root/testdata/help/circleci/workflow/cancel.txt
@@ -31,7 +31,7 @@ Use --force (-f) to skip the prompt for scripting.
 
 ## Arguments
 
-<workflow-id> is the UUID of the workflow to cancel. Workflow IDs are
+workflow-id is the UUID of the workflow to cancel. Workflow IDs are
 shown in the output of "circleci run get".
 
 ## Examples

--- a/internal/cmd/root/testdata/help/circleci/workflow/get.txt
+++ b/internal/cmd/root/testdata/help/circleci/workflow/get.txt
@@ -32,7 +32,7 @@ For more information about output formatting flags, see `circleci help formattin
 
 ## Arguments
 
-<workflow-id> is the UUID of the workflow to look up. Workflow IDs are
+workflow-id is the UUID of the workflow to look up. Workflow IDs are
 shown in the output of "circleci run get".
 
 ## Examples

--- a/internal/cmd/root/testdata/help/circleci/workflow/list.txt
+++ b/internal/cmd/root/testdata/help/circleci/workflow/list.txt
@@ -47,7 +47,7 @@ For more information about output formatting flags, see `circleci help formattin
 
 ## Arguments
 
-<run-id> is optional and selects a single run. It can be:
+run-id is optional and selects a single run. It can be:
 - a run UUID (shown in "circleci run list --json")
 - a run number (shown in "circleci run list"); the project is
   inferred from the git remote unless overridden with --project

--- a/internal/cmd/root/testdata/help/circleci/workflow/open.txt
+++ b/internal/cmd/root/testdata/help/circleci/workflow/open.txt
@@ -17,7 +17,7 @@ Open workflow in browser
 
 ## Arguments
 
-<workflow-id> is the UUID of the workflow to look up. Workflow IDs are
+workflow-id is the UUID of the workflow to look up. Workflow IDs are
 shown in the output of "circleci run get".
 
 ## Examples

--- a/internal/cmd/root/testdata/help/circleci/workflow/rerun.txt
+++ b/internal/cmd/root/testdata/help/circleci/workflow/rerun.txt
@@ -29,7 +29,7 @@ Workflow IDs are shown in the output of 'circleci run get'.
 
 ## Arguments
 
-<workflow-id> is the UUID of the workflow to rerun. Workflow IDs are
+workflow-id is the UUID of the workflow to rerun. Workflow IDs are
 shown in the output of "circleci run get".
 
 ## Examples

--- a/internal/cmd/root/testdata/usage/circleci/project/link.txt
+++ b/internal/cmd/root/testdata/usage/circleci/project/link.txt
@@ -2,5 +2,5 @@ Usage:  circleci project link [flags]
 
 Flags:
   -f, --force            Overwrite an existing .circleci/info.yml
-      --project string   Project slug (e.g. gh/org/repo or circleci/<orgID>/<projectID>)
+      --project string   Project slug (e.g. gh/org/repo or circleci/orgID/projectID)
   

--- a/internal/cmd/root/testdata/usage/circleci/testresult/get.txt
+++ b/internal/cmd/root/testdata/usage/circleci/testresult/get.txt
@@ -1,7 +1,7 @@
 Usage:  circleci testresult get <job-id> <name> [flags]
 
 Flags:
-  --filter stringArray   Disambiguate by classname=<value> when a name is shared; repeatable
+  --filter stringArray   Disambiguate by classname=value when a name is shared; repeatable
   --jq string            Process values from the response using jq syntax
   --json                 Output as JSON
   --plain                Print only the raw test message, verbatim and unformatted

--- a/internal/cmd/run/cancel.go
+++ b/internal/cmd/run/cancel.go
@@ -49,7 +49,7 @@ func newCancelCmd() *cobra.Command {
 		Short: "Cancel a run",
 		Annotations: map[string]string{
 			"help:arguments": heredoc.Doc(`
-				<run-number-or-id> identifies the run to cancel. It can be:
+				run-number-or-id identifies the run to cancel. It can be:
 				- a run UUID (shown in "circleci run list --json")
 				- a run number (shown in "circleci run list"); the project is
 				  inferred from the git remote unless overridden with --project

--- a/internal/cmd/run/get.go
+++ b/internal/cmd/run/get.go
@@ -64,7 +64,7 @@ func newGetCmd() *cobra.Command {
 		Short: "Get a run's status",
 		Annotations: map[string]string{
 			"help:arguments": heredoc.Doc(`
-				<run-id> is optional and is the UUID of the run to look up. When
+				run-id is optional and is the UUID of the run to look up. When
 				omitted, the latest run is resolved from the project and branch
 				inferred from the current git repository's remote and checked-out
 				branch (override with --project and --branch).

--- a/internal/cmd/run/watch.go
+++ b/internal/cmd/run/watch.go
@@ -69,7 +69,7 @@ func newWatchCmd() *cobra.Command {
 		Short: "Watch a run until it completes",
 		Annotations: map[string]string{
 			"help:arguments": heredoc.Doc(`
-				<run-id> is optional and selects the run to watch. It can be:
+				run-id is optional and selects the run to watch. It can be:
 				- a run UUID (shown in "circleci run list --json")
 				- a run number (shown in "circleci run list"); the project is
 				  inferred from the git remote unless overridden with --project

--- a/internal/cmd/runner/config.go
+++ b/internal/cmd/runner/config.go
@@ -47,7 +47,7 @@ func newConfigCmd() *cobra.Command {
 		Short: "Generate a runner agent configuration file",
 		Annotations: map[string]string{
 			"help:arguments": heredoc.Doc(`
-				<resource-class> is the runner resource class to generate config for,
+				resource-class is the runner resource class to generate config for,
 				in the form "namespace/name" (e.g. my-org/my-runner).
 			`),
 		},

--- a/internal/cmd/runner/token.go
+++ b/internal/cmd/runner/token.go
@@ -195,7 +195,7 @@ func newTokenCreateCmd() *cobra.Command {
 		Short: "Create a token for a resource class",
 		Annotations: map[string]string{
 			"help:arguments": heredoc.Doc(`
-				<resource-class> is the runner resource class to create a token for,
+				resource-class is the runner resource class to create a token for,
 				in the form "namespace/name" (e.g. my-org/my-runner).
 			`),
 		},
@@ -285,8 +285,8 @@ func newTokenDeleteCmd() *cobra.Command {
 		Short:   "Delete a runner token",
 		Annotations: map[string]string{
 			"help:arguments": heredoc.Doc(`
-				<token-id> is the ID of the token to delete (a UUID). Find token IDs
-				with: circleci runner token list --resource-class <namespace/name>
+				token-id is the ID of the token to delete (a UUID). Find token IDs
+				with: circleci runner token list --resource-class namespace/name
 			`),
 		},
 		Long: heredoc.Doc(`
@@ -295,7 +295,7 @@ func newTokenDeleteCmd() *cobra.Command {
 			Any runner agents using this token will immediately lose their ability
 			to claim new jobs. Running jobs are not affected.
 
-			Find token IDs with: circleci runner token list <resource-class>
+			Find token IDs with: circleci runner token list resource-class
 
 			In a terminal, you will be prompted to confirm before deleting.
 			Use --force (-f) to skip the prompt for scripting.

--- a/internal/cmd/setting/set.go
+++ b/internal/cmd/setting/set.go
@@ -42,8 +42,8 @@ func newSetCmd() *cobra.Command {
 		Short: "Set a CLI setting",
 		Annotations: map[string]string{
 			"help:arguments": heredoc.Doc(`
-				- <key> is the setting to change: token, host, telemetry, or theme.
-				- <value> is the value to store. Pass "-" to read it from stdin.
+				- key is the setting to change: token, host, telemetry, or theme.
+				- value is the value to store. Pass "-" to read it from stdin.
 				  May be omitted for "theme" to pick interactively.
 			`),
 		},

--- a/internal/cmd/setting/unset.go
+++ b/internal/cmd/setting/unset.go
@@ -38,7 +38,7 @@ func newUnsetCmd() *cobra.Command {
 		Short: "Remove a stored CLI setting",
 		Annotations: map[string]string{
 			"help:arguments": heredoc.Doc(`
-				<key> is the setting to remove. Currently only "token" is supported.
+				key is the setting to remove. Currently only "token" is supported.
 			`),
 		},
 		Long: heredoc.Doc(`

--- a/internal/cmd/setup/setup.go
+++ b/internal/cmd/setup/setup.go
@@ -60,9 +60,9 @@ func NewSetupCmd() *cobra.Command {
 			flow from the legacy CLI is not reimplemented.
 
 			For new usage, prefer:
-			  circleci auth login                 interactive, browser-based
-			  circleci setting set host <host>    store the host
-			  circleci setting set token <token>  store the token
+			  circleci auth login                interactive, browser-based
+			  circleci setting set host host     store the host
+			  circleci setting set token token   store the token
 		`),
 		Example: heredoc.Doc(`
 			# Configure the CLI non-interactively (the path the orb uses)

--- a/internal/cmd/signingconfig/signingconfig.go
+++ b/internal/cmd/signingconfig/signingconfig.go
@@ -137,13 +137,13 @@ func newCreateCmd() *cobra.Command {
 			# Create a signing config (org inferred from git remote)
 			$ circleci signing-config create \
 			    --name production-signing \
-			    --cert-id <cert-id> \
+			    --cert-id cert-id \
 			    --profile ./MyApp.mobileprovision
 
 			# Multiple profiles
 			$ circleci signing-config create \
 			    --name multi-target-signing \
-			    --cert-id <cert-id> \
+			    --cert-id cert-id \
 			    --profile ./MyApp.mobileprovision \
 			    --profile ./MyAppExtension.mobileprovision
 
@@ -328,7 +328,7 @@ func newDeleteCmd() *cobra.Command {
 		Short:   "Delete an iOS signing config",
 		Annotations: map[string]string{
 			"help:arguments": heredoc.Doc(`
-				<signing-config-id> is the ID of the signing config to delete
+				signing-config-id is the ID of the signing config to delete
 				(see: circleci signing-config list).
 			`),
 		},

--- a/internal/cmd/testresult/get.go
+++ b/internal/cmd/testresult/get.go
@@ -50,11 +50,11 @@ func newGetCmd() *cobra.Command {
 		Short: "Get a single test result by name",
 		Annotations: map[string]string{
 			"help:arguments": heredoc.Doc(`
-				<job-id> is the UUID of the job whose test results to search. Job
+				job-id is the UUID of the job whose test results to search. Job
 				UUIDs are shown in "circleci job get" and "circleci run get --json".
 
-				<name> is the exact test name to look up. If more than one test
-				shares that name, use --filter classname=<value> to disambiguate.
+				name is the exact test name to look up. If more than one test
+				shares that name, use --filter classname=value to disambiguate.
 			`),
 		},
 		Long: heredoc.Doc(`
@@ -62,7 +62,7 @@ func newGetCmd() *cobra.Command {
 
 			The name must match exactly. When several tests share a name — for
 			example the same test running under different suites — the lookup is
-			ambiguous and fails; pass --filter classname=<value> to narrow to one.
+			ambiguous and fails; pass --filter classname=value to narrow to one.
 			classname is matched as a case-insensitive substring and may be
 			repeated to accept any of several suites.
 
@@ -103,7 +103,7 @@ func newGetCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringArrayVar(&filters, "filter", nil, "Disambiguate by classname=<value> when a name is shared; repeatable")
+	cmd.Flags().StringArrayVar(&filters, "filter", nil, "Disambiguate by classname=value when a name is shared; repeatable")
 	cmd.Flags().BoolVar(&plain, "plain", false, "Print only the raw test message, verbatim and unformatted")
 	cmdutil.AddJSONFlag(cmd, &jsonOut)
 	cmdutil.AddJQFlag(cmd)

--- a/internal/cmd/testresult/list.go
+++ b/internal/cmd/testresult/list.go
@@ -63,7 +63,7 @@ func newListCmd() *cobra.Command {
 		Short:   "List test results for a job",
 		Annotations: map[string]string{
 			"help:arguments": heredoc.Doc(`
-				<job-id> is the UUID of the job whose test results to list. Job
+				job-id is the UUID of the job whose test results to list. Job
 				UUIDs are shown in "circleci job get" and "circleci run get --json".
 			`),
 		},
@@ -71,7 +71,7 @@ func newListCmd() *cobra.Command {
 			Show the test results recorded for a CircleCI job.
 
 			By default only failed tests are shown. Pass --all to show every
-			result, or --filter result=<value> to select specific outcomes.
+			result, or --filter result=value to select specific outcomes.
 
 			--filter takes key=value and may be repeated. Repeating the same key
 			matches any of its values (OR); different keys must all match (AND).

--- a/internal/cmd/workflow/cancel.go
+++ b/internal/cmd/workflow/cancel.go
@@ -44,7 +44,7 @@ func newCancelCmd() *cobra.Command {
 		Short: "Cancel a running workflow",
 		Annotations: map[string]string{
 			"help:arguments": heredoc.Doc(`
-				<workflow-id> is the UUID of the workflow to cancel. Workflow IDs are
+				workflow-id is the UUID of the workflow to cancel. Workflow IDs are
 				shown in the output of "circleci run get".
 			`),
 		},

--- a/internal/cmd/workflow/get.go
+++ b/internal/cmd/workflow/get.go
@@ -45,7 +45,7 @@ func newGetCmd() *cobra.Command {
 		Short: "Get workflow details",
 		Annotations: map[string]string{
 			"help:arguments": heredoc.Doc(`
-				<workflow-id> is the UUID of the workflow to look up. Workflow IDs are
+				workflow-id is the UUID of the workflow to look up. Workflow IDs are
 				shown in the output of "circleci run get".
 			`),
 		},

--- a/internal/cmd/workflow/list.go
+++ b/internal/cmd/workflow/list.go
@@ -53,7 +53,7 @@ func newListCmd() *cobra.Command {
 		Short:   "List workflows for a run or recent runs",
 		Annotations: map[string]string{
 			"help:arguments": heredoc.Doc(`
-				<run-id> is optional and selects a single run. It can be:
+				run-id is optional and selects a single run. It can be:
 				- a run UUID (shown in "circleci run list --json")
 				- a run number (shown in "circleci run list"); the project is
 				  inferred from the git remote unless overridden with --project

--- a/internal/cmd/workflow/open.go
+++ b/internal/cmd/workflow/open.go
@@ -41,7 +41,7 @@ func newOpenCmd() *cobra.Command {
 		Short: "Open workflow in browser",
 		Annotations: map[string]string{
 			"help:arguments": heredoc.Doc(`
-				<workflow-id> is the UUID of the workflow to look up. Workflow IDs are
+				workflow-id is the UUID of the workflow to look up. Workflow IDs are
 				shown in the output of "circleci run get".
 			`),
 		},

--- a/internal/cmd/workflow/rerun.go
+++ b/internal/cmd/workflow/rerun.go
@@ -41,7 +41,7 @@ func newRerunCmd() *cobra.Command {
 		Short: "Rerun a workflow",
 		Annotations: map[string]string{
 			"help:arguments": heredoc.Doc(`
-				<workflow-id> is the UUID of the workflow to rerun. Workflow IDs are
+				workflow-id is the UUID of the workflow to rerun. Workflow IDs are
 				shown in the output of "circleci run get".
 			`),
 		},


### PR DESCRIPTION
## Problem

<placeholder>-style argument text (<path>, <job-id> etc.) was silently losing the placeholder word wherever it appeared in prose, both in the Hugo reference site and in real (color-enabled) terminal --help output. 

Flag-description table cells and the free-form Arguments/Long text were affected. Use: lines and $-prefixed Example commands work fine.

## Root cause

Terminal help and the Hugo reference page are both rendered from generated markdown. Both parse raw HTML in markdown with unsafe HTML enabled. An unescaped <path> in prose is parsed as an HTML tag. The sanitizer strips the tag name and keeps only surrounding text, so "<path> is the request path" renders as "is the request path". Confirmed this reproduces in real glamour rendering (not just the non-TTY fallback used by tests) and in the built Hugo HTML.

## Fix

Removed the angle brackets from placeholder mentions in prose.