### PR TITLE
Display arguments in help text

### DIFF
--- a/internal/cmd/api/api.go
+++ b/internal/cmd/api/api.go
@@ -60,17 +60,17 @@ func NewAPICmd() *cobra.Command {
 		Use:   "api <path>",
 		Short: "Call the CircleCI REST API directly",
 		Annotations: map[string]string{
-			"help:arguments": heredoc.Doc(`
-				<path> is the request path. It is relative to /api/v3 by default
+			"help:arguments": heredoc.Docf(`
+				%[1]s<path>%[1]s is the request path. It is relative to /api/v3 by default
 				(e.g. "projects/{project-id}"). To target
 				a different version prefix, include it explicitly, e.g. "api/v2/me".
-			`),
+			`, "`"),
 		},
-		Long: heredoc.Doc(`
+		Long: heredoc.Docf(`
 			Make an authenticated HTTP request to the REST APIs and print
 			the raw response body.
 
-			<path> is relative to /api/v3 (e.g. projects/{project-id}). To target
+			%[1]s<path>%[1]s is relative to /api/v3 (e.g. %[1]sprojects/{project-id}%[1]s). To target
 			a different version prefix, include it explicitly:
 			  circleci api api/v2/me
 
@@ -84,7 +84,7 @@ func NewAPICmd() *cobra.Command {
 			default method is POST.
 
 			Exit code reflects the HTTP response: 0 for 2xx, 4 for 4xx/5xx.
-		`),
+		`, "`"),
 		Example: heredoc.Doc(`
 			# Get your user profile
 			$ circleci api api/v2/me

--- a/internal/cmd/artifacts/artifacts.go
+++ b/internal/cmd/artifacts/artifacts.go
@@ -47,11 +47,11 @@ func NewArtifactCmd() *cobra.Command {
 		GroupID: "ci",
 		Short:   "List and download a job's artifact files",
 		Annotations: map[string]string{
-			"help:arguments": heredoc.Doc(`
-				<job-id> is the UUID of the job whose artifacts you want to
+			"help:arguments": heredoc.Docf(`
+				%[1]s<job-id>%[1]s is the UUID of the job whose artifacts you want to
 				list or download,
-				e.g. 5034460f-c7c4-4c43-9457-de07e2029e7b.
-			`),
+				for example. %[1]s5034460f-c7c4-4c43-9457-de07e2029e7b%[1]s.
+			`, "`"),
 		},
 		Long: heredoc.Doc(`
 			List or download artifacts produced by a CircleCI job.

--- a/internal/cmd/certificate/certificate.go
+++ b/internal/cmd/certificate/certificate.go
@@ -296,10 +296,10 @@ func newDeleteCmd() *cobra.Command {
 		Aliases: []string{"rm"},
 		Short:   "Delete an iOS certificate",
 		Annotations: map[string]string{
-			"help:arguments": heredoc.Doc(`
-				<cert-id> is the ID of the certificate to delete
+			"help:arguments": heredoc.Docf(`
+				%[1]s<cert-id>%[1]s is the ID of the certificate to delete
 				(see: circleci certificate list).
-			`),
+			`, "`"),
 		},
 		Long: heredoc.Doc(`
 			Remove an Apple certificate from your organization's secure storage.

--- a/internal/cmd/cmdauth/id.go
+++ b/internal/cmd/cmdauth/id.go
@@ -38,8 +38,8 @@ func newDeviceIDCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "id",
 		Short: "Show the device ID for this CLI installation",
-		Long: heredoc.Doc(`
-			Print the device ID for this CLI installation as "<os>:<uuid>".
+		Long: heredoc.Docf(`
+			Print the device ID for this CLI installation as "%[1]s<os>:<uuid>%[1]s".
 
 			The UUID is generated on first use and stored in the config file.
 			The OS prefix (e.g. darwin, linux) is added at print time so you
@@ -48,8 +48,8 @@ func newDeviceIDCmd() *cobra.Command {
 			a token in the CircleCI UI back to this installation.
 
 			JSON fields:
-			  device_id  string  Stable identifier in the form <os>:<uuid>
-		`),
+			  device_id  string  Stable identifier in the form %[1]s<os>:<uuid>%[1]s
+		`, "`"),
 		Example: heredoc.Doc(`
 			# Print the device ID
 			$ circleci auth id

--- a/internal/cmd/config/generate.go
+++ b/internal/cmd/config/generate.go
@@ -40,9 +40,9 @@ func newGenerateCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "generate [path]",
 		Short: "Generate .circleci/config.yml from a repository scan",
-		Long: heredoc.Doc(`
+		Long: heredoc.Docf(`
 			Detect the language stack, container image, and setup commands for a
-			repository, then write a starter pipeline to <path>/.circleci/config.yml.
+			repository, then write a starter pipeline to %[1]s<path>/.circleci/config.yml%[1]s.
 
 			If no supported stack is detected, a minimal cimg/base:stable template
 			with a placeholder build step is written instead so you have something
@@ -51,7 +51,7 @@ func newGenerateCmd() *cobra.Command {
 			If a config file already exists at that path, generate does not overwrite
 			it; it prints a confirmation and exits successfully. The .circleci/
 			directory is created if needed, and the file is written atomically.
-		`),
+		`, "`"),
 		Example: heredoc.Doc(`
 			# Generate a config for the current directory
 			$ circleci config generate

--- a/internal/cmd/config/pack.go
+++ b/internal/cmd/config/pack.go
@@ -38,11 +38,11 @@ func newPackCmd() *cobra.Command {
 		Use:   "pack <path>",
 		Short: "Bundle split config files into a single YAML document",
 		Annotations: map[string]string{
-			"help:arguments": heredoc.Doc(`
-				<path> is the path to a split config directory to pack,
-				e.g. ".circleci" or "src/ci". The directory structure is
+			"help:arguments": heredoc.Docf(`
+				%[1]s<path>%[1]s is the path to a split config directory to pack,
+				for example, %[1]s.circleci%[1]s or %[1]ssrc/ci%[1]s. The directory structure is
 				mapped to YAML keys in the merged document.
-			`),
+			`, "`"),
 		},
 		Long: heredoc.Doc(`
 			Bundle a split CircleCI config directory into a single YAML document.

--- a/internal/cmd/config/process.go
+++ b/internal/cmd/config/process.go
@@ -48,11 +48,11 @@ func newProcessCmd() *cobra.Command {
 		Use:   "process <path>",
 		Short: "Compile and expand a pipeline config file",
 		Annotations: map[string]string{
-			"help:arguments": heredoc.Doc(`
-				<path> is the path to a pipeline config file to compile,
-				e.g. ".circleci/config.yml". Pass "-" to read the config
+			"help:arguments": heredoc.Docf(`
+				%[1]s<path>%[1]s is the path to a pipeline config file to compile,
+				for example, %[1]s.circleci/config.yml%[1]s. Pass %[1]s-%[1]s to read the config
 				from stdin.
-			`),
+			`, "`"),
 		},
 		Long: heredoc.Doc(`
 			Compile a CircleCI pipeline config file and print the fully expanded YAML.

--- a/internal/cmd/envvar/env.go
+++ b/internal/cmd/envvar/env.go
@@ -41,7 +41,7 @@ func NewEnvVarCmd() *cobra.Command {
 		Use:     "envvar <command>",
 		GroupID: "management",
 		Short:   "List, set and delete a project's environment variables",
-		Long: heredoc.Doc(`
+		Long: heredoc.Docf(`
 			List, set, and delete environment variables for a CircleCI project.
 
 			The project is inferred from the current git repository's remote
@@ -50,8 +50,8 @@ func NewEnvVarCmd() *cobra.Command {
 			Environment variable values are masked in list output (shown as "xxxx").
 			The full value is never retrievable after it has been set.
 
-			Also available as: circleci project envvar <command>
-		`),
+			Also available as: circleci project envvar %[1]s<command>%[1]s
+		`, "`"),
 		Example: heredoc.Doc(`
 			# List all environment variables for the current project
 			$ circleci envvar list

--- a/internal/cmd/job/artifacts.go
+++ b/internal/cmd/job/artifacts.go
@@ -44,11 +44,11 @@ func newArtifactCmd() *cobra.Command {
 		Use:   "artifact <job-id>",
 		Short: "List or download artifacts for a job",
 		Annotations: map[string]string{
-			"help:arguments": heredoc.Doc(`
-				<job-id> is the UUID of the job whose artifacts to list or download.
+			"help:arguments": heredoc.Docf(`
+				%[1]s<job-id>%[1]s is the UUID of the job whose artifacts to list or download.
 				Job UUIDs are shown in the output of "circleci workflow get" and
 				"circleci run get --json".
-			`),
+			`, "`"),
 		},
 		Long: heredoc.Doc(`
 			List or download artifacts produced by a specific job.

--- a/internal/cmd/job/get.go
+++ b/internal/cmd/job/get.go
@@ -45,10 +45,10 @@ func newGetCmd() *cobra.Command {
 		Use:   "get <job-id>",
 		Short: "Get job details",
 		Annotations: map[string]string{
-			"help:arguments": heredoc.Doc(`
-				<job-id> is the UUID of the job to look up. Job UUIDs are shown in
+			"help:arguments": heredoc.Docf(`
+				%[1]s<job-id>%[1]s is the UUID of the job to look up. Job UUIDs are shown in
 				the output of "circleci workflow get" and "circleci run get --json".
-			`),
+			`, "`"),
 		},
 		Long: heredoc.Doc(`
 			Display the status and steps of a CircleCI job.

--- a/internal/cmd/job/open.go
+++ b/internal/cmd/job/open.go
@@ -40,10 +40,10 @@ func newOpenCmd() *cobra.Command {
 		Use:   "open <job-id>",
 		Short: "Open job in browser",
 		Annotations: map[string]string{
-			"help:arguments": heredoc.Doc(`
-				<job-id> is the UUID of the job to look up. Job UUIDs are shown in
+			"help:arguments": heredoc.Docf(`
+				%[1]s<job-id>%[1]s is the UUID of the job to look up. Job UUIDs are shown in
 				the output of "circleci workflow get" and "circleci run get --json".
-			`),
+			`, "`"),
 		},
 		Example: heredoc.Doc(`
 			# Open job by UUID

--- a/internal/cmd/job/output_get.go
+++ b/internal/cmd/job/output_get.go
@@ -51,11 +51,11 @@ func newOutputGetCmd() *cobra.Command {
 		Use:   "get <job-id>",
 		Short: "Get the output of a job step",
 		Annotations: map[string]string{
-			"help:arguments": heredoc.Doc(`
-				<job-id> is the UUID of the job whose step output to fetch. Job UUIDs
+			"help:arguments": heredoc.Docf(`
+				%[1]s<job-id>%[1]s is the UUID of the job whose step output to fetch. Job UUIDs
 				are shown in the output of "circleci workflow get" and "circleci job get".
 				Use --step-num to select which step's output to read.
-			`),
+			`, "`"),
 		},
 		Long: heredoc.Doc(`
 			Fetch the raw stdout and stderr of a single step within a job and

--- a/internal/cmd/job/output_list.go
+++ b/internal/cmd/job/output_list.go
@@ -89,11 +89,11 @@ func newOutputListCmd() *cobra.Command {
 		Use:   "list <job-id>",
 		Short: "List a job's steps with their output",
 		Annotations: map[string]string{
-			"help:arguments": heredoc.Doc(`
-				<job-id> is the UUID of the job whose steps and output to list. Job
+			"help:arguments": heredoc.Docf(`
+				%[1]s<job-id>%[1]s is the UUID of the job whose steps and output to list. Job
 				UUIDs are shown in the output of "circleci workflow get" and
 				"circleci job get".
-			`),
+			`, "`"),
 		},
 		Long: heredoc.Doc(`
 			List every step in a job alongside its terminal-processed output.

--- a/internal/cmd/namespace/create.go
+++ b/internal/cmd/namespace/create.go
@@ -43,10 +43,10 @@ func newCreateCmd() *cobra.Command {
 		Use:   "create <name> --org <org>",
 		Short: "Create a namespace",
 		Annotations: map[string]string{
-			"help:arguments": heredoc.Doc(`
-				<name> is the namespace name to create. It must be globally unique
+			"help:arguments": heredoc.Docf(`
+				%[1]s<name>%[1]s is the namespace name to create. It must be globally unique
 				across CircleCI, e.g. "myorg".
-			`),
+			`, "`"),
 		},
 		Long: heredoc.Doc(`
 			Create a CircleCI orb namespace for an organization.

--- a/internal/cmd/namespace/delete.go
+++ b/internal/cmd/namespace/delete.go
@@ -44,9 +44,9 @@ func newDeleteCmd() *cobra.Command {
 		Aliases: []string{"rm"},
 		Short:   "Delete a namespace and all its orbs",
 		Annotations: map[string]string{
-			"help:arguments": heredoc.Doc(`
-				<name> is the name of the namespace to delete, e.g. "myorg".
-			`),
+			"help:arguments": heredoc.Docf(`
+				%[1]s<name>%[1]s is the name of the namespace to delete, e.g. "myorg".
+			`, "`"),
 		},
 		Long: heredoc.Doc(`
 			Delete a CircleCI orb namespace and all orbs published under it.

--- a/internal/cmd/namespace/get.go
+++ b/internal/cmd/namespace/get.go
@@ -41,9 +41,9 @@ func newGetCmd() *cobra.Command {
 		Use:   "get <name>",
 		Short: "Get details of a namespace",
 		Annotations: map[string]string{
-			"help:arguments": heredoc.Doc(`
-				<name> is the name of the namespace to look up, e.g. "myorg".
-			`),
+			"help:arguments": heredoc.Docf(`
+				%[1]s<name>%[1]s is the name of the namespace to look up, e.g. "myorg".
+			`, "`"),
 		},
 		Long: heredoc.Doc(`
 			Display details of a CircleCI orb namespace.

--- a/internal/cmd/namespace/namespace.go
+++ b/internal/cmd/namespace/namespace.go
@@ -41,13 +41,13 @@ func NewNamespaceCmd() *cobra.Command {
 		Use:     "namespace <command>",
 		GroupID: "management",
 		Short:   "Manage the org namespace orbs publish under",
-		Long: heredoc.Doc(`
+		Long: heredoc.Docf(`
 			Work with CircleCI orb namespaces.
 
 			Namespaces are unique identifiers used to publish orbs.
 			Each organization may claim one namespace. Orbs are published
-			and referenced as <namespace>/<orb>. All published orbs are world-readable.
-		`),
+			and referenced as %[1]s<namespace>/<orb>%[1]s. All published orbs are world-readable.
+		`, "`"),
 		RunE:               cmdutil.GroupRunE,
 		FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
 	}

--- a/internal/cmd/namespace/rename.go
+++ b/internal/cmd/namespace/rename.go
@@ -40,10 +40,10 @@ func newRenameCmd() *cobra.Command {
 		Use:   "rename <name> <new-name>",
 		Short: "Rename a namespace",
 		Annotations: map[string]string{
-			"help:arguments": heredoc.Doc(`
-				- <name> is the current name of the namespace, e.g. "oldname".
-				- <new-name> is the new name to assign, e.g. "newname".
-			`),
+			"help:arguments": heredoc.Docf(`
+				- %[1]s<name>%[1]s is the current name of the namespace, e.g. "oldname".
+				- %[1]s<new-name>%[1]s is the new name to assign, e.g. "newname".
+			`, "`"),
 		},
 		Long: heredoc.Doc(`
 			Rename a CircleCI orb namespace.

--- a/internal/cmd/orb/add_to_category.go
+++ b/internal/cmd/orb/add_to_category.go
@@ -38,10 +38,10 @@ func newAddToCategoryCmd() *cobra.Command {
 		Use:   "add-to-category <ns>/<orb> <category>",
 		Short: "Add an orb to a registry category",
 		Annotations: map[string]string{
-			"help:arguments": heredoc.Doc(`
-				- <ns>/<orb>: the orb to add, as "namespace/orb-name"
-				- <category>: the registry category name, e.g. "Testing"
-			`),
+			"help:arguments": heredoc.Docf(`
+				- %[1]s<ns>/<orb>%[1]s: the orb to add, as "namespace/orb-name"
+				- %[1]s<category>%[1]s: the registry category name, e.g. "Testing"
+			`, "`"),
 		},
 		Long: heredoc.Doc(`
 			Add an orb to an orb registry category.

--- a/internal/cmd/orb/create.go
+++ b/internal/cmd/orb/create.go
@@ -45,10 +45,10 @@ func newCreateCmd() *cobra.Command {
 		Use:   "create <namespace>/<orb>",
 		Short: "Reserve an orb name in a namespace",
 		Annotations: map[string]string{
-			"help:arguments": heredoc.Doc(`
-				- <namespace>/<orb>: the orb name to reserve, as "namespace/orb-name".
+			"help:arguments": heredoc.Docf(`
+				- %[1]s<namespace>/<orb>%[1]s: the orb name to reserve, as "namespace/orb-name".
 				  The namespace must already exist.
-			`),
+			`, "`"),
 		},
 		Long: heredoc.Doc(`
 			Reserve an orb name in the given namespace.

--- a/internal/cmd/orb/diff.go
+++ b/internal/cmd/orb/diff.go
@@ -48,9 +48,9 @@ func newDiffCmd() *cobra.Command {
 		Use:   "diff <ns>/<orb> --from <v1> --to <v2>",
 		Short: "Show a unified diff between two orb versions",
 		Annotations: map[string]string{
-			"help:arguments": heredoc.Doc(`
-				- <ns>/<orb>: the orb to diff, as "namespace/orb-name"
-			`),
+			"help:arguments": heredoc.Docf(`
+				- %[1]s<ns>/<orb>%[1]s: the orb to diff, as "namespace/orb-name"
+			`, "`"),
 		},
 		Long: heredoc.Doc(`
 			Show a unified diff between two versions of an orb.

--- a/internal/cmd/orb/list.go
+++ b/internal/cmd/orb/list.go
@@ -46,10 +46,10 @@ func newListCmd() *cobra.Command {
 		Aliases: []string{"ls"},
 		Short:   "List orbs in the registry",
 		Annotations: map[string]string{
-			"help:arguments": heredoc.Doc(`
-				- <namespace>: optional. When given, lists all orbs in that namespace.
+			"help:arguments": heredoc.Docf(`
+				- %[1]s<namespace>%[1]s: optional. When given, lists all orbs in that namespace.
 				  When omitted, lists certified orbs globally.
-			`),
+			`, "`"),
 		},
 		Long: heredoc.Doc(`
 			List orbs in the CircleCI orb registry.

--- a/internal/cmd/orb/pack.go
+++ b/internal/cmd/orb/pack.go
@@ -39,9 +39,9 @@ func newPackCmd() *cobra.Command {
 		Use:   "pack <path>",
 		Short: "Pack a multi-file orb directory into a single YAML",
 		Annotations: map[string]string{
-			"help:arguments": heredoc.Doc(`
-				- <path>: path to an orb source directory or a single orb YAML file.
-			`),
+			"help:arguments": heredoc.Docf(`
+				- %[1]s<path>%[1]s: path to an orb source directory or a single orb YAML file.
+			`, "`"),
 		},
 		Long: heredoc.Doc(`
 			Pack an orb source directory into a single YAML file.

--- a/internal/cmd/orb/process.go
+++ b/internal/cmd/orb/process.go
@@ -42,9 +42,9 @@ func newProcessCmd() *cobra.Command {
 		Use:   "process <path>",
 		Short: "Validate and print expanded orb YAML",
 		Annotations: map[string]string{
-			"help:arguments": heredoc.Doc(`
-				- <path>: path to an orb YAML file. Pass '-' to read from stdin.
-			`),
+			"help:arguments": heredoc.Docf(`
+				- %[1]s<path>%[1]s: path to an orb YAML file. Pass '-' to read from stdin.
+			`, "`"),
 		},
 		Long: heredoc.Doc(`
 			Validate an orb YAML file and print the expanded (processed) YAML.

--- a/internal/cmd/orb/publish.go
+++ b/internal/cmd/orb/publish.go
@@ -41,18 +41,18 @@ func newPublishCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "publish <command>",
 		Short: "Publish orb versions",
-		Long: heredoc.Doc(`
+		Long: heredoc.Docf(`
 			Publish orb versions to the CircleCI orb registry.
 
 			To publish a specific version:
-			  circleci orb publish <path> <ns>/<orb>@<version>
+			  circleci orb publish %[1]s<path> <ns>/<orb>@<version>%[1]s
 
 			To promote a dev version to a stable semver:
-			  circleci orb publish promote <ns>/<orb>@dev:<label> --bump major|minor|patch
+			  circleci orb publish promote %[1]s<ns>/<orb>@dev:<label>%[1]s --bump major|minor|patch
 
 			To increment the latest stable version and publish:
-			  circleci orb publish increment <path> <ns>/<orb> --bump major|minor|patch
-		`),
+			  circleci orb publish increment %[1]s<path> <ns>/<orb>%[1]s --bump major|minor|patch
+		`, "`"),
 		Example: heredoc.Doc(`
 			# Publish a specific version
 			$ circleci orb publish orb.yml myorg/my-orb@1.0.0
@@ -99,17 +99,17 @@ func newPublishPromoteCmd() *cobra.Command {
 		Use:   "promote <ns>/<orb>@dev:<label> --bump major|minor|patch",
 		Short: "Promote a dev orb version to a stable semver",
 		Annotations: map[string]string{
-			"help:arguments": heredoc.Doc(`
-				- <ns>/<orb>@dev:<label>: the dev version to promote, e.g. "namespace/orb-name@dev:my-branch"
-			`),
+			"help:arguments": heredoc.Docf(`
+				- %[1]s<ns>/<orb>@dev:<label>%[1]s: the dev version to promote, e.g. "namespace/orb-name@dev:my-branch"
+			`, "`"),
 		},
-		Long: heredoc.Doc(`
+		Long: heredoc.Docf(`
 			Promote a dev orb version to a stable semver version.
 
-			The dev version ref must be in the form <ns>/<orb>@dev:<label>.
+			The dev version ref must be in the form %[1]s<ns>/<orb>@dev:<label>%[1]s.
 			The --bump flag determines how the version is incremented
 			from the latest stable release.
-		`),
+		`, "`"),
 		Example: heredoc.Doc(`
 			# Promote dev:my-branch to a patch release
 			$ circleci orb publish promote myorg/my-orb@dev:my-branch --bump patch
@@ -151,10 +151,10 @@ func newPublishIncrementCmd() *cobra.Command {
 		Use:   "increment <path> <ns>/<orb> --bump major|minor|patch",
 		Short: "Increment and publish a new orb version",
 		Annotations: map[string]string{
-			"help:arguments": heredoc.Doc(`
-				- <path>: path to the orb YAML to publish. Pass '-' to read from stdin.
-				- <ns>/<orb>: the orb to publish, as "namespace/orb-name"
-			`),
+			"help:arguments": heredoc.Docf(`
+				- %[1]s<path>%[1]s: path to the orb YAML to publish. Pass '-' to read from stdin.
+				- %[1]s<ns>/<orb>%[1]s: the orb to publish, as "namespace/orb-name"
+			`, "`"),
 		},
 		Long: heredoc.Doc(`
 			Read orb YAML from path, compute the next version by incrementing

--- a/internal/cmd/orb/remove_from_category.go
+++ b/internal/cmd/orb/remove_from_category.go
@@ -38,18 +38,18 @@ func newRemoveFromCategoryCmd() *cobra.Command {
 		Use:   "remove-from-category <ns>/<orb> <category>",
 		Short: "Remove an orb from a registry category",
 		Annotations: map[string]string{
-			"help:arguments": heredoc.Doc(`
-				- <ns>/<orb>: the orb to remove, as "namespace/orb-name"
-				- <category>: the registry category name, e.g. "Testing"
-			`),
+			"help:arguments": heredoc.Docf(`
+				- %[1]s<ns>/<orb>%[1]s: the orb to remove, as "namespace/orb-name"
+				- %[1]s<category>%[1]s: the registry category name, e.g. "Testing"
+			`, "`"),
 		},
-		Long: heredoc.Doc(`
+		Long: heredoc.Docf(`
 			Remove an orb from an orb registry category.
 
-			Use 'circleci orb get <ns>/<orb>' to see the current categories
+			Use 'circleci orb get %[1]s<ns>/<orb>%[1]s' to see the current categories
 			for an orb, and 'circleci orb list-categories' for all available
 			categories.
-		`),
+		`, "`"),
 		Example: heredoc.Doc(`
 			# Remove an orb from the Testing category
 			$ circleci orb remove-from-category myorg/my-orb "Testing"

--- a/internal/cmd/orb/source.go
+++ b/internal/cmd/orb/source.go
@@ -39,18 +39,18 @@ func newSourceCmd() *cobra.Command {
 		Use:   "source <ns>/<orb>[@<version>]",
 		Short: "Print the YAML source of an orb version",
 		Annotations: map[string]string{
-			"help:arguments": heredoc.Doc(`
-				- <ns>/<orb>[@<version>]: the orb to print, as "namespace/orb-name".
-				  Optionally append @<version> (e.g. @1.2.3, @volatile, or @dev:my-branch).
+			"help:arguments": heredoc.Docf(`
+				- %[1]s<ns>/<orb>[@<version>]%[1]s: the orb to print, as "namespace/orb-name".
+				  Optionally append %[1]s@<version>%[1]s (e.g. @1.2.3, @volatile, or @dev:my-branch).
 				  When omitted, the latest published version is shown.
-			`),
+			`, "`"),
 		},
-		Long: heredoc.Doc(`
+		Long: heredoc.Docf(`
 			Print the raw YAML source of an orb version.
 
 			If no version is specified, the latest published version is shown.
-			Specify a version with @<version> (e.g. @1.2.3 or @volatile for latest).
-		`),
+			Specify a version with %[1]s@<version>%[1]s (e.g. @1.2.3 or @volatile for latest).
+		`, "`"),
 		Example: heredoc.Doc(`
 			# Print source of the latest version
 			$ circleci orb source myorg/my-orb

--- a/internal/cmd/orb/unlist.go
+++ b/internal/cmd/orb/unlist.go
@@ -40,9 +40,9 @@ func newUnlistCmd() *cobra.Command {
 		Use:   "unlist <ns>/<orb>",
 		Short: "Hide or restore an orb in the registry",
 		Annotations: map[string]string{
-			"help:arguments": heredoc.Doc(`
-				- <ns>/<orb>: the orb to update, as "namespace/orb-name"
-			`),
+			"help:arguments": heredoc.Docf(`
+				- %[1]s<ns>/<orb>%[1]s: the orb to update, as "namespace/orb-name"
+			`, "`"),
 		},
 		Long: heredoc.Doc(`
 			Control whether an orb is visible in the CircleCI orb registry.

--- a/internal/cmd/orb/validate.go
+++ b/internal/cmd/orb/validate.go
@@ -44,9 +44,9 @@ func newValidateCmd() *cobra.Command {
 		Use:   "validate <path>",
 		Short: "Validate an orb YAML file",
 		Annotations: map[string]string{
-			"help:arguments": heredoc.Doc(`
-				- <path>: path to an orb YAML file. Pass '-' to read from stdin.
-			`),
+			"help:arguments": heredoc.Docf(`
+				- %[1]s<path>%[1]s: path to an orb YAML file. Pass '-' to read from stdin.
+			`, "`"),
 		},
 		Long: heredoc.Doc(`
 			Validate an orb YAML file against the CircleCI API.

--- a/internal/cmd/policy/diff.go
+++ b/internal/cmd/policy/diff.go
@@ -44,11 +44,11 @@ func newDiffCmd() *cobra.Command {
 		Use:   "diff <path>",
 		Short: "Show diff between local and remote policy bundles",
 		Annotations: map[string]string{
-			"help:arguments": heredoc.Doc(`
-				<path> is the path to a local directory of .rego policy files,
+			"help:arguments": heredoc.Docf(`
+				%[1]s<path>%[1]s is the path to a local directory of .rego policy files,
 				e.g. "./policies". Its contents are compared against the remote
 				policy bundle.
-			`),
+			`, "`"),
 		},
 		Long: heredoc.Doc(`
 			Compare a local directory of .rego files against the remote policy

--- a/internal/cmd/policy/push.go
+++ b/internal/cmd/policy/push.go
@@ -46,11 +46,11 @@ func newPushCmd() *cobra.Command {
 		Use:   "push <path>",
 		Short: "Push a policy bundle to CircleCI",
 		Annotations: map[string]string{
-			"help:arguments": heredoc.Doc(`
-				<path> is the path to a local directory of .rego policy files,
+			"help:arguments": heredoc.Docf(`
+				%[1]s<path>%[1]s is the path to a local directory of .rego policy files,
 				e.g. "./policies". Its contents are uploaded as the policy
 				bundle, replacing the existing bundle.
-			`),
+			`, "`"),
 		},
 		Long: heredoc.Doc(`
 			Upload a directory of .rego files as a policy bundle.

--- a/internal/cmd/project/env.go
+++ b/internal/cmd/project/env.go
@@ -163,11 +163,11 @@ func NewEnvSetCmd() *cobra.Command {
 		Use:   "set <name> <value>",
 		Short: "Set a project environment variable",
 		Annotations: map[string]string{
-			"help:arguments": heredoc.Doc(`
-				<name> is the name of the environment variable to create or
-				update. <value> is the value to store; it is never retrievable
+			"help:arguments": heredoc.Docf(`
+				%[1]s<name>%[1]s is the name of the environment variable to create or
+				update. %[1]s<value>%[1]s is the value to store; it is never retrievable
 				after being set and is masked in all subsequent list output.
-			`),
+			`, "`"),
 		},
 		Long: heredoc.Doc(`
 			Create or update an environment variable for a CircleCI project.
@@ -240,10 +240,10 @@ func NewEnvDeleteCmd() *cobra.Command {
 		Aliases: []string{"rm"},
 		Short:   "Delete a project environment variable",
 		Annotations: map[string]string{
-			"help:arguments": heredoc.Doc(`
-				<name> is the name of the environment variable to delete from
+			"help:arguments": heredoc.Docf(`
+				%[1]s<name>%[1]s is the name of the environment variable to delete from
 				the project. This action is irreversible.
-			`),
+			`, "`"),
 		},
 		Long: heredoc.Doc(`
 			Delete an environment variable from a CircleCI project.

--- a/internal/cmd/project/link.go
+++ b/internal/cmd/project/link.go
@@ -50,13 +50,13 @@ func newLinkCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "link",
 		Short: "Bind this checkout to a CircleCI project",
-		Long: heredoc.Doc(`
+		Long: heredoc.Docf(`
 			Record the CircleCI project for the current checkout in
 			.circleci/info.yml so other commands can resolve it without
 			re-detecting from the git remote each time.
 
 			Resolution order:
-			  1. --project <slug>, if given.
+			  1. --project %[1]s<slug>%[1]s, if given.
 			  2. The git remote (origin) of the current directory.
 			  3. An interactive prompt — used when neither of the above
 			     yields a project the API recognises.
@@ -67,7 +67,7 @@ func newLinkCmd() *cobra.Command {
 
 			An existing .circleci/info.yml is preserved unless --force
 			is passed.
-		`),
+		`, "`"),
 		Example: heredoc.Doc(`
 			# Auto-detect from the current git repository
 			$ circleci project link
@@ -88,7 +88,7 @@ func newLinkCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&projectSlug, "project", "", "Project slug (e.g. gh/org/repo or circleci/<orgID>/<projectID>)")
+	cmd.Flags().StringVar(&projectSlug, "project", "", "Project slug (e.g. gh/org/repo or `circleci/<orgID>/<projectID>`)")
 	cmd.Flags().BoolVarP(&force, "force", "f", false, "Overwrite an existing .circleci/info.yml")
 
 	return cmd

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -183,12 +183,12 @@ func NewRootCmd(version string) *cobra.Command {
 	cmd.Version = version
 	cmd.SetVersionTemplate("circleci version {{.Version}}\n")
 
-	cmd.PersistentFlags().StringP("config", "c", "", "path to config file (default: ~/.config/circleci/config.yml)")
-	cmd.PersistentFlags().BoolP("quiet", "q", false, "suppress informational output; data on stdout is unaffected")
-	cmd.PersistentFlags().BoolP("debug", "", false, "enable debug logging")
-	cmd.PersistentFlags().StringP("theme", "", "auto", "set the color theme (default: auto)")
+	cmd.PersistentFlags().StringP("config", "c", "", "Path to config file (default: ~/.config/circleci/config.yml)")
+	cmd.PersistentFlags().BoolP("quiet", "q", false, "Suppress informational output. Data on stdout is unaffected")
+	cmd.PersistentFlags().BoolP("debug", "", false, "Enable debug logging")
+	cmd.PersistentFlags().StringP("theme", "", "auto", "Set the color theme (default: auto)")
 	_ = cmd.PersistentFlags().MarkHidden("theme")
-	cmd.PersistentFlags().BoolP("no-color", "", false, "disable ANSI color output (same as setting NO_COLOR)")
+	cmd.PersistentFlags().BoolP("no-color", "", false, "Disable ANSI color output (same as setting NO_COLOR)")
 
 	cmd.PersistentFlags().BoolP("insecure-storage", "", false, "do not use the system's secure storage for storing tokens")
 	_ = cmd.PersistentFlags().MarkHidden("insecure-storage")

--- a/internal/cmd/root/testdata/help/circleci.txt
+++ b/internal/cmd/root/testdata/help/circleci.txt
@@ -66,11 +66,11 @@ Work with CircleCI from the command line.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
 | `-h, --help`          | help for circleci                                            |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 | `-v, --version`       | version for circleci                                         |
 
 ## Learn More

--- a/internal/cmd/root/testdata/help/circleci/api.txt
+++ b/internal/cmd/root/testdata/help/circleci/api.txt
@@ -3,7 +3,7 @@
 Make an authenticated HTTP request to the REST APIs and print
 the raw response body.
 
-<path> is relative to /api/v3 (e.g. projects/{project-id}). To target
+`<path>` is relative to /api/v3 (e.g. `projects/{project-id}`). To target
 a different version prefix, include it explicitly:
   circleci api api/v2/me
 
@@ -38,14 +38,14 @@ For more information about output formatting flags, see `circleci help formattin
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Arguments
 
-<path> is the request path. It is relative to /api/v3 by default
+`<path>` is the request path. It is relative to /api/v3 by default
 (e.g. "projects/{project-id}"). To target
 a different version prefix, include it explicitly, e.g. "api/v2/me".
 

--- a/internal/cmd/root/testdata/help/circleci/artifact.txt
+++ b/internal/cmd/root/testdata/help/circleci/artifact.txt
@@ -25,16 +25,16 @@ For more information about output formatting flags, see `circleci help formattin
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Arguments
 
-<job-id> is the UUID of the job whose artifacts you want to
+`<job-id>` is the UUID of the job whose artifacts you want to
 list or download,
-e.g. 5034460f-c7c4-4c43-9457-de07e2029e7b.
+for example. `5034460f-c7c4-4c43-9457-de07e2029e7b`.
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/auth.txt
+++ b/internal/cmd/root/testdata/help/circleci/auth.txt
@@ -25,10 +25,10 @@ Use 'circleci auth logout' to clear your stored credentials.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/auth/id.txt
+++ b/internal/cmd/root/testdata/help/circleci/auth/id.txt
@@ -1,6 +1,6 @@
 # CircleCI CLI
 
-Print the device ID for this CLI installation as "<os>:<uuid>".
+Print the device ID for this CLI installation as "`<os>:<uuid>`".
 
 The UUID is generated on first use and stored in the config file.
 The OS prefix (e.g. darwin, linux) is added at print time so you
@@ -9,7 +9,7 @@ is sent with every OAuth authorization request, so you can match
 a token in the CircleCI UI back to this installation.
 
 JSON fields:
-  device_id  string  Stable identifier in the form <os>:<uuid>
+  device_id  string  Stable identifier in the form `<os>:<uuid>`
 
 ## Usage
 
@@ -25,10 +25,10 @@ JSON fields:
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/auth/login.txt
+++ b/internal/cmd/root/testdata/help/circleci/auth/login.txt
@@ -23,10 +23,10 @@ subsequent CLI commands.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/auth/logout.txt
+++ b/internal/cmd/root/testdata/help/circleci/auth/logout.txt
@@ -19,10 +19,10 @@ For more information about output formatting flags, see `circleci help formattin
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/auth/me.txt
+++ b/internal/cmd/root/testdata/help/circleci/auth/me.txt
@@ -19,10 +19,10 @@ For more information about output formatting flags, see `circleci help formattin
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/auth/signup.txt
+++ b/internal/cmd/root/testdata/help/circleci/auth/signup.txt
@@ -22,10 +22,10 @@ already have a CircleCI account, use 'circleci auth login' instead.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/certificate.txt
+++ b/internal/cmd/root/testdata/help/circleci/certificate.txt
@@ -28,10 +28,10 @@ signing config.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/certificate/delete.txt
+++ b/internal/cmd/root/testdata/help/circleci/certificate/delete.txt
@@ -27,14 +27,14 @@ Use --force (-f) to skip the prompt for scripting.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Arguments
 
-<cert-id> is the ID of the certificate to delete
+`<cert-id>` is the ID of the certificate to delete
 (see: circleci certificate list).
 
 ## Examples

--- a/internal/cmd/root/testdata/help/circleci/certificate/list.txt
+++ b/internal/cmd/root/testdata/help/circleci/certificate/list.txt
@@ -30,10 +30,10 @@ For more information about output formatting flags, see `circleci help formattin
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/certificate/upload.txt
+++ b/internal/cmd/root/testdata/help/circleci/certificate/upload.txt
@@ -35,10 +35,10 @@ For more information about output formatting flags, see `circleci help formattin
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/completion.txt
+++ b/internal/cmd/root/testdata/help/circleci/completion.txt
@@ -25,10 +25,10 @@ To install manually, add one of the following to your shell profile:
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/completion/bash.txt
+++ b/internal/cmd/root/testdata/help/circleci/completion/bash.txt
@@ -16,10 +16,10 @@ Generate bash completion script
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/completion/install.txt
+++ b/internal/cmd/root/testdata/help/circleci/completion/install.txt
@@ -13,10 +13,10 @@ The line is tagged so it can be cleanly removed with:
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/completion/uninstall.txt
+++ b/internal/cmd/root/testdata/help/circleci/completion/uninstall.txt
@@ -11,10 +11,10 @@ Other content in your shell profile is left untouched.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/completion/zsh.txt
+++ b/internal/cmd/root/testdata/help/circleci/completion/zsh.txt
@@ -16,10 +16,10 @@ Generate zsh completion script
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/config.txt
+++ b/internal/cmd/root/testdata/help/circleci/config.txt
@@ -22,10 +22,10 @@ tool settings (API token, host, defaults), use 'circleci setting'.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/config/generate.txt
+++ b/internal/cmd/root/testdata/help/circleci/config/generate.txt
@@ -1,7 +1,7 @@
 # CircleCI CLI
 
 Detect the language stack, container image, and setup commands for a
-repository, then write a starter pipeline to <path>/.circleci/config.yml.
+repository, then write a starter pipeline to `<path>/.circleci/config.yml`.
 
 If no supported stack is detected, a minimal cimg/base:stable template
 with a placeholder build step is written instead so you have something
@@ -19,10 +19,10 @@ directory is created if needed, and the file is written atomically.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/config/pack.txt
+++ b/internal/cmd/root/testdata/help/circleci/config/pack.txt
@@ -25,15 +25,15 @@ The merged YAML is printed to stdout.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Arguments
 
-<path> is the path to a split config directory to pack,
-e.g. ".circleci" or "src/ci". The directory structure is
+`<path>` is the path to a split config directory to pack,
+for example, `.circleci` or `src/ci`. The directory structure is
 mapped to YAML keys in the merged document.
 
 ## Examples

--- a/internal/cmd/root/testdata/help/circleci/config/process.txt
+++ b/internal/cmd/root/testdata/help/circleci/config/process.txt
@@ -24,15 +24,15 @@ Pass a file path or "-" to read from stdin.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Arguments
 
-<path> is the path to a pipeline config file to compile,
-e.g. ".circleci/config.yml". Pass "-" to read the config
+`<path>` is the path to a pipeline config file to compile,
+for example, `.circleci/config.yml`. Pass `-` to read the config
 from stdin.
 
 ## Examples

--- a/internal/cmd/root/testdata/help/circleci/config/validate.txt
+++ b/internal/cmd/root/testdata/help/circleci/config/validate.txt
@@ -27,9 +27,9 @@ JSON fields (--json):
 
 | Flag          | Description                                                 |
 | ------------- | ----------------------------------------------------------- |
-| `--debug`     | enable debug logging                                        |
-| `--no-color`  | disable ANSI color output (same as setting NO_COLOR)        |
-| `-q, --quiet` | suppress informational output; data on stdout is unaffected |
+| `--debug`     | Enable debug logging                                        |
+| `--no-color`  | Disable ANSI color output (same as setting NO_COLOR)        |
+| `-q, --quiet` | Suppress informational output. Data on stdout is unaffected |
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/context.txt
+++ b/internal/cmd/root/testdata/help/circleci/context.txt
@@ -36,10 +36,10 @@ reference a context to inject its variables into the build environment.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/context/create.txt
+++ b/internal/cmd/root/testdata/help/circleci/context/create.txt
@@ -26,10 +26,10 @@ For more information about output formatting flags, see `circleci help formattin
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Arguments
 

--- a/internal/cmd/root/testdata/help/circleci/context/delete.txt
+++ b/internal/cmd/root/testdata/help/circleci/context/delete.txt
@@ -31,10 +31,10 @@ Use --force (-f) to skip the prompt for scripting.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Arguments
 

--- a/internal/cmd/root/testdata/help/circleci/context/get.txt
+++ b/internal/cmd/root/testdata/help/circleci/context/get.txt
@@ -30,10 +30,10 @@ For more information about output formatting flags, see `circleci help formattin
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Arguments
 

--- a/internal/cmd/root/testdata/help/circleci/context/list.txt
+++ b/internal/cmd/root/testdata/help/circleci/context/list.txt
@@ -31,10 +31,10 @@ For more information about output formatting flags, see `circleci help formattin
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/context/open.txt
+++ b/internal/cmd/root/testdata/help/circleci/context/open.txt
@@ -21,10 +21,10 @@ remotes.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/context/restriction.txt
+++ b/internal/cmd/root/testdata/help/circleci/context/restriction.txt
@@ -22,10 +22,10 @@ accessible to all members of the organization.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/context/restriction/create.txt
+++ b/internal/cmd/root/testdata/help/circleci/context/restriction/create.txt
@@ -31,10 +31,10 @@ For more information about output formatting flags, see `circleci help formattin
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Arguments
 

--- a/internal/cmd/root/testdata/help/circleci/context/restriction/delete.txt
+++ b/internal/cmd/root/testdata/help/circleci/context/restriction/delete.txt
@@ -32,10 +32,10 @@ Use --force (-f) to skip the prompt for scripting.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Arguments
 

--- a/internal/cmd/root/testdata/help/circleci/context/secret.txt
+++ b/internal/cmd/root/testdata/help/circleci/context/secret.txt
@@ -21,10 +21,10 @@ context. Variable values are never returned by the API after being set.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/context/secret/delete.txt
+++ b/internal/cmd/root/testdata/help/circleci/context/secret/delete.txt
@@ -32,10 +32,10 @@ Use --force (-f) to skip the prompt for scripting.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Arguments
 

--- a/internal/cmd/root/testdata/help/circleci/context/secret/list.txt
+++ b/internal/cmd/root/testdata/help/circleci/context/secret/list.txt
@@ -33,10 +33,10 @@ For more information about output formatting flags, see `circleci help formattin
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Arguments
 

--- a/internal/cmd/root/testdata/help/circleci/context/secret/set.txt
+++ b/internal/cmd/root/testdata/help/circleci/context/secret/set.txt
@@ -29,10 +29,10 @@ interactively with input masking.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Arguments
 

--- a/internal/cmd/root/testdata/help/circleci/deploy.txt
+++ b/internal/cmd/root/testdata/help/circleci/deploy.txt
@@ -20,10 +20,10 @@ View deployed components and their versions across environments.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/deploy/init.txt
+++ b/internal/cmd/root/testdata/help/circleci/deploy/init.txt
@@ -27,10 +27,10 @@ Works offline — no API calls required.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/deploy/list.txt
+++ b/internal/cmd/root/testdata/help/circleci/deploy/list.txt
@@ -31,10 +31,10 @@ For more information about output formatting flags, see `circleci help formattin
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/deploy/open.txt
+++ b/internal/cmd/root/testdata/help/circleci/deploy/open.txt
@@ -21,10 +21,10 @@ GitLab remotes.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/dlc.txt
+++ b/internal/cmd/root/testdata/help/circleci/dlc.txt
@@ -22,10 +22,10 @@ These commands are also available under 'circleci project dlc'.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/dlc/purge.txt
+++ b/internal/cmd/root/testdata/help/circleci/dlc/purge.txt
@@ -28,10 +28,10 @@ JSON fields (--json): project_id, project_slug
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/envvar.txt
+++ b/internal/cmd/root/testdata/help/circleci/envvar.txt
@@ -8,7 +8,7 @@ unless overridden with --project.
 Environment variable values are masked in list output (shown as "xxxx").
 The full value is never retrievable after it has been set.
 
-Also available as: circleci project envvar <command>
+Also available as: circleci project envvar `<command>`
 
 ## Usage
 
@@ -31,10 +31,10 @@ Also available as: circleci project envvar <command>
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/envvar/delete.txt
+++ b/internal/cmd/root/testdata/help/circleci/envvar/delete.txt
@@ -30,14 +30,14 @@ Use --force (-f) to skip the prompt for scripting.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Arguments
 
-<name> is the name of the environment variable to delete from
+`<name>` is the name of the environment variable to delete from
 the project. This action is irreversible.
 
 ## Examples

--- a/internal/cmd/root/testdata/help/circleci/envvar/list.txt
+++ b/internal/cmd/root/testdata/help/circleci/envvar/list.txt
@@ -32,10 +32,10 @@ For more information about output formatting flags, see `circleci help formattin
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/envvar/set.txt
+++ b/internal/cmd/root/testdata/help/circleci/envvar/set.txt
@@ -23,15 +23,15 @@ unless overridden with --project.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Arguments
 
-<name> is the name of the environment variable to create or
-update. <value> is the value to store; it is never retrievable
+`<name>` is the name of the environment variable to create or
+update. `<value>` is the value to store; it is never retrievable
 after being set and is masked in all subsequent list output.
 
 ## Examples

--- a/internal/cmd/root/testdata/help/circleci/job.txt
+++ b/internal/cmd/root/testdata/help/circleci/job.txt
@@ -21,10 +21,10 @@ Jobs are the individual units of work within a workflow.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/job/artifact.txt
+++ b/internal/cmd/root/testdata/help/circleci/job/artifact.txt
@@ -25,14 +25,14 @@ For more information about output formatting flags, see `circleci help formattin
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Arguments
 
-<job-id> is the UUID of the job whose artifacts to list or download.
+`<job-id>` is the UUID of the job whose artifacts to list or download.
 Job UUIDs are shown in the output of "circleci workflow get" and
 "circleci run get --json".
 

--- a/internal/cmd/root/testdata/help/circleci/job/get.txt
+++ b/internal/cmd/root/testdata/help/circleci/job/get.txt
@@ -26,14 +26,14 @@ For more information about output formatting flags, see `circleci help formattin
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Arguments
 
-<job-id> is the UUID of the job to look up. Job UUIDs are shown in
+`<job-id>` is the UUID of the job to look up. Job UUIDs are shown in
 the output of "circleci workflow get" and "circleci run get --json".
 
 ## Examples

--- a/internal/cmd/root/testdata/help/circleci/job/open.txt
+++ b/internal/cmd/root/testdata/help/circleci/job/open.txt
@@ -10,14 +10,14 @@ Open job in browser
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Arguments
 
-<job-id> is the UUID of the job to look up. Job UUIDs are shown in
+`<job-id>` is the UUID of the job to look up. Job UUIDs are shown in
 the output of "circleci workflow get" and "circleci run get --json".
 
 ## Examples

--- a/internal/cmd/root/testdata/help/circleci/job/output.txt
+++ b/internal/cmd/root/testdata/help/circleci/job/output.txt
@@ -20,10 +20,10 @@ jobs, an execution index selects which executor's output to fetch.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/job/output/get.txt
+++ b/internal/cmd/root/testdata/help/circleci/job/output/get.txt
@@ -38,14 +38,14 @@ Use --strip-ansi to force this rendering even on a terminal, or
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Arguments
 
-<job-id> is the UUID of the job whose step output to fetch. Job UUIDs
+`<job-id>` is the UUID of the job whose step output to fetch. Job UUIDs
 are shown in the output of "circleci workflow get" and "circleci job get".
 Use --step-num to select which step's output to read.
 

--- a/internal/cmd/root/testdata/help/circleci/job/output/list.txt
+++ b/internal/cmd/root/testdata/help/circleci/job/output/list.txt
@@ -39,14 +39,14 @@ For more information about output formatting flags, see `circleci help formattin
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Arguments
 
-<job-id> is the UUID of the job whose steps and output to list. Job
+`<job-id>` is the UUID of the job whose steps and output to list. Job
 UUIDs are shown in the output of "circleci workflow get" and
 "circleci job get".
 

--- a/internal/cmd/root/testdata/help/circleci/man.txt
+++ b/internal/cmd/root/testdata/help/circleci/man.txt
@@ -16,10 +16,10 @@ Generates manpages
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/mcp.txt
+++ b/internal/cmd/root/testdata/help/circleci/mcp.txt
@@ -21,10 +21,10 @@ Manage MCP servers for AI assistants and code editors
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/mcp/claude.txt
+++ b/internal/cmd/root/testdata/help/circleci/mcp/claude.txt
@@ -18,10 +18,10 @@ Manage MCP server configuration for Claude Desktop
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/mcp/claude/disable.txt
+++ b/internal/cmd/root/testdata/help/circleci/mcp/claude/disable.txt
@@ -17,10 +17,10 @@ Remove this application from Claude Desktop MCP servers
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/mcp/claude/enable.txt
+++ b/internal/cmd/root/testdata/help/circleci/mcp/claude/enable.txt
@@ -19,10 +19,10 @@ Add this application as an MCP server in Claude Desktop
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/mcp/claude/list.txt
+++ b/internal/cmd/root/testdata/help/circleci/mcp/claude/list.txt
@@ -16,10 +16,10 @@ Show all MCP servers configured in Claude Desktop
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/mcp/cursor.txt
+++ b/internal/cmd/root/testdata/help/circleci/mcp/cursor.txt
@@ -18,10 +18,10 @@ Manage MCP server configuration for Cursor
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/mcp/cursor/disable.txt
+++ b/internal/cmd/root/testdata/help/circleci/mcp/cursor/disable.txt
@@ -18,10 +18,10 @@ Remove this application from Cursor MCP servers
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/mcp/cursor/enable.txt
+++ b/internal/cmd/root/testdata/help/circleci/mcp/cursor/enable.txt
@@ -20,10 +20,10 @@ Add this application as an MCP server in Cursor
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/mcp/cursor/list.txt
+++ b/internal/cmd/root/testdata/help/circleci/mcp/cursor/list.txt
@@ -17,10 +17,10 @@ Show all MCP servers configured in Cursor
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/mcp/start.txt
+++ b/internal/cmd/root/testdata/help/circleci/mcp/start.txt
@@ -16,10 +16,10 @@ Start stdio server to expose CLI commands to AI assistants
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/mcp/stream.txt
+++ b/internal/cmd/root/testdata/help/circleci/mcp/stream.txt
@@ -18,10 +18,10 @@ Start HTTP server to expose CLI commands to AI assistants
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/mcp/tools.txt
+++ b/internal/cmd/root/testdata/help/circleci/mcp/tools.txt
@@ -16,10 +16,10 @@ Export available MCP tools to mcp-tools.json for inspection
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/mcp/vscode.txt
+++ b/internal/cmd/root/testdata/help/circleci/mcp/vscode.txt
@@ -18,10 +18,10 @@ Manage MCP server configuration for Visual Studio Code
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/mcp/vscode/disable.txt
+++ b/internal/cmd/root/testdata/help/circleci/mcp/vscode/disable.txt
@@ -18,10 +18,10 @@ Remove this application from VSCode MCP servers
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/mcp/vscode/enable.txt
+++ b/internal/cmd/root/testdata/help/circleci/mcp/vscode/enable.txt
@@ -20,10 +20,10 @@ Add this application as an MCP server in VSCode
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/mcp/vscode/list.txt
+++ b/internal/cmd/root/testdata/help/circleci/mcp/vscode/list.txt
@@ -17,10 +17,10 @@ Show all MCP servers configured in VSCode
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/my.txt
+++ b/internal/cmd/root/testdata/help/circleci/my.txt
@@ -20,10 +20,10 @@ git repository.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/my/runs.txt
+++ b/internal/cmd/root/testdata/help/circleci/my/runs.txt
@@ -32,10 +32,10 @@ For more information about output formatting flags, see `circleci help formattin
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/namespace.txt
+++ b/internal/cmd/root/testdata/help/circleci/namespace.txt
@@ -4,7 +4,7 @@ Work with CircleCI orb namespaces.
 
 Namespaces are unique identifiers used to publish orbs.
 Each organization may claim one namespace. Orbs are published
-and referenced as <namespace>/<orb>. All published orbs are world-readable.
+and referenced as `<namespace>/<orb>`. All published orbs are world-readable.
 
 ## Usage
 
@@ -28,10 +28,10 @@ and referenced as <namespace>/<orb>. All published orbs are world-readable.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/namespace/create.txt
+++ b/internal/cmd/root/testdata/help/circleci/namespace/create.txt
@@ -26,14 +26,14 @@ For more information about output formatting flags, see `circleci help formattin
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Arguments
 
-<name> is the namespace name to create. It must be globally unique
+`<name>` is the namespace name to create. It must be globally unique
 across CircleCI, e.g. "myorg".
 
 ## Examples

--- a/internal/cmd/root/testdata/help/circleci/namespace/delete.txt
+++ b/internal/cmd/root/testdata/help/circleci/namespace/delete.txt
@@ -28,14 +28,14 @@ Use --dry-run (-n) to preview what would be deleted without deleting.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Arguments
 
-<name> is the name of the namespace to delete, e.g. "myorg".
+`<name>` is the name of the namespace to delete, e.g. "myorg".
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/namespace/get.txt
+++ b/internal/cmd/root/testdata/help/circleci/namespace/get.txt
@@ -21,14 +21,14 @@ For more information about output formatting flags, see `circleci help formattin
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Arguments
 
-<name> is the name of the namespace to look up, e.g. "myorg".
+`<name>` is the name of the namespace to look up, e.g. "myorg".
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/namespace/rename.txt
+++ b/internal/cmd/root/testdata/help/circleci/namespace/rename.txt
@@ -25,15 +25,15 @@ For more information about output formatting flags, see `circleci help formattin
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Arguments
 
-- <name> is the current name of the namespace, e.g. "oldname".
-- <new-name> is the new name to assign, e.g. "newname".
+- `<name>` is the current name of the namespace, e.g. "oldname".
+- `<new-name>` is the new name to assign, e.g. "newname".
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/onboard.txt
+++ b/internal/cmd/root/testdata/help/circleci/onboard.txt
@@ -22,10 +22,10 @@ choose between scanning the current repo or signing up directly.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/orb.txt
+++ b/internal/cmd/root/testdata/help/circleci/orb.txt
@@ -38,10 +38,10 @@ Use 'circleci namespace' to manage namespaces before publishing orbs.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/orb/add-to-category.txt
+++ b/internal/cmd/root/testdata/help/circleci/orb/add-to-category.txt
@@ -13,15 +13,15 @@ to see available categories.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Arguments
 
-- <ns>/<orb>: the orb to add, as "namespace/orb-name"
-- <category>: the registry category name, e.g. "Testing"
+- `<ns>/<orb>`: the orb to add, as "namespace/orb-name"
+- `<category>`: the registry category name, e.g. "Testing"
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/orb/create.txt
+++ b/internal/cmd/root/testdata/help/circleci/orb/create.txt
@@ -28,14 +28,14 @@ For more information about output formatting flags, see `circleci help formattin
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Arguments
 
-- <namespace>/<orb>: the orb name to reserve, as "namespace/orb-name".
+- `<namespace>/<orb>`: the orb name to reserve, as "namespace/orb-name".
   The namespace must already exist.
 
 ## Examples

--- a/internal/cmd/root/testdata/help/circleci/orb/diff.txt
+++ b/internal/cmd/root/testdata/help/circleci/orb/diff.txt
@@ -22,14 +22,14 @@ Exit code is 0 regardless of whether the versions differ.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Arguments
 
-- <ns>/<orb>: the orb to diff, as "namespace/orb-name"
+- `<ns>/<orb>`: the orb to diff, as "namespace/orb-name"
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/orb/get.txt
+++ b/internal/cmd/root/testdata/help/circleci/orb/get.txt
@@ -26,10 +26,10 @@ For more information about output formatting flags, see `circleci help formattin
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Arguments
 

--- a/internal/cmd/root/testdata/help/circleci/orb/list-categories.txt
+++ b/internal/cmd/root/testdata/help/circleci/orb/list-categories.txt
@@ -24,10 +24,10 @@ For more information about output formatting flags, see `circleci help formattin
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/orb/list.txt
+++ b/internal/cmd/root/testdata/help/circleci/orb/list.txt
@@ -33,14 +33,14 @@ For more information about output formatting flags, see `circleci help formattin
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Arguments
 
-- <namespace>: optional. When given, lists all orbs in that namespace.
+- `<namespace>`: optional. When given, lists all orbs in that namespace.
   When omitted, lists certified orbs globally.
 
 ## Examples

--- a/internal/cmd/root/testdata/help/circleci/orb/pack.txt
+++ b/internal/cmd/root/testdata/help/circleci/orb/pack.txt
@@ -19,14 +19,14 @@ The merged YAML is written to stdout.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Arguments
 
-- <path>: path to an orb source directory or a single orb YAML file.
+- `<path>`: path to an orb source directory or a single orb YAML file.
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/orb/process.txt
+++ b/internal/cmd/root/testdata/help/circleci/orb/process.txt
@@ -22,14 +22,14 @@ Pass '-' as the path to read from stdin.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Arguments
 
-- <path>: path to an orb YAML file. Pass '-' to read from stdin.
+- `<path>`: path to an orb YAML file. Pass '-' to read from stdin.
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/orb/publish.txt
+++ b/internal/cmd/root/testdata/help/circleci/orb/publish.txt
@@ -3,13 +3,13 @@
 Publish orb versions to the CircleCI orb registry.
 
 To publish a specific version:
-  circleci orb publish <path> <ns>/<orb>@<version>
+  circleci orb publish `<path> <ns>/<orb>@<version>`
 
 To promote a dev version to a stable semver:
-  circleci orb publish promote <ns>/<orb>@dev:<label> --bump major|minor|patch
+  circleci orb publish promote `<ns>/<orb>@dev:<label>` --bump major|minor|patch
 
 To increment the latest stable version and publish:
-  circleci orb publish increment <path> <ns>/<orb> --bump major|minor|patch
+  circleci orb publish increment `<path> <ns>/<orb>` --bump major|minor|patch
 
 ## Usage
 
@@ -26,10 +26,10 @@ To increment the latest stable version and publish:
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/orb/publish/increment.txt
+++ b/internal/cmd/root/testdata/help/circleci/orb/publish/increment.txt
@@ -23,15 +23,15 @@ Pass '-' as the path to read from stdin.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Arguments
 
-- <path>: path to the orb YAML to publish. Pass '-' to read from stdin.
-- <ns>/<orb>: the orb to publish, as "namespace/orb-name"
+- `<path>`: path to the orb YAML to publish. Pass '-' to read from stdin.
+- `<ns>/<orb>`: the orb to publish, as "namespace/orb-name"
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/orb/publish/promote.txt
+++ b/internal/cmd/root/testdata/help/circleci/orb/publish/promote.txt
@@ -2,7 +2,7 @@
 
 Promote a dev orb version to a stable semver version.
 
-The dev version ref must be in the form <ns>/<orb>@dev:<label>.
+The dev version ref must be in the form `<ns>/<orb>@dev:<label>`.
 The --bump flag determines how the version is incremented
 from the latest stable release.
 
@@ -20,14 +20,14 @@ from the latest stable release.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Arguments
 
-- <ns>/<orb>@dev:<label>: the dev version to promote, e.g. "namespace/orb-name@dev:my-branch"
+- `<ns>/<orb>@dev:<label>`: the dev version to promote, e.g. "namespace/orb-name@dev:my-branch"
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/orb/remove-from-category.txt
+++ b/internal/cmd/root/testdata/help/circleci/orb/remove-from-category.txt
@@ -2,7 +2,7 @@
 
 Remove an orb from an orb registry category.
 
-Use 'circleci orb get <ns>/<orb>' to see the current categories
+Use 'circleci orb get `<ns>/<orb>`' to see the current categories
 for an orb, and 'circleci orb list-categories' for all available
 categories.
 
@@ -14,15 +14,15 @@ categories.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Arguments
 
-- <ns>/<orb>: the orb to remove, as "namespace/orb-name"
-- <category>: the registry category name, e.g. "Testing"
+- `<ns>/<orb>`: the orb to remove, as "namespace/orb-name"
+- `<category>`: the registry category name, e.g. "Testing"
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/orb/source.txt
+++ b/internal/cmd/root/testdata/help/circleci/orb/source.txt
@@ -3,7 +3,7 @@
 Print the raw YAML source of an orb version.
 
 If no version is specified, the latest published version is shown.
-Specify a version with @<version> (e.g. @1.2.3 or @volatile for latest).
+Specify a version with `@<version>` (e.g. @1.2.3 or @volatile for latest).
 
 ## Usage
 
@@ -13,15 +13,15 @@ Specify a version with @<version> (e.g. @1.2.3 or @volatile for latest).
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Arguments
 
-- <ns>/<orb>[@<version>]: the orb to print, as "namespace/orb-name".
-  Optionally append @<version> (e.g. @1.2.3, @volatile, or @dev:my-branch).
+- `<ns>/<orb>[@<version>]`: the orb to print, as "namespace/orb-name".
+  Optionally append `@<version>` (e.g. @1.2.3, @volatile, or @dev:my-branch).
   When omitted, the latest published version is shown.
 
 ## Examples

--- a/internal/cmd/root/testdata/help/circleci/orb/unlist.txt
+++ b/internal/cmd/root/testdata/help/circleci/orb/unlist.txt
@@ -21,14 +21,14 @@ Unlisted orbs can still be used if you know the exact orb reference.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Arguments
 
-- <ns>/<orb>: the orb to update, as "namespace/orb-name"
+- `<ns>/<orb>`: the orb to update, as "namespace/orb-name"
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/orb/validate.txt
+++ b/internal/cmd/root/testdata/help/circleci/orb/validate.txt
@@ -23,14 +23,14 @@ Exit code 7 if the orb is invalid.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Arguments
 
-- <path>: path to an orb YAML file. Pass '-' to read from stdin.
+- `<path>`: path to an orb YAML file. Pass '-' to read from stdin.
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/pipeline.txt
+++ b/internal/cmd/root/testdata/help/circleci/pipeline.txt
@@ -28,10 +28,10 @@ CircleCI compiles into workflows. Attach triggers to a definition with
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/pipeline/create.txt
+++ b/internal/cmd/root/testdata/help/circleci/pipeline/create.txt
@@ -47,10 +47,10 @@ For more information about output formatting flags, see `circleci help formattin
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/pipeline/list.txt
+++ b/internal/cmd/root/testdata/help/circleci/pipeline/list.txt
@@ -34,10 +34,10 @@ For more information about output formatting flags, see `circleci help formattin
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/pipeline/run.txt
+++ b/internal/cmd/root/testdata/help/circleci/pipeline/run.txt
@@ -46,10 +46,10 @@ For more information about output formatting flags, see `circleci help formattin
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/policy.txt
+++ b/internal/cmd/root/testdata/help/circleci/policy.txt
@@ -39,10 +39,10 @@ Find it at: https://app.circleci.com/settings/organization
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/policy/decide.txt
+++ b/internal/cmd/root/testdata/help/circleci/policy/decide.txt
@@ -32,10 +32,10 @@ For more information about output formatting flags, see `circleci help formattin
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/policy/diff.txt
+++ b/internal/cmd/root/testdata/help/circleci/policy/diff.txt
@@ -24,14 +24,14 @@ For more information about output formatting flags, see `circleci help formattin
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Arguments
 
-<path> is the path to a local directory of .rego policy files,
+`<path>` is the path to a local directory of .rego policy files,
 e.g. "./policies". Its contents are compared against the remote
 policy bundle.
 

--- a/internal/cmd/root/testdata/help/circleci/policy/fetch.txt
+++ b/internal/cmd/root/testdata/help/circleci/policy/fetch.txt
@@ -26,10 +26,10 @@ For more information about output formatting flags, see `circleci help formattin
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/policy/logs.txt
+++ b/internal/cmd/root/testdata/help/circleci/policy/logs.txt
@@ -38,10 +38,10 @@ For more information about output formatting flags, see `circleci help formattin
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/policy/push.txt
+++ b/internal/cmd/root/testdata/help/circleci/policy/push.txt
@@ -30,14 +30,14 @@ For more information about output formatting flags, see `circleci help formattin
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Arguments
 
-<path> is the path to a local directory of .rego policy files,
+`<path>` is the path to a local directory of .rego policy files,
 e.g. "./policies". Its contents are uploaded as the policy
 bundle, replacing the existing bundle.
 

--- a/internal/cmd/root/testdata/help/circleci/policy/settings.txt
+++ b/internal/cmd/root/testdata/help/circleci/policy/settings.txt
@@ -20,10 +20,10 @@ against the policy bundle before running.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/policy/settings/get.txt
+++ b/internal/cmd/root/testdata/help/circleci/policy/settings/get.txt
@@ -23,10 +23,10 @@ For more information about output formatting flags, see `circleci help formattin
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/policy/settings/set.txt
+++ b/internal/cmd/root/testdata/help/circleci/policy/settings/set.txt
@@ -27,10 +27,10 @@ For more information about output formatting flags, see `circleci help formattin
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/project.txt
+++ b/internal/cmd/root/testdata/help/circleci/project.txt
@@ -42,10 +42,10 @@ To manage environment variables directly, use the top-level alias:
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/project/create.txt
+++ b/internal/cmd/root/testdata/help/circleci/project/create.txt
@@ -33,10 +33,10 @@ JSON fields: id, slug, name, organization_name, organization_slug,
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Arguments
 

--- a/internal/cmd/root/testdata/help/circleci/project/dlc.txt
+++ b/internal/cmd/root/testdata/help/circleci/project/dlc.txt
@@ -22,10 +22,10 @@ These commands are also available under 'circleci project dlc'.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/project/dlc/purge.txt
+++ b/internal/cmd/root/testdata/help/circleci/project/dlc/purge.txt
@@ -28,10 +28,10 @@ JSON fields (--json): project_id, project_slug
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/project/envvar.txt
+++ b/internal/cmd/root/testdata/help/circleci/project/envvar.txt
@@ -24,10 +24,10 @@ For quick access, use the top-level alias:
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/project/envvar/delete.txt
+++ b/internal/cmd/root/testdata/help/circleci/project/envvar/delete.txt
@@ -30,14 +30,14 @@ Use --force (-f) to skip the prompt for scripting.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Arguments
 
-<name> is the name of the environment variable to delete from
+`<name>` is the name of the environment variable to delete from
 the project. This action is irreversible.
 
 ## Examples

--- a/internal/cmd/root/testdata/help/circleci/project/envvar/list.txt
+++ b/internal/cmd/root/testdata/help/circleci/project/envvar/list.txt
@@ -32,10 +32,10 @@ For more information about output formatting flags, see `circleci help formattin
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/project/envvar/set.txt
+++ b/internal/cmd/root/testdata/help/circleci/project/envvar/set.txt
@@ -23,15 +23,15 @@ unless overridden with --project.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Arguments
 
-<name> is the name of the environment variable to create or
-update. <value> is the value to store; it is never retrievable
+`<name>` is the name of the environment variable to create or
+update. `<value>` is the value to store; it is never retrievable
 after being set and is masked in all subsequent list output.
 
 ## Examples

--- a/internal/cmd/root/testdata/help/circleci/project/follow.txt
+++ b/internal/cmd/root/testdata/help/circleci/project/follow.txt
@@ -22,10 +22,10 @@ Following a project that is already followed is a no-op.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/project/get.txt
+++ b/internal/cmd/root/testdata/help/circleci/project/get.txt
@@ -25,10 +25,10 @@ JSON fields: id, slug, name, organization_name, organization_slug,
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/project/link.txt
+++ b/internal/cmd/root/testdata/help/circleci/project/link.txt
@@ -5,7 +5,7 @@ Record the CircleCI project for the current checkout in
 re-detecting from the git remote each time.
 
 Resolution order:
-  1. --project <slug>, if given.
+  1. --project `<slug>`, if given.
   2. The git remote (origin) of the current directory.
   3. An interactive prompt — used when neither of the above
      yields a project the API recognises.
@@ -23,19 +23,19 @@ is passed.
 
 ## Flags
 
-| Flag               | Description                                                     |
-| ------------------ | --------------------------------------------------------------- |
-| `-f, --force`      | Overwrite an existing .circleci/info.yml                        |
-| `--project string` | Project slug (e.g. gh/org/repo or circleci/<orgID>/<projectID>) |
+| Flag                                     | Description                                                     |
+| ---------------------------------------- | --------------------------------------------------------------- |
+| `-f, --force`                            | Overwrite an existing .circleci/info.yml                        |
+| `--project circleci/<orgID>/<projectID>` | Project slug (e.g. gh/org/repo or circleci/<orgID>/<projectID>) |
 
 ## Inherited Flags
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/project/list.txt
+++ b/internal/cmd/root/testdata/help/circleci/project/list.txt
@@ -29,10 +29,10 @@ For more information about output formatting flags, see `circleci help formattin
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/project/open.txt
+++ b/internal/cmd/root/testdata/help/circleci/project/open.txt
@@ -21,10 +21,10 @@ GitLab remotes.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/project/trigger.txt
+++ b/internal/cmd/root/testdata/help/circleci/project/trigger.txt
@@ -21,10 +21,10 @@ connected via the CircleCI GitHub App are supported.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/project/trigger/create.txt
+++ b/internal/cmd/root/testdata/help/circleci/project/trigger/create.txt
@@ -61,10 +61,10 @@ For more information about output formatting flags, see `circleci help formattin
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/project/trigger/list.txt
+++ b/internal/cmd/root/testdata/help/circleci/project/trigger/list.txt
@@ -37,10 +37,10 @@ For more information about output formatting flags, see `circleci help formattin
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/receive-telemetry.txt
+++ b/internal/cmd/root/testdata/help/circleci/receive-telemetry.txt
@@ -10,10 +10,10 @@ Receive telemetry events and forward them to Segment
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/reference.txt
+++ b/internal/cmd/root/testdata/help/circleci/reference.txt
@@ -5,10 +5,10 @@ Work with CircleCI from the command line.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 
 ## CI Commands
@@ -26,9 +26,9 @@ List and download a job's artifact files
 
 **Arguments:**
 
-<job-id> is the UUID of the job whose artifacts you want to
+`<job-id>` is the UUID of the job whose artifacts you want to
 list or download,
-e.g. 5034460f-c7c4-4c43-9457-de07e2029e7b.
+for example. `5034460f-c7c4-4c43-9457-de07e2029e7b`.
 
 ### `circleci config <command>`
 
@@ -44,8 +44,8 @@ Bundle split config files into a single YAML document
 
 **Arguments:**
 
-<path> is the path to a split config directory to pack,
-e.g. ".circleci" or "src/ci". The directory structure is
+`<path>` is the path to a split config directory to pack,
+for example, `.circleci` or `src/ci`. The directory structure is
 mapped to YAML keys in the merged document.
 
 #### `circleci config process <path> [flags]`
@@ -61,8 +61,8 @@ Compile and expand a pipeline config file
 
 **Arguments:**
 
-<path> is the path to a pipeline config file to compile,
-e.g. ".circleci/config.yml". Pass "-" to read the config
+`<path>` is the path to a pipeline config file to compile,
+for example, `.circleci/config.yml`. Pass `-` to read the config
 from stdin.
 
 #### `circleci config validate [flags]`
@@ -94,7 +94,7 @@ List or download artifacts for a job
 
 **Arguments:**
 
-<job-id> is the UUID of the job whose artifacts to list or download.
+`<job-id>` is the UUID of the job whose artifacts to list or download.
 Job UUIDs are shown in the output of "circleci workflow get" and
 "circleci run get --json".
 
@@ -110,7 +110,7 @@ Get job details
 
 **Arguments:**
 
-<job-id> is the UUID of the job to look up. Job UUIDs are shown in
+`<job-id>` is the UUID of the job to look up. Job UUIDs are shown in
 the output of "circleci workflow get" and "circleci run get --json".
 
 #### `circleci job open <job-id>`
@@ -119,7 +119,7 @@ Open job in browser
 
 **Arguments:**
 
-<job-id> is the UUID of the job to look up. Job UUIDs are shown in
+`<job-id>` is the UUID of the job to look up. Job UUIDs are shown in
 the output of "circleci workflow get" and "circleci run get --json".
 
 #### `circleci job output <command>`
@@ -139,7 +139,7 @@ Get the output of a job step
 
 **Arguments:**
 
-<job-id> is the UUID of the job whose step output to fetch. Job UUIDs
+`<job-id>` is the UUID of the job whose step output to fetch. Job UUIDs
 are shown in the output of "circleci workflow get" and "circleci job get".
 Use --step-num to select which step's output to read.
 
@@ -157,7 +157,7 @@ List a job's steps with their output
 
 **Arguments:**
 
-<job-id> is the UUID of the job whose steps and output to list. Job
+`<job-id>` is the UUID of the job whose steps and output to list. Job
 UUIDs are shown in the output of "circleci workflow get" and
 "circleci job get".
 
@@ -232,7 +232,7 @@ Cancel a run
 
 **Arguments:**
 
-<run-number-or-id> identifies the run to cancel. It can be:
+`<run-number-or-id>` identifies the run to cancel. It can be:
 - a run UUID (shown in "circleci run list --json")
 - a run number (shown in "circleci run list"); the project is
   inferred from the git remote unless overridden with --project
@@ -251,7 +251,7 @@ Get a run's status
 
 **Arguments:**
 
-<run-id> is optional and is the UUID of the run to look up. When
+`<run-id>` is optional and is the UUID of the run to look up. When
 omitted, the latest run is resolved from the project and branch
 inferred from the current git repository's remote and checked-out
 branch (override with --project and --branch).
@@ -313,7 +313,7 @@ Watch a run until it completes
 
 **Arguments:**
 
-<run-id> is optional and selects the run to watch. It can be:
+`<run-id>` is optional and selects the run to watch. It can be:
 - a run UUID (shown in "circleci run list --json")
 - a run number (shown in "circleci run list"); the project is
   inferred from the git remote unless overridden with --project
@@ -329,21 +329,21 @@ Inspect test results for a job
 
 Get a single test result by name
 
-| Flag                   | Description                                                         |
-| ---------------------- | ------------------------------------------------------------------- |
-| `--filter stringArray` | Disambiguate by classname=<value> when a name is shared; repeatable |
-| `--jq string`          | Process values from the response using jq syntax                    |
-| `--json`               | Output as JSON                                                      |
-| `--plain`              | Print only the raw test message, verbatim and unformatted           |
+| Flag               | Description                                                         |
+| ------------------ | ------------------------------------------------------------------- |
+| `--filter <value>` | Disambiguate by classname=<value> when a name is shared; repeatable |
+| `--jq string`      | Process values from the response using jq syntax                    |
+| `--json`           | Output as JSON                                                      |
+| `--plain`          | Print only the raw test message, verbatim and unformatted           |
 
 
 **Arguments:**
 
-<job-id> is the UUID of the job whose test results to search. Job
+`<job-id>` is the UUID of the job whose test results to search. Job
 UUIDs are shown in "circleci job get" and "circleci run get --json".
 
-<name> is the exact test name to look up. If more than one test
-shares that name, use --filter classname=<value> to disambiguate.
+`<name>` is the exact test name to look up. If more than one test
+shares that name, use --filter classname=`<value>` to disambiguate.
 
 #### `circleci testresult list <job-id> [flags]`
 
@@ -361,7 +361,7 @@ List test results for a job
 
 **Arguments:**
 
-<job-id> is the UUID of the job whose test results to list. Job
+`<job-id>` is the UUID of the job whose test results to list. Job
 UUIDs are shown in "circleci job get" and "circleci run get --json".
 
 **Aliases:**
@@ -384,7 +384,7 @@ Cancel a running workflow
 
 **Arguments:**
 
-<workflow-id> is the UUID of the workflow to cancel. Workflow IDs are
+`<workflow-id>` is the UUID of the workflow to cancel. Workflow IDs are
 shown in the output of "circleci run get".
 
 #### `circleci workflow get <workflow-id> [flags]`
@@ -399,7 +399,7 @@ Get workflow details
 
 **Arguments:**
 
-<workflow-id> is the UUID of the workflow to look up. Workflow IDs are
+`<workflow-id>` is the UUID of the workflow to look up. Workflow IDs are
 shown in the output of "circleci run get".
 
 #### `circleci workflow list [<run-id>] [flags]`
@@ -417,7 +417,7 @@ List workflows for a run or recent runs
 
 **Arguments:**
 
-<run-id> is optional and selects a single run. It can be:
+`<run-id>` is optional and selects a single run. It can be:
 - a run UUID (shown in "circleci run list --json")
 - a run number (shown in "circleci run list"); the project is
   inferred from the git remote unless overridden with --project
@@ -436,7 +436,7 @@ Open workflow in browser
 
 **Arguments:**
 
-<workflow-id> is the UUID of the workflow to look up. Workflow IDs are
+`<workflow-id>` is the UUID of the workflow to look up. Workflow IDs are
 shown in the output of "circleci run get".
 
 #### `circleci workflow rerun <workflow-id> [flags]`
@@ -450,7 +450,7 @@ Rerun a workflow
 
 **Arguments:**
 
-<workflow-id> is the UUID of the workflow to rerun. Workflow IDs are
+`<workflow-id>` is the UUID of the workflow to rerun. Workflow IDs are
 shown in the output of "circleci run get".
 
 ## Management Commands
@@ -470,7 +470,7 @@ Delete an iOS certificate
 
 **Arguments:**
 
-<cert-id> is the ID of the certificate to delete
+`<cert-id>` is the ID of the certificate to delete
 (see: circleci certificate list).
 
 **Aliases:**
@@ -770,7 +770,7 @@ Delete a project environment variable
 
 **Arguments:**
 
-<name> is the name of the environment variable to delete from
+`<name>` is the name of the environment variable to delete from
 the project. This action is irreversible.
 
 **Aliases:**
@@ -805,8 +805,8 @@ Set a project environment variable
 
 **Arguments:**
 
-<name> is the name of the environment variable to create or
-update. <value> is the value to store; it is never retrievable
+`<name>` is the name of the environment variable to create or
+update. `<value>` is the value to store; it is never retrievable
 after being set and is masked in all subsequent list output.
 
 ### `circleci namespace <command>`
@@ -826,7 +826,7 @@ Create a namespace
 
 **Arguments:**
 
-<name> is the namespace name to create. It must be globally unique
+`<name>` is the namespace name to create. It must be globally unique
 across CircleCI, e.g. "myorg".
 
 #### `circleci namespace delete <name> [flags]`
@@ -841,7 +841,7 @@ Delete a namespace and all its orbs
 
 **Arguments:**
 
-<name> is the name of the namespace to delete, e.g. "myorg".
+`<name>` is the name of the namespace to delete, e.g. "myorg".
 
 **Aliases:**
 
@@ -860,7 +860,7 @@ Get details of a namespace
 
 **Arguments:**
 
-<name> is the name of the namespace to look up, e.g. "myorg".
+`<name>` is the name of the namespace to look up, e.g. "myorg".
 
 #### `circleci namespace rename <name> <new-name> [flags]`
 
@@ -874,8 +874,8 @@ Rename a namespace
 
 **Arguments:**
 
-- <name> is the current name of the namespace, e.g. "oldname".
-- <new-name> is the new name to assign, e.g. "newname".
+- `<name>` is the current name of the namespace, e.g. "oldname".
+- `<new-name>` is the new name to assign, e.g. "newname".
 
 ### `circleci orb <command>`
 
@@ -887,8 +887,8 @@ Add an orb to a registry category
 
 **Arguments:**
 
-- <ns>/<orb>: the orb to add, as "namespace/orb-name"
-- <category>: the registry category name, e.g. "Testing"
+- `<ns>/<orb>`: the orb to add, as "namespace/orb-name"
+- `<category>`: the registry category name, e.g. "Testing"
 
 #### `circleci orb create <namespace>/<orb> [flags]`
 
@@ -903,7 +903,7 @@ Reserve an orb name in a namespace
 
 **Arguments:**
 
-- <namespace>/<orb>: the orb name to reserve, as "namespace/orb-name".
+- `<namespace>/<orb>`: the orb name to reserve, as "namespace/orb-name".
   The namespace must already exist.
 
 #### `circleci orb diff <ns>/<orb> --from <v1> --to <v2> [flags]`
@@ -918,7 +918,7 @@ Show a unified diff between two orb versions
 
 **Arguments:**
 
-- <ns>/<orb>: the orb to diff, as "namespace/orb-name"
+- `<ns>/<orb>`: the orb to diff, as "namespace/orb-name"
 
 #### `circleci orb get <ns>/<orb>[@<version>]/<orb-id> [flags]`
 
@@ -950,7 +950,7 @@ List orbs in the registry
 
 **Arguments:**
 
-- <namespace>: optional. When given, lists all orbs in that namespace.
+- `<namespace>`: optional. When given, lists all orbs in that namespace.
   When omitted, lists certified orbs globally.
 
 **Aliases:**
@@ -974,7 +974,7 @@ Pack a multi-file orb directory into a single YAML
 
 **Arguments:**
 
-- <path>: path to an orb source directory or a single orb YAML file.
+- `<path>`: path to an orb source directory or a single orb YAML file.
 
 #### `circleci orb process <path> [flags]`
 
@@ -987,7 +987,7 @@ Validate and print expanded orb YAML
 
 **Arguments:**
 
-- <path>: path to an orb YAML file. Pass '-' to read from stdin.
+- `<path>`: path to an orb YAML file. Pass '-' to read from stdin.
 
 #### `circleci orb publish <command>`
 
@@ -1004,8 +1004,8 @@ Increment and publish a new orb version
 
 **Arguments:**
 
-- <path>: path to the orb YAML to publish. Pass '-' to read from stdin.
-- <ns>/<orb>: the orb to publish, as "namespace/orb-name"
+- `<path>`: path to the orb YAML to publish. Pass '-' to read from stdin.
+- `<ns>/<orb>`: the orb to publish, as "namespace/orb-name"
 
 ##### `circleci orb publish promote <ns>/<orb>@dev:<label> --bump major|minor|patch [flags]`
 
@@ -1018,7 +1018,7 @@ Promote a dev orb version to a stable semver
 
 **Arguments:**
 
-- <ns>/<orb>@dev:<label>: the dev version to promote, e.g. "namespace/orb-name@dev:my-branch"
+- `<ns>/<orb>@dev:<label>`: the dev version to promote, e.g. "namespace/orb-name@dev:my-branch"
 
 #### `circleci orb remove-from-category <ns>/<orb> <category>`
 
@@ -1026,8 +1026,8 @@ Remove an orb from a registry category
 
 **Arguments:**
 
-- <ns>/<orb>: the orb to remove, as "namespace/orb-name"
-- <category>: the registry category name, e.g. "Testing"
+- `<ns>/<orb>`: the orb to remove, as "namespace/orb-name"
+- `<category>`: the registry category name, e.g. "Testing"
 
 #### `circleci orb source <ns>/<orb>[@<version>]`
 
@@ -1035,8 +1035,8 @@ Print the YAML source of an orb version
 
 **Arguments:**
 
-- <ns>/<orb>[@<version>]: the orb to print, as "namespace/orb-name".
-  Optionally append @<version> (e.g. @1.2.3, @volatile, or @dev:my-branch).
+- `<ns>/<orb>[@<version>]`: the orb to print, as "namespace/orb-name".
+  Optionally append `@<version>` (e.g. @1.2.3, @volatile, or @dev:my-branch).
   When omitted, the latest published version is shown.
 
 #### `circleci orb unlist <ns>/<orb> [flags]`
@@ -1050,7 +1050,7 @@ Hide or restore an orb in the registry
 
 **Arguments:**
 
-- <ns>/<orb>: the orb to update, as "namespace/orb-name"
+- `<ns>/<orb>`: the orb to update, as "namespace/orb-name"
 
 #### `circleci orb validate <path> [flags]`
 
@@ -1063,7 +1063,7 @@ Validate an orb YAML file
 
 **Arguments:**
 
-- <path>: path to an orb YAML file. Pass '-' to read from stdin.
+- `<path>`: path to an orb YAML file. Pass '-' to read from stdin.
 
 ### `circleci policy <command>`
 
@@ -1099,7 +1099,7 @@ Show diff between local and remote policy bundles
 
 **Arguments:**
 
-<path> is the path to a local directory of .rego policy files,
+`<path>` is the path to a local directory of .rego policy files,
 e.g. "./policies". Its contents are compared against the remote
 policy bundle.
 
@@ -1149,7 +1149,7 @@ Push a policy bundle to CircleCI
 
 **Arguments:**
 
-<path> is the path to a local directory of .rego policy files,
+`<path>` is the path to a local directory of .rego policy files,
 e.g. "./policies". Its contents are uploaded as the policy
 bundle, replacing the existing bundle.
 
@@ -1233,7 +1233,7 @@ Delete a project environment variable
 
 **Arguments:**
 
-<name> is the name of the environment variable to delete from
+`<name>` is the name of the environment variable to delete from
 the project. This action is irreversible.
 
 **Aliases:**
@@ -1268,8 +1268,8 @@ Set a project environment variable
 
 **Arguments:**
 
-<name> is the name of the environment variable to create or
-update. <value> is the value to store; it is never retrievable
+`<name>` is the name of the environment variable to create or
+update. `<value>` is the value to store; it is never retrievable
 after being set and is masked in all subsequent list output.
 
 #### `circleci project follow [flags]`
@@ -1295,10 +1295,10 @@ Show project details
 
 Bind this checkout to a CircleCI project
 
-| Flag               | Description                                                     |
-| ------------------ | --------------------------------------------------------------- |
-| `-f, --force`      | Overwrite an existing .circleci/info.yml                        |
-| `--project string` | Project slug (e.g. gh/org/repo or circleci/<orgID>/<projectID>) |
+| Flag                                     | Description                                                     |
+| ---------------------------------------- | --------------------------------------------------------------- |
+| `-f, --force`                            | Overwrite an existing .circleci/info.yml                        |
+| `--project circleci/<orgID>/<projectID>` | Project slug (e.g. gh/org/repo or circleci/<orgID>/<projectID>) |
 
 
 #### `circleci project list [flags]`
@@ -1382,7 +1382,7 @@ Generate a runner agent configuration file
 
 **Arguments:**
 
-<resource-class> is the runner resource class to generate config for,
+`<resource-class>` is the runner resource class to generate config for,
 in the form "namespace/name" (e.g. my-org/my-runner).
 
 #### `circleci runner instance <command>`
@@ -1500,7 +1500,7 @@ Create a token for a resource class
 
 **Arguments:**
 
-<resource-class> is the runner resource class to create a token for,
+`<resource-class>` is the runner resource class to create a token for,
 in the form "namespace/name" (e.g. my-org/my-runner).
 
 ##### `circleci runner token delete <token-id> [flags]`
@@ -1514,8 +1514,8 @@ Delete a runner token
 
 **Arguments:**
 
-<token-id> is the ID of the token to delete (a UUID). Find token IDs
-with: circleci runner token list --resource-class <namespace/name>
+`<token-id>` is the ID of the token to delete (a UUID). Find token IDs
+with: circleci runner token list --resource-class `<namespace/name>`
 
 **Aliases:**
 
@@ -1567,7 +1567,7 @@ Delete an iOS signing config
 
 **Arguments:**
 
-<signing-config-id> is the ID of the signing config to delete
+`<signing-config-id>` is the ID of the signing config to delete
 (see: circleci signing-config list).
 
 **Aliases:**
@@ -1856,8 +1856,8 @@ Set a CLI setting
 
 **Arguments:**
 
-- <key> is the setting to change: token, host, telemetry, or theme.
-- <value> is the value to store. Pass "-" to read it from stdin.
+- `<key>` is the setting to change: token, host, telemetry, or theme.
+- `<value>` is the value to store. Pass "-" to read it from stdin.
   May be omitted for "theme" to pick interactively.
 
 #### `circleci setting unset <key>`
@@ -1866,7 +1866,7 @@ Remove a stored CLI setting
 
 **Arguments:**
 
-<key> is the setting to remove. Currently only "token" is supported.
+`<key>` is the setting to remove. Currently only "token" is supported.
 
 ## Additional Commands
 
@@ -1885,7 +1885,7 @@ Call the CircleCI REST API directly
 
 **Arguments:**
 
-<path> is the request path. It is relative to /api/v3 by default
+`<path>` is the request path. It is relative to /api/v3 by default
 (e.g. "projects/{project-id}"). To target
 a different version prefix, include it explicitly, e.g. "api/v2/me".
 

--- a/internal/cmd/root/testdata/help/circleci/run.txt
+++ b/internal/cmd/root/testdata/help/circleci/run.txt
@@ -30,10 +30,10 @@ each workflow in turn contains jobs.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/run/cancel.txt
+++ b/internal/cmd/root/testdata/help/circleci/run/cancel.txt
@@ -26,14 +26,14 @@ Use --force (-f) to skip the prompt for scripting.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Arguments
 
-<run-number-or-id> identifies the run to cancel. It can be:
+`<run-number-or-id>` identifies the run to cancel. It can be:
 - a run UUID (shown in "circleci run list --json")
 - a run number (shown in "circleci run list"); the project is
   inferred from the git remote unless overridden with --project

--- a/internal/cmd/root/testdata/help/circleci/run/get.txt
+++ b/internal/cmd/root/testdata/help/circleci/run/get.txt
@@ -31,14 +31,14 @@ For more information about output formatting flags, see `circleci help formattin
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Arguments
 
-<run-id> is optional and is the UUID of the run to look up. When
+`<run-id>` is optional and is the UUID of the run to look up. When
 omitted, the latest run is resolved from the project and branch
 inferred from the current git repository's remote and checked-out
 branch (override with --project and --branch).

--- a/internal/cmd/root/testdata/help/circleci/run/list.txt
+++ b/internal/cmd/root/testdata/help/circleci/run/list.txt
@@ -34,10 +34,10 @@ For more information about output formatting flags, see `circleci help formattin
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/run/open.txt
+++ b/internal/cmd/root/testdata/help/circleci/run/open.txt
@@ -23,10 +23,10 @@ Use --current-branch or --branch/-b to filter runs to a specific branch.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/run/trigger.txt
+++ b/internal/cmd/root/testdata/help/circleci/run/trigger.txt
@@ -30,10 +30,10 @@ For more information about output formatting flags, see `circleci help formattin
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/run/watch.txt
+++ b/internal/cmd/root/testdata/help/circleci/run/watch.txt
@@ -36,14 +36,14 @@ without waiting for the remaining workflows to finish.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Arguments
 
-<run-id> is optional and selects the run to watch. It can be:
+`<run-id>` is optional and selects the run to watch. It can be:
 - a run UUID (shown in "circleci run list --json")
 - a run number (shown in "circleci run list"); the project is
   inferred from the git remote unless overridden with --project

--- a/internal/cmd/root/testdata/help/circleci/runner.txt
+++ b/internal/cmd/root/testdata/help/circleci/runner.txt
@@ -38,10 +38,10 @@ Resource class names use the format: namespace/name
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/runner/config.txt
+++ b/internal/cmd/root/testdata/help/circleci/runner/config.txt
@@ -29,14 +29,14 @@ launch-agent-config.yaml.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Arguments
 
-<resource-class> is the runner resource class to generate config for,
+`<resource-class>` is the runner resource class to generate config for,
 in the form "namespace/name" (e.g. my-org/my-runner).
 
 ## Examples

--- a/internal/cmd/root/testdata/help/circleci/runner/instance.txt
+++ b/internal/cmd/root/testdata/help/circleci/runner/instance.txt
@@ -18,10 +18,10 @@ Instances are live runner agents currently connected to CircleCI.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/runner/instance/list.txt
+++ b/internal/cmd/root/testdata/help/circleci/runner/instance/list.txt
@@ -39,10 +39,10 @@ For more information about output formatting flags, see `circleci help formattin
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/runner/open.txt
+++ b/internal/cmd/root/testdata/help/circleci/runner/open.txt
@@ -21,10 +21,10 @@ remotes.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/runner/resource-class.txt
+++ b/internal/cmd/root/testdata/help/circleci/runner/resource-class.txt
@@ -26,10 +26,10 @@ Each resource class belongs to a namespace (usually your organization).
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/runner/resource-class/create.txt
+++ b/internal/cmd/root/testdata/help/circleci/runner/resource-class/create.txt
@@ -25,10 +25,10 @@ For more information about output formatting flags, see `circleci help formattin
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Arguments
 

--- a/internal/cmd/root/testdata/help/circleci/runner/resource-class/delete.txt
+++ b/internal/cmd/root/testdata/help/circleci/runner/resource-class/delete.txt
@@ -26,10 +26,10 @@ Use --force (-f) to skip the prompt for scripting.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Arguments
 

--- a/internal/cmd/root/testdata/help/circleci/runner/resource-class/list.txt
+++ b/internal/cmd/root/testdata/help/circleci/runner/resource-class/list.txt
@@ -31,10 +31,10 @@ For more information about output formatting flags, see `circleci help formattin
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/runner/task.txt
+++ b/internal/cmd/root/testdata/help/circleci/runner/task.txt
@@ -26,10 +26,10 @@ For more information about output formatting flags, see `circleci help formattin
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/runner/token.txt
+++ b/internal/cmd/root/testdata/help/circleci/runner/token.txt
@@ -28,10 +28,10 @@ Token values are only shown once at creation time and cannot be retrieved afterw
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/runner/token/create.txt
+++ b/internal/cmd/root/testdata/help/circleci/runner/token/create.txt
@@ -26,14 +26,14 @@ For more information about output formatting flags, see `circleci help formattin
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Arguments
 
-<resource-class> is the runner resource class to create a token for,
+`<resource-class>` is the runner resource class to create a token for,
 in the form "namespace/name" (e.g. my-org/my-runner).
 
 ## Examples

--- a/internal/cmd/root/testdata/help/circleci/runner/token/delete.txt
+++ b/internal/cmd/root/testdata/help/circleci/runner/token/delete.txt
@@ -5,7 +5,7 @@ Delete a CircleCI runner authentication token by its ID.
 Any runner agents using this token will immediately lose their ability
 to claim new jobs. Running jobs are not affected.
 
-Find token IDs with: circleci runner token list <resource-class>
+Find token IDs with: circleci runner token list `<resource-class>`
 
 In a terminal, you will be prompted to confirm before deleting.
 Use --force (-f) to skip the prompt for scripting.
@@ -28,15 +28,15 @@ Use --force (-f) to skip the prompt for scripting.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Arguments
 
-<token-id> is the ID of the token to delete (a UUID). Find token IDs
-with: circleci runner token list --resource-class <namespace/name>
+`<token-id>` is the ID of the token to delete (a UUID). Find token IDs
+with: circleci runner token list --resource-class `<namespace/name>`
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/runner/token/list.txt
+++ b/internal/cmd/root/testdata/help/circleci/runner/token/list.txt
@@ -32,10 +32,10 @@ For more information about output formatting flags, see `circleci help formattin
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/setting.txt
+++ b/internal/cmd/root/testdata/help/circleci/setting.txt
@@ -30,10 +30,10 @@ For pipeline YAML operations, see 'circleci config'.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/setting/list.txt
+++ b/internal/cmd/root/testdata/help/circleci/setting/list.txt
@@ -28,10 +28,10 @@ For more information about output formatting flags, see `circleci help formattin
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/setting/set.txt
+++ b/internal/cmd/root/testdata/help/circleci/setting/set.txt
@@ -22,15 +22,15 @@ terminal to pick a theme from a list.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Arguments
 
-- <key> is the setting to change: token, host, telemetry, or theme.
-- <value> is the value to store. Pass "-" to read it from stdin.
+- `<key>` is the setting to change: token, host, telemetry, or theme.
+- `<value>` is the value to store. Pass "-" to read it from stdin.
   May be omitted for "theme" to pick interactively.
 
 ## Examples

--- a/internal/cmd/root/testdata/help/circleci/setting/unset.txt
+++ b/internal/cmd/root/testdata/help/circleci/setting/unset.txt
@@ -13,14 +13,14 @@ Supported keys:
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Arguments
 
-<key> is the setting to remove. Currently only "token" is supported.
+`<key>` is the setting to remove. Currently only "token" is supported.
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/setup.txt
+++ b/internal/cmd/root/testdata/help/circleci/setup.txt
@@ -9,8 +9,8 @@ flow from the legacy CLI is not reimplemented.
 
 For new usage, prefer:
   circleci auth login                 interactive, browser-based
-  circleci setting set host <host>    store the host
-  circleci setting set token <token>  store the token
+  circleci setting set host `<host>`    store the host
+  circleci setting set token `<token>`  store the token
 
 ## Usage
 
@@ -28,10 +28,10 @@ For new usage, prefer:
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/signing-config.txt
+++ b/internal/cmd/root/testdata/help/circleci/signing-config.txt
@@ -28,10 +28,10 @@ install it onto the macOS runner during a job.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/signing-config/create.txt
+++ b/internal/cmd/root/testdata/help/circleci/signing-config/create.txt
@@ -34,22 +34,22 @@ For more information about output formatting flags, see `circleci help formattin
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Examples
 
 - Create a signing config (org inferred from git remote): 
   `circleci signing-config create \`
 - --name production-signing \
-- --cert-id <cert-id> \
+- --cert-id `<cert-id>` \
 - --profile ./MyApp.mobileprovision
 - Multiple profiles: 
   `circleci signing-config create \`
 - --name multi-target-signing \
-- --cert-id <cert-id> \
+- --cert-id `<cert-id>` \
 - --profile ./MyApp.mobileprovision \
 - --profile ./MyAppExtension.mobileprovision
 - Explicit org and capture the id for scripting: 

--- a/internal/cmd/root/testdata/help/circleci/signing-config/delete.txt
+++ b/internal/cmd/root/testdata/help/circleci/signing-config/delete.txt
@@ -26,14 +26,14 @@ Use --force (-f) to skip the prompt for scripting.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Arguments
 
-<signing-config-id> is the ID of the signing config to delete
+`<signing-config-id>` is the ID of the signing config to delete
 (see: circleci signing-config list).
 
 ## Examples

--- a/internal/cmd/root/testdata/help/circleci/signing-config/list.txt
+++ b/internal/cmd/root/testdata/help/circleci/signing-config/list.txt
@@ -29,10 +29,10 @@ For more information about output formatting flags, see `circleci help formattin
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/step.txt
+++ b/internal/cmd/root/testdata/help/circleci/step.txt
@@ -16,10 +16,10 @@ Control job step execution
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/step/halt.txt
+++ b/internal/cmd/root/testdata/help/circleci/step/halt.txt
@@ -15,10 +15,10 @@ within a running CircleCI job.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/testresult.txt
+++ b/internal/cmd/root/testdata/help/circleci/testresult.txt
@@ -27,10 +27,10 @@ web UI.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/testresult/get.txt
+++ b/internal/cmd/root/testdata/help/circleci/testresult/get.txt
@@ -4,7 +4,7 @@ Get a single test result from a job by its exact name.
 
 The name must match exactly. When several tests share a name — for
 example the same test running under different suites — the lookup is
-ambiguous and fails; pass --filter classname=<value> to narrow to one.
+ambiguous and fails; pass --filter classname=`<value>` to narrow to one.
 classname is matched as a case-insensitive substring and may be
 repeated to accept any of several suites.
 
@@ -26,29 +26,29 @@ For more information about output formatting flags, see `circleci help formattin
 
 ## Flags
 
-| Flag                   | Description                                                         |
-| ---------------------- | ------------------------------------------------------------------- |
-| `--filter stringArray` | Disambiguate by classname=<value> when a name is shared; repeatable |
-| `--jq string`          | Process values from the response using jq syntax                    |
-| `--json`               | Output as JSON                                                      |
-| `--plain`              | Print only the raw test message, verbatim and unformatted           |
+| Flag               | Description                                                         |
+| ------------------ | ------------------------------------------------------------------- |
+| `--filter <value>` | Disambiguate by classname=<value> when a name is shared; repeatable |
+| `--jq string`      | Process values from the response using jq syntax                    |
+| `--json`           | Output as JSON                                                      |
+| `--plain`          | Print only the raw test message, verbatim and unformatted           |
 
 ## Inherited Flags
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Arguments
 
-<job-id> is the UUID of the job whose test results to search. Job
+`<job-id>` is the UUID of the job whose test results to search. Job
 UUIDs are shown in "circleci job get" and "circleci run get --json".
 
-<name> is the exact test name to look up. If more than one test
-shares that name, use --filter classname=<value> to disambiguate.
+`<name>` is the exact test name to look up. If more than one test
+shares that name, use --filter classname=`<value>` to disambiguate.
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/testresult/list.txt
+++ b/internal/cmd/root/testdata/help/circleci/testresult/list.txt
@@ -3,7 +3,7 @@
 Show the test results recorded for a CircleCI job.
 
 By default only failed tests are shown. Pass --all to show every
-result, or --filter result=<value> to select specific outcomes.
+result, or --filter result=`<value>` to select specific outcomes.
 
 --filter takes key=value and may be repeated. Repeating the same key
 matches any of its values (OR); different keys must all match (AND).
@@ -52,14 +52,14 @@ For more information about output formatting flags, see `circleci help formattin
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Arguments
 
-<job-id> is the UUID of the job whose test results to list. Job
+`<job-id>` is the UUID of the job whose test results to list. Job
 UUIDs are shown in "circleci job get" and "circleci run get --json".
 
 ## Examples

--- a/internal/cmd/root/testdata/help/circleci/version.txt
+++ b/internal/cmd/root/testdata/help/circleci/version.txt
@@ -21,10 +21,10 @@ JSON fields:
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Examples
 

--- a/internal/cmd/root/testdata/help/circleci/workflow.txt
+++ b/internal/cmd/root/testdata/help/circleci/workflow.txt
@@ -30,10 +30,10 @@ Workflow IDs are shown in the output of 'circleci run get'.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/workflow/cancel.txt
+++ b/internal/cmd/root/testdata/help/circleci/workflow/cancel.txt
@@ -24,14 +24,14 @@ Use --force (-f) to skip the prompt for scripting.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Arguments
 
-<workflow-id> is the UUID of the workflow to cancel. Workflow IDs are
+`<workflow-id>` is the UUID of the workflow to cancel. Workflow IDs are
 shown in the output of "circleci run get".
 
 ## Examples

--- a/internal/cmd/root/testdata/help/circleci/workflow/get.txt
+++ b/internal/cmd/root/testdata/help/circleci/workflow/get.txt
@@ -25,14 +25,14 @@ For more information about output formatting flags, see `circleci help formattin
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Arguments
 
-<workflow-id> is the UUID of the workflow to look up. Workflow IDs are
+`<workflow-id>` is the UUID of the workflow to look up. Workflow IDs are
 shown in the output of "circleci run get".
 
 ## Examples

--- a/internal/cmd/root/testdata/help/circleci/workflow/list.txt
+++ b/internal/cmd/root/testdata/help/circleci/workflow/list.txt
@@ -40,14 +40,14 @@ For more information about output formatting flags, see `circleci help formattin
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Arguments
 
-<run-id> is optional and selects a single run. It can be:
+`<run-id>` is optional and selects a single run. It can be:
 - a run UUID (shown in "circleci run list --json")
 - a run number (shown in "circleci run list"); the project is
   inferred from the git remote unless overridden with --project

--- a/internal/cmd/root/testdata/help/circleci/workflow/open.txt
+++ b/internal/cmd/root/testdata/help/circleci/workflow/open.txt
@@ -10,14 +10,14 @@ Open workflow in browser
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Arguments
 
-<workflow-id> is the UUID of the workflow to look up. Workflow IDs are
+`<workflow-id>` is the UUID of the workflow to look up. Workflow IDs are
 shown in the output of "circleci run get".
 
 ## Examples

--- a/internal/cmd/root/testdata/help/circleci/workflow/rerun.txt
+++ b/internal/cmd/root/testdata/help/circleci/workflow/rerun.txt
@@ -22,14 +22,14 @@ Workflow IDs are shown in the output of 'circleci run get'.
 
 | Flag                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `-c, --config string` | path to config file (default: ~/.config/circleci/config.yml) |
-| `--debug`             | enable debug logging                                         |
-| `--no-color`          | disable ANSI color output (same as setting NO_COLOR)         |
-| `-q, --quiet`         | suppress informational output; data on stdout is unaffected  |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
 
 ## Arguments
 
-<workflow-id> is the UUID of the workflow to rerun. Workflow IDs are
+`<workflow-id>` is the UUID of the workflow to rerun. Workflow IDs are
 shown in the output of "circleci run get".
 
 ## Examples

--- a/internal/cmd/root/testdata/usage/circleci/project/link.txt
+++ b/internal/cmd/root/testdata/usage/circleci/project/link.txt
@@ -1,6 +1,6 @@
 Usage:  circleci project link [flags]
 
 Flags:
-  -f, --force            Overwrite an existing .circleci/info.yml
-      --project string   Project slug (e.g. gh/org/repo or circleci/<orgID>/<projectID>)
+  -f, --force                                  Overwrite an existing .circleci/info.yml
+      --project circleci/<orgID>/<projectID>   Project slug (e.g. gh/org/repo or circleci/<orgID>/<projectID>)
   

--- a/internal/cmd/root/testdata/usage/circleci/testresult/get.txt
+++ b/internal/cmd/root/testdata/usage/circleci/testresult/get.txt
@@ -1,8 +1,8 @@
 Usage:  circleci testresult get <job-id> <name> [flags]
 
 Flags:
-  --filter stringArray   Disambiguate by classname=<value> when a name is shared; repeatable
-  --jq string            Process values from the response using jq syntax
-  --json                 Output as JSON
-  --plain                Print only the raw test message, verbatim and unformatted
+  --filter <value>   Disambiguate by classname=<value> when a name is shared; repeatable
+  --jq string        Process values from the response using jq syntax
+  --json             Output as JSON
+  --plain            Print only the raw test message, verbatim and unformatted
   

--- a/internal/cmd/run/cancel.go
+++ b/internal/cmd/run/cancel.go
@@ -48,12 +48,12 @@ func newCancelCmd() *cobra.Command {
 		Use:   "cancel <run-number-or-id>",
 		Short: "Cancel a run",
 		Annotations: map[string]string{
-			"help:arguments": heredoc.Doc(`
-				<run-number-or-id> identifies the run to cancel. It can be:
+			"help:arguments": heredoc.Docf(`
+				%[1]s<run-number-or-id>%[1]s identifies the run to cancel. It can be:
 				- a run UUID (shown in "circleci run list --json")
 				- a run number (shown in "circleci run list"); the project is
 				  inferred from the git remote unless overridden with --project
-			`),
+			`, "`"),
 		},
 		Long: heredoc.Doc(`
 			Cancel a running CircleCI run by number or UUID.

--- a/internal/cmd/run/get.go
+++ b/internal/cmd/run/get.go
@@ -63,12 +63,12 @@ func newGetCmd() *cobra.Command {
 		Use:   "get [<run-id>]",
 		Short: "Get a run's status",
 		Annotations: map[string]string{
-			"help:arguments": heredoc.Doc(`
-				<run-id> is optional and is the UUID of the run to look up. When
+			"help:arguments": heredoc.Docf(`
+				%[1]s<run-id>%[1]s is optional and is the UUID of the run to look up. When
 				omitted, the latest run is resolved from the project and branch
 				inferred from the current git repository's remote and checked-out
 				branch (override with --project and --branch).
-			`),
+			`, "`"),
 		},
 		Long: heredoc.Doc(`
 			Display the status of a CircleCI run and its workflows.

--- a/internal/cmd/run/watch.go
+++ b/internal/cmd/run/watch.go
@@ -68,15 +68,15 @@ func newWatchCmd() *cobra.Command {
 		Use:   "watch [<run-id>]",
 		Short: "Watch a run until it completes",
 		Annotations: map[string]string{
-			"help:arguments": heredoc.Doc(`
-				<run-id> is optional and selects the run to watch. It can be:
+			"help:arguments": heredoc.Docf(`
+				%[1]s<run-id>%[1]s is optional and selects the run to watch. It can be:
 				- a run UUID (shown in "circleci run list --json")
 				- a run number (shown in "circleci run list"); the project is
 				  inferred from the git remote unless overridden with --project
 
 				When omitted, the latest run for the current branch is watched
 				(override the branch with --branch, or match a commit with --sha).
-			`),
+			`, "`"),
 		},
 		Long: heredoc.Doc(`
 			Monitor a CircleCI run and block until it reaches a terminal state.

--- a/internal/cmd/runner/config.go
+++ b/internal/cmd/runner/config.go
@@ -46,10 +46,10 @@ func newConfigCmd() *cobra.Command {
 		Use:   "config <resource-class>",
 		Short: "Generate a runner agent configuration file",
 		Annotations: map[string]string{
-			"help:arguments": heredoc.Doc(`
-				<resource-class> is the runner resource class to generate config for,
+			"help:arguments": heredoc.Docf(`
+				%[1]s<resource-class>%[1]s is the runner resource class to generate config for,
 				in the form "namespace/name" (e.g. my-org/my-runner).
-			`),
+			`, "`"),
 		},
 		Long: heredoc.Doc(`
 			Generate a runner agent configuration YAML for a resource class.

--- a/internal/cmd/runner/token.go
+++ b/internal/cmd/runner/token.go
@@ -194,10 +194,10 @@ func newTokenCreateCmd() *cobra.Command {
 		Use:   "create <resource-class>",
 		Short: "Create a token for a resource class",
 		Annotations: map[string]string{
-			"help:arguments": heredoc.Doc(`
-				<resource-class> is the runner resource class to create a token for,
+			"help:arguments": heredoc.Docf(`
+				%[1]s<resource-class>%[1]s is the runner resource class to create a token for,
 				in the form "namespace/name" (e.g. my-org/my-runner).
-			`),
+			`, "`"),
 		},
 		Long: heredoc.Doc(`
 			Create a new authentication token for a runner resource class.
@@ -284,22 +284,22 @@ func newTokenDeleteCmd() *cobra.Command {
 		Aliases: []string{"rm"},
 		Short:   "Delete a runner token",
 		Annotations: map[string]string{
-			"help:arguments": heredoc.Doc(`
-				<token-id> is the ID of the token to delete (a UUID). Find token IDs
-				with: circleci runner token list --resource-class <namespace/name>
-			`),
+			"help:arguments": heredoc.Docf(`
+				%[1]s<token-id>%[1]s is the ID of the token to delete (a UUID). Find token IDs
+				with: circleci runner token list --resource-class %[1]s<namespace/name>%[1]s
+			`, "`"),
 		},
-		Long: heredoc.Doc(`
+		Long: heredoc.Docf(`
 			Delete a CircleCI runner authentication token by its ID.
 
 			Any runner agents using this token will immediately lose their ability
 			to claim new jobs. Running jobs are not affected.
 
-			Find token IDs with: circleci runner token list <resource-class>
+			Find token IDs with: circleci runner token list %[1]s<resource-class>%[1]s
 
 			In a terminal, you will be prompted to confirm before deleting.
 			Use --force (-f) to skip the prompt for scripting.
-		`),
+		`, "`"),
 		Example: heredoc.Doc(`
 			# Delete a token by ID (with confirmation prompt)
 			$ circleci runner token delete abc12345-0000-0000-0000-000000000000

--- a/internal/cmd/setting/set.go
+++ b/internal/cmd/setting/set.go
@@ -41,11 +41,11 @@ func newSetCmd() *cobra.Command {
 		Use:   "set <key> <value>",
 		Short: "Set a CLI setting",
 		Annotations: map[string]string{
-			"help:arguments": heredoc.Doc(`
-				- <key> is the setting to change: token, host, telemetry, or theme.
-				- <value> is the value to store. Pass "-" to read it from stdin.
+			"help:arguments": heredoc.Docf(`
+				- %[1]s<key>%[1]s is the setting to change: token, host, telemetry, or theme.
+				- %[1]s<value>%[1]s is the value to store. Pass "-" to read it from stdin.
 				  May be omitted for "theme" to pick interactively.
-			`),
+			`, "`"),
 		},
 		Long: heredoc.Doc(`
 			Set a CLI setting by key.

--- a/internal/cmd/setting/unset.go
+++ b/internal/cmd/setting/unset.go
@@ -37,9 +37,9 @@ func newUnsetCmd() *cobra.Command {
 		Use:   "unset <key>",
 		Short: "Remove a stored CLI setting",
 		Annotations: map[string]string{
-			"help:arguments": heredoc.Doc(`
-				<key> is the setting to remove. Currently only "token" is supported.
-			`),
+			"help:arguments": heredoc.Docf(`
+				%[1]s<key>%[1]s is the setting to remove. Currently only "token" is supported.
+			`, "`"),
 		},
 		Long: heredoc.Doc(`
 			Remove a stored CLI setting by key.

--- a/internal/cmd/setup/setup.go
+++ b/internal/cmd/setup/setup.go
@@ -51,7 +51,7 @@ func NewSetupCmd() *cobra.Command {
 		Use:    "setup",
 		Short:  "Configure the CLI with a host and token (legacy compatibility)",
 		Hidden: true,
-		Long: heredoc.Doc(`
+		Long: heredoc.Docf(`
 			Persist a CircleCI host and API token to the CLI config file.
 
 			This command exists only for backwards compatibility with the
@@ -61,9 +61,9 @@ func NewSetupCmd() *cobra.Command {
 
 			For new usage, prefer:
 			  circleci auth login                 interactive, browser-based
-			  circleci setting set host <host>    store the host
-			  circleci setting set token <token>  store the token
-		`),
+			  circleci setting set host %[1]s<host>%[1]s    store the host
+			  circleci setting set token %[1]s<token>%[1]s  store the token
+		`, "`"),
 		Example: heredoc.Doc(`
 			# Configure the CLI non-interactively (the path the orb uses)
 			$ circleci setup --no-prompt --host https://circleci.com --token mytoken123

--- a/internal/cmd/signingconfig/signingconfig.go
+++ b/internal/cmd/signingconfig/signingconfig.go
@@ -133,23 +133,23 @@ func newCreateCmd() *cobra.Command {
 
 			JSON fields: id, name, cert_id
 		`),
-		Example: heredoc.Doc(`
+		Example: heredoc.Docf(`
 			# Create a signing config (org inferred from git remote)
 			$ circleci signing-config create \
 			    --name production-signing \
-			    --cert-id <cert-id> \
+			    --cert-id %[1]s<cert-id>%[1]s \
 			    --profile ./MyApp.mobileprovision
 
 			# Multiple profiles
 			$ circleci signing-config create \
 			    --name multi-target-signing \
-			    --cert-id <cert-id> \
+			    --cert-id %[1]s<cert-id>%[1]s \
 			    --profile ./MyApp.mobileprovision \
 			    --profile ./MyAppExtension.mobileprovision
 
 			# Explicit org and capture the id for scripting
 			$ circleci signing-config create --org gh/acme --name prod --cert-id <cert-id> --profile ./p.mobileprovision --json --jq -r '.id'
-		`),
+		`, "`"),
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if name == "" {
@@ -327,10 +327,10 @@ func newDeleteCmd() *cobra.Command {
 		Aliases: []string{"rm"},
 		Short:   "Delete an iOS signing config",
 		Annotations: map[string]string{
-			"help:arguments": heredoc.Doc(`
-				<signing-config-id> is the ID of the signing config to delete
+			"help:arguments": heredoc.Docf(`
+				%[1]s<signing-config-id>%[1]s is the ID of the signing config to delete
 				(see: circleci signing-config list).
-			`),
+			`, "`"),
 		},
 		Long: heredoc.Doc(`
 			Permanently remove an iOS signing config from your organization.

--- a/internal/cmd/testresult/get.go
+++ b/internal/cmd/testresult/get.go
@@ -49,20 +49,20 @@ func newGetCmd() *cobra.Command {
 		Use:   "get <job-id> <name>",
 		Short: "Get a single test result by name",
 		Annotations: map[string]string{
-			"help:arguments": heredoc.Doc(`
-				<job-id> is the UUID of the job whose test results to search. Job
+			"help:arguments": heredoc.Docf(`
+				%[1]s<job-id>%[1]s is the UUID of the job whose test results to search. Job
 				UUIDs are shown in "circleci job get" and "circleci run get --json".
 
-				<name> is the exact test name to look up. If more than one test
-				shares that name, use --filter classname=<value> to disambiguate.
-			`),
+				%[1]s<name>%[1]s is the exact test name to look up. If more than one test
+				shares that name, use --filter classname=%[1]s<value>%[1]s to disambiguate.
+			`, "`"),
 		},
-		Long: heredoc.Doc(`
+		Long: heredoc.Docf(`
 			Get a single test result from a job by its exact name.
 
 			The name must match exactly. When several tests share a name — for
 			example the same test running under different suites — the lookup is
-			ambiguous and fails; pass --filter classname=<value> to narrow to one.
+			ambiguous and fails; pass --filter classname=%[1]s<value>%[1]s to narrow to one.
 			classname is matched as a case-insensitive substring and may be
 			repeated to accept any of several suites.
 
@@ -75,7 +75,7 @@ func newGetCmd() *cobra.Command {
 			piping a failure's output to another tool.
 
 			JSON fields: classname, name, result, run_time, message
-		`),
+		`, "`"),
 		Example: heredoc.Doc(`
 			# Get a test by name
 			$ circleci testresult get 8e50c384-0083-43d0-bc8f-93f0db589d6b TestLogin
@@ -103,7 +103,7 @@ func newGetCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringArrayVar(&filters, "filter", nil, "Disambiguate by classname=<value> when a name is shared; repeatable")
+	cmd.Flags().StringArrayVar(&filters, "filter", nil, "Disambiguate by classname=`<value>` when a name is shared; repeatable")
 	cmd.Flags().BoolVar(&plain, "plain", false, "Print only the raw test message, verbatim and unformatted")
 	cmdutil.AddJSONFlag(cmd, &jsonOut)
 	cmdutil.AddJQFlag(cmd)

--- a/internal/cmd/testresult/list.go
+++ b/internal/cmd/testresult/list.go
@@ -62,16 +62,16 @@ func newListCmd() *cobra.Command {
 		Aliases: []string{"ls"},
 		Short:   "List test results for a job",
 		Annotations: map[string]string{
-			"help:arguments": heredoc.Doc(`
-				<job-id> is the UUID of the job whose test results to list. Job
+			"help:arguments": heredoc.Docf(`
+				%[1]s<job-id>%[1]s is the UUID of the job whose test results to list. Job
 				UUIDs are shown in "circleci job get" and "circleci run get --json".
-			`),
+			`, "`"),
 		},
-		Long: heredoc.Doc(`
+		Long: heredoc.Docf(`
 			Show the test results recorded for a CircleCI job.
 
 			By default only failed tests are shown. Pass --all to show every
-			result, or --filter result=<value> to select specific outcomes.
+			result, or --filter result=%[1]s<value>%[1]s to select specific outcomes.
 
 			--filter takes key=value and may be repeated. Repeating the same key
 			matches any of its values (OR); different keys must all match (AND).
@@ -94,7 +94,7 @@ func newListCmd() *cobra.Command {
 			'.name' prints one name per line), and jq's inputs builtin pulls the
 			rest of the stream, e.g. '[.,inputs] | length' or
 			'[.,inputs] | group_by(.result) | map({(.[0].result): length})'.
-		`),
+		`, "`"),
 		Example: heredoc.Doc(`
 			# List failed tests for a job (the default)
 			$ circleci testresult list 8e50c384-0083-43d0-bc8f-93f0db589d6b

--- a/internal/cmd/workflow/cancel.go
+++ b/internal/cmd/workflow/cancel.go
@@ -43,10 +43,10 @@ func newCancelCmd() *cobra.Command {
 		Use:   "cancel <workflow-id>",
 		Short: "Cancel a running workflow",
 		Annotations: map[string]string{
-			"help:arguments": heredoc.Doc(`
-				<workflow-id> is the UUID of the workflow to cancel. Workflow IDs are
+			"help:arguments": heredoc.Docf(`
+				%[1]s<workflow-id>%[1]s is the UUID of the workflow to cancel. Workflow IDs are
 				shown in the output of "circleci run get".
-			`),
+			`, "`"),
 		},
 		Long: heredoc.Doc(`
 			Cancel a running CircleCI workflow.

--- a/internal/cmd/workflow/get.go
+++ b/internal/cmd/workflow/get.go
@@ -44,10 +44,10 @@ func newGetCmd() *cobra.Command {
 		Use:   "get <workflow-id>",
 		Short: "Get workflow details",
 		Annotations: map[string]string{
-			"help:arguments": heredoc.Doc(`
-				<workflow-id> is the UUID of the workflow to look up. Workflow IDs are
+			"help:arguments": heredoc.Docf(`
+				%[1]s<workflow-id>%[1]s is the UUID of the workflow to look up. Workflow IDs are
 				shown in the output of "circleci run get".
-			`),
+			`, "`"),
 		},
 		Long: heredoc.Doc(`
 			Display the status and jobs of a CircleCI workflow.

--- a/internal/cmd/workflow/list.go
+++ b/internal/cmd/workflow/list.go
@@ -52,15 +52,15 @@ func newListCmd() *cobra.Command {
 		Aliases: []string{"ls"},
 		Short:   "List workflows for a run or recent runs",
 		Annotations: map[string]string{
-			"help:arguments": heredoc.Doc(`
-				<run-id> is optional and selects a single run. It can be:
+			"help:arguments": heredoc.Docf(`
+				%[1]s<run-id>%[1]s is optional and selects a single run. It can be:
 				- a run UUID (shown in "circleci run list --json")
 				- a run number (shown in "circleci run list"); the project is
 				  inferred from the git remote unless overridden with --project
 
 				When omitted, workflows for recent runs in the current project are
 				listed, grouped by run.
-			`),
+			`, "`"),
 		},
 		Long: heredoc.Doc(`
 			List workflows for a CircleCI run.

--- a/internal/cmd/workflow/open.go
+++ b/internal/cmd/workflow/open.go
@@ -40,10 +40,10 @@ func newOpenCmd() *cobra.Command {
 		Use:   "open <workflow-id>",
 		Short: "Open workflow in browser",
 		Annotations: map[string]string{
-			"help:arguments": heredoc.Doc(`
-				<workflow-id> is the UUID of the workflow to look up. Workflow IDs are
+			"help:arguments": heredoc.Docf(`
+				%[1]s<workflow-id>%[1]s is the UUID of the workflow to look up. Workflow IDs are
 				shown in the output of "circleci run get".
-			`),
+			`, "`"),
 		},
 		Example: heredoc.Doc(`
 			# Open workflow details

--- a/internal/cmd/workflow/rerun.go
+++ b/internal/cmd/workflow/rerun.go
@@ -40,10 +40,10 @@ func newRerunCmd() *cobra.Command {
 		Use:   "rerun <workflow-id>",
 		Short: "Rerun a workflow",
 		Annotations: map[string]string{
-			"help:arguments": heredoc.Doc(`
-				<workflow-id> is the UUID of the workflow to rerun. Workflow IDs are
+			"help:arguments": heredoc.Docf(`
+				%[1]s<workflow-id>%[1]s is the UUID of the workflow to rerun. Workflow IDs are
 				shown in the output of "circleci run get".
-			`),
+			`, "`"),
 		},
 		Long: heredoc.Doc(`
 			Rerun a CircleCI workflow.


### PR DESCRIPTION
## Problem

`<placeholder>`-style argument text (`<path>`, `<job-id>` etc.) was silently losing the placeholder word wherever it appeared in prose, both in the Hugo reference site and in real (color-enabled) terminal `--help` output. 

Flag-description table cells and the free-form Arguments/Long text were affected. Use: lines and $-prefixed Example commands work fine.

## Root cause

Terminal help and the Hugo reference page are both rendered from generated markdown. Both parse raw HTML in markdown with unsafe HTML enabled. An unescaped `<path>` in prose is parsed as an HTML tag. The sanitizer strips the tag name and keeps only surrounding text, so "`<path>` is the request path" renders as "is the request path". Confirmed this reproduces in real glamour rendering (not just the non-TTY fallback used by tests) and in the built Hugo HTML.

## Fix

Keep the <placeholder> syntax exactly as originally written and made it render correctly by wrapping each occurrence in a backtick code span, using `heredoc.Docf `with a `%[1]s` format to inject the backtick (since a raw `heredoc.Doc` string literal can't contain a literal backtick itself).

I also updated a few other IDs and things that would benefit from literal formatting but there are a lot of changes to make so I will follow up with more.