### PR TITLE
Remove duplicate context params

### DIFF
--- a/cmd/context.go
+++ b/cmd/context.go
@@ -89,9 +89,6 @@ are injected at runtime.`,
 				VCSType: vcsType,
 				OrgName: orgName,
 			}
-			params.OrgID = orgID
-			params.VCSType = vcsType
-			params.OrgName = orgName
 			org, err := api.GetOrganization(gqlClient, params)
 			if err != nil {
 				return err
@@ -184,9 +181,6 @@ are injected at runtime.`,
 				VCSType: vcsType,
 				OrgName: orgName,
 			}
-			params.OrgID = orgID
-			params.VCSType = vcsType
-			params.OrgName = orgName
 			org, err := api.GetOrganization(gqlClient, params)
 			if err != nil {
 				return err


### PR DESCRIPTION
Removes redundant `GetOrganizationParams` assignments in `context list` and `context delete`.

Fixes #1194.

Tested with `go test ./cmd -ginkgo.focus="Context integration tests.*(list|delete)" -ginkgo.skip="should inform about invalid token|should handle errors"`.