### PR TITLE
Add telemetry events to onboard signup flow

### DIFF
--- a/internal/cmd/cmdauth/signup.go
+++ b/internal/cmd/cmdauth/signup.go
@@ -77,10 +77,25 @@ func newSignupCmd() *cobra.Command {
 	return cmd
 }
 
+// SignupOutcome describes what SignupIfNeeded did.
+type SignupOutcome string
+
+const (
+	SignupAlreadyAuthenticated SignupOutcome = "already_authenticated"
+	SignupCompleted            SignupOutcome = "completed"
+)
+
+// SignupResult is returned by SignupIfNeeded so callers can distinguish
+// between "already signed in" and "signup just completed."
+type SignupResult struct {
+	Outcome SignupOutcome
+}
+
 // SignupIfNeeded is the idempotent variant of signup used by orchestrators
 // like `circleci onboard`. If a valid token already exists, it prints a
-// confirmation and returns nil. Otherwise it runs the standard signup flow.
-func SignupIfNeeded(ctx context.Context, noBrowser, secureStorage bool, configPath string) error {
+// confirmation and returns the AlreadyAuthenticated outcome. Otherwise it
+// runs the standard signup flow and returns the Completed outcome.
+func SignupIfNeeded(ctx context.Context, noBrowser, secureStorage bool, configPath string) (SignupResult, error) {
 	cfg := cmdutil.GetConfig(ctx)
 
 	token := cfg.EffectiveToken()
@@ -95,7 +110,10 @@ func SignupIfNeeded(ctx context.Context, noBrowser, secureStorage bool, configPa
 			  • Deploy visibility across your whole org, out of the box
 
 		`))
-		return runSignup(ctx, noBrowser, secureStorage, configPath)
+		if err := runSignup(ctx, noBrowser, secureStorage, configPath); err != nil {
+			return SignupResult{}, err
+		}
+		return SignupResult{Outcome: SignupCompleted}, nil
 	}
 
 	client := apiclient.New(apiclient.Config{
@@ -105,7 +123,7 @@ func SignupIfNeeded(ctx context.Context, noBrowser, secureStorage bool, configPa
 	})
 	me, err := client.GetMe(ctx)
 	if err != nil {
-		return clierrors.New(
+		return SignupResult{}, clierrors.New(
 			"auth.signup.stale_token",
 			"Could not verify existing token",
 			fmt.Sprintf("A token is configured but the identity check failed: %s.", err),
@@ -116,7 +134,7 @@ func SignupIfNeeded(ctx context.Context, noBrowser, secureStorage bool, configPa
 	}
 
 	iostream.Printf(ctx, "%s Already signed in as %s\n", iostream.SymbolOK(ctx), me.Login)
-	return nil
+	return SignupResult{Outcome: SignupAlreadyAuthenticated}, nil
 }
 
 func runSignup(ctx context.Context, noBrowser, secureStorage bool, configPath string) error {

--- a/internal/cmd/cmdauth/signup.go
+++ b/internal/cmd/cmdauth/signup.go
@@ -80,6 +80,7 @@ func newSignupCmd() *cobra.Command {
 // SignupOutcome describes what SignupIfNeeded did.
 type SignupOutcome string
 
+// Possible SignupOutcome values.
 const (
 	SignupAlreadyAuthenticated SignupOutcome = "already_authenticated"
 	SignupCompleted            SignupOutcome = "completed"

--- a/internal/onboarder/onboarder.go
+++ b/internal/onboarder/onboarder.go
@@ -68,10 +68,19 @@ func Run(ctx context.Context, dir string, opts Options) error {
 		return err
 	}
 
+	trackOnboard(ctx, "onboard_mode_selected", map[string]any{
+		"mode": modeString(m),
+	})
+
 	if m == modeSignup {
-		if err := cmdauth.SignupIfNeeded(ctx, opts.NoBrowser, opts.SecureStorage, opts.ConfigPath); err != nil {
+		result, err := cmdauth.SignupIfNeeded(ctx, opts.NoBrowser, opts.SecureStorage, opts.ConfigPath)
+		if err != nil {
 			return err
 		}
+		trackOnboard(ctx, "onboard_signup", map[string]any{
+			"mode":    "signup",
+			"outcome": string(result.Outcome),
+		})
 		return postSignupGuidance(ctx)
 	}
 
@@ -139,9 +148,14 @@ func Run(ctx context.Context, dir string, opts Options) error {
 		return err
 	}
 
-	if err := cmdauth.SignupIfNeeded(ctx, opts.NoBrowser, opts.SecureStorage, opts.ConfigPath); err != nil {
+	signupResult, err := cmdauth.SignupIfNeeded(ctx, opts.NoBrowser, opts.SecureStorage, opts.ConfigPath)
+	if err != nil {
 		return err
 	}
+	trackOnboard(ctx, "onboard_signup", map[string]any{
+		"mode":    "scan",
+		"outcome": string(signupResult.Outcome),
+	})
 
 	return postSignupGuidance(ctx)
 }
@@ -260,6 +274,25 @@ func followClassicProject(ctx context.Context, client *apiclient.Client, appURL,
 
 func printManualGuidance(ctx context.Context) {
 	iostream.Printf(ctx, "\nRun 'circleci project create' to connect this repo to CircleCI.\n")
+}
+
+func trackOnboard(ctx context.Context, event string, props map[string]any) {
+	tc := cmdutil.GetTelemetry(ctx)
+	if tc == nil {
+		return
+	}
+	_ = tc.Track(event, props)
+}
+
+func modeString(m mode) string {
+	switch m {
+	case modeScan:
+		return "scan"
+	case modeSignup:
+		return "signup"
+	default:
+		return "unknown"
+	}
 }
 
 func resolveMode(ctx context.Context, opts Options) (mode, error) {


### PR DESCRIPTION
## Summary

- Add two telemetry events to the onboard command to track signup funnel behavior:
  - `onboard_mode_selected` — which mode the user chose (scan vs signup)
  - `onboard_signup` — whether the signup step completed or the user was already authenticated
- `SignupIfNeeded` now returns a `SignupResult` with an outcome field so callers can distinguish between a fresh signup and an existing session

## Test plan

- [ ] `go build ./...` passes
- [ ] Acceptance tests pass (`go test -run TestOnboard ./acceptance/...`)
- [ ] Run `circleci onboard --signup` with `CIRCLE_DEBUG=1` and verify `onboard_mode_selected` and `onboard_signup` events are logged
- [ ] Run `circleci onboard --scan` and verify events fire with correct mode/outcome