### PR TITLE
Fix sidebar depth-4 nav items truncating to a single character

### DIFF
--- a/docs/website/assets/css/main.css
+++ b/docs/website/assets/css/main.css
@@ -841,6 +841,12 @@ a:hover {
 }
 
 /* ── TOC (sidebar nav) ──────────────────────────────────────────────────── */
+.toc ul {
+  padding-left: 0;
+  margin: 0;
+  list-style: none;
+}
+
 .toc a {
   display: block;
   overflow: hidden;


### PR DESCRIPTION
## Summary

- Browser-default `padding-left: 40px` on `<ul>` was accumulating at every nesting level in the sidebar TOC
- By depth 4, that added 160px of extra indent on top of the `3rem` CSS value, leaving only ~16px of visible text width — enough for one character before the ellipsis (`g...`, `o...`, `l...`)
- Reset `padding-left`, `margin`, and `list-style` on `.toc ul` so indentation is controlled solely by the `a[data-depth="N"]` rules; depth-4 items now have ~192px of text width

## Test plan

- [x] Run `task docs:server` and scroll the sidebar to the CI/Management/User command subcommands — all verbs should be fully readable
- [x] Confirm depth-1 through depth-3 indentation still looks correct

Before -> after

<img width="348" height="1263" alt="Screenshot 2026-07-08 at 3 28 51 PM" src="https://github.com/user-attachments/assets/55e6f80f-f3d4-4c5d-aa50-6837924a3cfc" />

<img width="348" height="1263" alt="Screenshot 2026-07-08 at 3 28 26 PM" src="https://github.com/user-attachments/assets/dd8e94df-1eaf-4d5c-b2c0-95b72986bf5d" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)