### PR TITLE
Add `--mine` flag to `run get`

### DIFF
--- a/internal/cmd/root/testdata/help/circleci/reference.txt
+++ b/internal/cmd/root/testdata/help/circleci/reference.txt
@@ -252,6 +252,7 @@ Get a run's status
 | `-b, --branch string` | Branch name (defaults to the current branch, or main when --project is set) |
 | `--jq string`         | Process values from the response using jq syntax                            |
 | `--json`              | Output as JSON                                                              |
+| `-m, --mine`          | Filter to runs owned by you.                                                |
 | `--project string`    | Project slug (e.g. gh/org/repo); used for latest-run lookup                 |
 
 

--- a/internal/cmd/root/testdata/help/circleci/run/get.txt
+++ b/internal/cmd/root/testdata/help/circleci/run/get.txt
@@ -9,6 +9,8 @@ which is meaningless for a different project) unless --branch is set.
 
 Pass a run UUID to look up a specific run.
 
+Use the --mine flag to show only your runs.
+
 JSON fields: id, phase, outcome, current_outcome, branch, tag, revision,
              created_at, errors[].type/message,
              workflows[].id/name/phase/outcome/current_outcome/duration/
@@ -27,6 +29,7 @@ For more information about output formatting flags, see `circleci help formattin
 | `-b, --branch string` | Branch name (defaults to the current branch, or main when --project is set) |
 | `--jq string`         | Process values from the response using jq syntax                            |
 | `--json`              | Output as JSON                                                              |
+| `-m, --mine`          | Filter to runs owned by you.                                                |
 | `--project string`    | Project slug (e.g. gh/org/repo); used for latest-run lookup                 |
 
 ## Inherited Flags
@@ -54,6 +57,8 @@ branch (override with `--project` and `--branch`). With
   `circleci run get 5034460f-c7c4-4c43-9457-de07e2029e7b`
 - Output as JSON for scripting: 
   `circleci run get --json`
+- Get only your runs: 
+  `circleci run get --mine`
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/usage/circleci/run/get.txt
+++ b/internal/cmd/root/testdata/usage/circleci/run/get.txt
@@ -4,5 +4,6 @@ Flags:
   -b, --branch string    Branch name (defaults to the current branch, or main when --project is set)
       --jq string        Process values from the response using jq syntax
       --json             Output as JSON
+  -m, --mine             Filter to runs owned by you.
       --project string   Project slug (e.g. gh/org/repo); used for latest-run lookup
   

--- a/internal/cmd/run/get.go
+++ b/internal/cmd/run/get.go
@@ -63,6 +63,7 @@ func newGetCmd() *cobra.Command {
 		projectSlug string
 		branch      string
 		jsonOut     bool
+		mine        bool
 	)
 
 	cmd := &cobra.Command{
@@ -87,6 +88,8 @@ func newGetCmd() *cobra.Command {
 
 			Pass a run UUID to look up a specific run.
 
+			Use the --mine flag to show only your runs.
+
 			JSON fields: id, phase, outcome, current_outcome, branch, tag, revision,
 			             created_at, errors[].type/message,
 			             workflows[].id/name/phase/outcome/current_outcome/duration/
@@ -101,6 +104,9 @@ func newGetCmd() *cobra.Command {
 
 			# Output as JSON for scripting
 			$ circleci run get --json
+
+			# Get only your runs
+			$ circleci run get --mine
 		`),
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -109,12 +115,13 @@ func newGetCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return runGet(ctx, client, args, projectSlug, branch, jsonOut)
+			return runGet(ctx, client, args, projectSlug, branch, jsonOut, mine)
 		},
 	}
 
 	cmd.Flags().StringVar(&projectSlug, "project", "", "Project slug (e.g. gh/org/repo); used for latest-run lookup")
 	cmd.Flags().StringVarP(&branch, "branch", "b", "", "Branch name (defaults to the current branch, or main when --project is set)")
+	cmd.Flags().BoolVarP(&mine, "mine", "m", false, "Filter to runs owned by you.")
 	cmdutil.AddJSONFlag(cmd, &jsonOut)
 	cmdutil.AddJQFlag(cmd)
 
@@ -158,12 +165,12 @@ type jobOutput struct {
 	Type           string    `json:"type,omitempty"`
 }
 
-func runGet(ctx context.Context, client *apiclient.Client, args []string, projectSlug, branch string, jsonOut bool) error {
+func runGet(ctx context.Context, client *apiclient.Client, args []string, projectSlug, branch string, jsonOut bool, mine bool) error {
 	// With no run ID and an interactive terminal, walk the user through a series
 	// of pickers (run → workflow → job) instead of silently resolving the latest
 	// run. JSON output stays non-interactive so scripting is unaffected.
 	if len(args) == 0 && !jsonOut && iostream.IsInteractive(ctx) {
-		return runGetInteractive(ctx, client, projectSlug, branch)
+		return runGetInteractive(ctx, client, projectSlug, branch, mine)
 	}
 
 	var r *apiclient.RunV3
@@ -306,29 +313,22 @@ func createdWindow(created ui.RunCreatedFilter, now time.Time) (from, to time.Ti
 // Each terminal choice reuses the existing command's output code so the
 // rendered markdown matches its non-interactive counterpart exactly. The
 // pickers are cancellable with esc/ctrl+c, which returns nil (no output).
-func runGetInteractive(ctx context.Context, client *apiclient.Client, projectSlug, branch string) error {
+func runGetInteractive(ctx context.Context, client *apiclient.Client, projectSlug, branch string, mine bool) error {
 	effectiveBranch := branch
-	var (
-		defaultBranch string
-		myRunsOnly    bool
-	)
-	// When --project is given explicitly the local checkout is meaningless for a
-	// (possibly different) project, so git is not consulted at all: the branch
-	// defaults to "main" when not supplied, and the default-branch toggle stays
-	// off. Otherwise the git remote supplies the project and (when not supplied)
-	// the branch and default branch. When no project could be inferred (not inside
-	// a repository) fall back to a "my runs" only flow — the authenticated user's
-	// runs across all projects — rather than erroring: project- and branch-scoped
-	// runs need a project, but "my runs" does not.
+	var defaultBranch string
+
+	// Resolve the project slug and branch from the git remote when not given
+	// explicitly. When --project is set the local checkout is irrelevant, so
+	// git is not consulted. When no project can be inferred (not inside a
+	// repository), FetchRuns stays nil and the UI falls back to the "my runs"
+	// scope automatically.
 	if projectSlug != "" {
 		if effectiveBranch == "" {
 			effectiveBranch = defaultBranchGuess
 		}
 	} else {
 		info, err := gitremote.Detect()
-		if err != nil {
-			myRunsOnly = true
-		} else {
+		if err == nil {
 			projectSlug = info.Slug
 			if effectiveBranch == "" {
 				effectiveBranch = info.Branch
@@ -337,56 +337,36 @@ func runGetInteractive(ctx context.Context, client *apiclient.Client, projectSlu
 		}
 	}
 
-	// The project is resolved only for the project-scoped flow; the "my runs"
-	// fallback lists across all projects and needs no project lookup.
-	var projectID string
-	if !myRunsOnly {
+	// Build the project-scoped fetch callback when a project is available.
+	// When nil, the UI offers only the "my runs" scope.
+	var fetchRuns func(ctx context.Context, branch, status string, created ui.RunCreatedFilter) ([]ui.RunGetItem, error)
+	if projectSlug != "" {
 		proj, err := client.GetProjectBySlug(ctx, projectSlug)
 		if err != nil {
 			return apiErr(err, projectSlug)
 		}
-		projectID = proj.ID.String()
+		projectID := proj.ID.String()
+		fetchRuns = func(ctx context.Context, br, status string, created ui.RunCreatedFilter) ([]ui.RunGetItem, error) {
+			now := time.Now().UTC()
+			from, to := now.AddDate(0, 0, -90), now
+			if created.Active() {
+				from, to = createdWindow(created, now)
+			}
+			runs, err := client.SearchRunsV3(ctx, apiclient.RunSearchParams{
+				ProjectIDs: []string{projectID},
+				From:       from,
+				To:         to,
+				Filter:     apiclient.BuildRunFilter(br, status),
+				Limit:      10,
+			})
+			if err != nil {
+				return nil, apiErr(err, fmt.Sprintf("%s@%s", projectSlug, br))
+			}
+			return runItems(runs), nil
+		}
 	}
 
-	// fetchRuns lists the 10 most recent runs for a branch as picker items,
-	// optionally narrowed to a pipeline status and a created-age window. It is used
-	// for the initial load and re-run on each branch-scope toggle, status-filter or
-	// created-filter change. Unused in the "my runs" only flow (there is no project
-	// to scope to).
-	fetchRuns := func(ctx context.Context, br, status string, created ui.RunCreatedFilter) ([]ui.RunGetItem, error) {
-		now := time.Now().UTC()
-		// The default window is the last 90 days; a created filter narrows it to
-		// runs older or newer than its relative age (still floored at 90 days).
-		from, to := now.AddDate(0, 0, -90), now
-		if created.Active() {
-			from, to = createdWindow(created, now)
-		}
-		runs, err := client.SearchRunsV3(ctx, apiclient.RunSearchParams{
-			ProjectIDs: []string{projectID},
-			From:       from,
-			To:         to,
-			Filter:     apiclient.BuildRunFilter(br, status),
-			Limit:      10,
-		})
-		if err != nil {
-			return nil, apiErr(err, fmt.Sprintf("%s@%s", projectSlug, br))
-		}
-		return runItems(runs), nil
-	}
-
-	// fetchMyRuns lists the authenticated user's recent runs across all projects
-	// (optionally narrowed to a pipeline status), backing the run picker's "my
-	// runs" scope. Unlike fetchRuns it is neither project- nor branch-scoped (the
-	// counterpart to "circleci my runs"). Because it spans projects, each row folds
-	// its project (the "org/repo" slug from the run's repository URL) into the ref
-	// bracket as "[project:branch]".
 	fetchMyRuns := func(ctx context.Context, status string, created ui.RunCreatedFilter) ([]ui.RunGetItem, error) {
-		// Only send explicit bounds when a created filter is active. With no filter,
-		// leave from/to nil so the endpoint applies its own default window (as
-		// "circleci my runs" does). An active filter must always send an explicit
-		// lower bound: an "older than" query would otherwise inherit the endpoint's
-		// implicit ~14-day default from, which also collapses the recently-active
-		// project set to nothing and returns no runs (see RUN_DATE_RANGES.md).
 		params := apiclient.MyRunsParams{Limit: 10, Status: status}
 		if created.Active() {
 			from, to := createdWindow(created, time.Now().UTC())
@@ -399,36 +379,17 @@ func runGetInteractive(ctx context.Context, client *apiclient.Client, projectSlu
 		return runItemsWithProjects(runs, true), nil
 	}
 
-	var (
-		items []ui.RunGetItem
-		err   error
-	)
-	if myRunsOnly {
-		sp := iostream.Spinner(ctx, true, "Fetching your recent runs")
-		items, err = fetchMyRuns(ctx, "", ui.RunCreatedFilter{})
-		sp.Stop()
-	} else {
-		sp := iostream.Spinner(ctx, true, fmt.Sprintf("Fetching recent runs for %s on branch %s", projectSlug, effectiveBranch))
-		items, err = fetchRuns(ctx, effectiveBranch, "", ui.RunCreatedFilter{})
-		sp.Stop()
-	}
-	if err != nil {
-		return err
-	}
-	if len(items) == 0 {
-		if myRunsOnly {
-			return apiErr(fmt.Errorf("no runs found"), "your runs")
-		}
-		return apiErr(fmt.Errorf("no runs found"), fmt.Sprintf("%s@%s", projectSlug, effectiveBranch))
+	initialScope := ui.ScopeCurrentBranch
+	if mine || fetchRuns == nil {
+		initialScope = ui.ScopeMyRuns
 	}
 
 	model := ui.NewRunGetFlow(ctx, ui.RunGetFlowOptions{
-		Runs:             items,
 		Color:            iostream.ColorEnabled(ctx),
 		Animate:          iostream.SpinnerEnabled(ctx),
 		CurrentBranch:    effectiveBranch,
 		DefaultBranch:    defaultBranch,
-		MyRunsOnly:       myRunsOnly,
+		InitialScope:     initialScope,
 		FetchRuns:        fetchRuns,
 		FetchMyRuns:      fetchMyRuns,
 		StatusFilters:    runStatusFilters,

--- a/internal/ui/run_filter_dialog_test.go
+++ b/internal/ui/run_filter_dialog_test.go
@@ -49,7 +49,7 @@ var (
 // branches, your runs — each carrying its glyph) and two statuses, seeded on the
 // current branch / all statuses, sized to a known terminal.
 func newTestDialog() runFilterDialog {
-	scopes := buildRunScopes("main", "", true, false)
+	scopes := buildRunScopes("main", "", true, true)
 	statuses := []RunStatusFilter{
 		{Label: "all statuses", Icon: "★"},
 		{Value: "failed", Label: "failed", Icon: "✗"},
@@ -172,7 +172,7 @@ func TestRunFilterDialog_CreatedViewShowsPickerAndDirection(t *testing.T) {
 func TestRunFilterDialog_CreatedSeededFromActiveFilter(t *testing.T) {
 	// Opening with an active created filter selects its age and direction so the
 	// dialog reflects what the picker is already showing.
-	scopes := buildRunScopes("main", "", true, false)
+	scopes := buildRunScopes("main", "", true, true)
 	statuses := []RunStatusFilter{{Label: "all statuses", Icon: "★"}}
 	created := RunCreatedFilter{Newer: true, Duration: 24 * time.Hour, Label: "24 Hours"}
 	d := newRunFilterDialog(scopes, statuses, 0, 0, created, false).SetSize(80, 24)

--- a/internal/ui/run_get_flow.go
+++ b/internal/ui/run_get_flow.go
@@ -233,9 +233,14 @@ type RunGetResult struct {
 }
 
 // RunGetFlowOptions configures a RunGetFlowModel. The fetch callbacks keep this
-// program decoupled from the API client: the caller supplies the already-built
-// run list and closures that return the next level's items on demand.
+// program decoupled from the API client: the caller supplies closures that
+// return each level's items on demand. When Runs is nil the model fetches its
+// own initial data on Init() based on InitialScope; when Runs is pre-populated
+// the model starts directly on the run picker (useful for tests).
 type RunGetFlowOptions struct {
+	// Runs is an optional pre-loaded run list. When non-nil the model skips the
+	// initial fetch and opens the picker immediately. When nil, Init() fetches
+	// runs for the InitialScope asynchronously.
 	Runs            []RunGetItem
 	FetchWorkflows  func(ctx context.Context, runID uuid.UUID) ([]RunGetItem, error)
 	FetchJobs       func(ctx context.Context, workflowID uuid.UUID) ([]RunGetItem, error)
@@ -255,28 +260,31 @@ type RunGetFlowOptions struct {
 	// loading line stays static instead of repainting.
 	Animate bool
 
-	// CurrentBranch is the branch the initial Runs were fetched for.
-	// DefaultBranch is the project's default branch. When the two differ, the run
-	// picker offers a shift+tab toggle between them, re-fetching via FetchRuns.
-	// When DefaultBranch is empty or equal to CurrentBranch, the toggle is hidden.
-	// The status argument to FetchRuns is the active status filter (the "s" key),
-	// a pipeline.status value ("" = every status). The created argument is the
-	// active "Created" filter from the filter dialog (an inactive zero value when
-	// none is set).
+	// CurrentBranch is the branch the initial Runs were fetched for (or that
+	// the initial scope-based fetch will target). When FetchRuns is non-nil
+	// (project available), the picker offers branch scopes and optionally "my
+	// runs". When FetchRuns is nil (no project), only the "my runs" scope is
+	// available.
 	CurrentBranch string
+	// DefaultBranch is the project's default branch. When it differs from
+	// CurrentBranch a second branch scope is added to the toggle cycle. When
+	// empty or equal to CurrentBranch the extra scope is omitted.
 	DefaultBranch string
-	FetchRuns     func(ctx context.Context, branch, status string, created RunCreatedFilter) ([]RunGetItem, error)
+	// FetchRuns lists runs for a branch. The status argument is the active
+	// status filter ("" = every status). The created argument is the active
+	// "Created" filter from the filter dialog.
+	FetchRuns func(ctx context.Context, branch, status string, created RunCreatedFilter) ([]RunGetItem, error)
 	// FetchMyRuns lists the authenticated user's recent runs across all projects
 	// (the counterpart to "circleci my runs"). When set, the run picker's
 	// shift+tab cycle gains a "my runs" scope that fetches via this callback
 	// rather than by branch; when nil the scope is omitted. status and created are
 	// the active status and created filters, as for FetchRuns.
 	FetchMyRuns func(ctx context.Context, status string, created RunCreatedFilter) ([]RunGetItem, error)
-	// MyRunsOnly restricts the run picker to the cross-project "my runs" scope,
-	// used when no project could be resolved (e.g. run outside a git repository).
-	// The branch scopes and the shift+tab branch toggle are then omitted; the
-	// picker opens directly on the user's runs across all projects.
-	MyRunsOnly bool
+	// InitialScope selects which scope the picker opens on. The default
+	// (ScopeCurrentBranch) starts on the current branch. Use ScopeMyRuns to
+	// open on the user's runs. When FetchRuns is nil, InitialScope is ignored
+	// and "my runs" is the only available scope.
+	InitialScope RunScopeKind
 	// StatusFilters are the pipeline statuses the "s" key cycles through, in
 	// order. The picker prepends an "all statuses" (no filter) entry, so pressing
 	// "s" cycles no-filter → each status → back. When empty, the "s" action is
@@ -290,6 +298,20 @@ type RunGetFlowOptions struct {
 	// and no help hint is shown.
 	RenderMarkdown func(md string, width int) string
 }
+
+// RunScopeKind identifies a scope for the run picker's initial selection.
+type RunScopeKind int
+
+const (
+	// ScopeCurrentBranch starts the picker on the current branch (default).
+	ScopeCurrentBranch RunScopeKind = iota
+	// ScopeDefaultBranch starts the picker on the default branch.
+	ScopeDefaultBranch
+	// ScopeAllBranches starts the picker on the "all branches" scope.
+	ScopeAllBranches
+	// ScopeMyRuns starts the picker on the cross-project "my runs" scope.
+	ScopeMyRuns
+)
 
 // runScope is one entry in the run picker's shift+tab cycle: a branch filter
 // ("" means all branches) with the label shown in the picker title and loading
@@ -336,15 +358,13 @@ func (s runScope) where() string {
 	}
 }
 
-// buildRunScopes assembles the toggle cycle: the current branch, then the
-// default branch when it is known and distinct, then "all branches", and
-// finally "my runs" when includeMyRuns is set (i.e. FetchMyRuns is wired). The
-// cycle always includes all-branches so a toggle is offered even when there is
-// only one branch to name.
-func buildRunScopes(current, defaultBranch string, includeMyRuns, myRunsOnly bool) []runScope {
-	// With no project resolved, "my runs" is the only available scope: there is
-	// no branch to filter by, so the branch scopes and toggle are omitted.
-	if myRunsOnly {
+// buildRunScopes assembles the toggle cycle from the available callbacks.
+// When hasProject is true (FetchRuns is wired), the cycle includes the current
+// branch, the default branch (when distinct), "all branches", and optionally
+// "my runs" (when FetchMyRuns is also wired). When hasProject is false, "my
+// runs" is the only scope. There is no branch to filter by.
+func buildRunScopes(current, defaultBranch string, hasProject, includeMyRuns bool) []runScope {
+	if !hasProject {
 		return []runScope{{myRuns: true, label: "my runs", pickerLabel: "my runs", icon: scopeIconMyRuns}}
 	}
 	// The current/default branch rows spell out their role ("current branch") and
@@ -365,6 +385,32 @@ func buildRunScopes(current, defaultBranch string, includeMyRuns, myRunsOnly boo
 		scopes = append(scopes, runScope{myRuns: true, label: "my runs", pickerLabel: "my runs", icon: scopeIconMyRuns})
 	}
 	return scopes
+}
+
+// resolveScopeIndex maps a RunScopeKind to an index into the scope slice.
+// Returns 0 if the requested scope is not present.
+func resolveScopeIndex(scopes []runScope, kind RunScopeKind) int {
+	for i, s := range scopes {
+		switch kind {
+		case ScopeMyRuns:
+			if s.myRuns {
+				return i
+			}
+		case ScopeAllBranches:
+			if !s.myRuns && s.branch == "" {
+				return i
+			}
+		case ScopeDefaultBranch:
+			if s.pickerLabel == "default branch" {
+				return i
+			}
+		case ScopeCurrentBranch:
+			if s.pickerLabel == "current branch" {
+				return i
+			}
+		}
+	}
+	return 0
 }
 
 // Trigger glyphs shown beside each scope in the filter dialog's Trigger tab.
@@ -649,32 +695,46 @@ type (
 
 // NewRunGetFlow returns a RunGetFlowModel ready to pass to tea.NewProgram.
 func NewRunGetFlow(ctx context.Context, opts RunGetFlowOptions) RunGetFlowModel {
+	hasProject := opts.FetchRuns != nil
+	scopes := buildRunScopes(opts.CurrentBranch, opts.DefaultBranch, hasProject, opts.FetchMyRuns != nil)
+	initialIdx := resolveScopeIndex(scopes, opts.InitialScope)
+	stage := runGetStageLoadingRuns
+	if opts.Runs != nil {
+		stage = runGetStageRunSelect
+	}
 	m := RunGetFlowModel{
-		ctx:           ctx,
-		opts:          opts,
-		stage:         runGetStageRunSelect,
-		spin:          components.NewSpinner(opts.Color),
-		pager:         components.NewPager().WithKeys(stepPagerKeys...),
-		runs:          opts.Runs,
-		scopes:        buildRunScopes(opts.CurrentBranch, opts.DefaultBranch, opts.FetchMyRuns != nil, opts.MyRunsOnly),
-		statusFilters: buildStatusCycle(opts.StatusFilters),
-		// activeScopeIdx and statusIdx start at 0: the current branch is always the
-		// first scope, and "all statuses" the first filter.
-		stepCursor: -1,
+		ctx:            ctx,
+		opts:           opts,
+		stage:          stage,
+		spin:           components.NewSpinner(opts.Color),
+		pager:          components.NewPager().WithKeys(stepPagerKeys...),
+		runs:           opts.Runs,
+		scopes:         scopes,
+		activeScopeIdx: initialIdx,
+		statusFilters:  buildStatusCycle(opts.StatusFilters),
+		loadingLabel:   "Fetching runs for " + scopes[initialIdx].label,
+		stepCursor:     -1,
 	}
 	if opts.RenderMarkdown != nil {
 		m.help = components.NewHelp(func(w int) string {
 			return opts.RenderMarkdown(runGetHelpMarkdown, w)
 		})
 	}
-	m.runSelect = m.newRunSelect()
+	if opts.Runs != nil {
+		m.runSelect = m.newRunSelect()
+	}
 	return m
 }
 
 // Result returns the final outcome. Only valid after tea.Program.Run() returns.
 func (m RunGetFlowModel) Result() RunGetResult { return m.result }
 
-func (m RunGetFlowModel) Init() tea.Cmd { return nil }
+func (m RunGetFlowModel) Init() tea.Cmd {
+	if m.opts.Runs != nil {
+		return nil // pre-loaded, no fetch needed
+	}
+	return m.loadingCmd(m.cmdFetchRuns(m.activeScopeIdx, m.statusIdx, m.createdFilter))
+}
 
 func (m RunGetFlowModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	// Remember the terminal size for pickers built on later stages and for the

--- a/internal/ui/run_get_flow_test.go
+++ b/internal/ui/run_get_flow_test.go
@@ -352,6 +352,58 @@ func TestRunGetFlow_MyRunsOmittedWithoutFetch(t *testing.T) {
 	}))
 }
 
+// TestRunGetFlow_InitialScopeMyRuns confirms that InitialScope: ScopeMyRuns opens
+// the picker on "my runs" while keeping all scopes available (i.e. the "change trigger"
+// hint is visible).
+func TestRunGetFlow_InitialScopeMyRuns(t *testing.T) {
+	newFlow := func() ui.RunGetFlowModel {
+		return ui.NewRunGetFlow(context.Background(), ui.RunGetFlowOptions{
+			Runs:          []ui.RunGetItem{runItem("ddddddd [mine] - 1 minute ago")},
+			CurrentBranch: "feature",
+			DefaultBranch: "main",
+			InitialScope:  ui.ScopeMyRuns,
+			FetchRuns: fetchByBranch(map[string][]ui.RunGetItem{
+				"feature": {runItem("abcdefg [feature] - 2 minutes ago")},
+			}),
+			FetchMyRuns: func(context.Context, string, ui.RunCreatedFilter) ([]ui.RunGetItem, error) {
+				return []ui.RunGetItem{runItem("ddddddd [mine] - 1 minute ago")}, nil
+			},
+		})
+	}
+
+	assert.Assert(t, t.Run("opens on my runs with other scopes available", func(t *testing.T) {
+		v := flowSnapshot(t, startFlow(t, newFlow()))
+		assert.Check(t, cmp.Contains(v, "Select a run [my runs]"))
+		assert.Check(t, cmp.Contains(v, "ddddddd [mine]"))
+		assert.Check(t, cmp.Contains(v, "change trigger")) // we can change out the my runs scope
+	}))
+	assert.Assert(t, t.Run("toggle from my runs reaches current branch", func(t *testing.T) {
+		tm := startFlow(t, newFlow())
+		tm.Send(switchKey) // my runs -> feature
+		waitForOutput(t, tm, "abcdefg [feature]")
+		v := flowSnapshot(t, tm)
+		assert.Check(t, cmp.Contains(v, "Select a run [feature]"))
+	}))
+}
+
+// TestRunGetFlow_InitialScopeMyRunsNoProject confirms that when FetchRuns is nil
+// (no project available), InitialScope is effectively forced to ScopeMyRuns and
+// the shift+tab toggle is hidden (only one scope exists).
+func TestRunGetFlow_InitialScopeMyRunsNoProject(t *testing.T) {
+	tm := startFlow(t, ui.NewRunGetFlow(context.Background(), ui.RunGetFlowOptions{
+		Runs: []ui.RunGetItem{runItem("ddddddd [mine] - 1 minute ago")},
+		FetchMyRuns: func(context.Context, string, ui.RunCreatedFilter) ([]ui.RunGetItem, error) {
+			return []ui.RunGetItem{runItem("ddddddd [mine] - 1 minute ago")}, nil
+		},
+	}))
+
+	v := flowSnapshot(t, tm)
+	assert.Check(t, cmp.Contains(v, "Select a run [my runs]"))
+	assert.Check(t, cmp.Contains(v, "ddddddd [mine]"))
+	// Only one scope. The change trigger hint should be absent.
+	assert.Check(t, !strings.Contains(v, "change trigger"))
+}
+
 // TestRunGetFlow_ToggleNoRuns swaps in an empty-state placeholder (committing the
 // empty scope, so the title names it) when the toggled-to scope has no runs.
 // Committing the empty scope is what keeps cycling from getting stuck.


### PR DESCRIPTION
Adds `--mine` / `-m` to `circleci run get` so the interactive picker opens on "my runs" while keeping all scopes available via shift+tab and "/".

I found that often I'd want to open the CLI and immediately see my runs (across projects), and the quickest way would be to load it, it would fetch stuff for the current project, then I'd press / to switch it to my runs. This allows you to just go straight into your runs without wasting some API calls.

**Changes:**
- New `--mine` flag on `run get`
- `InitialScope` (typed enum) replaces `MyRunsOnly` boolean
- Scopes derived from `FetchRuns != nil` instead of caller declared ones
- Model self-fetches on `Init()` when `Runs` is nil
- Tests for initial scope selection and no-project fallback

# Cool video



https://github.com/user-attachments/assets/d7548b6f-1d69-4793-9751-f95199eb14c5



