### PR TITLE
Avoid needing to write the CIRCLE_MCP env var to config

### DIFF
--- a/acceptance/mcp_test.go
+++ b/acceptance/mcp_test.go
@@ -1,0 +1,119 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package acceptance_test
+
+import (
+	"context"
+	"fmt"
+	"net/http/httptest"
+	"os/exec"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/poll"
+
+	"github.com/CircleCI-Public/circleci-cli/internal/iostream"
+	"github.com/CircleCI-Public/circleci-cli/internal/telemetry"
+	testenv "github.com/CircleCI-Public/circleci-cli/internal/testing/env"
+	"github.com/CircleCI-Public/circleci-cli/internal/testing/fakesegment"
+)
+
+// TestMCPServerAttributesToolCallsAsMCP verifies the CIRCLE_MCP plumbing in
+// internal/cmd/root: `mcp start` sets CIRCLE_MCP=1 on itself before serving, so
+// every CLI subprocess it spawns per tool call inherits it and agent.Detect()
+// reports "mcp/<agent>". Because the var is set in the server's RunE — after the
+// root PersistentPreRunE has already run agent.Detect() — the server's *own*
+// command_invocation is attributed to the plain underlying agent, not MCP.
+//
+// The test drives a real `mcp start` server over stdio with the MCP client SDK,
+// calls the `circleci_setting_list` tool (no API needed — it reads local
+// config), and inspects the telemetry both processes emit to a fake Segment
+// endpoint. CLAUDECODE=1 stands in for a real coding agent so the underlying
+// name is deterministic.
+func TestMCPServerAttributesToolCallsAsMCP(t *testing.T) {
+	ctx := iostream.Testing(context.Background())
+
+	env := testenv.New(t)
+	env.Telemetry = true
+	fs := fakesegment.New(ctx, telemetry.SegmentKey)
+	fsSrv := httptest.NewServer(fs)
+	t.Cleanup(fsSrv.Close)
+	env.Extra["CIRCLE_TELEMETRY_ENDPOINT"] = fsSrv.URL
+	// Stand in for a real coding agent so detectUnderlying() is deterministic.
+	env.Extra["CLAUDECODE"] = "1"
+
+	// Launch the MCP server as a subprocess over stdio. Its environment is what
+	// the per-tool-call subprocesses inherit, so the CIRCLE_MCP=1 that its RunE
+	// sets propagates to them.
+	serverCmd := exec.Command(binaryPath, "mcp", "start")
+	serverCmd.Env = env.Environ()
+	serverCmd.Dir = t.TempDir()
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "acceptance-test", Version: "dev"}, nil)
+	session, err := client.Connect(ctx, &mcp.CommandTransport{Command: serverCmd}, nil)
+	assert.NilError(t, err)
+
+	// The generated tool schema requires a "flags" object; an empty one is fine.
+	res, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "circleci_setting_list",
+		Arguments: map[string]any{"flags": map[string]any{}},
+	})
+	assert.NilError(t, err)
+	assert.Check(t, !res.IsError, "tool call reported an error")
+
+	// Closing the session shuts down the server, which then flushes its own
+	// telemetry. Poll until both events land.
+	assert.NilError(t, session.Close())
+
+	poll.WaitOn(t, func(poll.LogT) poll.Result {
+		byCommand := map[string]string{} // command path -> agent trait
+		for _, batch := range fs.Batches() {
+			for _, msg := range batch.Messages {
+				if msg.Event != "command_invocation" || msg.Context == nil {
+					continue
+				}
+				command, _ := msg.Properties["command"].(string)
+				agent, _ := msg.Context.Traits["agent"].(string)
+				byCommand[command] = agent
+			}
+		}
+
+		// The tool-call subprocess inherits CIRCLE_MCP=1 -> "mcp/claude-code".
+		if got, ok := byCommand["circleci setting list"]; !ok {
+			return poll.Continue("no telemetry yet for the tool-call subprocess")
+		} else if got != "mcp/claude-code" {
+			return poll.Error(fmt.Errorf("tool-call subprocess: expected agent %q, got %q", "mcp/claude-code", got))
+		}
+
+		// The server process itself detected its agent before RunE set
+		// CIRCLE_MCP, so it is attributed to the plain underlying agent.
+		if got, ok := byCommand["circleci mcp start"]; !ok {
+			return poll.Continue("no telemetry yet for the server process")
+		} else if got != "claude-code" {
+			return poll.Error(fmt.Errorf("server process: expected agent %q, got %q", "claude-code", got))
+		}
+
+		return poll.Success()
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.8
 	github.com/hexops/gotextdiff v1.0.3
 	github.com/itchyny/gojq v0.12.19
+	github.com/modelcontextprotocol/go-sdk v1.6.1
 	github.com/muesli/mango-cobra v1.3.0
 	github.com/muesli/roff v0.1.0
 	github.com/njayp/ophis v1.1.4
@@ -89,7 +90,6 @@ require (
 	github.com/lufia/plan9stats v0.0.0-20260330125221-c963978e514e // indirect
 	github.com/mattn/go-runewidth v0.0.24 // indirect
 	github.com/microcosm-cc/bluemonday v1.0.27 // indirect
-	github.com/modelcontextprotocol/go-sdk v1.6.1 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/mango v0.2.0 // indirect
 	github.com/muesli/mango-pflag v0.2.0 // indirect

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -247,19 +247,29 @@ func NewRootCmd(version string) *cobra.Command {
 
 	// Wire in MCP commands. ophis sets its own terse Short; override it so the
 	// root command table explains what the command actually does.
-	//
-	// DefaultEnv injects CIRCLE_MCP=1 into the editor config that ophis writes
-	// (e.g. claude_desktop_config.json). The MCP host passes it to the server
-	// process, which inherits it into every subprocess spawned per tool call.
-	// agent.Detect() then produces "mcp/<agent>" instead of just "<agent>".
-	mcpCmd := ophis.Command(&ophis.Config{
-		DefaultEnv: map[string]string{
-			"CIRCLE_MCP": "1",
-		},
-	})
+	mcpCmd := ophis.Command(nil)
 	mcpCmd.Short = "Run the CLI as an MCP server for AI tools"
 	mcpCmd.GroupID = "user"
 	cmd.AddCommand(mcpCmd)
+
+	// The MCP server (`mcp start` / `mcp stream`) spawns a fresh CLI subprocess
+	// per tool call, and those inherit the server process's environment. Setting
+	// CIRCLE_MCP on the server here — rather than baking it into the editor
+	// config that `mcp <editor> enable` writes to disk — makes agent.Detect()
+	// report "mcp/<agent>" in every tool-call subprocess. Scoped to the server
+	// commands so `mcp <editor> enable` and friends aren't misattributed to MCP.
+	// Wrapping RunE (which spawns the subprocesses) keeps the root bootstrap's
+	// PersistentPreRunE unshadowed.
+	for _, sub := range mcpCmd.Commands() {
+		switch sub.Name() {
+		case "start", "stream":
+			orig := sub.RunE
+			sub.RunE = func(cmd *cobra.Command, args []string) error {
+				_ = os.Setenv("CIRCLE_MCP", "1")
+				return orig(cmd, args)
+			}
+		}
+	}
 
 	// Help topics
 	var referenceCmd *cobra.Command


### PR DESCRIPTION
- Decorate the MCP commands instead

<!--
  Thank you for contributing to CircleCI CLI!
  For PRs adding new features, please raise an issue first.
-->
