### PR TITLE
TEST-212 Add official extension prompt command

### DIFF
--- a/acceptance/extension_test.go
+++ b/acceptance/extension_test.go
@@ -23,6 +23,7 @@
 package acceptance_test
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -37,6 +38,57 @@ import (
 	testenv "github.com/CircleCI-Public/circleci-cli/internal/testing/env"
 	"github.com/CircleCI-Public/circleci-cli/internal/testing/fakes"
 )
+
+func TestExtensionInstall_OfficialExtensionNotFound(t *testing.T) {
+	f := fakes.NewExtensionRegistry(t)
+	env := testenv.New(t)
+	env.Token = testToken
+	env.ExtensionRegistryURL = f.URL()
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"testsuite"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+	assert.Check(t, cmp.Equal(result.ExitCode, 6))
+	assert.Check(t, cmp.Len(result.Stdout, 0))
+	assert.Check(t, golden.String(result.Stderr, t.Name()+".stderr.txt"))
+}
+
+func TestExtensionInstall_OfficialExtensionNotFound_Interactive(t *testing.T) {
+	f := fakes.NewExtensionRegistry(t)
+	env := testenv.New(t)
+	env.Token = testToken
+	env.ExtensionRegistryURL = f.URL()
+
+	extName := "testsuite"
+
+	f.WithExtension(t,
+		extension.Manifest{
+			Name:       extName,
+			BinaryName: "circleci-" + extName,
+			Version:    "1.0.0",
+			Path:       testBinaryPath,
+		},
+		fakes.ExtensionMeta{
+			Arch: runtime.GOARCH,
+			Sys:  runtime.GOOS,
+		},
+	)
+	console := binary.RunCLIInteractive(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"testsuite"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	_, err := console.ExpectString(fmt.Sprintf("%q is not installed. Install %q now?", extName, extName))
+	assert.NilError(t, err)
+
+	_, err = console.Send("Y\r")
+	assert.NilError(t, err)
+}
 
 func TestExtensionInstall_InvalidExtensionName(t *testing.T) {
 	f := fakes.NewExtensionRegistry(t)

--- a/acceptance/testdata/TestExtensionInstall_OfficialExtensionNotFound.stderr.txt
+++ b/acceptance/testdata/TestExtensionInstall_OfficialExtensionNotFound.stderr.txt
@@ -1,0 +1,4 @@
+error: extension "testsuite" is not installed
+
+Suggestions:
+  • Install with: 'circleci extension install testsuite'

--- a/internal/cmd/extension/extension.go
+++ b/internal/cmd/extension/extension.go
@@ -42,6 +42,12 @@ import (
 	"github.com/CircleCI-Public/circleci-cli/internal/config"
 	clierrors "github.com/CircleCI-Public/circleci-cli/internal/errors"
 	"github.com/CircleCI-Public/circleci-cli/internal/extension"
+	"github.com/CircleCI-Public/circleci-cli/internal/iostream"
+)
+
+const (
+	// Testsuite is the official extension for running tests.
+	Testsuite = "testsuite"
 )
 
 func RegisterExtensions(rootCmd *cobra.Command) {
@@ -58,10 +64,53 @@ func RegisterExtensions(rootCmd *cobra.Command) {
 	exts, err := extension.FindAll(extsDir)
 	cobra.CheckErr(err)
 
+	officialInstalled := map[string]bool{
+		Testsuite: false,
+	}
+
 	for _, ext := range exts {
 		if !builtins[ext.Name] {
+			if _, ok := officialInstalled[ext.Name]; ok {
+				officialInstalled[ext.Name] = true
+			}
+
 			rootCmd.AddCommand(newCmd(ext))
 		}
+	}
+
+	for extName, installed := range officialInstalled {
+		if !installed {
+			rootCmd.AddCommand(newPromptCmd(extName))
+		}
+	}
+}
+
+func newPromptCmd(name string) *cobra.Command {
+	return &cobra.Command{
+		Use:   name,
+		Short: "Extension (circleci-" + name + ")",
+		Long: heredoc.Doc(fmt.Sprintf(`
+			The CircleCI %q extension is not installed by default.
+			
+			Install it with 'circleci extension install %s'.
+		`, name, name)),
+		GroupID: "extension",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
+			s := iostream.Get(ctx)
+			if s.IsInteractive() {
+				prompt := fmt.Sprintf("%q is not installed. Install %q now?", name, name)
+				if s.Confirm(ctx, prompt) {
+					return installExtension(ctx, name)
+				}
+			}
+
+			return clierrors.New("extension.not_installed", "Extension not installed",
+				fmt.Sprintf("extension %q is not installed", name)).
+				WithSuggestions(fmt.Sprintf("Install with: 'circleci extension install %s'", name)).
+				WithExitCode(clierrors.ExitCancelled)
+		},
 	}
 }
 

--- a/internal/cmd/extension/install.go
+++ b/internal/cmd/extension/install.go
@@ -23,6 +23,7 @@
 package extension
 
 import (
+	"context"
 	"errors"
 	"strings"
 
@@ -61,43 +62,46 @@ func newInstallCmd() *cobra.Command {
 			}
 
 			ctx := cmd.Context()
-
-			extDir, err := config.ExtensionsDir()
-			if err != nil {
-				return err
-			}
-
-			cfg := cmdutil.GetConfig(ctx)
-
-			m := extension.NewManager(extension.Config{
-				Version:       cmdutil.GetVersion(ctx),
-				Agent:         cmdutil.GetAgentName(ctx),
-				ExtensionsDir: extDir,
-				BaseURL:       cfg.EffectiveExtensionHost(),
-			})
-
-			name := args[0]
-			if !strings.HasPrefix(name, "circleci-") {
-				name = "circleci-" + args[0]
-			}
-			ext, err := m.Get(ctx, name)
-			if err != nil {
-				return installCLIError(err)
-			}
-
-			iostream.Printf(ctx, "Installing %s version %s...\n", ext.BinaryName, ext.Version)
-
-			err = m.Install(ctx, ext)
-			if err != nil {
-				return installCLIError(err)
-			}
-
-			iostream.Printf(ctx, "%s Installed %s version %s\n", iostream.SymbolOK(ctx), ext.BinaryName, ext.Version)
-			return nil
+			return installExtension(ctx, args[0])
 		},
 	}
 
 	return cmd
+}
+
+func installExtension(ctx context.Context, name string) error {
+	extDir, err := config.ExtensionsDir()
+	if err != nil {
+		return err
+	}
+
+	cfg := cmdutil.GetConfig(ctx)
+
+	m := extension.NewManager(extension.Config{
+		Version:       cmdutil.GetVersion(ctx),
+		Agent:         cmdutil.GetAgentName(ctx),
+		ExtensionsDir: extDir,
+		BaseURL:       cfg.EffectiveExtensionHost(),
+	})
+
+	n := name
+	if !strings.HasPrefix(n, "circleci-") {
+		n = "circleci-" + name
+	}
+	ext, err := m.Get(ctx, n)
+	if err != nil {
+		return installCLIError(err)
+	}
+
+	iostream.Printf(ctx, "Installing %s version %s...\n", ext.BinaryName, ext.Version)
+
+	err = m.Install(ctx, ext)
+	if err != nil {
+		return installCLIError(err)
+	}
+
+	iostream.Printf(ctx, "%s Installed %s version %s\n", iostream.SymbolOK(ctx), ext.BinaryName, ext.Version)
+	return nil
 }
 
 func installCLIError(err error) error {

--- a/internal/cmd/root/testdata/help/circleci.txt
+++ b/internal/cmd/root/testdata/help/circleci.txt
@@ -48,9 +48,10 @@ Work with CircleCI from the command line.
 
 ## Extension Commands
 
-| Command     | Description           |
-| ----------- | --------------------- |
-| `extension` | Manage CLI extensions |
+| Command     | Description                    |
+| ----------- | ------------------------------ |
+| `extension` | Manage CLI extensions          |
+| `testsuite` | Extension (circleci-testsuite) |
 
 ## Additional Commands
 

--- a/internal/cmd/root/testdata/help/circleci/reference.txt
+++ b/internal/cmd/root/testdata/help/circleci/reference.txt
@@ -2011,6 +2011,10 @@ Install an extension
 
 Remove an installed extension
 
+### `circleci testsuite`
+
+Extension (circleci-testsuite)
+
 ## Additional Commands
 
 ### `circleci api <path> [flags]`

--- a/internal/cmd/root/testdata/help/circleci/testsuite.txt
+++ b/internal/cmd/root/testdata/help/circleci/testsuite.txt
@@ -1,0 +1,25 @@
+# CircleCI CLI
+
+The CircleCI "testsuite" extension is not installed by default.
+
+Install it with 'circleci extension install testsuite'.
+
+## Usage
+
+`circleci testsuite [flags]`
+
+## Inherited Flags
+
+| Flag                  | Description                                                  |
+| --------------------- | ------------------------------------------------------------ |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
+
+## Learn More
+
+- Use `circleci <command> <subcommand> --help` for more information about a command.
+- Read the manual at <https://cli.circleci.com/reference/>
+- Support at <https://github.com/CircleCI-Public/circleci-cli/issues>
+

--- a/internal/cmd/root/testdata/usage/circleci.txt
+++ b/internal/cmd/root/testdata/usage/circleci.txt
@@ -27,5 +27,6 @@ Available commands:
   setting
   signing-config
   testresult
+  testsuite
   version
   workflow

--- a/internal/cmd/root/testdata/usage/circleci/testsuite.txt
+++ b/internal/cmd/root/testdata/usage/circleci/testsuite.txt
@@ -1,0 +1,1 @@
+Usage:  circleci testsuite


### PR DESCRIPTION
When an official extension is not installed, and the command is run, the CLI will prompt an installation.

Currently, the only official extension is `testsuite`.

<img width="514" height="85" alt="Screenshot 2026-07-10 at 11 43 11" src="https://github.com/user-attachments/assets/fc83faab-a3b5-4f9f-8942-f938585159aa" />

