### PR TITLE
Add missing h5/h6 heading spacing on the reference site

### DIFF
--- a/docs/website/assets/css/main.css
+++ b/docs/website/assets/css/main.css
@@ -733,6 +733,20 @@ a:hover {
   color: var(--color-site-muted);
 }
 
+.content h5 {
+  margin-top: 1.25rem;
+  margin-bottom: 0.375rem;
+  font-size: 1.05rem;
+  color: var(--color-site-muted);
+}
+
+.content h6 {
+  margin-top: 1rem;
+  margin-bottom: 0.375rem;
+  font-size: 1rem;
+  color: var(--color-site-muted);
+}
+
 /* Section headings are self-anchoring links (see render-heading.html). The
    link inherits the heading's color/font so it reads as a heading, with a
    faint "#" affordance that brightens on hover/focus. */
@@ -784,7 +798,9 @@ a:hover {
 .content h1 code,
 .content h2 code,
 .content h3 code,
-.content h4 code {
+.content h4 code,
+.content h5 code,
+.content h6 code {
   background-color: transparent;
   padding: 0;
   /* Don't shrink: command-name headings are entirely <code>, so the default


### PR DESCRIPTION
## Summary

Commands nested 3 levels deep (e.g. `circleci orb publish promote <ns>/<orb>@dev:<label> --bump major|minor|patch [flags]`) render as `<h5>` headings on the reference site. The CSS reset zeroes all margins, and `.content h1`–`h4` each had explicit margin rules restoring spacing — but `h5`/`h6` were never covered, so these headings sat flush against the preceding content with no visual separation.

Fix: added `.content h5`/`.content h6` margin/font-size/color rules, continuing the existing step-down scale already defined for h1–h4, and extended the "transparent code background in headings" rule to also cover h5/h6 so command names containing inline code render consistently.

Before:
<img width="914" height="331" alt="Screenshot 2026-07-06 at 12 49 58" src="https://github.com/user-attachments/assets/cd762703-c02f-4028-97dd-ac602b94b4aa" />

After:
<img width="1127" height="213" alt="Screenshot 2026-07-06 at 12 50 10" src="https://github.com/user-attachments/assets/0396646e-8f49-4042-b9cd-30d3c8eecb5d" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)