### PR TITLE
Include MCP context in user agent string

### DIFF
--- a/internal/agent/detect.go
+++ b/internal/agent/detect.go
@@ -59,7 +59,7 @@ func Detect() string {
 
 // isMCP reports whether the CLI is running as a subprocess of the MCP server.
 func isMCP() bool {
-	v, ok := os.LookupEnv("CIRCLECI_MCP")
+	v, ok := os.LookupEnv("CIRCLE_MCP")
 	return ok && v != ""
 }
 

--- a/internal/agent/detect.go
+++ b/internal/agent/detect.go
@@ -23,6 +23,7 @@
 package agent
 
 import (
+	"fmt"
 	"os"
 	"regexp"
 )
@@ -33,6 +34,7 @@ const (
 	agentCodex      = "codex"
 	agentCopilotCLI = "copilot-cli"
 	agentGeminiCLI  = "gemini-cli"
+	agentMCP        = "mcp"
 	agentOpencode   = "opencode"
 )
 
@@ -43,6 +45,27 @@ func Detect() string {
 		}
 	}
 
+	mcp := isMCP()
+	underlying := detectUnderlying()
+
+	if mcp && underlying != "" {
+		return fmt.Sprintf("%s/%s", agentMCP, underlying)
+	}
+	if mcp {
+		return agentMCP
+	}
+	return underlying
+}
+
+// isMCP reports whether the CLI is running as a subprocess of the MCP server.
+func isMCP() bool {
+	v, ok := os.LookupEnv("CIRCLECI_MCP")
+	return ok && v != ""
+}
+
+// detectUnderlying returns the coding agent name based on well-known environment
+// variables, without considering the MCP context.
+func detectUnderlying() string {
 	// Check AGENT=amp before the more generic CLAUDECODE=1 since Amp sets both.
 	if v, ok := os.LookupEnv("AGENT"); ok && v == "amp" {
 		return agentAmp

--- a/internal/agent/detect_test.go
+++ b/internal/agent/detect_test.go
@@ -120,10 +120,46 @@ func TestDetect(t *testing.T) {
 			env:       map[string]string{"AI_AGENT": "bad agent", "GEMINI_CLI": "1"},
 			wantAgent: "gemini-cli",
 		},
+		{
+			name:      "CIRCLECI_MCP alone produces mcp",
+			env:       map[string]string{"CIRCLECI_MCP": "1"},
+			wantAgent: "mcp",
+		},
+		{
+			name:      "CIRCLECI_MCP with CLAUDECODE produces mcp/claude-code",
+			env:       map[string]string{"CIRCLECI_MCP": "1", "CLAUDECODE": "1"},
+			wantAgent: "mcp/claude-code",
+		},
+		{
+			name:      "CIRCLECI_MCP with AGENT=amp produces mcp/amp",
+			env:       map[string]string{"CIRCLECI_MCP": "1", "AGENT": "amp"},
+			wantAgent: "mcp/amp",
+		},
+		{
+			name:      "CIRCLECI_MCP with GEMINI_CLI produces mcp/gemini-cli",
+			env:       map[string]string{"CIRCLECI_MCP": "1", "GEMINI_CLI": "1"},
+			wantAgent: "mcp/gemini-cli",
+		},
+		{
+			name:      "AI_AGENT takes priority over CIRCLECI_MCP composite",
+			env:       map[string]string{"CIRCLECI_MCP": "1", "CLAUDECODE": "1", "AI_AGENT": "custom"},
+			wantAgent: "custom",
+		},
+	}
+
+	// All env vars that Detect() inspects — must be cleared before each case
+	// so ambient vars (e.g. CLAUDECODE=1 from Claude Code) don't leak through.
+	allDetectionVars := []string{
+		"AI_AGENT", "AGENT", "CIRCLECI_MCP",
+		"CODEX_SANDBOX", "CODEX_CI", "CODEX_THREAD_ID",
+		"GEMINI_CLI", "COPILOT_CLI", "OPENCODE", "CLAUDECODE",
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			for _, k := range allDetectionVars {
+				t.Setenv(k, "")
+			}
 			for k, v := range tt.env {
 				t.Setenv(k, v)
 			}

--- a/internal/agent/detect_test.go
+++ b/internal/agent/detect_test.go
@@ -121,28 +121,28 @@ func TestDetect(t *testing.T) {
 			wantAgent: "gemini-cli",
 		},
 		{
-			name:      "CIRCLECI_MCP alone produces mcp",
-			env:       map[string]string{"CIRCLECI_MCP": "1"},
+			name:      "CIRCLE_MCP alone produces mcp",
+			env:       map[string]string{"CIRCLE_MCP": "1"},
 			wantAgent: "mcp",
 		},
 		{
-			name:      "CIRCLECI_MCP with CLAUDECODE produces mcp/claude-code",
-			env:       map[string]string{"CIRCLECI_MCP": "1", "CLAUDECODE": "1"},
+			name:      "CIRCLE_MCP with CLAUDECODE produces mcp/claude-code",
+			env:       map[string]string{"CIRCLE_MCP": "1", "CLAUDECODE": "1"},
 			wantAgent: "mcp/claude-code",
 		},
 		{
-			name:      "CIRCLECI_MCP with AGENT=amp produces mcp/amp",
-			env:       map[string]string{"CIRCLECI_MCP": "1", "AGENT": "amp"},
+			name:      "CIRCLE_MCP with AGENT=amp produces mcp/amp",
+			env:       map[string]string{"CIRCLE_MCP": "1", "AGENT": "amp"},
 			wantAgent: "mcp/amp",
 		},
 		{
-			name:      "CIRCLECI_MCP with GEMINI_CLI produces mcp/gemini-cli",
-			env:       map[string]string{"CIRCLECI_MCP": "1", "GEMINI_CLI": "1"},
+			name:      "CIRCLE_MCP with GEMINI_CLI produces mcp/gemini-cli",
+			env:       map[string]string{"CIRCLE_MCP": "1", "GEMINI_CLI": "1"},
 			wantAgent: "mcp/gemini-cli",
 		},
 		{
-			name:      "AI_AGENT takes priority over CIRCLECI_MCP composite",
-			env:       map[string]string{"CIRCLECI_MCP": "1", "CLAUDECODE": "1", "AI_AGENT": "custom"},
+			name:      "AI_AGENT takes priority over CIRCLE_MCP composite",
+			env:       map[string]string{"CIRCLE_MCP": "1", "CLAUDECODE": "1", "AI_AGENT": "custom"},
 			wantAgent: "custom",
 		},
 	}
@@ -150,7 +150,7 @@ func TestDetect(t *testing.T) {
 	// All env vars that Detect() inspects — must be cleared before each case
 	// so ambient vars (e.g. CLAUDECODE=1 from Claude Code) don't leak through.
 	allDetectionVars := []string{
-		"AI_AGENT", "AGENT", "CIRCLECI_MCP",
+		"AI_AGENT", "AGENT", "CIRCLE_MCP",
 		"CODEX_SANDBOX", "CODEX_CI", "CODEX_THREAD_ID",
 		"GEMINI_CLI", "COPILOT_CLI", "OPENCODE", "CLAUDECODE",
 	}

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -248,13 +248,13 @@ func NewRootCmd(version string) *cobra.Command {
 	// Wire in MCP commands. ophis sets its own terse Short; override it so the
 	// root command table explains what the command actually does.
 	//
-	// DefaultEnv injects CIRCLECI_MCP=1 into the editor config that ophis writes
+	// DefaultEnv injects CIRCLE_MCP=1 into the editor config that ophis writes
 	// (e.g. claude_desktop_config.json). The MCP host passes it to the server
 	// process, which inherits it into every subprocess spawned per tool call.
 	// agent.Detect() then produces "mcp/<agent>" instead of just "<agent>".
 	mcpCmd := ophis.Command(&ophis.Config{
 		DefaultEnv: map[string]string{
-			"CIRCLECI_MCP": "1",
+			"CIRCLE_MCP": "1",
 		},
 	})
 	mcpCmd.Short = "Run the CLI as an MCP server for AI tools"

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -247,7 +247,16 @@ func NewRootCmd(version string) *cobra.Command {
 
 	// Wire in MCP commands. ophis sets its own terse Short; override it so the
 	// root command table explains what the command actually does.
-	mcpCmd := ophis.Command(nil)
+	//
+	// DefaultEnv injects CIRCLECI_MCP=1 into the editor config that ophis writes
+	// (e.g. claude_desktop_config.json). The MCP host passes it to the server
+	// process, which inherits it into every subprocess spawned per tool call.
+	// agent.Detect() then produces "mcp/<agent>" instead of just "<agent>".
+	mcpCmd := ophis.Command(&ophis.Config{
+		DefaultEnv: map[string]string{
+			"CIRCLECI_MCP": "1",
+		},
+	})
 	mcpCmd.Short = "Run the CLI as an MCP server for AI tools"
 	mcpCmd.GroupID = "user"
 	cmd.AddCommand(mcpCmd)


### PR DESCRIPTION
So we can distinguish MCP traffic from general command invocation.

When the CLI is invoked as a subprocess by the MCP server, the user agent now reads "mcp/<agent>" (e.g. "mcp/claude-code") instead of just "<agent>".

ophis's DefaultEnv injects CIRCLECI_MCP=1 into the editor config it writes (claude_desktop_config.json etc.). The MCP host passes this to the server process, which each tool-call subprocess inherits. agent.Detect() then combines the MCP flag with the underlying coding agent detection.

<!--
  Thank you for contributing to CircleCI CLI!
  For PRs adding new features, please raise an issue first.
-->
