### PR TITLE
Further `run get` filter dialogue refinements

### DIFF
--- a/acceptance/run_test.go
+++ b/acceptance/run_test.go
@@ -431,6 +431,36 @@ func TestRunGet_NoToken(t *testing.T) {
 	assert.Check(t, golden.String(result.Stderr, t.Name()+".stderr.txt"))
 }
 
+// TestRunGet_ProjectDefaultsBranchToMain confirms that with --project given (and
+// no --branch), the latest-run lookup defaults to the main branch without
+// consulting the local git remote — the checkout is meaningless for a possibly
+// different project. Run from a bare temp dir (no repo): it must not error, and
+// must resolve the main-branch run rather than the feature-branch one.
+func TestRunGet_ProjectDefaultsBranchToMain(t *testing.T) {
+	fake := fakes.NewCircleCI(t)
+	addProjectBySlug(fake, testSlug, runTestProjectID)
+	mainRunID := "e0000000-0000-4000-8000-0000000000b1"
+	featureRunID := "e0000000-0000-4000-8000-0000000000b2"
+	fake.AddRunV3(mainRunID, runTestProjectID, fakeRunV3(mainRunID, runTestProjectID, "ended", "succeeded", "main", "abc1234def5678"))
+	fake.AddRunV3(featureRunID, runTestProjectID, fakeRunV3(featureRunID, runTestProjectID, "ended", "failed", "feature", "deadbeef12345678"))
+
+	env := testenv.New(t)
+	env.Token = testToken
+	env.CircleCIURL = fake.URL()
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"run", "get", "--project", testSlug, "--json"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(), // not a git repo → must not be required
+	})
+
+	assert.Check(t, cmp.Equal(result.ExitCode, 0))
+	var out map[string]any
+	assert.NilError(t, json.Unmarshal([]byte(result.Stdout), &out))
+	assert.Check(t, cmp.Equal(out["id"], mainRunID)) // the main-branch run, not feature
+}
+
 // --- run get (interactive picker) ---
 
 const (
@@ -880,6 +910,50 @@ func TestRunGet_Interactive_SwitchToMyRuns(t *testing.T) {
 	assert.NilError(t, err)
 }
 
+// TestRunGet_Interactive_NoProject runs "run get" interactively with neither a
+// --project flag nor a resolvable git remote (a bare temp dir). Rather than
+// erroring that no project could be inferred, the flow falls back to the
+// cross-project "my runs" scope and opens directly on the user's runs.
+func TestRunGet_Interactive_NoProject(t *testing.T) {
+	env := setupRunGetInteractiveFake(t)
+	console := binary.RunCLIInteractive(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"run", "get"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(), // not a git repo → detection fails
+	})
+
+	// The picker opens straight on the user's cross-project runs, its project
+	// folded into the ref bracket as "[project:branch]".
+	_, err := console.ExpectString("cafed00 [testorg/testrepo:mine]")
+	assert.NilError(t, err)
+
+	// esc on the first picker quits, so the program exits cleanly.
+	_, err = console.Send(keyEsc)
+	assert.NilError(t, err)
+}
+
+// TestRunGet_Interactive_ProjectNoBranch runs the interactive picker with
+// --project but no --branch, outside a git repo. It must not require a remote:
+// the branch defaults to main, so the project's main-branch runs load directly.
+func TestRunGet_Interactive_ProjectNoBranch(t *testing.T) {
+	env := setupRunGetInteractiveFake(t)
+	console := binary.RunCLIInteractive(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"run", "get", "--project", testSlug},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(), // not a git repo → must not be required
+	})
+
+	// The defaulted main branch's run loads (not the feature-branch one).
+	_, err := console.ExpectString("abc1234 [main]")
+	assert.NilError(t, err)
+
+	// esc on the first picker quits, so the program exits cleanly.
+	_, err = console.Send(keyEsc)
+	assert.NilError(t, err)
+}
+
 // TestRunGet_Interactive_FilterStatus presses "s" to narrow the run picker by
 // pipeline status. The first status in the cycle is "canceled", which no
 // main-branch run has, so the picker keeps its list and shows the empty-status
@@ -935,7 +1009,7 @@ func TestRunGet_Interactive_FilterStatusMyRuns(t *testing.T) {
 	// phase=ended/current_outcome=canceled filter matches nothing.
 	_, err = console.Send("s")
 	assert.NilError(t, err)
-	_, err = console.ExpectString("canceled runs in your runs")
+	_, err = console.ExpectString("canceled runs in my runs")
 	assert.NilError(t, err)
 
 	_, err = console.Send(keyEsc)

--- a/internal/cmd/root/testdata/help/circleci/reference.txt
+++ b/internal/cmd/root/testdata/help/circleci/reference.txt
@@ -241,12 +241,12 @@ Cancel a run
 
 Get a run's status
 
-| Flag                  | Description                                                 |
-| --------------------- | ----------------------------------------------------------- |
-| `-b, --branch string` | Branch name (defaults to current branch)                    |
-| `--jq string`         | Process values from the response using jq syntax            |
-| `--json`              | Output as JSON                                              |
-| `--project string`    | Project slug (e.g. gh/org/repo); used for latest-run lookup |
+| Flag                  | Description                                                                 |
+| --------------------- | --------------------------------------------------------------------------- |
+| `-b, --branch string` | Branch name (defaults to the current branch, or main when --project is set) |
+| `--jq string`         | Process values from the response using jq syntax                            |
+| `--json`              | Output as JSON                                                              |
+| `--project string`    | Project slug (e.g. gh/org/repo); used for latest-run lookup                 |
 
 
 **Arguments:**
@@ -254,7 +254,8 @@ Get a run's status
 `<run-id>` is optional and is the UUID of the run to look up. When
 omitted, the latest run is resolved from the project and branch
 inferred from the current git repository's remote and checked-out
-branch (override with --project and --branch).
+branch (override with --project and --branch). With --project set, the
+branch defaults to main unless --branch is given.
 
 #### `circleci run list [flags]`
 

--- a/internal/cmd/root/testdata/help/circleci/run/get.txt
+++ b/internal/cmd/root/testdata/help/circleci/run/get.txt
@@ -3,7 +3,9 @@
 Display the status of a CircleCI run and its workflows.
 
 When called without arguments, the project and branch are inferred from
-the current git repository's remote and checked-out branch.
+the current git repository's remote and checked-out branch. When
+--project is given, the branch defaults to main (not the local checkout,
+which is meaningless for a different project) unless --branch is set.
 
 Pass a run UUID to look up a specific run.
 
@@ -20,12 +22,12 @@ For more information about output formatting flags, see `circleci help formattin
 
 ## Flags
 
-| Flag                  | Description                                                 |
-| --------------------- | ----------------------------------------------------------- |
-| `-b, --branch string` | Branch name (defaults to current branch)                    |
-| `--jq string`         | Process values from the response using jq syntax            |
-| `--json`              | Output as JSON                                              |
-| `--project string`    | Project slug (e.g. gh/org/repo); used for latest-run lookup |
+| Flag                  | Description                                                                 |
+| --------------------- | --------------------------------------------------------------------------- |
+| `-b, --branch string` | Branch name (defaults to the current branch, or main when --project is set) |
+| `--jq string`         | Process values from the response using jq syntax                            |
+| `--json`              | Output as JSON                                                              |
+| `--project string`    | Project slug (e.g. gh/org/repo); used for latest-run lookup                 |
 
 ## Inherited Flags
 
@@ -41,7 +43,8 @@ For more information about output formatting flags, see `circleci help formattin
 `<run-id>` is optional and is the UUID of the run to look up. When
 omitted, the latest run is resolved from the project and branch
 inferred from the current git repository's remote and checked-out
-branch (override with --project and --branch).
+branch (override with --project and --branch). With --project set, the
+branch defaults to main unless --branch is given.
 
 ## Examples
 

--- a/internal/cmd/root/testdata/usage/circleci/run/get.txt
+++ b/internal/cmd/root/testdata/usage/circleci/run/get.txt
@@ -1,7 +1,7 @@
 Usage:  circleci run get [<run-id>] [flags]
 
 Flags:
-  -b, --branch string    Branch name (defaults to current branch)
+  -b, --branch string    Branch name (defaults to the current branch, or main when --project is set)
       --jq string        Process values from the response using jq syntax
       --json             Output as JSON
       --project string   Project slug (e.g. gh/org/repo); used for latest-run lookup

--- a/internal/cmd/run/get.go
+++ b/internal/cmd/run/get.go
@@ -50,6 +50,12 @@ import (
 const (
 	statusCanceled     = "canceled"
 	maxWorkflowFetches = 8
+
+	// defaultBranchGuess is the branch assumed for latest-run lookup when
+	// --project is given explicitly but --branch is not. The local checkout's
+	// current branch is meaningless for a (possibly different) project, so rather
+	// than consulting git we guess the common default branch name.
+	defaultBranchGuess = "main"
 )
 
 func newGetCmd() *cobra.Command {
@@ -67,14 +73,17 @@ func newGetCmd() *cobra.Command {
 				%[1]s<run-id>%[1]s is optional and is the UUID of the run to look up. When
 				omitted, the latest run is resolved from the project and branch
 				inferred from the current git repository's remote and checked-out
-				branch (override with --project and --branch).
+				branch (override with --project and --branch). With --project set, the
+				branch defaults to main unless --branch is given.
 			`, "`"),
 		},
 		Long: heredoc.Doc(`
 			Display the status of a CircleCI run and its workflows.
 
 			When called without arguments, the project and branch are inferred from
-			the current git repository's remote and checked-out branch.
+			the current git repository's remote and checked-out branch. When
+			--project is given, the branch defaults to main (not the local checkout,
+			which is meaningless for a different project) unless --branch is set.
 
 			Pass a run UUID to look up a specific run.
 
@@ -105,7 +114,7 @@ func newGetCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&projectSlug, "project", "", "Project slug (e.g. gh/org/repo); used for latest-run lookup")
-	cmd.Flags().StringVarP(&branch, "branch", "b", "", "Branch name (defaults to current branch)")
+	cmd.Flags().StringVarP(&branch, "branch", "b", "", "Branch name (defaults to the current branch, or main when --project is set)")
 	cmdutil.AddJSONFlag(cmd, &jsonOut)
 	cmdutil.AddJQFlag(cmd)
 
@@ -170,17 +179,23 @@ func runGet(ctx context.Context, client *apiclient.Client, args []string, projec
 			return apiErr(err, id.String())
 		}
 	} else {
-		info, err := gitremote.Detect()
-		if err != nil {
-			return cmdutil.GitDetectErr(err, "Or provide a run UUID: circleci run get <uuid>")
-		}
-		if projectSlug == "" {
-			projectSlug = info.Slug
-		}
-
 		effectiveBranch := branch
-		if effectiveBranch == "" {
-			effectiveBranch = info.Branch
+		if projectSlug == "" {
+			// No --project: infer both the project and (when not supplied) the
+			// branch from the current git repository.
+			info, err := gitremote.Detect()
+			if err != nil {
+				return cmdutil.GitDetectErr(err, "Or provide a run UUID: circleci run get <uuid>")
+			}
+			projectSlug = info.Slug
+			if effectiveBranch == "" {
+				effectiveBranch = info.Branch
+			}
+		} else if effectiveBranch == "" {
+			// --project was given explicitly; the local branch is meaningless for a
+			// (possibly different) project, so default to "main" rather than the
+			// checked-out branch.
+			effectiveBranch = defaultBranchGuess
 		}
 
 		proj, err := client.GetProjectBySlug(ctx, projectSlug)
@@ -275,37 +290,54 @@ func displayRun(ctx context.Context, client *apiclient.Client, r *apiclient.RunV
 // pickers are cancellable with esc/ctrl+c, which returns nil (no output).
 func runGetInteractive(ctx context.Context, client *apiclient.Client, projectSlug, branch string) error {
 	effectiveBranch := branch
-	var defaultBranch string
-	// Only consult the git remote for whatever the flags did not supply, so
-	// --project and --branch together work outside a repository. The default
-	// branch is taken from the remote when detection runs; with both flags given
-	// it stays empty, which disables the run picker's branch toggle.
-	if projectSlug == "" || effectiveBranch == "" {
+	var (
+		defaultBranch string
+		myRunsOnly    bool
+	)
+	// When --project is given explicitly the local checkout is meaningless for a
+	// (possibly different) project, so git is not consulted at all: the branch
+	// defaults to "main" when not supplied, and the default-branch toggle stays
+	// off. Otherwise the git remote supplies the project and (when not supplied)
+	// the branch and default branch. When no project could be inferred (not inside
+	// a repository) fall back to a "my runs" only flow — the authenticated user's
+	// runs across all projects — rather than erroring: project- and branch-scoped
+	// runs need a project, but "my runs" does not.
+	if projectSlug != "" {
+		if effectiveBranch == "" {
+			effectiveBranch = defaultBranchGuess
+		}
+	} else {
 		info, err := gitremote.Detect()
 		if err != nil {
-			return cmdutil.GitDetectErr(err, "Or provide a run UUID: circleci run get <uuid>")
-		}
-		if projectSlug == "" {
+			myRunsOnly = true
+		} else {
 			projectSlug = info.Slug
+			if effectiveBranch == "" {
+				effectiveBranch = info.Branch
+			}
+			defaultBranch = info.DefaultBranch
 		}
-		if effectiveBranch == "" {
-			effectiveBranch = info.Branch
-		}
-		defaultBranch = info.DefaultBranch
 	}
 
-	proj, err := client.GetProjectBySlug(ctx, projectSlug)
-	if err != nil {
-		return apiErr(err, projectSlug)
+	// The project is resolved only for the project-scoped flow; the "my runs"
+	// fallback lists across all projects and needs no project lookup.
+	var projectID string
+	if !myRunsOnly {
+		proj, err := client.GetProjectBySlug(ctx, projectSlug)
+		if err != nil {
+			return apiErr(err, projectSlug)
+		}
+		projectID = proj.ID.String()
 	}
 
 	// fetchRuns lists the 10 most recent runs for a branch as picker items,
 	// optionally narrowed to a pipeline status. It is used for the initial load
-	// and re-run on each branch-scope toggle or status-filter change.
+	// and re-run on each branch-scope toggle or status-filter change. Unused in
+	// the "my runs" only flow (there is no project to scope to).
 	fetchRuns := func(ctx context.Context, br, status string) ([]ui.RunGetItem, error) {
 		now := time.Now().UTC()
 		runs, err := client.SearchRunsV3(ctx, apiclient.RunSearchParams{
-			ProjectIDs: []string{proj.ID.String()},
+			ProjectIDs: []string{projectID},
 			From:       now.AddDate(0, 0, -90),
 			To:         now,
 			Filter:     apiclient.BuildRunFilter(br, status),
@@ -331,13 +363,26 @@ func runGetInteractive(ctx context.Context, client *apiclient.Client, projectSlu
 		return runItemsWithProjects(runs, true), nil
 	}
 
-	sp := iostream.Spinner(ctx, true, fmt.Sprintf("Fetching recent runs for %s on branch %s", projectSlug, effectiveBranch))
-	items, err := fetchRuns(ctx, effectiveBranch, "")
-	sp.Stop()
+	var (
+		items []ui.RunGetItem
+		err   error
+	)
+	if myRunsOnly {
+		sp := iostream.Spinner(ctx, true, "Fetching your recent runs")
+		items, err = fetchMyRuns(ctx, "")
+		sp.Stop()
+	} else {
+		sp := iostream.Spinner(ctx, true, fmt.Sprintf("Fetching recent runs for %s on branch %s", projectSlug, effectiveBranch))
+		items, err = fetchRuns(ctx, effectiveBranch, "")
+		sp.Stop()
+	}
 	if err != nil {
 		return err
 	}
 	if len(items) == 0 {
+		if myRunsOnly {
+			return apiErr(fmt.Errorf("no runs found"), "your runs")
+		}
 		return apiErr(fmt.Errorf("no runs found"), fmt.Sprintf("%s@%s", projectSlug, effectiveBranch))
 	}
 
@@ -347,6 +392,7 @@ func runGetInteractive(ctx context.Context, client *apiclient.Client, projectSlu
 		Animate:          iostream.SpinnerEnabled(ctx),
 		CurrentBranch:    effectiveBranch,
 		DefaultBranch:    defaultBranch,
+		MyRunsOnly:       myRunsOnly,
 		FetchRuns:        fetchRuns,
 		FetchMyRuns:      fetchMyRuns,
 		StatusFilters:    runStatusFilters,

--- a/internal/ui/run_filter_dialog.go
+++ b/internal/ui/run_filter_dialog.go
@@ -50,7 +50,7 @@ var (
 )
 
 // runFilterOutcome is the state of a runFilterDialog after an Update: still open,
-// applied (the user confirmed a branch + status selection), or cancelled.
+// applied (the user confirmed a trigger + status selection), or cancelled.
 type runFilterOutcome int
 
 const (
@@ -59,16 +59,16 @@ const (
 	runFilterCancel
 )
 
-// runFilterTab is the active facet in the dialog: the branch (scope) list or the
+// runFilterTab is the active facet in the dialog: the trigger (scope) list or the
 // status-filter list.
 type runFilterTab int
 
 const (
-	filterTabBranch runFilterTab = iota
+	filterTabTrigger runFilterTab = iota
 	filterTabStatus
 )
 
-// dialog keys. left/right (and tab/shift+tab) switch the active Branch/Status
+// dialog keys. left/right (and tab/shift+tab) switch the active Trigger/Status
 // tab; "r" resets the selection to its defaults. Enter applies and esc cancels
 // (via the shared bindings).
 var (
@@ -78,7 +78,7 @@ var (
 )
 
 // runFilterDialog is the "/" search overlay on the run picker: a two-tab
-// (Branch / Status) chooser that lets the user set the branch scope and status
+// (Trigger / Status) chooser that lets the user set the trigger scope and status
 // filter explicitly from lists. It embeds two components.SelectModel lists (one
 // per tab) so the picker's navigation, scrolling and rendering are reused; the
 // dialog only adds the tab bar on top. Enter applies, esc cancels, "r" resets.
@@ -88,8 +88,8 @@ type runFilterDialog struct {
 	scopes   []runScope
 	statuses []RunStatusFilter
 
-	branchSel components.SelectModel
-	statusSel components.SelectModel
+	triggerSel components.SelectModel
+	statusSel  components.SelectModel
 
 	tab runFilterTab
 
@@ -111,19 +111,39 @@ func newRunFilterDialog(scopes []runScope, statuses []RunStatusFilter, scopeIdx,
 	d := runFilterDialog{
 		scopes:   scopes,
 		statuses: statuses,
-		tab:      filterTabBranch,
+		tab:      filterTabTrigger,
 		color:    color,
 	}
-	d.branchSel = d.newBranchSelect(scopeIdx)
+	d.triggerSel = d.newTriggerSelect(scopeIdx)
 	d.statusSel = d.newStatusSelect(statusIdx)
 	return d
 }
 
-// newBranchSelect builds the chrome-free branch list (no title, no footer) seeded
-// at idx.
-func (d runFilterDialog) newBranchSelect(idx int) components.SelectModel {
-	return components.NewSelectModel("", scopeLabels(d.scopes)).
-		WithCursor(idx).WithKeys().WithHeight(d.listHeight)
+// newTriggerSelect builds the chrome-free trigger list (no title, no footer)
+// seeded at idx. Each trigger carries a glyph (see scopeIcons): a heart for
+// "my runs", and distinct marks for the current branch, default branch and
+// "all branches".
+func (d runFilterDialog) newTriggerSelect(idx int) components.SelectModel {
+	return components.NewSelectModel("", d.scopeLabels()).
+		WithCursor(idx).WithKeys().WithHeight(d.listHeight).
+		WithIcons(d.scopeIcons())
+}
+
+// scopeIcons renders each trigger's glyph for the list, colored per its role
+// (see triggerIconStyle) when color is on: blue for the current branch, green for
+// the default branch, gold for "all branches", and a red heart for "my runs".
+func (d runFilterDialog) scopeIcons() []string {
+	icons := make([]string, len(d.scopes))
+	for i, s := range d.scopes {
+		icon := s.icon
+		if d.color && icon != "" {
+			if style, ok := triggerIconStyle(icon); ok {
+				icon = style.Render(icon)
+			}
+		}
+		icons[i] = icon
+	}
+	return icons
 }
 
 // newStatusSelect builds the chrome-free status list seeded at idx. Each status
@@ -170,12 +190,34 @@ func (d runFilterDialog) statusIcons() []string {
 	return icons
 }
 
-func scopeLabels(scopes []runScope) []string {
-	labels := make([]string, len(scopes))
-	for i, s := range scopes {
-		labels[i] = s.titleName()
+// scopeLabels renders the Trigger tab's row labels. When color is on, each
+// label's trailing "[…]" (the branch name on the current/default branch scopes)
+// is tinted with the secondary gold accent, matching the run picker title's
+// scope bracket.
+func (d runFilterDialog) scopeLabels() []string {
+	labels := make([]string, len(d.scopes))
+	for i, s := range d.scopes {
+		label := s.pickerLabel
+		if d.color {
+			label = colorizeLabelBracket(label)
+		}
+		labels[i] = label
 	}
 	return labels
+}
+
+// colorizeLabelBracket tints a trailing "[…]" segment of a label with the
+// secondary (gold) accent. A label with no trailing bracket (e.g. "all branches",
+// "my runs") is returned unchanged.
+func colorizeLabelBracket(label string) string {
+	if !strings.HasSuffix(label, "]") {
+		return label
+	}
+	open := strings.LastIndexByte(label, '[')
+	if open < 0 {
+		return label
+	}
+	return label[:open] + theme.SecondaryStyle.Render(label[open:])
 }
 
 func statusLabels(statuses []RunStatusFilter) []string {
@@ -202,7 +244,7 @@ func (d runFilterDialog) SetSize(width, height int) runFilterDialog {
 		listHeight = 2
 	}
 	d.listHeight = listHeight
-	d.branchSel = d.branchSel.WithHeight(listHeight)
+	d.triggerSel = d.triggerSel.WithHeight(listHeight)
 	d.statusSel = d.statusSel.WithHeight(listHeight)
 	return d
 }
@@ -214,7 +256,7 @@ func (d runFilterDialog) Outcome() runFilterOutcome { return d.outcome }
 // Selected returns the chosen scope and status indexes. Valid once Outcome() is
 // runFilterApply.
 func (d runFilterDialog) Selected() (scopeIdx, statusIdx int) {
-	return d.branchSel.Selected(), d.statusSel.Selected()
+	return d.triggerSel.Selected(), d.statusSel.Selected()
 }
 
 func (d runFilterDialog) Init() tea.Cmd { return nil }
@@ -222,7 +264,7 @@ func (d runFilterDialog) Init() tea.Cmd { return nil }
 // Update handles the dialog's keys. It never emits a command; navigation (up/
 // down/paging) is forwarded to the active tab's embedded list. ctrl+c is left to
 // the host (it quits the whole program), so the dialog binds esc (cancel), enter
-// (apply), "r" (reset), and left/right + tab/shift+tab (switch the Branch/Status
+// (apply), "r" (reset), and left/right + tab/shift+tab (switch the Trigger/Status
 // tab).
 func (d runFilterDialog) Update(msg tea.Msg) (runFilterDialog, tea.Cmd) {
 	if ws, ok := msg.(tea.WindowSizeMsg); ok {
@@ -244,16 +286,16 @@ func (d runFilterDialog) Update(msg tea.Msg) (runFilterDialog, tea.Cmd) {
 		d.reset()
 		return d, nil
 	case key.Matches(k, filterKeyLeft):
-		d.tab = filterTabBranch
+		d.tab = filterTabTrigger
 		return d, nil
 	case key.Matches(k, filterKeyRight):
 		d.tab = filterTabStatus
 		return d, nil
 	case key.Matches(k, components.KeyTab, components.KeyShiftTab):
-		if d.tab == filterTabBranch {
+		if d.tab == filterTabTrigger {
 			d.tab = filterTabStatus
 		} else {
-			d.tab = filterTabBranch
+			d.tab = filterTabTrigger
 		}
 		return d, nil
 	}
@@ -263,20 +305,20 @@ func (d runFilterDialog) Update(msg tea.Msg) (runFilterDialog, tea.Cmd) {
 	return d, nil
 }
 
-// reset restores the branch and status selections to their defaults (the current
-// branch, all statuses) and returns to the Branch tab.
+// reset restores the trigger and status selections to their defaults (the current
+// branch, all statuses) and returns to the Trigger tab.
 func (d *runFilterDialog) reset() {
-	d.branchSel = d.newBranchSelect(d.defaultScope)
+	d.triggerSel = d.newTriggerSelect(d.defaultScope)
 	d.statusSel = d.newStatusSelect(d.defaultStatus)
-	d.tab = filterTabBranch
+	d.tab = filterTabTrigger
 }
 
 // forwardToList sends a message to whichever tab's list is active, keeping the
 // embedded SelectModel's navigation and scrolling behaviour.
 func (d *runFilterDialog) forwardToList(msg tea.Msg) {
-	if d.tab == filterTabBranch {
-		updated, _ := d.branchSel.Update(msg)
-		d.branchSel = updated.(components.SelectModel)
+	if d.tab == filterTabTrigger {
+		updated, _ := d.triggerSel.Update(msg)
+		d.triggerSel = updated.(components.SelectModel)
 	} else {
 		updated, _ := d.statusSel.Update(msg)
 		d.statusSel = updated.(components.SelectModel)
@@ -343,10 +385,13 @@ func (d runFilterDialog) renderDialog() string {
 // tabBody lays out the active tab as two columns: the options list on the left, a
 // vertical divider, and the tab's help description on the right. Both columns are
 // sized to a fixed width and height (the same for either tab) so switching tabs
-// never resizes the dialog.
+// never resizes the dialog. The options list is vertically centered in its
+// column so a short list (e.g. the trigger picker) sits beside the middle of the
+// taller help text rather than hugging the top.
 func (d runFilterDialog) tabBody() string {
 	h := d.panelHeight()
 	left := lipgloss.NewStyle().Width(d.listColumnWidth()).Height(h).
+		AlignVertical(lipgloss.Center).
 		Render(strings.TrimRight(d.activeList(), "\n"))
 
 	// The divider is muted so it recedes; the description is left in the terminal's
@@ -372,7 +417,7 @@ func (d runFilterDialog) tabBody() string {
 // render at the same height regardless of which has more options or longer help.
 func (d runFilterDialog) panelHeight() int {
 	h := max(len(d.scopes), len(d.statuses))
-	for _, help := range []string{branchHelpText, statusHelpText} {
+	for _, help := range []string{triggerHelpText, statusHelpText} {
 		wrapped := lipgloss.NewStyle().Width(filterHelpWidth).Render(help)
 		h = max(h, lipgloss.Height(wrapped))
 	}
@@ -383,31 +428,31 @@ func (d runFilterDialog) panelHeight() int {
 // so the column (and thus the dialog) stays the same width on either tab.
 func (d runFilterDialog) listColumnWidth() int {
 	return max(
-		lipgloss.Width(strings.TrimRight(d.branchSel.View().Content, "\n")),
+		lipgloss.Width(strings.TrimRight(d.triggerSel.View().Content, "\n")),
 		lipgloss.Width(strings.TrimRight(d.statusSel.View().Content, "\n")),
 	)
 }
 
 // activeList renders the embedded list for the active tab.
 func (d runFilterDialog) activeList() string {
-	if d.tab == filterTabBranch {
-		return d.branchSel.View().Content
+	if d.tab == filterTabTrigger {
+		return d.triggerSel.View().Content
 	}
 	return d.statusSel.View().Content
 }
 
 // tabHelp is the description shown on the right of the active tab.
 func (d runFilterDialog) tabHelp() string {
-	if d.tab == filterTabBranch {
-		return branchHelpText
+	if d.tab == filterTabTrigger {
+		return triggerHelpText
 	}
 	return statusHelpText
 }
 
 const (
-	branchHelpText = "Filter runs by branch.\n\n" +
+	triggerHelpText = "Filter runs by trigger.\n\n" +
 		"Pick a branch to list only its runs. \"all branches\" shows every branch; " +
-		"\"your runs\" lists your runs across all projects."
+		"\"my runs\" lists your runs across all projects."
 	statusHelpText = "Filter runs by status.\n\n" +
 		"\"all statuses\" clears the filter. Pick a status to show only the runs in " +
 		"that state."
@@ -419,8 +464,8 @@ const (
 // row seams into the window's side borders below.
 func (d runFilterDialog) renderTabs(rowWidth int) string {
 	widths := splitWidth(rowWidth, 2)
-	labels := [2]string{"Branch", "Status"}
-	active := [2]bool{d.tab == filterTabBranch, d.tab == filterTabStatus}
+	labels := [2]string{"Trigger", "Status"}
+	active := [2]bool{d.tab == filterTabTrigger, d.tab == filterTabStatus}
 
 	cells := make([]string, 2)
 	for i := 0; i < 2; i++ {

--- a/internal/ui/run_filter_dialog_test.go
+++ b/internal/ui/run_filter_dialog_test.go
@@ -41,13 +41,11 @@ var (
 	dlgReset = tea.KeyPressMsg{Code: 'r', Text: "r"}
 )
 
-// newTestDialog builds a dialog with two branch scopes and two statuses, seeded
-// on the current branch / all statuses, sized to a known terminal.
+// newTestDialog builds a dialog with the trigger scopes (current branch, all
+// branches, your runs — each carrying its glyph) and two statuses, seeded on the
+// current branch / all statuses, sized to a known terminal.
 func newTestDialog() runFilterDialog {
-	scopes := []runScope{
-		{branch: "main", label: "main branch"},
-		{label: "all branches"},
-	}
+	scopes := buildRunScopes("main", "", true, false)
 	statuses := []RunStatusFilter{
 		{Label: "all statuses", Icon: "★"},
 		{Value: "failed", Label: "failed", Icon: "✗"},
@@ -72,13 +70,13 @@ func TestRunFilterDialog_OpensOnActiveSelection(t *testing.T) {
 }
 
 func TestRunFilterDialog_ListNavigationSetsSelection(t *testing.T) {
-	// Branch tab: down selects the second scope.
+	// Trigger tab: down selects the second scope.
 	d := drive(newTestDialog(), dlgDown)
 	scope, _ := d.Selected()
 	assert.Check(t, cmp.Equal(scope, 1))
 
 	// Right switches to the Status tab; down there selects the second status,
-	// leaving the branch selection untouched.
+	// leaving the trigger selection untouched.
 	d = drive(d, dlgRight, dlgDown)
 	scope, status := d.Selected()
 	assert.Check(t, cmp.Equal(scope, 1))
@@ -86,16 +84,16 @@ func TestRunFilterDialog_ListNavigationSetsSelection(t *testing.T) {
 }
 
 func TestRunFilterDialog_TabSwitching(t *testing.T) {
-	// left selects the Branch tab, right the Status tab, regardless of the current
+	// left selects the Trigger tab, right the Status tab, regardless of the current
 	// tab; tab toggles between them.
 	d := drive(newTestDialog(), dlgRight)
 	assert.Check(t, cmp.Equal(d.tab, filterTabStatus))
 	d = drive(d, dlgLeft)
-	assert.Check(t, cmp.Equal(d.tab, filterTabBranch))
+	assert.Check(t, cmp.Equal(d.tab, filterTabTrigger))
 	d = drive(d, dlgTab)
 	assert.Check(t, cmp.Equal(d.tab, filterTabStatus))
 	d = drive(d, dlgTab)
-	assert.Check(t, cmp.Equal(d.tab, filterTabBranch))
+	assert.Check(t, cmp.Equal(d.tab, filterTabTrigger))
 }
 
 func TestRunFilterDialog_EnterApplies(t *testing.T) {
@@ -122,15 +120,16 @@ func TestRunFilterDialog_ResetRestoresDefaults(t *testing.T) {
 	assert.Check(t, cmp.Equal(d.Outcome(), runFilterOpen), "reset should not close the dialog")
 	assert.Check(t, cmp.Equal(scope, 0))
 	assert.Check(t, cmp.Equal(status, 0))
-	assert.Check(t, cmp.Equal(d.tab, filterTabBranch), "reset returns to the Branch tab")
+	assert.Check(t, cmp.Equal(d.tab, filterTabTrigger), "reset returns to the Trigger tab")
 }
 
 func TestRunFilterDialog_ViewShowsTabsAndOptions(t *testing.T) {
-	// The Branch tab is active on open: both tabs, its branch options and its help
-	// description show.
+	// The Trigger tab is active on open: both tabs, its trigger options (the
+	// current branch spelled out with its name, and a heart glyph on "my runs")
+	// and its help description show.
 	v := ansi.Strip(newTestDialog().View().Content)
-	for _, want := range []string{"Branch", "Status", "main", "all branches", "Filter runs by branch"} {
-		assert.Check(t, cmp.Contains(v, want), "branch view missing %q", want)
+	for _, want := range []string{"Trigger", "Status", "current branch [main]", "all branches", "♥ my runs", "Filter runs by trigger"} {
+		assert.Check(t, cmp.Contains(v, want), "trigger view missing %q", want)
 	}
 
 	// Switching to the Status tab shows the status options (with icons: a star for

--- a/internal/ui/run_get_flow.go
+++ b/internal/ui/run_get_flow.go
@@ -94,10 +94,10 @@ This has some additional keys:
 
 | Key | Action |
 | --- | --- |
-| ` + "`" + switchScopeKeyLabel + "`" + ` | Switch trigger — cycle branches and your runs |
+| ` + "`" + switchScopeKeyLabel + "`" + ` | Switch trigger — cycle branches and my runs |
 | ` + "`s`" + ` | Cycle the status filter |
 | ` + "`S`" + ` | Clear the status filter (back to all statuses) |
-| ` + "`/`" + ` | Open the filter dialog — pick a branch and status from lists |
+| ` + "`/`" + ` | Open the filter dialog — pick a trigger and status from lists |
 
 ### The filter dialog
 
@@ -105,7 +105,7 @@ Opened with ` + "`/`" + ` on the run picker:
 
 | Key | Action |
 | --- | --- |
-| ` + "`←` / `→`" + ` (or ` + "`tab`" + `) | Switch the Branch / Status tab |
+| ` + "`←` / `→`" + ` (or ` + "`tab`" + `) | Switch the Trigger / Status tab |
 | ` + "`↑` / `↓`" + ` | Move within the active list |
 | ` + "`enter`" + ` | Apply the selection |
 | ` + "`r`" + ` | Reset to the defaults (current branch, all statuses) |
@@ -267,6 +267,11 @@ type RunGetFlowOptions struct {
 	// rather than by branch; when nil the scope is omitted. status is the active
 	// status filter, as for FetchRuns.
 	FetchMyRuns func(ctx context.Context, status string) ([]RunGetItem, error)
+	// MyRunsOnly restricts the run picker to the cross-project "my runs" scope,
+	// used when no project could be resolved (e.g. run outside a git repository).
+	// The branch scopes and the shift+tab branch toggle are then omitted; the
+	// picker opens directly on the user's runs across all projects.
+	MyRunsOnly bool
 	// StatusFilters are the pipeline statuses the "s" key cycles through, in
 	// order. The picker prepends an "all statuses" (no filter) entry, so pressing
 	// "s" cycles no-filter → each status → back. When empty, the "s" action is
@@ -289,6 +294,12 @@ type runScope struct {
 	branch string // "" = all branches (ignored when myRuns)
 	myRuns bool   // list the authenticated user's runs across all projects
 	label  string // title/loading wording, e.g. "main branch", "all branches"
+	icon   string // glyph shown beside the scope in the filter dialog's Trigger tab
+	// pickerLabel is the row text in the filter dialog's Trigger tab. Unlike the
+	// compact title bracket (titleName), it spells out the scope's role — e.g.
+	// "current branch [main]" or "default branch [develop]" — so the two branch
+	// scopes are distinguishable at a glance.
+	pickerLabel string
 }
 
 // titleName is the bracket-inner text for the picker title: the bare branch
@@ -306,11 +317,11 @@ func (s runScope) titleName() string {
 }
 
 // where is the location phrase used in the "no runs" footer note, e.g.
-// "on main", "on any branch", or "in your runs".
+// "on main", "on any branch", or "in my runs".
 func (s runScope) where() string {
 	switch {
 	case s.myRuns:
-		return "in your runs"
+		return "in my runs"
 	case s.branch == "":
 		return "on any branch"
 	default:
@@ -323,19 +334,67 @@ func (s runScope) where() string {
 // finally "my runs" when includeMyRuns is set (i.e. FetchMyRuns is wired). The
 // cycle always includes all-branches so a toggle is offered even when there is
 // only one branch to name.
-func buildRunScopes(current, defaultBranch string, includeMyRuns bool) []runScope {
-	branchScope := func(b string) runScope {
-		return runScope{branch: b, label: b + " branch"}
+func buildRunScopes(current, defaultBranch string, includeMyRuns, myRunsOnly bool) []runScope {
+	// With no project resolved, "my runs" is the only available scope: there is
+	// no branch to filter by, so the branch scopes and toggle are omitted.
+	if myRunsOnly {
+		return []runScope{{myRuns: true, label: "my runs", pickerLabel: "my runs", icon: scopeIconMyRuns}}
 	}
-	scopes := []runScope{branchScope(current)}
+	// The current branch's picker label spells out its role and names the branch,
+	// e.g. "current branch [main]"; it falls back to the bare phrase for a
+	// detached HEAD (no branch name to show).
+	currentPicker := "current branch"
+	if current != "" {
+		currentPicker = "current branch [" + current + "]"
+	}
+	scopes := []runScope{{
+		branch: current, label: current + " branch", pickerLabel: currentPicker, icon: scopeIconCurrentBranch,
+	}}
 	if defaultBranch != "" && defaultBranch != current {
-		scopes = append(scopes, branchScope(defaultBranch))
+		scopes = append(scopes, runScope{
+			branch: defaultBranch, label: defaultBranch + " branch",
+			pickerLabel: "default branch [" + defaultBranch + "]", icon: scopeIconDefaultBranch,
+		})
 	}
-	scopes = append(scopes, runScope{label: "all branches"})
+	scopes = append(scopes, runScope{label: "all branches", pickerLabel: "all branches", icon: scopeIconAllBranches})
 	if includeMyRuns {
-		scopes = append(scopes, runScope{myRuns: true, label: "your runs"})
+		scopes = append(scopes, runScope{myRuns: true, label: "my runs", pickerLabel: "my runs", icon: scopeIconMyRuns})
 	}
 	return scopes
+}
+
+// Trigger glyphs shown beside each scope in the filter dialog's Trigger tab.
+// They are deliberately not status symbols (see statusIconStyle) so they take
+// their own colors (see triggerIconStyle) rather than a status color:
+//   - the current branch is where you are now (a filled "you are here" target);
+//   - the default branch is the project's home base (a house);
+//   - "all branches" is the generic branch mark;
+//   - "my runs" — the cross-project scope — gets a heart.
+const (
+	scopeIconCurrentBranch = "◉"
+	scopeIconDefaultBranch = "⌂"
+	scopeIconAllBranches   = "⎇"
+	scopeIconMyRuns        = "♥"
+)
+
+// triggerIconStyle maps a trigger glyph (a scopeIcon* constant) to its color:
+// the current branch reads as active/here (blue), the default branch as the
+// project's home base (green), "all branches" as a neutral gold accent (matching
+// the Status tab's "all statuses" star), and "my runs" as a red heart. The
+// bool is false for an unrecognised glyph, which is then left uncolored.
+func triggerIconStyle(glyph string) (lipgloss.Style, bool) {
+	switch glyph {
+	case scopeIconCurrentBranch:
+		return theme.RunningStyle, true // blue — the branch you're on now
+	case scopeIconDefaultBranch:
+		return theme.SuccessStyle, true // green — the project's home base
+	case scopeIconAllBranches:
+		return theme.SecondaryStyle, true // gold — neutral catch-all
+	case scopeIconMyRuns:
+		return theme.ErrorStyle, true // red — a red heart
+	default:
+		return lipgloss.Style{}, false
+	}
 }
 
 // RunStatusFilter is one selectable pipeline-status filter offered by the run
@@ -360,7 +419,7 @@ func buildStatusCycle(selectable []RunStatusFilter) []RunStatusFilter {
 
 // runsEmptyNote is the transient footer note shown when a scope+status
 // combination has no runs, e.g. "No runs found on main" or "No failed runs in
-// your runs".
+// my runs".
 func runsEmptyNote(scope runScope, status RunStatusFilter) string {
 	if status.Value == "" {
 		return "No runs found " + scope.where()
@@ -514,7 +573,7 @@ type RunGetFlowModel struct {
 	help            components.HelpModel
 	helpReturnStage runGetStage
 
-	// filter is the "/" search dialog on the run picker: a tabbed Branch/Status
+	// filter is the "/" search dialog on the run picker: a tabbed Trigger/Status
 	// chooser with OK/Cancel/Reset buttons. It is (re)built each time "/" opens it.
 	filter runFilterDialog
 
@@ -570,7 +629,7 @@ func NewRunGetFlow(ctx context.Context, opts RunGetFlowOptions) RunGetFlowModel 
 		spin:          components.NewSpinner(opts.Color),
 		pager:         components.NewPager().WithKeys(stepPagerKeys...),
 		runs:          opts.Runs,
-		scopes:        buildRunScopes(opts.CurrentBranch, opts.DefaultBranch, opts.FetchMyRuns != nil),
+		scopes:        buildRunScopes(opts.CurrentBranch, opts.DefaultBranch, opts.FetchMyRuns != nil, opts.MyRunsOnly),
 		statusFilters: buildStatusCycle(opts.StatusFilters),
 		// activeScopeIdx and statusIdx start at 0: the current branch is always the
 		// first scope, and "all statuses" the first filter.
@@ -1434,7 +1493,10 @@ func (m RunGetFlowModel) newRunSelect() components.SelectModel {
 	// the (bold, uncolored) title.
 	prompt := "Select a run"
 	var parts []string
-	if len(m.scopes) >= 2 {
+	// Name the scope when there is more than one to choose from, or when the sole
+	// scope is the cross-project "my runs" (so it reads "[my runs]" rather than an
+	// unlabelled project-branch list).
+	if len(m.scopes) >= 2 || m.activeScope().myRuns {
 		parts = append(parts, m.activeScope().titleName())
 	}
 	if status := m.statusFilters[m.statusIdx]; status.Value != "" {

--- a/internal/ui/run_get_flow_test.go
+++ b/internal/ui/run_get_flow_test.go
@@ -801,7 +801,7 @@ func TestRunGetFlow_StepPagerEscResumes(t *testing.T) {
 }
 
 // TestRunGetFlow_FilterDialogOpensOnSlash confirms "/" opens the search dialog
-// with its Branch/Status tabs.
+// with its Trigger/Status tabs.
 func TestRunGetFlow_FilterDialogOpensOnSlash(t *testing.T) {
 	tm := startFlow(t, newStatusFlow(
 		map[string][]ui.RunGetItem{"": {runItem("aaaaaaa [main] - all")}},
@@ -809,10 +809,10 @@ func TestRunGetFlow_FilterDialogOpensOnSlash(t *testing.T) {
 	))
 
 	tm.Send(keySlash)
-	waitForOutput(t, tm, "Branch")
+	waitForOutput(t, tm, "Trigger")
 
 	v := flowSnapshot(t, tm)
-	for _, want := range []string{"Branch", "Status", "Filter runs by branch"} {
+	for _, want := range []string{"Trigger", "Status", "Filter runs by trigger"} {
 		assert.Check(t, cmp.Contains(v, want), "dialog missing %q", want)
 	}
 }
@@ -830,8 +830,8 @@ func TestRunGetFlow_FilterApplyRefetchesRuns(t *testing.T) {
 	))
 
 	tm.Send(keySlash)
-	waitForOutput(t, tm, "Branch")
-	tm.Send(keyRight) // Branch → Status tab
+	waitForOutput(t, tm, "Trigger")
+	tm.Send(keyRight) // Trigger → Status tab
 	tm.Send(keyDown)  // all statuses → failed
 	tm.Send(keyEnt)   // apply
 	waitForOutput(t, tm, "ccccccc [main] - failed")
@@ -849,13 +849,13 @@ func TestRunGetFlow_FilterCancelReturnsToPicker(t *testing.T) {
 	))
 
 	tm.Send(keySlash)
-	waitForOutput(t, tm, "Branch")
+	waitForOutput(t, tm, "Trigger")
 	tm.Send(keyEsc)
 	waitForOutput(t, tm, "Select a run")
 
 	v := flowSnapshot(t, tm)
 	assert.Check(t, cmp.Contains(v, "aaaaaaa [main] - all"))
-	assert.Check(t, !strings.Contains(v, "Branch"), "dialog should be dismissed")
+	assert.Check(t, !strings.Contains(v, "Trigger"), "dialog should be dismissed")
 }
 
 // TestRunGetFlow_FilterHintShownWhenEnabled confirms the run picker footer


### PR DESCRIPTION
- When `run get` is run without a project, just show `my runs`.
- When `--project` is specified, default to `main` branch, as locally detected branch is meaningless.
- Correctly refer to selection as "trigger" rather than branch.
- Improve styling of dialog (icons and colors).
- Better labels for current and default branch options.
- `your runs` -> `my runs`.
- Vertically center trigger picker.


<img width="1570" height="1022" alt="Screenshot 2026-07-05 at 21 48 56" src="https://github.com/user-attachments/assets/e70f4d45-cb94-46c1-89a8-c54a1b1a1b24" />

