### PR TITLE
TEST-212 Accept all flags/args in uninstalled extension stub cmd

### DIFF
--- a/acceptance/extension_test.go
+++ b/acceptance/extension_test.go
@@ -57,6 +57,23 @@ func TestExtensionInstall_OfficialExtensionNotFound(t *testing.T) {
 	assert.Check(t, golden.String(result.Stderr, t.Name()+".stderr.txt"))
 }
 
+func TestExtensionInstall_OfficialExtensionNotFound_AcceptsFlagsAndArgs(t *testing.T) {
+	f := fakes.NewExtensionRegistry(t)
+	env := testenv.New(t)
+	env.Token = testToken
+	env.ExtensionRegistryURL = f.URL()
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"testsuite", "ci tests", "--doctor"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+	assert.Check(t, cmp.Equal(result.ExitCode, 6))
+	assert.Check(t, cmp.Len(result.Stdout, 0))
+	assert.Check(t, golden.String(result.Stderr, t.Name()+".stderr.txt"))
+}
+
 func TestExtensionInstall_OfficialExtensionNotFound_Interactive(t *testing.T) {
 	f := fakes.NewExtensionRegistry(t)
 	env := testenv.New(t)

--- a/acceptance/testdata/TestExtensionInstall_OfficialExtensionNotFound_AcceptsFlagsAndArgs.stderr.txt
+++ b/acceptance/testdata/TestExtensionInstall_OfficialExtensionNotFound_AcceptsFlagsAndArgs.stderr.txt
@@ -1,0 +1,4 @@
+error: extension "testsuite" is not installed
+
+Suggestions:
+  • Install with: 'circleci extension install testsuite'

--- a/internal/cmd/extension/extension.go
+++ b/internal/cmd/extension/extension.go
@@ -103,10 +103,11 @@ func newPromptCmd(name string) *cobra.Command {
 		Short: "Extension (circleci-" + name + ")",
 		Long: heredoc.Doc(fmt.Sprintf(`
 			The CircleCI %q extension is not installed by default.
-			
+
 			Install it with 'circleci extension install %s'.
 		`, name, name)),
-		GroupID: "extension",
+		GroupID:            "extension",
+		DisableFlagParsing: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 


### PR DESCRIPTION
Stub commands don't currently do anything with flags/args but the
command needs to run to prompt installing the extension.
