### PR TITLE
Add date filter in `run get`

### DIFF
--- a/internal/apiclient/run.go
+++ b/internal/apiclient/run.go
@@ -219,23 +219,37 @@ func (c *Client) SearchRunsV3(ctx context.Context, params RunSearchParams) ([]Ru
 	return runs, nil
 }
 
+// MyRunsParams configures a ListMyRunsV3 request. All fields are optional: the
+// zero value lists every recent run the endpoint defaults to.
+type MyRunsParams struct {
+	// Limit caps the page size; a value <= 0 uses the server default.
+	Limit int
+	// Status narrows the list to runs with that pipeline status (e.g. "failed",
+	// "on_hold"); an empty status lists every status.
+	Status string
+	// From and To bound the list to runs created within that window
+	// (filter[from]/filter[to], RFC3339). A nil bound is omitted, letting the
+	// endpoint apply its own default for that side.
+	From *time.Time
+	To   *time.Time
+}
+
 // ListMyRunsV3 lists runs triggered by the authenticated user across all
-// projects, via GET /api/v3/runs?filter[user_id]=me. limit caps the page size;
-// a value <= 0 uses the server default. A non-empty status narrows the list to
-// runs with that pipeline status (e.g. "failed", "on_hold"); an empty status
-// lists every status.
+// projects, via GET /api/v3/runs?filter[user_id]=me.
 //
 // Unlike the runs/search endpoint, this endpoint has no pipeline.status filter —
 // it filters on the run's own phase and current_outcome — so the status is
 // converted to those via StatusPhaseOutcome.
-func (c *Client) ListMyRunsV3(ctx context.Context, limit int, status string) ([]RunV3, error) {
-	phase, currentOutcome := StatusPhaseOutcome(status)
+func (c *Client) ListMyRunsV3(ctx context.Context, params MyRunsParams) ([]RunV3, error) {
+	phase, currentOutcome := StatusPhaseOutcome(params.Status)
 	var resp v3List[runWire]
 	if err := c.getV3(ctx, "/runs", &resp,
 		filterParam("user_id", "me"),
 		filterParam("phase", phase),
 		filterParam("current_outcome", currentOutcome),
-		pageLimit(limit)); err != nil {
+		filterParam("from", rfc3339OrEmpty(params.From)),
+		filterParam("to", rfc3339OrEmpty(params.To)),
+		pageLimit(params.Limit)); err != nil {
 		return nil, err
 	}
 
@@ -296,6 +310,15 @@ func StatusPhaseOutcome(status string) (phase, currentOutcome string) {
 	default:
 		return "", ""
 	}
+}
+
+// rfc3339OrEmpty formats t as an RFC3339 timestamp, or returns "" for a nil
+// pointer so filterParam omits the bound entirely.
+func rfc3339OrEmpty(t *time.Time) string {
+	if t == nil {
+		return ""
+	}
+	return t.Format(time.RFC3339)
 }
 
 // BuildRunFilter constructs a filter expression for the V3 runs/search endpoint.

--- a/internal/cmd/my/runs.go
+++ b/internal/cmd/my/runs.go
@@ -102,7 +102,7 @@ type runEntry struct {
 }
 
 func runMyRuns(ctx context.Context, client *apiclient.Client, limit int, jsonOut bool) error {
-	runs, err := client.ListMyRunsV3(ctx, limit, "")
+	runs, err := client.ListMyRunsV3(ctx, apiclient.MyRunsParams{Limit: limit})
 	if err != nil {
 		return cmdutil.APIErr(err, "your runs",
 			"my.runs_failed", "Could not list your runs.")

--- a/internal/cmd/run/get.go
+++ b/internal/cmd/run/get.go
@@ -275,6 +275,24 @@ func displayRun(ctx context.Context, client *apiclient.Client, r *apiclient.RunV
 	return nil
 }
 
+// createdWindow resolves the explicit [from, to] creation-time window for an
+// active "Created" filter, measured from now. Both bounds are always set —
+// including a 90-day floor on the lower bound for an "older than" query — so the
+// runs endpoints never fall back to their implicit (~14-day) default window. That
+// matters most for "my runs", where an implicit lower bound also narrows the
+// recently-active project set and can hide every matching run (see
+// RUN_DATE_RANGES.md). Call only when created.Active().
+//
+// The relative-age buckets are all well under 90 days, so the older-than window
+// [now-90d, now-duration] is always a valid, non-empty range.
+func createdWindow(created ui.RunCreatedFilter, now time.Time) (from, to time.Time) {
+	cut := now.Add(-created.Duration)
+	if created.Newer {
+		return cut, now // newer than the cut, up to now
+	}
+	return now.AddDate(0, 0, -90), cut // older than the cut, floored at 90 days
+}
+
 // runGetInteractive drives the interactive picker flow used when "circleci run
 // get" is run in a terminal with no run ID:
 //
@@ -331,15 +349,22 @@ func runGetInteractive(ctx context.Context, client *apiclient.Client, projectSlu
 	}
 
 	// fetchRuns lists the 10 most recent runs for a branch as picker items,
-	// optionally narrowed to a pipeline status. It is used for the initial load
-	// and re-run on each branch-scope toggle or status-filter change. Unused in
-	// the "my runs" only flow (there is no project to scope to).
-	fetchRuns := func(ctx context.Context, br, status string) ([]ui.RunGetItem, error) {
+	// optionally narrowed to a pipeline status and a created-age window. It is used
+	// for the initial load and re-run on each branch-scope toggle, status-filter or
+	// created-filter change. Unused in the "my runs" only flow (there is no project
+	// to scope to).
+	fetchRuns := func(ctx context.Context, br, status string, created ui.RunCreatedFilter) ([]ui.RunGetItem, error) {
 		now := time.Now().UTC()
+		// The default window is the last 90 days; a created filter narrows it to
+		// runs older or newer than its relative age (still floored at 90 days).
+		from, to := now.AddDate(0, 0, -90), now
+		if created.Active() {
+			from, to = createdWindow(created, now)
+		}
 		runs, err := client.SearchRunsV3(ctx, apiclient.RunSearchParams{
 			ProjectIDs: []string{projectID},
-			From:       now.AddDate(0, 0, -90),
-			To:         now,
+			From:       from,
+			To:         to,
 			Filter:     apiclient.BuildRunFilter(br, status),
 			Limit:      10,
 		})
@@ -355,8 +380,19 @@ func runGetInteractive(ctx context.Context, client *apiclient.Client, projectSlu
 	// counterpart to "circleci my runs"). Because it spans projects, each row folds
 	// its project (the "org/repo" slug from the run's repository URL) into the ref
 	// bracket as "[project:branch]".
-	fetchMyRuns := func(ctx context.Context, status string) ([]ui.RunGetItem, error) {
-		runs, err := client.ListMyRunsV3(ctx, 10, status)
+	fetchMyRuns := func(ctx context.Context, status string, created ui.RunCreatedFilter) ([]ui.RunGetItem, error) {
+		// Only send explicit bounds when a created filter is active. With no filter,
+		// leave from/to nil so the endpoint applies its own default window (as
+		// "circleci my runs" does). An active filter must always send an explicit
+		// lower bound: an "older than" query would otherwise inherit the endpoint's
+		// implicit ~14-day default from, which also collapses the recently-active
+		// project set to nothing and returns no runs (see RUN_DATE_RANGES.md).
+		params := apiclient.MyRunsParams{Limit: 10, Status: status}
+		if created.Active() {
+			from, to := createdWindow(created, time.Now().UTC())
+			params.From, params.To = &from, &to
+		}
+		runs, err := client.ListMyRunsV3(ctx, params)
 		if err != nil {
 			return nil, apiErr(err, "your runs")
 		}
@@ -369,11 +405,11 @@ func runGetInteractive(ctx context.Context, client *apiclient.Client, projectSlu
 	)
 	if myRunsOnly {
 		sp := iostream.Spinner(ctx, true, "Fetching your recent runs")
-		items, err = fetchMyRuns(ctx, "")
+		items, err = fetchMyRuns(ctx, "", ui.RunCreatedFilter{})
 		sp.Stop()
 	} else {
 		sp := iostream.Spinner(ctx, true, fmt.Sprintf("Fetching recent runs for %s on branch %s", projectSlug, effectiveBranch))
-		items, err = fetchRuns(ctx, effectiveBranch, "")
+		items, err = fetchRuns(ctx, effectiveBranch, "", ui.RunCreatedFilter{})
 		sp.Stop()
 	}
 	if err != nil {

--- a/internal/cmd/run/get_test.go
+++ b/internal/cmd/run/get_test.go
@@ -31,7 +31,32 @@ import (
 	is "gotest.tools/v3/assert/cmp"
 
 	"github.com/CircleCI-Public/circleci-cli/internal/apiclient"
+	"github.com/CircleCI-Public/circleci-cli/internal/ui"
 )
+
+// TestCreatedWindow verifies the created-filter time window always carries an
+// explicit lower bound, so an "older than" query does not inherit the runs
+// endpoints' implicit ~14-day default from (which would hide older runs, and for
+// "my runs" return nothing — see RUN_DATE_RANGES.md).
+func TestCreatedWindow(t *testing.T) {
+	now := time.Date(2026, 7, 6, 12, 0, 0, 0, time.UTC)
+
+	t.Run("older than floors the lower bound at 90 days", func(t *testing.T) {
+		// "older than 2 weeks" is the case that previously returned no runs: the
+		// upper bound is 2 weeks ago and the lower bound must be an explicit 90-day
+		// floor, not left unset.
+		from, to := createdWindow(ui.RunCreatedFilter{Duration: 14 * 24 * time.Hour}, now)
+		assert.Check(t, is.Equal(from, now.AddDate(0, 0, -90)))
+		assert.Check(t, is.Equal(to, now.Add(-14*24*time.Hour)))
+		assert.Check(t, from.Before(to), "the window must be non-empty")
+	})
+
+	t.Run("newer than spans the age up to now", func(t *testing.T) {
+		from, to := createdWindow(ui.RunCreatedFilter{Newer: true, Duration: time.Hour}, now)
+		assert.Check(t, is.Equal(from, now.Add(-time.Hour)))
+		assert.Check(t, is.Equal(to, now))
+	})
+}
 
 // TestStepRows_UnfinishedStep verifies that a step with no stop time renders "~"
 // in the duration column (rather than a blank gap), while a finished step shows

--- a/internal/ui/components/keys.go
+++ b/internal/ui/components/keys.go
@@ -49,6 +49,7 @@ var (
 	KeyNo       = key.NewBinding(key.WithKeys("n", "N"))
 	KeyTab      = key.NewBinding(key.WithKeys("tab"))
 	KeyShiftTab = key.NewBinding(key.WithKeys("shift+tab"))
+	KeySpace    = key.NewBinding(key.WithKeys(" ", "space"))
 
 	// List/viewport movement. k/j accompany the arrows for vim-style navigation.
 	KeyUp       = key.NewBinding(key.WithKeys("up", "k"))

--- a/internal/ui/components/select.go
+++ b/internal/ui/components/select.go
@@ -40,16 +40,17 @@ import (
 // Esc/Ctrl+C cancels. When the option list is taller than the available height
 // the list scrolls to keep the cursor visible (see WithHeight).
 type SelectModel struct {
-	prompt  string
-	options []string
-	icons   []string
-	keys    []key.Binding // footer key bindings; nil renders no hint line
-	help    help.Model    // renders keys into the muted footer line
-	note    string        // optional lines rendered between the title and the options
-	cursor  int
-	offset  int // index of the first visible option when the list scrolls
-	height  int // terminal rows available; 0 = unlimited (render every option)
-	chosen  bool
+	prompt   string
+	options  []string
+	icons    []string
+	children []string      // optional nested, non-selectable sub-entry per option
+	keys     []key.Binding // footer key bindings; nil renders no hint line
+	help     help.Model    // renders keys into the muted footer line
+	note     string        // optional lines rendered between the title and the options
+	cursor   int
+	offset   int // index of the first visible option when the list scrolls
+	height   int // terminal rows available; 0 = unlimited (render every option)
+	chosen   bool
 
 	// itemStyleFunc, when set, supplies a per-option label style so a caller can
 	// mark a row as special (e.g. a muted "all statuses" no-filter entry). It is
@@ -104,6 +105,20 @@ func (m SelectModel) WithItemStyleFunc(fn func(i int) lipgloss.Style) SelectMode
 // carries an icon.
 func (m SelectModel) WithIcons(icons []string) SelectModel {
 	m.icons = icons
+	return m
+}
+
+// WithChildren attaches an optional nested sub-entry to each option. children is
+// parallel to the options; an empty string means "no child" for that row. A
+// child renders as a muted, non-selectable "└ value" line indented beneath its
+// option (e.g. a branch name under a trigger), keeping a long attribute off the
+// option's own row. Children are meant for short lists shown in full; the list
+// still scrolls by option when it overflows, but the window is sized to show
+// every option and its children together, so a caller relying on children should
+// leave enough height for them.
+func (m SelectModel) WithChildren(children []string) SelectModel {
+	m.children = children
+	m.clampOffset()
 	return m
 }
 
@@ -197,16 +212,37 @@ func (m SelectModel) reservedRows() int {
 }
 
 // visibleRows is how many option rows fit, reserving lines for the prompt, hint
-// and note. Zero height (or a list that already fits) means no limit.
+// and note. Zero height (or a list that already fits, counting each option's
+// nested child line) means no limit.
 func (m SelectModel) visibleRows() int {
 	reserved := m.reservedRows()
-	if m.height <= 0 || m.height-reserved >= len(m.options) {
+	if m.height <= 0 || m.height-reserved >= len(m.options)+m.childLines() {
 		return len(m.options)
 	}
 	if rows := m.height - reserved; rows > 0 {
 		return rows
 	}
 	return 1
+}
+
+// childLines is the number of options carrying a nested child sub-entry (each
+// renders one extra line beneath its option).
+func (m SelectModel) childLines() int {
+	n := 0
+	for _, c := range m.children {
+		if c != "" {
+			n++
+		}
+	}
+	return n
+}
+
+// childAt returns option i's nested sub-entry, or "" when it has none.
+func (m SelectModel) childAt(i int) string {
+	if i >= 0 && i < len(m.children) {
+		return m.children[i]
+	}
+	return ""
 }
 
 // clampOffset scrolls the visible window so the cursor stays inside it and the
@@ -279,8 +315,20 @@ func (m SelectModel) renderOptions(start, end int) string {
 		EnumeratorStyle(lipgloss.NewStyle())
 	for i := start; i < end; i++ {
 		l.Item(m.renderRow(i))
+		if child := m.childAt(i); child != "" {
+			l.Item(m.renderChild(i, child))
+		}
 	}
 	return l.String()
+}
+
+// renderChild renders a non-selectable sub-entry on its own line beneath option
+// i, aligned with where the option's label text begins (i.e. past the "› "/"  "
+// cursor prefix and the icon column). The value is emitted verbatim so a caller
+// can style it (e.g. tint a branch name).
+func (m SelectModel) renderChild(i int, child string) string {
+	indent := len("  ") + lipgloss.Width(m.iconPrefix(i))
+	return strings.Repeat(" ", indent) + child
 }
 
 // renderRow renders option i as "› label" (cursor) or "  label", styled so the

--- a/internal/ui/components/select_test.go
+++ b/internal/ui/components/select_test.go
@@ -124,6 +124,41 @@ func TestSelectModel_FitsWithoutScrolling(t *testing.T) {
 	assert.Check(t, !strings.Contains(view, " of "), "unexpected scroll indicator: %q", view)
 }
 
+// TestSelectModel_Children verifies WithChildren renders a value verbatim on its
+// own line, indented beneath its option, that the child is not a selectable row
+// (the cursor moves option-to-option, skipping it), and that options without a
+// child render none.
+func TestSelectModel_Children(t *testing.T) {
+	m := components.NewSelectModel("Pick", []string{"current branch", "all branches"}).
+		WithChildren([]string{"[main]", ""})
+	view := finalView(t, start(t, m, 80, 24))
+
+	// The child renders on its own line, indented past its option's label, and
+	// only where set.
+	assert.Check(t, cmp.Contains(view, "[main]"))
+	assert.Check(t, strings.Index(view, "current branch") < strings.Index(view, "[main]"),
+		"child should render beneath its option: %q", view)
+	assert.Check(t, !strings.Contains(view, "[all"), "an option with no child renders none")
+
+	// The child is decoration, not a selectable row: one Down moves from the first
+	// option straight to the second, so confirming lands on index 1.
+	assert.Check(t, cmp.Equal(runSelectChildren(t, tea.KeyDown), 1))
+}
+
+// runSelectChildren drives a two-option picker (the first carrying a child) with
+// the given keys followed by Enter, and returns the confirmed index.
+func runSelectChildren(t *testing.T, codes ...rune) int {
+	t.Helper()
+	m := components.NewSelectModel("Pick", []string{"current branch", "all branches"}).
+		WithChildren([]string{"main", ""})
+	tm := start(t, m, 80, 24)
+	pressKeys(tm, codes...)
+	pressKeys(tm, tea.KeyEnter)
+	fm := tm.FinalModel(t, teatest.WithFinalTimeout(time.Second)).(selectHarness)
+	assert.Check(t, fm.m.Done(), "expected the picker to have confirmed a choice")
+	return fm.m.Selected()
+}
+
 // TestSelectModel_Note verifies WithNote renders its line(s) between the title
 // and the options, and that a note reserves rows so the option window shrinks
 // accordingly (leaving room for the note without overflowing the height).

--- a/internal/ui/components/tabs.go
+++ b/internal/ui/components/tabs.go
@@ -1,0 +1,199 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package components
+
+import (
+	"charm.land/bubbles/v2/key"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+
+	"github.com/CircleCI-Public/circleci-cli/internal/ui/theme"
+)
+
+// Tab-switching bindings: left/h/shift+tab select the previous tab, right/l/tab
+// the next (both wrap). They are internal to the Tabs component so a host does
+// not have to re-declare them.
+var (
+	tabKeyPrev = key.NewBinding(key.WithKeys("left", "h", "shift+tab"))
+	tabKeyNext = key.NewBinding(key.WithKeys("right", "l", "tab"))
+)
+
+// Tab borders, styled after the lipgloss "layout" example: an active tab opens at
+// the bottom (a blank Bottom edge) so it reads as continuous with the window body
+// below it, while an inactive tab is a closed box whose bottom line forms part of
+// the window's top border. The first/last tab's bottom outer corner is patched at
+// render time so the tab row seams into the window's side borders (see View).
+var (
+	activeTabBorder = lipgloss.Border{
+		Top: "─", Bottom: " ", Left: "│", Right: "│",
+		TopLeft: "╭", TopRight: "╮", BottomLeft: "┘", BottomRight: "└",
+	}
+	inactiveTabBorder = lipgloss.Border{
+		Top: "─", Bottom: "─", Left: "│", Right: "│",
+		TopLeft: "╭", TopRight: "╮", BottomLeft: "┴", BottomRight: "┴",
+	}
+)
+
+// Tabs is a horizontal tab bar seamed into a rounded-bordered window: the active
+// tab's label reads as continuous with the body below it. It owns the active-tab
+// index and the switch keys (←/→, tab/shift+tab); the host supplies the labels
+// and, per frame, the active tab's body content (Tabs draws only the chrome, not
+// the body — the host decides what each tab shows). Enter/esc and body navigation
+// are left to the host.
+type Tabs struct {
+	labels []string
+	active int
+	color  bool
+}
+
+// NewTabs builds a tab bar over labels with the first tab active.
+func NewTabs(labels []string, color bool) Tabs {
+	return Tabs{labels: labels, color: color}
+}
+
+// Active returns the index of the active tab.
+func (t Tabs) Active() int { return t.active }
+
+// Count returns the number of tabs.
+func (t Tabs) Count() int { return len(t.labels) }
+
+// SetActive returns a copy with tab i active (wrapped into range).
+func (t Tabs) SetActive(i int) Tabs {
+	if n := len(t.labels); n > 0 {
+		t.active = ((i % n) + n) % n
+	}
+	return t
+}
+
+// Next / Prev return a copy with the following / preceding tab active, wrapping
+// at the ends.
+func (t Tabs) Next() Tabs { return t.SetActive(t.active + 1) }
+func (t Tabs) Prev() Tabs { return t.SetActive(t.active - 1) }
+
+// Update switches the active tab on a tab-switch key (←/→, tab/shift+tab). The
+// returned bool reports whether the key was consumed, so the host can forward
+// everything else to the active tab's body.
+func (t Tabs) Update(msg tea.Msg) (Tabs, bool) {
+	k, ok := msg.(tea.KeyPressMsg)
+	if !ok {
+		return t, false
+	}
+	switch {
+	case key.Matches(k, tabKeyNext):
+		return t.Next(), true
+	case key.Matches(k, tabKeyPrev):
+		return t.Prev(), true
+	}
+	return t, false
+}
+
+// View renders the tab row over a rounded-bordered window wrapping body: the tab
+// row supplies the window's top edge, and the row is split to the window's width
+// so the two seam together. The window is sized to the body's width.
+func (t Tabs) View(body string) string {
+	contentWidth := lipgloss.Width(body)
+	// rowWidth is the outer window width. lipgloss .Width() sets the outer box
+	// width (border + padding included), so the window is body + border(2) +
+	// padding(2); the tab row is set to the same width so they line up. Round up so
+	// the width splits evenly across the tabs (symmetric cells).
+	rowWidth := contentWidth + 4
+	if n := len(t.labels); n > 0 {
+		if r := rowWidth % n; r != 0 {
+			rowWidth += n - r
+		}
+	}
+
+	window := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderTop(false). // the tab row supplies the top edge
+		Padding(0, 1).
+		Width(rowWidth)
+	if t.color {
+		window = window.BorderForeground(theme.ColorSecondary)
+	}
+
+	return lipgloss.JoinVertical(lipgloss.Left, t.renderRow(rowWidth), window.Render(body))
+}
+
+// renderRow draws the tab row at rowWidth, split evenly across the tabs. The
+// active tab uses the open-bottom border so it reads as continuous with the
+// window and its label is pink; the outer bottom corners of the first and last
+// tab are patched so the row seams into the window's side borders below, while
+// middle tabs keep their default corners.
+func (t Tabs) renderRow(rowWidth int) string {
+	n := len(t.labels)
+	widths := splitWidth(rowWidth, n)
+
+	cells := make([]string, n)
+	for i, label := range t.labels {
+		active := i == t.active
+		border := inactiveTabBorder
+		if active {
+			border = activeTabBorder
+		}
+		switch i {
+		case 0: // first tab: bottom-left seams into the window's left border
+			if active {
+				border.BottomLeft = "│"
+			} else {
+				border.BottomLeft = "├"
+			}
+		case n - 1: // last tab: bottom-right seams into the window's right border
+			if active {
+				border.BottomRight = "│"
+			} else {
+				border.BottomRight = "┤"
+			}
+		}
+
+		st := lipgloss.NewStyle().Border(border, true).Padding(0, 1).
+			Align(lipgloss.Center).Width(widths[i])
+		switch {
+		case t.color && active:
+			st = st.BorderForeground(theme.ColorSecondary).Foreground(theme.ColorAccent).Bold(true)
+		case t.color:
+			st = st.BorderForeground(theme.ColorSecondary).Foreground(theme.ColorMuted)
+		case active:
+			st = st.Bold(true)
+		}
+		cells[i] = st.Render(label)
+	}
+	return lipgloss.JoinHorizontal(lipgloss.Bottom, cells...)
+}
+
+// splitWidth divides total into n parts as evenly as possible, handing the
+// remainder to the leading parts, so the parts sum back to total.
+func splitWidth(total, n int) []int {
+	if n <= 0 {
+		return nil
+	}
+	base := total / n
+	out := make([]int, n)
+	for i := range out {
+		out[i] = base
+	}
+	for i := 0; i < total-base*n; i++ {
+		out[i]++
+	}
+	return out
+}

--- a/internal/ui/components/tabs_test.go
+++ b/internal/ui/components/tabs_test.go
@@ -1,0 +1,132 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package components_test
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"charm.land/bubbles/v2/key"
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/charmbracelet/x/exp/teatest/v2"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+
+	"github.com/CircleCI-Public/circleci-cli/internal/ui/components"
+)
+
+// tabsHarness drives a Tabs bar as a standalone teatest program, quitting on
+// ctrl+c. Tabs never quits itself (its host owns enter/esc), so the harness does.
+// The wrapped Tabs stays reachable via t for post-run assertions.
+type tabsHarness struct {
+	t components.Tabs
+}
+
+func (h tabsHarness) Init() tea.Cmd { return nil }
+
+func (h tabsHarness) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if k, ok := msg.(tea.KeyPressMsg); ok && key.Matches(k, components.KeyCtrlC) {
+		return h, tea.Quit
+	}
+	updated, _ := h.t.Update(msg)
+	h.t = updated
+	return h, nil
+}
+
+func (h tabsHarness) View() tea.View { return tea.NewView(h.t.View("body content")) }
+
+func startTabs(t *testing.T, tabs components.Tabs) *teatest.TestModel {
+	t.Helper()
+	tm := teatest.NewTestModel(t, tabsHarness{t: tabs}, teatest.WithInitialTermSize(60, 12))
+	teatest.WaitFor(t, tm.Output(), func(b []byte) bool {
+		return bytes.Contains(b, []byte("body content"))
+	}, teatest.WithDuration(time.Second))
+	return tm
+}
+
+func finalTabs(t *testing.T, tm *teatest.TestModel) components.Tabs {
+	t.Helper()
+	tm.Send(tea.KeyPressMsg{Code: 'c', Mod: tea.ModCtrl})
+	return tm.FinalModel(t, teatest.WithFinalTimeout(time.Second)).(tabsHarness).t
+}
+
+var (
+	tabRight    = tea.KeyPressMsg{Code: tea.KeyRight}
+	tabLeft     = tea.KeyPressMsg{Code: tea.KeyLeft}
+	tabTab      = tea.KeyPressMsg{Code: tea.KeyTab}
+	tabShiftTab = tea.KeyPressMsg{Code: tea.KeyTab, Mod: tea.ModShift}
+)
+
+func TestTabs_StartsOnFirst(t *testing.T) {
+	tm := startTabs(t, components.NewTabs([]string{"A", "B", "C"}, false))
+	assert.Check(t, cmp.Equal(finalTabs(t, tm).Active(), 0))
+}
+
+func TestTabs_RightAndTabAdvance(t *testing.T) {
+	tm := startTabs(t, components.NewTabs([]string{"A", "B", "C"}, false))
+	tm.Send(tabRight)
+	assert.Check(t, cmp.Equal(finalTabs(t, tm).Active(), 1))
+
+	tm = startTabs(t, components.NewTabs([]string{"A", "B", "C"}, false))
+	tm.Send(tabTab)
+	tm.Send(tabTab)
+	assert.Check(t, cmp.Equal(finalTabs(t, tm).Active(), 2))
+}
+
+func TestTabs_LeftAndShiftTabReverse(t *testing.T) {
+	tm := startTabs(t, components.NewTabs([]string{"A", "B", "C"}, false))
+	tm.Send(tabRight)
+	tm.Send(tabLeft)
+	assert.Check(t, cmp.Equal(finalTabs(t, tm).Active(), 0))
+
+	tm = startTabs(t, components.NewTabs([]string{"A", "B", "C"}, false))
+	tm.Send(tabShiftTab)
+	assert.Check(t, cmp.Equal(finalTabs(t, tm).Active(), 2), "shift+tab from the first wraps to the last")
+}
+
+func TestTabs_Wraps(t *testing.T) {
+	tm := startTabs(t, components.NewTabs([]string{"A", "B"}, false))
+	tm.Send(tabRight)
+	tm.Send(tabRight)
+	assert.Check(t, cmp.Equal(finalTabs(t, tm).Active(), 0), "advancing past the last wraps to the first")
+}
+
+func TestTabs_UpdateReportsHandled(t *testing.T) {
+	tabs := components.NewTabs([]string{"A", "B"}, false)
+	_, handled := tabs.Update(tabRight)
+	assert.Check(t, handled, "a tab-switch key is consumed")
+	_, handled = tabs.Update(tea.KeyPressMsg{Code: tea.KeyUp})
+	assert.Check(t, !handled, "a non-switch key is left for the host")
+}
+
+func TestTabs_ViewRendersLabelsAndBody(t *testing.T) {
+	tm := startTabs(t, components.NewTabs([]string{"Alpha", "Beta"}, false))
+	// A wide body so each tab cell is roomy enough to hold its label on one line.
+	body := "a reasonably wide body so the tab cells are not squished"
+	v := ansi.Strip(finalTabs(t, tm).View(body))
+	for _, want := range []string{"Alpha", "Beta", body} {
+		assert.Check(t, cmp.Contains(v, want), "view missing %q", want)
+	}
+}

--- a/internal/ui/run_filter_dialog.go
+++ b/internal/ui/run_filter_dialog.go
@@ -24,6 +24,7 @@ package ui
 
 import (
 	"strings"
+	"time"
 
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
@@ -31,22 +32,6 @@ import (
 
 	"github.com/CircleCI-Public/circleci-cli/internal/ui/components"
 	"github.com/CircleCI-Public/circleci-cli/internal/ui/theme"
-)
-
-// Tab borders, styled after the lipgloss "layout" example: an active tab opens at
-// the bottom (a blank Bottom edge) so it reads as continuous with the window body
-// below it, while an inactive tab is a closed box whose bottom line forms part of
-// the window's top border. The first/last tab's bottom outer corner is patched at
-// render time so the tab row seams into the window's side borders (see renderTabs).
-var (
-	filterActiveTabBorder = lipgloss.Border{
-		Top: "─", Bottom: " ", Left: "│", Right: "│",
-		TopLeft: "╭", TopRight: "╮", BottomLeft: "┘", BottomRight: "└",
-	}
-	filterTabBorder = lipgloss.Border{
-		Top: "─", Bottom: "─", Left: "│", Right: "│",
-		TopLeft: "╭", TopRight: "╮", BottomLeft: "┴", BottomRight: "┴",
-	}
 )
 
 // runFilterOutcome is the state of a runFilterDialog after an Update: still open,
@@ -59,29 +44,54 @@ const (
 	runFilterCancel
 )
 
-// runFilterTab is the active facet in the dialog: the trigger (scope) list or the
-// status-filter list.
+// runFilterTab is the active facet in the dialog: the trigger (scope) list, the
+// status-filter list, or the created-age picker. The values index the tab bar
+// (see components.Tabs), so their order must match filterTabLabels.
 type runFilterTab int
 
 const (
 	filterTabTrigger runFilterTab = iota
 	filterTabStatus
+	filterTabCreated
 )
 
-// dialog keys. left/right (and tab/shift+tab) switch the active Trigger/Status
-// tab; "r" resets the selection to its defaults. Enter applies and esc cancels
-// (via the shared bindings).
-var (
-	filterKeyLeft  = key.NewBinding(key.WithKeys("left", "h"))
-	filterKeyRight = key.NewBinding(key.WithKeys("right", "l"))
-	filterKeyReset = key.NewBinding(key.WithKeys("r", "R"))
-)
+// filterTabLabels are the tab bar's labels, in runFilterTab order.
+var filterTabLabels = []string{"Trigger", "Status", "Created"}
 
-// runFilterDialog is the "/" search overlay on the run picker: a two-tab
-// (Trigger / Status) chooser that lets the user set the trigger scope and status
-// filter explicitly from lists. It embeds two components.SelectModel lists (one
-// per tab) so the picker's navigation, scrolling and rendering are reused; the
-// dialog only adds the tab bar on top. Enter applies, esc cancels, "r" resets.
+// createdDuration is one selectable relative age on the Created tab: its display
+// label and the duration it maps to (measured back from now).
+type createdDuration struct {
+	label    string
+	duration time.Duration
+}
+
+// createdDurations are the fixed relative-age options on the Created tab, coarse
+// buckets rather than a free-form date picker.
+var createdDurations = []createdDuration{
+	{"1 Hour", time.Hour},
+	{"6 Hours", 6 * time.Hour},
+	{"12 Hours", 12 * time.Hour},
+	{"24 Hours", 24 * time.Hour},
+	{"7 Days", 7 * 24 * time.Hour},
+	{"2 Weeks", 14 * 24 * time.Hour},
+	{"1 Month", 30 * 24 * time.Hour},
+}
+
+// createdAllDatesLabel is the Created date picker's first entry: it clears the
+// created filter (no age constraint), analogous to the Status tab's "all
+// statuses".
+const createdAllDatesLabel = "all dates"
+
+// dialog keys. "r" resets the selection to its defaults; Enter applies and esc
+// cancels (via the shared bindings). Tab switching is owned by components.Tabs.
+var filterKeyReset = key.NewBinding(key.WithKeys("r", "R"))
+
+// runFilterDialog is the "/" search overlay on the run picker: a three-tab
+// (Trigger / Status / Created) chooser that lets the user set the trigger scope,
+// status filter and created-age window. It embeds a components.SelectModel list
+// per tab (so the picker's navigation, scrolling and rendering are reused) and a
+// components.Tabs bar for the chrome; the Created tab pairs its date list with an
+// older/newer direction toggled by space. Enter applies, esc cancels, "r" resets.
 // It never quits the program — the host reads Outcome() after each Update and
 // acts on Apply/Cancel.
 type runFilterDialog struct {
@@ -90,8 +100,12 @@ type runFilterDialog struct {
 
 	triggerSel components.SelectModel
 	statusSel  components.SelectModel
+	// dateSel is the Created tab's age picker ("all dates" plus the relative-age
+	// buckets); createdNewer is the older/newer direction the space key toggles.
+	dateSel      components.SelectModel
+	createdNewer bool
 
-	tab runFilterTab
+	tabs components.Tabs
 
 	// defaultScope / defaultStatus are the indexes "r" (reset) restores (the
 	// current branch and "all statuses" — always the first of each cycle).
@@ -104,29 +118,82 @@ type runFilterDialog struct {
 	outcome       runFilterOutcome
 }
 
-// newRunFilterDialog builds the dialog seeded with the currently active scope and
-// status so it opens on what the picker is already showing. scopeIdx/statusIdx are
-// the active selections; the defaults it resets to are the first of each cycle.
-func newRunFilterDialog(scopes []runScope, statuses []RunStatusFilter, scopeIdx, statusIdx int, color bool) runFilterDialog {
+// newRunFilterDialog builds the dialog seeded with the currently active scope,
+// status and created filter so it opens on what the picker is already showing.
+// scopeIdx/statusIdx are the active selections; the defaults it resets to are the
+// first of each cycle. created seeds the Created tab (an inactive zero value
+// leaves the age on "all dates" and the direction on its "older" default).
+func newRunFilterDialog(scopes []runScope, statuses []RunStatusFilter, scopeIdx, statusIdx int, created RunCreatedFilter, color bool) runFilterDialog {
 	d := runFilterDialog{
-		scopes:   scopes,
-		statuses: statuses,
-		tab:      filterTabTrigger,
-		color:    color,
+		scopes:       scopes,
+		statuses:     statuses,
+		tabs:         components.NewTabs(filterTabLabels, color),
+		createdNewer: created.Newer,
+		color:        color,
 	}
 	d.triggerSel = d.newTriggerSelect(scopeIdx)
 	d.statusSel = d.newStatusSelect(statusIdx)
+	d.dateSel = d.newDateSelect(createdDateCursor(created))
 	return d
 }
+
+// createdDateCursor maps a created filter to the date picker's cursor: the "all
+// dates" entry (0) when inactive, otherwise the row of the matching age bucket.
+func createdDateCursor(created RunCreatedFilter) int {
+	if created.Active() {
+		for i, cd := range createdDurations {
+			if cd.duration == created.Duration {
+				return i + 1 // +1 for the leading "all dates" entry
+			}
+		}
+	}
+	return 0
+}
+
+// newDateSelect builds the chrome-free Created date list seeded at idx. Its first
+// entry ("all dates") clears the filter and is italicised (and tinted when color
+// is on) so it reads as the special "no age filter" option, matching the Status
+// tab's "all statuses".
+func (d runFilterDialog) newDateSelect(idx int) components.SelectModel {
+	color := d.color
+	return components.NewSelectModel("", createdDateLabels()).
+		WithCursor(idx).WithKeys().WithHeight(d.listHeight).
+		WithItemStyleFunc(func(i int) lipgloss.Style {
+			if i == 0 { // the "all dates" no-filter entry
+				st := lipgloss.NewStyle().Italic(true)
+				if color {
+					st = st.Foreground(theme.ColorSecondary)
+				}
+				return st
+			}
+			return lipgloss.NewStyle()
+		})
+}
+
+// createdDateLabels lists the date picker's option labels: the "all dates" clear
+// entry followed by each relative-age bucket.
+func createdDateLabels() []string {
+	labels := make([]string, 0, len(createdDurations)+1)
+	labels = append(labels, createdAllDatesLabel)
+	for _, cd := range createdDurations {
+		labels = append(labels, cd.label)
+	}
+	return labels
+}
+
+// activeTab is the currently selected tab, read from the tab bar.
+func (d runFilterDialog) activeTab() runFilterTab { return runFilterTab(d.tabs.Active()) }
 
 // newTriggerSelect builds the chrome-free trigger list (no title, no footer)
 // seeded at idx. Each trigger carries a glyph (see scopeIcons): a heart for
 // "my runs", and distinct marks for the current branch, default branch and
-// "all branches".
+// "all branches". The current/default branch rows carry their branch name as a
+// nested child (see scopeChildren) rather than a "[…]" bracket on the row.
 func (d runFilterDialog) newTriggerSelect(idx int) components.SelectModel {
 	return components.NewSelectModel("", d.scopeLabels()).
 		WithCursor(idx).WithKeys().WithHeight(d.listHeight).
-		WithIcons(d.scopeIcons())
+		WithIcons(d.scopeIcons()).
+		WithChildren(d.scopeChildren())
 }
 
 // scopeIcons renders each trigger's glyph for the list, colored per its role
@@ -190,34 +257,33 @@ func (d runFilterDialog) statusIcons() []string {
 	return icons
 }
 
-// scopeLabels renders the Trigger tab's row labels. When color is on, each
-// label's trailing "[…]" (the branch name on the current/default branch scopes)
-// is tinted with the secondary gold accent, matching the run picker title's
-// scope bracket.
+// scopeLabels renders the Trigger tab's row labels — the scope roles ("current
+// branch", "all branches", …). The branch name is carried separately as a nested
+// child (see scopeChildren), not on the row.
 func (d runFilterDialog) scopeLabels() []string {
 	labels := make([]string, len(d.scopes))
 	for i, s := range d.scopes {
-		label := s.pickerLabel
-		if d.color {
-			label = colorizeLabelBracket(label)
-		}
-		labels[i] = label
+		labels[i] = s.pickerLabel
 	}
 	return labels
 }
 
-// colorizeLabelBracket tints a trailing "[…]" segment of a label with the
-// secondary (gold) accent. A label with no trailing bracket (e.g. "all branches",
-// "my runs") is returned unchanged.
-func colorizeLabelBracket(label string) string {
-	if !strings.HasSuffix(label, "]") {
-		return label
+// scopeChildren renders each trigger's nested branch-name sub-entry as "[branch]"
+// (empty for scopes without one). When color is on the bracket is tinted with the
+// secondary gold accent, matching the run picker title's scope bracket.
+func (d runFilterDialog) scopeChildren() []string {
+	children := make([]string, len(d.scopes))
+	for i, s := range d.scopes {
+		if s.pickerChild == "" {
+			continue
+		}
+		child := "[" + s.pickerChild + "]"
+		if d.color {
+			child = theme.SecondaryStyle.Render(child)
+		}
+		children[i] = child
 	}
-	open := strings.LastIndexByte(label, '[')
-	if open < 0 {
-		return label
-	}
-	return label[:open] + theme.SecondaryStyle.Render(label[open:])
+	return children
 }
 
 func statusLabels(statuses []RunStatusFilter) []string {
@@ -246,6 +312,7 @@ func (d runFilterDialog) SetSize(width, height int) runFilterDialog {
 	d.listHeight = listHeight
 	d.triggerSel = d.triggerSel.WithHeight(listHeight)
 	d.statusSel = d.statusSel.WithHeight(listHeight)
+	d.dateSel = d.dateSel.WithHeight(listHeight)
 	return d
 }
 
@@ -259,13 +326,27 @@ func (d runFilterDialog) Selected() (scopeIdx, statusIdx int) {
 	return d.triggerSel.Selected(), d.statusSel.Selected()
 }
 
+// Created returns the chosen created-age filter, or an inactive zero value when
+// the date picker is on "all dates". Valid once Outcome() is runFilterApply.
+func (d runFilterDialog) Created() RunCreatedFilter {
+	idx := d.dateSel.Selected()
+	if idx <= 0 || idx > len(createdDurations) {
+		return RunCreatedFilter{} // "all dates" (0) or out of range → no filter
+	}
+	cd := createdDurations[idx-1] // -1 for the leading "all dates" entry
+	return RunCreatedFilter{
+		Newer:    d.createdNewer,
+		Duration: cd.duration,
+		Label:    cd.label,
+	}
+}
+
 func (d runFilterDialog) Init() tea.Cmd { return nil }
 
-// Update handles the dialog's keys. It never emits a command; navigation (up/
-// down/paging) is forwarded to the active tab's embedded list. ctrl+c is left to
-// the host (it quits the whole program), so the dialog binds esc (cancel), enter
-// (apply), "r" (reset), and left/right + tab/shift+tab (switch the Trigger/Status
-// tab).
+// Update handles the dialog's keys. It never emits a command; tab switching is
+// delegated to the tab bar, and everything else (up/down/paging, and space on the
+// Created tab) drives the active tab. ctrl+c is left to the host (it quits the
+// whole program), so the dialog binds esc (cancel), enter (apply) and "r" (reset).
 func (d runFilterDialog) Update(msg tea.Msg) (runFilterDialog, tea.Cmd) {
 	if ws, ok := msg.(tea.WindowSizeMsg); ok {
 		d = d.SetSize(ws.Width, ws.Height)
@@ -285,55 +366,68 @@ func (d runFilterDialog) Update(msg tea.Msg) (runFilterDialog, tea.Cmd) {
 	case key.Matches(k, filterKeyReset):
 		d.reset()
 		return d, nil
-	case key.Matches(k, filterKeyLeft):
-		d.tab = filterTabTrigger
-		return d, nil
-	case key.Matches(k, filterKeyRight):
-		d.tab = filterTabStatus
-		return d, nil
-	case key.Matches(k, components.KeyTab, components.KeyShiftTab):
-		if d.tab == filterTabTrigger {
-			d.tab = filterTabStatus
-		} else {
-			d.tab = filterTabTrigger
-		}
+	}
+
+	// Tab switching (←/→, tab/shift+tab) is owned by the tab bar; a consumed key
+	// switches tabs, anything else drives the active tab's list.
+	if tabs, handled := d.tabs.Update(msg); handled {
+		d.tabs = tabs
 		return d, nil
 	}
 
-	// Any other key (up/down, paging, g/G) drives the active tab's list.
 	d.forwardToList(msg)
 	return d, nil
 }
 
 // reset restores the trigger and status selections to their defaults (the current
-// branch, all statuses) and returns to the Trigger tab.
+// branch, all statuses), returns the Created tab to "all dates" / older, and
+// returns to the Trigger tab.
 func (d *runFilterDialog) reset() {
 	d.triggerSel = d.newTriggerSelect(d.defaultScope)
 	d.statusSel = d.newStatusSelect(d.defaultStatus)
-	d.tab = filterTabTrigger
+	d.dateSel = d.newDateSelect(0) // "all dates" — no created filter
+	d.createdNewer = false         // older — the default direction
+	d.tabs = d.tabs.SetActive(int(filterTabTrigger))
 }
 
-// forwardToList sends a message to whichever tab's list is active, keeping the
-// embedded SelectModel's navigation and scrolling behaviour.
+// forwardToList sends a message to whichever tab is active, keeping the embedded
+// SelectModel's navigation behaviour. On the Created tab, space toggles the
+// older/newer direction; every other key drives the date list.
 func (d *runFilterDialog) forwardToList(msg tea.Msg) {
-	if d.tab == filterTabTrigger {
+	switch d.activeTab() {
+	case filterTabTrigger:
 		updated, _ := d.triggerSel.Update(msg)
 		d.triggerSel = updated.(components.SelectModel)
-	} else {
+	case filterTabStatus:
 		updated, _ := d.statusSel.Update(msg)
 		d.statusSel = updated.(components.SelectModel)
+	case filterTabCreated:
+		if k, ok := msg.(tea.KeyPressMsg); ok && key.Matches(k, components.KeySpace) {
+			d.createdNewer = !d.createdNewer
+			return
+		}
+		updated, _ := d.dateSel.Update(msg)
+		d.dateSel = updated.(components.SelectModel)
 	}
 }
 
 func (d runFilterDialog) View() tea.View {
 	dialog := d.renderDialog()
-	footer := components.Hints(
+	hints := []key.Binding{
 		key.NewBinding(key.WithKeys("left", "right"), key.WithHelp("←/→", "tab")),
 		components.BindMove,
+	}
+	// Space toggles older/newer, which only means something on the Created tab; on
+	// the list tabs it does nothing, so advertise it only there.
+	if d.activeTab() == filterTabCreated {
+		hints = append(hints, key.NewBinding(key.WithKeys(" "), key.WithHelp("space", "older/newer")))
+	}
+	hints = append(hints,
 		key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "apply")),
 		key.NewBinding(key.WithKeys("r"), key.WithHelp("r", "reset")),
 		key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "cancel")),
 	)
+	footer := components.Hints(hints...)
 
 	// Centre the dialog in the screen above the footer, and pin the help text to
 	// the very bottom row. The dialog fills the screen, so it renders on the
@@ -354,32 +448,11 @@ func (d runFilterDialog) View() tea.View {
 // filterHelpWidth is the column width of the right-hand help panel in each tab.
 const filterHelpWidth = 34
 
-// renderDialog assembles the tabbed window: a row of tabs whose bottom edge forms
-// the window's top border, over a rounded-bordered body holding the tab body
-// (options on the left, a help description on the right). The window is sized to
-// the content, and the tab row is split to the same width so the two seam
-// together.
+// renderDialog assembles the tabbed window: the tab bar (components.Tabs) draws
+// the tab row and the rounded-bordered window frame around the tab body (options
+// on the left, a help description on the right).
 func (d runFilterDialog) renderDialog() string {
-	body := d.tabBody()
-	contentWidth := max(lipgloss.Width(body), 44)
-	// rowWidth is the dialog's outer width. lipgloss .Width() here sets the outer
-	// box width (border + padding included), so the window is contentWidth +
-	// border(2) + padding(2); the tab row is set to the same width so they line up.
-	rowWidth := contentWidth + 4
-	if rowWidth%2 != 0 {
-		rowWidth++ // even split across the two tabs
-	}
-
-	window := lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
-		BorderTop(false). // the tab row supplies the top edge
-		Padding(0, 1).
-		Width(rowWidth)
-	if d.color {
-		window = window.BorderForeground(theme.ColorSecondary)
-	}
-
-	return lipgloss.JoinVertical(lipgloss.Left, d.renderTabs(rowWidth), window.Render(body))
+	return d.tabs.View(d.tabBody())
 }
 
 // tabBody lays out the active tab as two columns: the options list on the left, a
@@ -390,9 +463,12 @@ func (d runFilterDialog) renderDialog() string {
 // taller help text rather than hugging the top.
 func (d runFilterDialog) tabBody() string {
 	h := d.panelHeight()
+	// Centre the tab's content block horizontally within the column (as one unit,
+	// so a list's rows keep their shared left edge) and vertically beside the help.
+	content := centerHorizontally(strings.TrimRight(d.activeList(), "\n"), d.listColumnWidth())
 	left := lipgloss.NewStyle().Width(d.listColumnWidth()).Height(h).
 		AlignVertical(lipgloss.Center).
-		Render(strings.TrimRight(d.activeList(), "\n"))
+		Render(content)
 
 	// The divider is muted so it recedes; the description is left in the terminal's
 	// default foreground so it reads stronger than the muted divider and footer
@@ -412,41 +488,108 @@ func (d runFilterDialog) tabBody() string {
 	)
 }
 
-// panelHeight is the fixed row count of the tab body: the taller of the option
-// lists and the two help descriptions (wrapped to filterHelpWidth), so both tabs
-// render at the same height regardless of which has more options or longer help.
+// centerHorizontally shifts a (possibly multi-line) block right so it is centred
+// within width, preserving the block's internal left alignment — rather than
+// centring each line independently, which would leave a list's rows ragged. A
+// block already at least as wide as width is returned unchanged.
+func centerHorizontally(content string, width int) string {
+	pad := (width - lipgloss.Width(content)) / 2
+	if pad <= 0 {
+		return content
+	}
+	return lipgloss.NewStyle().PaddingLeft(pad).Render(content)
+}
+
+// panelHeight is the fixed row count of the tab body: the tallest of the option
+// lists (including the Created tab's stacked radios) and the tab help
+// descriptions (wrapped to filterHelpWidth), so every tab renders at the same
+// height regardless of which has more content.
 func (d runFilterDialog) panelHeight() int {
 	h := max(len(d.scopes), len(d.statuses))
-	for _, help := range []string{triggerHelpText, statusHelpText} {
+	h = max(h, lipgloss.Height(d.createdBody()))
+	for _, help := range []string{triggerHelpText, statusHelpText, createdHelpText} {
 		wrapped := lipgloss.NewStyle().Width(filterHelpWidth).Render(help)
 		h = max(h, lipgloss.Height(wrapped))
 	}
 	return h
 }
 
-// listColumnWidth is the width of the options column, the wider of the two lists
-// so the column (and thus the dialog) stays the same width on either tab.
+// listColumnWidth is the width of the options column, the widest of the tabs'
+// bodies so the column (and thus the dialog) stays the same width on every tab.
 func (d runFilterDialog) listColumnWidth() int {
 	return max(
 		lipgloss.Width(strings.TrimRight(d.triggerSel.View().Content, "\n")),
 		lipgloss.Width(strings.TrimRight(d.statusSel.View().Content, "\n")),
+		lipgloss.Width(d.createdBody()),
 	)
 }
 
 // activeList renders the embedded list for the active tab.
 func (d runFilterDialog) activeList() string {
-	if d.tab == filterTabTrigger {
-		return d.triggerSel.View().Content
+	switch d.activeTab() {
+	case filterTabStatus:
+		return d.statusSel.View().Content
+	case filterTabCreated:
+		return d.createdBody()
+	case filterTabTrigger:
 	}
-	return d.statusSel.View().Content
+	return d.triggerSel.View().Content
+}
+
+// createdBody renders the Created tab: the date list with the older/newer
+// direction toggle stacked vertically to its right. The direction options carry a
+// filled/hollow marker on the active one (space flips it); the whole toggle is
+// muted while the filter is inactive ("all dates" selected), since direction is
+// meaningless with no age.
+func (d runFilterDialog) createdBody() string {
+	dates := strings.TrimRight(d.dateSel.View().Content, "\n")
+	return lipgloss.JoinHorizontal(lipgloss.Top,
+		dates,
+		lipgloss.NewStyle().PaddingLeft(6).Render(d.createdDirectionColumn()),
+	)
+}
+
+// createdDirectionColumn renders the "older / newer" toggle as two stacked rows,
+// each "● word" (active) or "○ word", accenting the active one — or muting the
+// whole toggle when the created filter is inactive.
+func (d runFilterDialog) createdDirectionColumn() string {
+	inactive := !d.Created().Active()
+	return d.directionWord("older", !d.createdNewer, inactive) + "\n" +
+		d.directionWord("newer", d.createdNewer, inactive)
+}
+
+// directionWord renders one direction option as "● word" (active) or "○ word",
+// accenting the active word when color is on, or muting it when the created
+// filter is inactive.
+func (d runFilterDialog) directionWord(word string, active, inactive bool) string {
+	glyph := "○"
+	if active {
+		glyph = "●"
+	}
+	text := glyph + " " + word
+	if !d.color {
+		return text
+	}
+	switch {
+	case inactive:
+		return theme.HelperStyle.Render(text)
+	case active:
+		return theme.AccentStyle.Bold(true).Render(text)
+	default:
+		return theme.HelperStyle.Render(text)
+	}
 }
 
 // tabHelp is the description shown on the right of the active tab.
 func (d runFilterDialog) tabHelp() string {
-	if d.tab == filterTabTrigger {
-		return triggerHelpText
+	switch d.activeTab() {
+	case filterTabStatus:
+		return statusHelpText
+	case filterTabCreated:
+		return createdHelpText
+	case filterTabTrigger:
 	}
-	return statusHelpText
+	return triggerHelpText
 }
 
 const (
@@ -456,69 +599,15 @@ const (
 	statusHelpText = "Filter runs by status.\n\n" +
 		"\"all statuses\" clears the filter. Pick a status to show only the runs in " +
 		"that state."
+	createdHelpText = "Filter runs by age.\n\n" +
+		"Pick how far back to look; \"all dates\" clears the filter. Press space to " +
+		"toggle between older and newer than the chosen age."
 )
 
-// renderTabs draws the two-tab row at rowWidth, split evenly. The active tab uses
-// the open-bottom border so it reads as continuous with the window and its label
-// is pink; the outer bottom corners of the first and last tab are patched so the
-// row seams into the window's side borders below.
-func (d runFilterDialog) renderTabs(rowWidth int) string {
-	widths := splitWidth(rowWidth, 2)
-	labels := [2]string{"Trigger", "Status"}
-	active := [2]bool{d.tab == filterTabTrigger, d.tab == filterTabStatus}
-
-	cells := make([]string, 2)
-	for i := 0; i < 2; i++ {
-		border := filterTabBorder
-		if active[i] {
-			border = filterActiveTabBorder
-		}
-		switch i {
-		case 0: // first tab: bottom-left seams into the window's left border
-			if active[i] {
-				border.BottomLeft = "│"
-			} else {
-				border.BottomLeft = "├"
-			}
-		case 1: // last tab: bottom-right seams into the window's right border
-			if active[i] {
-				border.BottomRight = "│"
-			} else {
-				border.BottomRight = "┤"
-			}
-		}
-
-		st := lipgloss.NewStyle().Border(border, true).Padding(0, 1).
-			Align(lipgloss.Center).Width(widths[i])
-		switch {
-		case d.color && active[i]:
-			st = st.BorderForeground(theme.ColorSecondary).Foreground(theme.ColorAccent).Bold(true)
-		case d.color:
-			st = st.BorderForeground(theme.ColorSecondary).Foreground(theme.ColorMuted)
-		case active[i]:
-			st = st.Bold(true)
-		}
-		cells[i] = st.Render(labels[i])
-	}
-	return lipgloss.JoinHorizontal(lipgloss.Bottom, cells[0], cells[1])
-}
-
-// bodyRows is the number of option rows the lists hold: the longer of the two, so
-// both tabs reserve the same number of list rows.
+// bodyRows is the number of option rows the tabs' lists hold: the most of any
+// tab (the Created date list has the most, with its "all dates" entry plus the age
+// buckets), so every tab reserves the same number of list rows and switching tabs
+// never resizes the dialog.
 func (d runFilterDialog) bodyRows() int {
-	return max(len(d.scopes), len(d.statuses))
-}
-
-// splitWidth divides total into n parts as evenly as possible, handing the
-// remainder to the leading parts, so the parts sum back to total.
-func splitWidth(total, n int) []int {
-	base := total / n
-	out := make([]int, n)
-	for i := range out {
-		out[i] = base
-	}
-	for i := 0; i < total-base*n; i++ {
-		out[i]++
-	}
-	return out
+	return max(len(d.scopes), len(d.statuses), len(createdDurations)+1)
 }

--- a/internal/ui/run_filter_dialog_test.go
+++ b/internal/ui/run_filter_dialog_test.go
@@ -24,6 +24,7 @@ package ui
 
 import (
 	"testing"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/charmbracelet/x/ansi"
@@ -32,13 +33,16 @@ import (
 )
 
 var (
-	dlgLeft  = tea.KeyPressMsg{Code: tea.KeyLeft}
-	dlgRight = tea.KeyPressMsg{Code: tea.KeyRight}
-	dlgDown  = tea.KeyPressMsg{Code: tea.KeyDown}
-	dlgTab   = tea.KeyPressMsg{Code: tea.KeyTab}
-	dlgEnter = tea.KeyPressMsg{Code: tea.KeyEnter}
-	dlgEsc   = tea.KeyPressMsg{Code: tea.KeyEscape}
-	dlgReset = tea.KeyPressMsg{Code: 'r', Text: "r"}
+	dlgLeft     = tea.KeyPressMsg{Code: tea.KeyLeft}
+	dlgRight    = tea.KeyPressMsg{Code: tea.KeyRight}
+	dlgDown     = tea.KeyPressMsg{Code: tea.KeyDown}
+	dlgUp       = tea.KeyPressMsg{Code: tea.KeyUp}
+	dlgTab      = tea.KeyPressMsg{Code: tea.KeyTab}
+	dlgShiftTab = tea.KeyPressMsg{Code: tea.KeyTab, Mod: tea.ModShift}
+	dlgSpace    = tea.KeyPressMsg{Code: ' ', Text: " "}
+	dlgEnter    = tea.KeyPressMsg{Code: tea.KeyEnter}
+	dlgEsc      = tea.KeyPressMsg{Code: tea.KeyEscape}
+	dlgReset    = tea.KeyPressMsg{Code: 'r', Text: "r"}
 )
 
 // newTestDialog builds a dialog with the trigger scopes (current branch, all
@@ -50,7 +54,7 @@ func newTestDialog() runFilterDialog {
 		{Label: "all statuses", Icon: "★"},
 		{Value: "failed", Label: "failed", Icon: "✗"},
 	}
-	return newRunFilterDialog(scopes, statuses, 0, 0, false).SetSize(80, 24)
+	return newRunFilterDialog(scopes, statuses, 0, 0, RunCreatedFilter{}, false).SetSize(80, 24)
 }
 
 // drive feeds a sequence of messages through the dialog and returns the result.
@@ -84,16 +88,95 @@ func TestRunFilterDialog_ListNavigationSetsSelection(t *testing.T) {
 }
 
 func TestRunFilterDialog_TabSwitching(t *testing.T) {
-	// left selects the Trigger tab, right the Status tab, regardless of the current
-	// tab; tab toggles between them.
+	// right cycles Trigger → Status → Created → Trigger; left reverses.
 	d := drive(newTestDialog(), dlgRight)
-	assert.Check(t, cmp.Equal(d.tab, filterTabStatus))
+	assert.Check(t, cmp.Equal(d.activeTab(), filterTabStatus))
+	d = drive(d, dlgRight)
+	assert.Check(t, cmp.Equal(d.activeTab(), filterTabCreated))
+	d = drive(d, dlgRight)
+	assert.Check(t, cmp.Equal(d.activeTab(), filterTabTrigger))
 	d = drive(d, dlgLeft)
-	assert.Check(t, cmp.Equal(d.tab, filterTabTrigger))
-	d = drive(d, dlgTab)
-	assert.Check(t, cmp.Equal(d.tab, filterTabStatus))
-	d = drive(d, dlgTab)
-	assert.Check(t, cmp.Equal(d.tab, filterTabTrigger))
+	assert.Check(t, cmp.Equal(d.activeTab(), filterTabCreated))
+
+	// tab advances, shift+tab reverses.
+	d = drive(newTestDialog(), dlgTab)
+	assert.Check(t, cmp.Equal(d.activeTab(), filterTabStatus))
+	d = drive(d, dlgShiftTab)
+	assert.Check(t, cmp.Equal(d.activeTab(), filterTabTrigger))
+}
+
+// gotoCreated switches a freshly-opened dialog to the Created tab.
+func gotoCreated(d runFilterDialog) runFilterDialog {
+	return drive(d, dlgRight, dlgRight)
+}
+
+func TestRunFilterDialog_CreatedInactiveByDefault(t *testing.T) {
+	// The date picker opens on "all dates", so the created filter is inactive and
+	// adds no constraint.
+	assert.Check(t, !newTestDialog().Created().Active())
+}
+
+func TestRunFilterDialog_CreatedSelectsAgeOlderByDefault(t *testing.T) {
+	// On the Created tab the date list opens on "all dates"; moving down to an age
+	// (the cursor is the selection) activates the filter, older by default.
+	d := gotoCreated(newTestDialog())
+	d = drive(d, dlgDown) // all dates → 1 Hour
+	created := d.Created()
+	assert.Check(t, created.Active())
+	assert.Check(t, cmp.Equal(created.Duration, time.Hour))
+	assert.Check(t, cmp.Equal(created.Label, "1 Hour"))
+	assert.Check(t, !created.Newer, "direction should default to older")
+}
+
+func TestRunFilterDialog_CreatedSpaceTogglesDirection(t *testing.T) {
+	// Space toggles older ↔ newer for the selected age.
+	d := gotoCreated(newTestDialog())
+	d = drive(d, dlgDown) // select "1 Hour" (older by default)
+	assert.Assert(t, !d.Created().Newer)
+	d = drive(d, dlgSpace)
+	assert.Check(t, d.Created().Newer, "space should switch to newer")
+	d = drive(d, dlgSpace)
+	assert.Check(t, !d.Created().Newer, "space again should switch back to older")
+}
+
+func TestRunFilterDialog_CreatedAllDatesClearsFilter(t *testing.T) {
+	// Moving back to the "all dates" entry clears the created filter.
+	d := gotoCreated(newTestDialog())
+	d = drive(d, dlgDown, dlgDown) // 6 Hours
+	assert.Assert(t, d.Created().Active())
+	d = drive(d, dlgUp, dlgUp) // back to "all dates"
+	assert.Check(t, !d.Created().Active())
+}
+
+func TestRunFilterDialog_ResetClearsCreated(t *testing.T) {
+	// r resets every tab: the date list back to "all dates" and direction to older.
+	d := gotoCreated(newTestDialog())
+	d = drive(d, dlgDown, dlgSpace) // 1 Hour, newer
+	assert.Assert(t, d.Created().Active())
+	assert.Assert(t, d.Created().Newer)
+	d = drive(d, dlgReset)
+	assert.Check(t, !d.Created().Active())
+	assert.Check(t, !d.createdNewer, "reset returns direction to older")
+	assert.Check(t, cmp.Equal(d.activeTab(), filterTabTrigger), "reset returns to the Trigger tab")
+}
+
+func TestRunFilterDialog_CreatedViewShowsPickerAndDirection(t *testing.T) {
+	// The Created tab shows the direction toggle, the date options (including the
+	// "all dates" clear entry) and its help.
+	v := ansi.Strip(gotoCreated(newTestDialog()).View().Content)
+	for _, want := range []string{"older", "newer", "all dates", "1 Hour", "24 Hours", "1 Month", "Filter runs by age"} {
+		assert.Check(t, cmp.Contains(v, want), "created view missing %q", want)
+	}
+}
+
+func TestRunFilterDialog_CreatedSeededFromActiveFilter(t *testing.T) {
+	// Opening with an active created filter selects its age and direction so the
+	// dialog reflects what the picker is already showing.
+	scopes := buildRunScopes("main", "", true, false)
+	statuses := []RunStatusFilter{{Label: "all statuses", Icon: "★"}}
+	created := RunCreatedFilter{Newer: true, Duration: 24 * time.Hour, Label: "24 Hours"}
+	d := newRunFilterDialog(scopes, statuses, 0, 0, created, false).SetSize(80, 24)
+	assert.Check(t, cmp.Equal(d.Created(), created))
 }
 
 func TestRunFilterDialog_EnterApplies(t *testing.T) {
@@ -120,15 +203,15 @@ func TestRunFilterDialog_ResetRestoresDefaults(t *testing.T) {
 	assert.Check(t, cmp.Equal(d.Outcome(), runFilterOpen), "reset should not close the dialog")
 	assert.Check(t, cmp.Equal(scope, 0))
 	assert.Check(t, cmp.Equal(status, 0))
-	assert.Check(t, cmp.Equal(d.tab, filterTabTrigger), "reset returns to the Trigger tab")
+	assert.Check(t, cmp.Equal(d.activeTab(), filterTabTrigger), "reset returns to the Trigger tab")
 }
 
 func TestRunFilterDialog_ViewShowsTabsAndOptions(t *testing.T) {
 	// The Trigger tab is active on open: both tabs, its trigger options (the
-	// current branch spelled out with its name, and a heart glyph on "my runs")
-	// and its help description show.
+	// current branch role with its branch name nested beneath as "[main]", and a
+	// heart glyph on "my runs") and its help description show.
 	v := ansi.Strip(newTestDialog().View().Content)
-	for _, want := range []string{"Trigger", "Status", "current branch [main]", "all branches", "♥ my runs", "Filter runs by trigger"} {
+	for _, want := range []string{"Trigger", "Status", "current branch", "[main]", "all branches", "♥ my runs", "Filter runs by trigger"} {
 		assert.Check(t, cmp.Contains(v, want), "trigger view missing %q", want)
 	}
 

--- a/internal/ui/run_get_flow.go
+++ b/internal/ui/run_get_flow.go
@@ -97,18 +97,21 @@ This has some additional keys:
 | ` + "`" + switchScopeKeyLabel + "`" + ` | Switch trigger — cycle branches and my runs |
 | ` + "`s`" + ` | Cycle the status filter |
 | ` + "`S`" + ` | Clear the status filter (back to all statuses) |
-| ` + "`/`" + ` | Open the filter dialog — pick a trigger and status from lists |
+| ` + "`/`" + ` | Open the filter dialog — pick a trigger, status and created age |
 
 ### The filter dialog
 
-Opened with ` + "`/`" + ` on the run picker:
+Opened with ` + "`/`" + ` on the run picker. It has three tabs: Trigger, Status
+and Created (filter runs by how long ago they were created — pick an age, or
+"all dates" to clear it).
 
 | Key | Action |
 | --- | --- |
-| ` + "`←` / `→`" + ` (or ` + "`tab`" + `) | Switch the Trigger / Status tab |
-| ` + "`↑` / `↓`" + ` | Move within the active list |
+| ` + "`←` / `→`" + ` (or ` + "`tab`" + `) | Switch between the Trigger / Status / Created tabs |
+| ` + "`↑` / `↓`" + ` | Move within the active tab |
+| ` + "`space`" + ` | On the Created tab, toggle between older and newer than the chosen age |
 | ` + "`enter`" + ` | Apply the selection |
-| ` + "`r`" + ` | Reset to the defaults (current branch, all statuses) |
+| ` + "`r`" + ` | Reset the filters (current branch, all statuses, all dates) |
 | ` + "`esc`" + ` | Cancel and return to the run picker |
 
 ## Pager
@@ -257,16 +260,18 @@ type RunGetFlowOptions struct {
 	// picker offers a shift+tab toggle between them, re-fetching via FetchRuns.
 	// When DefaultBranch is empty or equal to CurrentBranch, the toggle is hidden.
 	// The status argument to FetchRuns is the active status filter (the "s" key),
-	// a pipeline.status value ("" = every status).
+	// a pipeline.status value ("" = every status). The created argument is the
+	// active "Created" filter from the filter dialog (an inactive zero value when
+	// none is set).
 	CurrentBranch string
 	DefaultBranch string
-	FetchRuns     func(ctx context.Context, branch, status string) ([]RunGetItem, error)
+	FetchRuns     func(ctx context.Context, branch, status string, created RunCreatedFilter) ([]RunGetItem, error)
 	// FetchMyRuns lists the authenticated user's recent runs across all projects
 	// (the counterpart to "circleci my runs"). When set, the run picker's
 	// shift+tab cycle gains a "my runs" scope that fetches via this callback
-	// rather than by branch; when nil the scope is omitted. status is the active
-	// status filter, as for FetchRuns.
-	FetchMyRuns func(ctx context.Context, status string) ([]RunGetItem, error)
+	// rather than by branch; when nil the scope is omitted. status and created are
+	// the active status and created filters, as for FetchRuns.
+	FetchMyRuns func(ctx context.Context, status string, created RunCreatedFilter) ([]RunGetItem, error)
 	// MyRunsOnly restricts the run picker to the cross-project "my runs" scope,
 	// used when no project could be resolved (e.g. run outside a git repository).
 	// The branch scopes and the shift+tab branch toggle are then omitted; the
@@ -295,11 +300,13 @@ type runScope struct {
 	myRuns bool   // list the authenticated user's runs across all projects
 	label  string // title/loading wording, e.g. "main branch", "all branches"
 	icon   string // glyph shown beside the scope in the filter dialog's Trigger tab
-	// pickerLabel is the row text in the filter dialog's Trigger tab. Unlike the
-	// compact title bracket (titleName), it spells out the scope's role — e.g.
-	// "current branch [main]" or "default branch [develop]" — so the two branch
-	// scopes are distinguishable at a glance.
+	// pickerLabel is the row text in the filter dialog's Trigger tab: the scope's
+	// role, e.g. "current branch", "default branch", "all branches" or "my runs".
 	pickerLabel string
+	// pickerChild is the branch name shown as a nested, non-selectable sub-entry
+	// beneath the row (empty for "all branches", "my runs" and a detached HEAD), so
+	// the branch is named without widening the row with a "[…]" bracket.
+	pickerChild string
 }
 
 // titleName is the bracket-inner text for the picker title: the bare branch
@@ -340,20 +347,17 @@ func buildRunScopes(current, defaultBranch string, includeMyRuns, myRunsOnly boo
 	if myRunsOnly {
 		return []runScope{{myRuns: true, label: "my runs", pickerLabel: "my runs", icon: scopeIconMyRuns}}
 	}
-	// The current branch's picker label spells out its role and names the branch,
-	// e.g. "current branch [main]"; it falls back to the bare phrase for a
-	// detached HEAD (no branch name to show).
-	currentPicker := "current branch"
-	if current != "" {
-		currentPicker = "current branch [" + current + "]"
-	}
+	// The current/default branch rows spell out their role ("current branch") and
+	// name the branch as a nested child, rather than a "[…]" bracket that widens the
+	// row. The child is empty for a detached HEAD (no branch name to show).
 	scopes := []runScope{{
-		branch: current, label: current + " branch", pickerLabel: currentPicker, icon: scopeIconCurrentBranch,
+		branch: current, label: current + " branch",
+		pickerLabel: "current branch", pickerChild: current, icon: scopeIconCurrentBranch,
 	}}
 	if defaultBranch != "" && defaultBranch != current {
 		scopes = append(scopes, runScope{
 			branch: defaultBranch, label: defaultBranch + " branch",
-			pickerLabel: "default branch [" + defaultBranch + "]", icon: scopeIconDefaultBranch,
+			pickerLabel: "default branch", pickerChild: defaultBranch, icon: scopeIconDefaultBranch,
 		})
 	}
 	scopes = append(scopes, runScope{label: "all branches", pickerLabel: "all branches", icon: scopeIconAllBranches})
@@ -406,6 +410,24 @@ type RunStatusFilter struct {
 	Label string // title/footer wording, e.g. "failed", "needs approval"
 	Icon  string // status glyph shown in the filter dialog's status list
 }
+
+// RunCreatedFilter narrows runs by creation time relative to now, as chosen on
+// the filter dialog's "Created" tab. Duration is the relative window (e.g. 24h);
+// a zero Duration means no created filter is active. Newer keeps runs created
+// within the window (newer than now-Duration); when false — the default — it
+// keeps runs older than now-Duration. Label is the human wording of the window
+// (e.g. "24 Hours") for the picker title.
+type RunCreatedFilter struct {
+	Newer    bool
+	Duration time.Duration
+	Label    string
+}
+
+// Active reports whether a created filter is set (a duration was chosen). The
+// caller resolves the actual [from, to] window it requests (an "older than" query
+// needs an explicit lower bound so the API does not apply its short default; see
+// RUN_DATE_RANGES.md and createdWindow in internal/cmd/run).
+func (f RunCreatedFilter) Active() bool { return f.Duration > 0 }
 
 // buildStatusCycle prepends the "all statuses" (no-filter) entry to the caller's
 // selectable statuses, so pressing "s" cycles no-filter → each status → back.
@@ -511,6 +533,10 @@ type RunGetFlowModel struct {
 	activeScopeIdx int
 	statusFilters  []RunStatusFilter
 	statusIdx      int
+	// createdFilter is the active "Created" filter (the filter dialog's Created
+	// tab): a relative-age window applied on top of the scope and status. Its zero
+	// value is inactive (no created filter).
+	createdFilter RunCreatedFilter
 
 	// Fetched data for the current selections, parallel to the pickers (the
 	// workflow/job/step pickers are offset by their leading summary options).
@@ -586,6 +612,7 @@ type (
 		items     []RunGetItem
 		scopeIdx  int
 		statusIdx int
+		created   RunCreatedFilter
 		err       error
 	}
 	runGetWorkflowsMsg struct {
@@ -757,7 +784,7 @@ func (m RunGetFlowModel) updateRunSelect(msg tea.Msg) (tea.Model, tea.Cmd) {
 				next := (m.activeScopeIdx + 1) % len(m.scopes)
 				m.stage = runGetStageLoadingRuns
 				m.loadingLabel = "Fetching runs for " + m.scopes[next].label
-				return m, m.loadingCmd(m.cmdFetchRuns(next, m.statusIdx))
+				return m, m.loadingCmd(m.cmdFetchRuns(next, m.statusIdx, m.createdFilter))
 			}
 			return m, nil
 		case key.Matches(k, components.BindStatus):
@@ -775,7 +802,7 @@ func (m RunGetFlowModel) updateRunSelect(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case key.Matches(k, components.BindRefresh):
 			m.stage = runGetStageLoadingRuns
 			m.loadingLabel = "Refreshing runs"
-			return m, m.loadingCmd(m.cmdFetchRuns(m.activeScopeIdx, m.statusIdx))
+			return m, m.loadingCmd(m.cmdFetchRuns(m.activeScopeIdx, m.statusIdx, m.createdFilter))
 		case key.Matches(k, components.BindSearch):
 			if m.filterEnabled() {
 				return m.openRunFilter()
@@ -820,6 +847,7 @@ func (m RunGetFlowModel) onRuns(msg runGetRunsMsg) (tea.Model, tea.Cmd) {
 	m.runs = msg.items
 	m.activeScopeIdx = msg.scopeIdx
 	m.statusIdx = msg.statusIdx
+	m.createdFilter = msg.created
 	m.runCursor = 0
 	m.runSelect = m.newRunSelect()
 	m.stage = runGetStageRunSelect
@@ -848,21 +876,21 @@ func (m RunGetFlowModel) fetchStatus(idx int) (tea.Model, tea.Cmd) {
 	} else {
 		m.loadingLabel = "Fetching runs"
 	}
-	return m, m.loadingCmd(m.cmdFetchRuns(m.activeScopeIdx, idx))
+	return m, m.loadingCmd(m.cmdFetchRuns(m.activeScopeIdx, idx, m.createdFilter))
 }
 
-// filterEnabled reports whether the "/" search dialog is worth offering: true
-// when there is more than one branch scope to choose from or at least one
-// selectable status filter. With neither there is nothing to pick, so "/" is
-// inert and its footer hint is suppressed.
+// filterEnabled reports whether the "/" search dialog is worth offering. The
+// dialog always carries the "Created" tab (a relative-age filter that applies to
+// any scope), so it is always worth opening — even a single-branch project with
+// no selectable statuses can still filter by creation time.
 func (m RunGetFlowModel) filterEnabled() bool {
-	return len(m.scopes) >= 2 || m.statusFilterEnabled()
+	return true
 }
 
 // openRunFilter builds and shows the "/" search dialog seeded with the active
-// scope and status, sized to the current terminal.
+// scope, status and created filter, sized to the current terminal.
 func (m RunGetFlowModel) openRunFilter() (tea.Model, tea.Cmd) {
-	m.filter = newRunFilterDialog(m.scopes, m.statusFilters, m.activeScopeIdx, m.statusIdx, m.opts.Color)
+	m.filter = newRunFilterDialog(m.scopes, m.statusFilters, m.activeScopeIdx, m.statusIdx, m.createdFilter, m.opts.Color)
 	if m.width > 0 && m.height > 0 {
 		m.filter = m.filter.SetSize(m.width, m.height)
 	}
@@ -886,15 +914,16 @@ func (m RunGetFlowModel) updateRunFilter(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Still open — keep showing the dialog.
 	case runFilterApply:
 		scopeIdx, statusIdx := m.filter.Selected()
-		if scopeIdx == m.activeScopeIdx && statusIdx == m.statusIdx {
+		created := m.filter.Created()
+		if scopeIdx == m.activeScopeIdx && statusIdx == m.statusIdx && created == m.createdFilter {
 			// Nothing changed — just close the dialog and redisplay the picker.
 			m.runSelect = m.newRunSelect()
 			m.stage = runGetStageRunSelect
 			return m, nil
 		}
 		m.stage = runGetStageLoadingRuns
-		m.loadingLabel = filterLoadingLabel(m.scopes[scopeIdx], m.statusFilters[statusIdx])
-		return m, m.loadingCmd(m.cmdFetchRuns(scopeIdx, statusIdx))
+		m.loadingLabel = filterLoadingLabel(m.scopes[scopeIdx], m.statusFilters[statusIdx], created)
+		return m, m.loadingCmd(m.cmdFetchRuns(scopeIdx, statusIdx, created))
 	case runFilterCancel:
 		m.runSelect = m.newRunSelect()
 		m.stage = runGetStageRunSelect
@@ -904,13 +933,28 @@ func (m RunGetFlowModel) updateRunFilter(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 // filterLoadingLabel is the loading line shown while the dialog's chosen
-// scope+status is fetched, e.g. "Fetching failed runs for main branch".
-func filterLoadingLabel(scope runScope, status RunStatusFilter) string {
+// scope+status+created filter is fetched, e.g. "Fetching failed runs for main
+// branch older than 24 Hours".
+func filterLoadingLabel(scope runScope, status RunStatusFilter, created RunCreatedFilter) string {
 	label := "Fetching"
 	if status.Value != "" {
 		label += " " + status.Label
 	}
-	return label + " runs for " + scope.label
+	label += " runs for " + scope.label
+	if created.Active() {
+		label += " " + createdPhrase(created)
+	}
+	return label
+}
+
+// createdPhrase renders a created filter as a title/label suffix, e.g.
+// "older than 24 Hours" or "newer than 7 Days".
+func createdPhrase(created RunCreatedFilter) string {
+	dir := "older than"
+	if created.Newer {
+		dir = "newer than"
+	}
+	return dir + " " + created.Label
 }
 
 func (m RunGetFlowModel) onWorkflows(msg runGetWorkflowsMsg) (tea.Model, tea.Cmd) {
@@ -1502,6 +1546,9 @@ func (m RunGetFlowModel) newRunSelect() components.SelectModel {
 	if status := m.statusFilters[m.statusIdx]; status.Value != "" {
 		parts = append(parts, status.Label)
 	}
+	if m.createdFilter.Active() {
+		parts = append(parts, createdPhrase(m.createdFilter))
+	}
 	if len(parts) > 0 {
 		scope := "[" + strings.Join(parts, " · ") + "]"
 		if m.opts.Color {
@@ -1782,7 +1829,7 @@ func statusIconStyle(symbol string) (lipgloss.Style, bool) {
 // FetchMyRuns), otherwise the branch-filtered runs (via FetchRuns). The scope
 // and status indexes ride along on the result so onRuns can commit them once the
 // fetch succeeds.
-func (m RunGetFlowModel) cmdFetchRuns(scopeIdx, statusIdx int) tea.Cmd {
+func (m RunGetFlowModel) cmdFetchRuns(scopeIdx, statusIdx int, created RunCreatedFilter) tea.Cmd {
 	ctx, scope := m.ctx, m.scopes[scopeIdx]
 	status := m.statusFilters[statusIdx].Value
 	fetchRuns, fetchMine := m.opts.FetchRuns, m.opts.FetchMyRuns
@@ -1792,11 +1839,11 @@ func (m RunGetFlowModel) cmdFetchRuns(scopeIdx, statusIdx int) tea.Cmd {
 			err   error
 		)
 		if scope.myRuns {
-			items, err = fetchMine(ctx, status)
+			items, err = fetchMine(ctx, status, created)
 		} else {
-			items, err = fetchRuns(ctx, scope.branch, status)
+			items, err = fetchRuns(ctx, scope.branch, status, created)
 		}
-		return runGetRunsMsg{items: items, scopeIdx: scopeIdx, statusIdx: statusIdx, err: err}
+		return runGetRunsMsg{items: items, scopeIdx: scopeIdx, statusIdx: statusIdx, created: created, err: err}
 	}
 }
 

--- a/internal/ui/run_get_flow_test.go
+++ b/internal/ui/run_get_flow_test.go
@@ -130,8 +130,8 @@ func runItem(label string) ui.RunGetItem {
 // fetchByBranch returns a FetchRuns that maps a branch filter ("" = all
 // branches) to its run list, returning an empty list for unmapped branches. The
 // status argument is ignored (status filtering is covered separately).
-func fetchByBranch(byBranch map[string][]ui.RunGetItem) func(context.Context, string, string) ([]ui.RunGetItem, error) {
-	return func(_ context.Context, branch, _ string) ([]ui.RunGetItem, error) {
+func fetchByBranch(byBranch map[string][]ui.RunGetItem) func(context.Context, string, string, ui.RunCreatedFilter) ([]ui.RunGetItem, error) {
+	return func(_ context.Context, branch, _ string, _ ui.RunCreatedFilter) ([]ui.RunGetItem, error) {
 		return byBranch[branch], nil
 	}
 }
@@ -139,7 +139,7 @@ func fetchByBranch(byBranch map[string][]ui.RunGetItem) func(context.Context, st
 // newToggleFlow builds a run-get flow on branch "feature" with default branch
 // "main". Animation is off so the loading command is the bare fetch (no spinner
 // tick), keeping the program loop deterministic under teatest.
-func newToggleFlow(fetch func(context.Context, string, string) ([]ui.RunGetItem, error)) ui.RunGetFlowModel {
+func newToggleFlow(fetch func(context.Context, string, string, ui.RunCreatedFilter) ([]ui.RunGetItem, error)) ui.RunGetFlowModel {
 	return ui.NewRunGetFlow(context.Background(), ui.RunGetFlowOptions{
 		Runs:          []ui.RunGetItem{runItem("aaaaaaa [feature] - 1 minute ago")},
 		CurrentBranch: "feature",
@@ -304,7 +304,7 @@ func TestRunGetFlow_ToggleReachesMyRuns(t *testing.T) {
 			"main":    {runItem("bbbbbbb [main] - 2 minutes ago")},
 			"":        {runItem("ccccccc [other] - 3 minutes ago")},
 		}),
-		FetchMyRuns: func(context.Context, string) ([]ui.RunGetItem, error) {
+		FetchMyRuns: func(context.Context, string, ui.RunCreatedFilter) ([]ui.RunGetItem, error) {
 			return []ui.RunGetItem{runItem("ddddddd [mine] - 4 minutes ago")}, nil
 		},
 	}))
@@ -392,7 +392,7 @@ func newStatusFlow(byStatus map[string][]ui.RunGetItem, statuses []ui.RunStatusF
 	return ui.NewRunGetFlow(context.Background(), ui.RunGetFlowOptions{
 		Runs:          byStatus[""],
 		CurrentBranch: "main",
-		FetchRuns: func(_ context.Context, _, status string) ([]ui.RunGetItem, error) {
+		FetchRuns: func(_ context.Context, _, status string, _ ui.RunCreatedFilter) ([]ui.RunGetItem, error) {
 			return byStatus[status], nil
 		},
 		StatusFilters: statuses,
@@ -491,7 +491,7 @@ func TestRunGetFlow_StatusFilterResetsWithShiftS(t *testing.T) {
 	tm := startFlow(t, ui.NewRunGetFlow(context.Background(), ui.RunGetFlowOptions{
 		Runs:          []ui.RunGetItem{runItem("aaaaaaa [main] - startup")},
 		CurrentBranch: "main",
-		FetchRuns: func(_ context.Context, _, status string) ([]ui.RunGetItem, error) {
+		FetchRuns: func(_ context.Context, _, status string, _ ui.RunCreatedFilter) ([]ui.RunGetItem, error) {
 			return byStatus[status], nil
 		},
 		StatusFilters: []ui.RunStatusFilter{
@@ -866,4 +866,37 @@ func TestRunGetFlow_FilterHintShownWhenEnabled(t *testing.T) {
 		[]ui.RunStatusFilter{{Value: "failed", Label: "failed"}},
 	)))
 	assert.Check(t, cmp.Contains(v, "/ search"))
+}
+
+// TestRunGetFlow_FilterApplyCreated drives the dialog to the Created tab, selects
+// an age, applies, and confirms the created filter reaches FetchRuns and is named
+// in the picker title.
+func TestRunGetFlow_FilterApplyCreated(t *testing.T) {
+	var gotCreated ui.RunCreatedFilter
+	m := ui.NewRunGetFlow(context.Background(), ui.RunGetFlowOptions{
+		Runs:          []ui.RunGetItem{runItem("aaaaaaa [main] - all")},
+		CurrentBranch: "main",
+		FetchRuns: func(_ context.Context, _, _ string, created ui.RunCreatedFilter) ([]ui.RunGetItem, error) {
+			gotCreated = created
+			return []ui.RunGetItem{runItem("ccccccc [main] - recent")}, nil
+		},
+		StatusFilters: []ui.RunStatusFilter{{Value: "failed", Label: "failed"}},
+	})
+	tm := startFlow(t, m)
+
+	tm.Send(keySlash)
+	waitForOutput(t, tm, "Trigger")
+	tm.Send(keyRight) // Trigger → Status
+	tm.Send(keyRight) // Status → Created
+	waitForOutput(t, tm, "1 Hour")
+	tm.Send(keyDown) // all dates → 1 Hour (the cursor is the selection)
+	tm.Send(keyEnt)  // apply
+	waitForOutput(t, tm, "ccccccc [main] - recent")
+
+	assert.Check(t, gotCreated.Active())
+	assert.Check(t, cmp.Equal(gotCreated.Duration, time.Hour))
+	assert.Check(t, !gotCreated.Newer, "direction defaults to older")
+
+	v := flowSnapshot(t, tm)
+	assert.Check(t, cmp.Contains(v, "older than 1 Hour"))
 }


### PR DESCRIPTION
- And further design tweaks of dialog.
- Extract tabs out as its own component.

## Narrower trigger picker

<img width="790" height="511" alt="Screenshot 2026-07-06 at 10 46 19" src="https://github.com/user-attachments/assets/f9e71120-243a-4d89-a8cf-f6ccc16b4734" />

## Centered content

<img width="790" height="511" alt="Screenshot 2026-07-06 at 10 46 22" src="https://github.com/user-attachments/assets/e00a75c1-8e42-4446-9c5f-d59f6fd8dbe6" />

## Created filter

<img width="790" height="511" alt="Screenshot 2026-07-06 at 10 55 08" src="https://github.com/user-attachments/assets/58b3bf07-3b40-4368-a5cd-eb5a2e66afff" />
