### PR TITLE
Fix heading scroll offset hiding under sticky navbar

### DIFF
--- a/docs/website/assets/css/main.css
+++ b/docs/website/assets/css/main.css
@@ -935,7 +935,7 @@ a:hover {
 .content h4,
 .content h5,
 .content h6 {
-  scroll-margin-top: 1rem;
+  scroll-margin-top: calc(var(--nav-height) + 1rem);
   font-family: var(--font-mono);
   line-height: 1.25;
   /* The base reset zeroes heading weight to inherit (400); restore a semibold


### PR DESCRIPTION
Currently when you click on a heading in the left hand nav the scroll takes you to just below the title you selected on the page. This change includes an offset to account for the header to see the heading at the top instead.