### PR TITLE
Fix highlights on docs page

### DIFF
--- a/docs/website/assets/css/main.css
+++ b/docs/website/assets/css/main.css
@@ -81,55 +81,218 @@
 }
 
 /* ── Reset ──────────────────────────────────────────────────────────────── */
-*, *::before, *::after {
+/*! modern-normalize v3.0.1 | MIT License | https://github.com/sindresorhus/modern-normalize */
+
+/*
+Document
+========
+*/
+
+/**
+Use a better box model (opinionated).
+*/
+
+*,
+::before,
+::after {
   box-sizing: border-box;
-  margin: 0;
-  padding: 0;
 }
 
 html {
-  line-height: 1.5;
-  -webkit-text-size-adjust: 100%;
-  tab-size: 4;
-  scroll-behavior: smooth;
-  scroll-padding-top: calc(var(--nav-height) + 1rem);
+  /* Improve consistency of default fonts in all browsers. (https://github.com/sindresorhus/modern-normalize/issues/3) */
+  font-family:
+          system-ui,
+          'Segoe UI',
+          Roboto,
+          Helvetica,
+          Arial,
+          sans-serif,
+          'Apple Color Emoji',
+          'Segoe UI Emoji';
+  line-height: 1.15; /* 1. Correct the line height in all browsers. */
+  -webkit-text-size-adjust: 100%; /* 2. Prevent adjustments of font size after orientation changes in iOS. */
+  tab-size: 4; /* 3. Use a more readable tab size (opinionated). */
 }
 
-h1, h2, h3, h4, h5, h6 {
-  font-size: inherit;
-  font-weight: inherit;
+/*
+Sections
+========
+*/
+
+body {
+  margin: 0; /* Remove the margin in all browsers. */
 }
 
-a {
-  color: inherit;
-  text-decoration: inherit;
+/*
+Text-level semantics
+====================
+*/
+
+/**
+Add the correct font weight in Chrome and Safari.
+*/
+
+b,
+strong {
+  font-weight: bolder;
 }
 
-b, strong { font-weight: bolder; }
+/**
+1. Improve consistency of default fonts in all browsers. (https://github.com/sindresorhus/modern-normalize/issues/3)
+2. Correct the odd 'em' font sizing in all browsers.
+*/
 
-code, kbd, samp, pre {
-  font-family: var(--font-mono);
-  font-size: 1em;
+code,
+kbd,
+samp,
+pre {
+  font-family:
+          ui-monospace,
+          SFMono-Regular,
+          Consolas,
+          'Liberation Mono',
+          Menlo,
+          monospace; /* 1 */
+  font-size: 1em; /* 2 */
 }
 
-small { font-size: 80%; }
+/**
+Add the correct font size in all browsers.
+*/
 
-ol, ul, menu { list-style: none; }
-
-img, svg, video, canvas, audio, iframe, embed, object {
-  display: block;
-  vertical-align: middle;
+small {
+  font-size: 80%;
 }
 
-img, video {
-  max-width: 100%;
+/**
+Prevent 'sub' and 'sup' elements from affecting the line height in all browsers.
+*/
+
+sub,
+sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+
+sub {
+  bottom: -0.25em;
+}
+
+sup {
+  top: -0.5em;
+}
+
+/*
+Tabular data
+============
+*/
+
+/**
+Correct table border color inheritance in Chrome and Safari. (https://issues.chromium.org/issues/40615503, https://bugs.webkit.org/show_bug.cgi?id=195016)
+*/
+
+table {
+  border-color: currentcolor;
+}
+
+/*
+Forms
+=====
+*/
+
+/**
+1. Change the font styles in all browsers.
+2. Remove the margin in Firefox and Safari.
+*/
+
+button,
+input,
+optgroup,
+select,
+textarea {
+  font-family: inherit; /* 1 */
+  font-size: 100%; /* 1 */
+  line-height: 1.15; /* 1 */
+  margin: 0; /* 2 */
+}
+
+/**
+Correct the inability to style clickable types in iOS and Safari.
+*/
+
+button,
+[type='button'],
+[type='reset'],
+[type='submit'] {
+  -webkit-appearance: button;
+}
+
+/**
+Remove the padding so developers are not caught out when they zero out 'fieldset' elements in all browsers.
+*/
+
+legend {
+  padding: 0;
+}
+
+/**
+Add the correct vertical alignment in Chrome and Firefox.
+*/
+
+progress {
+  vertical-align: baseline;
+}
+
+/**
+Correct the cursor style of increment and decrement buttons in Safari.
+*/
+
+::-webkit-inner-spin-button,
+::-webkit-outer-spin-button {
   height: auto;
 }
 
-table {
-  text-indent: 0;
-  border-color: inherit;
-  border-collapse: collapse;
+/**
+1. Correct the odd appearance in Chrome and Safari.
+2. Correct the outline style in Safari.
+*/
+
+[type='search'] {
+  -webkit-appearance: textfield; /* 1 */
+  outline-offset: -2px; /* 2 */
+}
+
+/**
+Remove the inner padding in Chrome and Safari on macOS.
+*/
+
+::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+/**
+1. Correct the inability to style clickable types in iOS and Safari.
+2. Change font properties to 'inherit' in Safari.
+*/
+
+::-webkit-file-upload-button {
+  -webkit-appearance: button; /* 1 */
+  font: inherit; /* 2 */
+}
+
+/*
+Interactive
+===========
+*/
+
+/*
+Add the correct display in Chrome and Safari.
+*/
+
+summary {
+  display: list-item;
 }
 
 /* ── Base ───────────────────────────────────────────────────────────────── */
@@ -546,12 +709,23 @@ a:hover {
   background-color: var(--color-site-surface);
 }
 
+/* The bar's overflow:hidden (for corner clipping) would also clip the UA focus
+   ring of its flush children — leaving only a sliver on the dropdown button's
+   inner edge. Draw the ring inset so it lands inside the border box. */
+.install-bar :focus-visible {
+  outline: 2px solid var(--color-site-accent);
+  outline-offset: -2px;
+}
+
 .install-dropdown-btn {
   display: flex;
   flex-shrink: 0;
   cursor: pointer;
   align-items: center;
   gap: 0.5rem;
+  /* Rounds the inset focus ring (an outline follows the element's own
+     border-radius) — matches the copy button, which carries the same radius. */
+  border-radius: 0.375rem;
   border-right: 1px solid var(--color-site-border-strong);
   padding-inline: 1rem;
   padding-block: 0.75rem;


### PR DESCRIPTION
- Use modern-normalize CSS reset.
- Set border radius on drop down.
- For better a11y support (good first step is making things keyboard navigable).