### PR TITLE
Flag destructive commands with `destructiveHint`

### DIFF
--- a/acceptance/dlc_test.go
+++ b/acceptance/dlc_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/CircleCI-Public/circleci-cli/internal/httpcl"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/assert/cmp"
+	"gotest.tools/v3/golden"
 
 	"github.com/CircleCI-Public/circleci-cli/internal/testing/binary"
 	testenv "github.com/CircleCI-Public/circleci-cli/internal/testing/env"
@@ -58,7 +59,7 @@ func TestDLCPurge(t *testing.T) {
 
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    []string{"dlc", "purge", "--project", "gh/myorg/myrepo"},
+		Args:    []string{"dlc", "purge", "--project", "gh/myorg/myrepo", "--force"},
 		Env:     env.Environ(),
 		WorkDir: t.TempDir(),
 	})
@@ -84,7 +85,7 @@ func TestDLCPurge_JSON(t *testing.T) {
 
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    []string{"dlc", "purge", "--project", "gh/myorg/myrepo", "--json"},
+		Args:    []string{"dlc", "purge", "--project", "gh/myorg/myrepo", "--force", "--json"},
 		Env:     env.Environ(),
 		WorkDir: t.TempDir(),
 	})
@@ -103,7 +104,7 @@ func TestDLCPurge_Color(t *testing.T) {
 
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    []string{"dlc", "purge", "--project", "gh/myorg/myrepo"},
+		Args:    []string{"dlc", "purge", "--project", "gh/myorg/myrepo", "--force"},
 		Env:     env.Environ(),
 		WorkDir: t.TempDir(),
 		TTY:     true,
@@ -118,7 +119,7 @@ func TestDLCPurge_ProjectSlug(t *testing.T) {
 
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    []string{"dlc", "purge", "--project", "gh/myorg/myrepo"},
+		Args:    []string{"dlc", "purge", "--project", "gh/myorg/myrepo", "--force"},
 		Env:     env.Environ(),
 		WorkDir: t.TempDir(),
 	})
@@ -133,7 +134,7 @@ func TestDLCPurge_Gone(t *testing.T) {
 
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    []string{"dlc", "purge", "--project", "gh/myorg/myrepo"},
+		Args:    []string{"dlc", "purge", "--project", "gh/myorg/myrepo", "--force"},
 		Env:     env.Environ(),
 		WorkDir: t.TempDir(),
 	})
@@ -172,12 +173,27 @@ func TestDLCPurge_NoToken(t *testing.T) {
 	assert.Equal(t, result.ExitCode, 3, "stderr: %s", result.Stderr)
 }
 
+func TestDLCPurge_RequiresForce(t *testing.T) {
+	_, env := setupDLCFake(t)
+
+	// In non-interactive mode (no TTY), --force is required.
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"dlc", "purge", "--project", "gh/myorg/myrepo"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 2, "stderr: %s", result.Stderr)
+	assert.Check(t, golden.String(result.Stderr, t.Name()+".stderr.txt"))
+}
+
 func TestProjectDLCPurge(t *testing.T) {
 	_, env := setupDLCFake(t)
 
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    []string{"project", "dlc", "purge", "--project", "gh/myorg/myrepo"},
+		Args:    []string{"project", "dlc", "purge", "--project", "gh/myorg/myrepo", "--force"},
 		Env:     env.Environ(),
 		WorkDir: t.TempDir(),
 	})

--- a/acceptance/extension_test.go
+++ b/acceptance/extension_test.go
@@ -381,7 +381,7 @@ func TestExtensionRemove(t *testing.T) {
 
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    []string{"extension", "remove", extName},
+		Args:    []string{"extension", "remove", "--force", extName},
 		Env:     env.Environ(),
 		WorkDir: t.TempDir(),
 	})
@@ -401,12 +401,28 @@ func TestExtensionRemove_NotInstalled(t *testing.T) {
 
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    []string{"extension", "remove", "testextension"},
+		Args:    []string{"extension", "remove", "--force", "testextension"},
 		Env:     env.Environ(),
 		WorkDir: t.TempDir(),
 	})
 
 	assert.Check(t, cmp.Equal(result.ExitCode, 5))
+	assert.Check(t, golden.String(result.Stderr, t.Name()+".stderr.txt"))
+}
+
+func TestExtensionRemove_RequiresForce(t *testing.T) {
+	env := testenv.New(t)
+	env.Token = testToken
+
+	// In non-interactive mode (no TTY), --force is required.
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"extension", "remove", "testextension"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Check(t, cmp.Equal(result.ExitCode, 2))
 	assert.Check(t, golden.String(result.Stderr, t.Name()+".stderr.txt"))
 }
 
@@ -416,7 +432,7 @@ func TestExtensionRemove_InvalidName(t *testing.T) {
 
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    []string{"extension", "remove", "^&*"},
+		Args:    []string{"extension", "remove", "--force", "^&*"},
 		Env:     env.Environ(),
 		WorkDir: t.TempDir(),
 	})

--- a/acceptance/mcp_test.go
+++ b/acceptance/mcp_test.go
@@ -24,20 +24,107 @@ package acceptance_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http/httptest"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/poll"
 
 	"github.com/CircleCI-Public/circleci-cli/internal/iostream"
 	"github.com/CircleCI-Public/circleci-cli/internal/telemetry"
+	"github.com/CircleCI-Public/circleci-cli/internal/testing/binary"
 	testenv "github.com/CircleCI-Public/circleci-cli/internal/testing/env"
 	"github.com/CircleCI-Public/circleci-cli/internal/testing/fakesegment"
 )
+
+// mcpTool mirrors the relevant fields of the JSON objects written by
+// "circleci mcp tools".
+type mcpTool struct {
+	Name        string         `json:"name"`
+	Annotations map[string]any `json:"annotations"`
+}
+
+func runMCPTools(t *testing.T) []mcpTool {
+	t.Helper()
+	env := testenv.New(t)
+	env.Token = testToken
+	workDir := t.TempDir()
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"mcp", "tools"},
+		Env:     env.Environ(),
+		WorkDir: workDir,
+	})
+	assert.Equal(t, result.ExitCode, 0, "mcp tools failed\nstderr: %s", result.Stderr)
+
+	data, err := os.ReadFile(filepath.Join(workDir, "mcp-tools.json"))
+	assert.NilError(t, err)
+
+	var tools []mcpTool
+	assert.NilError(t, json.Unmarshal(data, &tools))
+	return tools
+}
+
+// TestMCPTools_DestructiveHints verifies that all known destructive commands
+// are exported with destructiveHint: true, and that a sampling of read-only
+// commands are not marked destructive.
+func TestMCPTools_DestructiveHints(t *testing.T) {
+	tools := runMCPTools(t)
+
+	byName := make(map[string]mcpTool, len(tools))
+	for _, tool := range tools {
+		byName[tool.Name] = tool
+	}
+
+	wantDestructive := []string{
+		"circleci_certificate_delete",
+		"circleci_context_delete",
+		"circleci_context_restriction_delete",
+		"circleci_context_secret_delete",
+		"circleci_dlc_purge",
+		"circleci_envvar_delete",
+		"circleci_extension_remove",
+		"circleci_namespace_delete",
+		"circleci_project_dlc_purge",
+		"circleci_project_envvar_delete",
+		"circleci_run_cancel",
+		"circleci_runner_resource-class_delete",
+		"circleci_runner_token_delete",
+		"circleci_signing-config_delete",
+		"circleci_workflow_cancel",
+	}
+	for _, name := range wantDestructive {
+		t.Run(name, func(t *testing.T) {
+			tool, ok := byName[name]
+			assert.Assert(t, ok, "tool %q not found in mcp-tools.json", name)
+			assert.Check(t, cmp.Equal(tool.Annotations["destructiveHint"], true),
+				"expected destructiveHint: true on %s", name)
+		})
+	}
+
+	wantReadOnly := []string{
+		"circleci_run_list",
+		"circleci_context_list",
+		"circleci_pipeline_list",
+		"circleci_workflow_list",
+	}
+	for _, name := range wantReadOnly {
+		t.Run(name+"_not_destructive", func(t *testing.T) {
+			tool, ok := byName[name]
+			assert.Assert(t, ok, "tool %q not found in mcp-tools.json", name)
+			assert.Check(t, cmp.Equal(tool.Annotations["destructiveHint"], nil),
+				"expected no destructiveHint on %s", name)
+		})
+	}
+}
 
 // TestMCPServerAttributesToolCallsAsMCP verifies the CIRCLE_MCP plumbing in
 // internal/cmd/root: `mcp start` sets CIRCLE_MCP=1 on itself before serving, so

--- a/acceptance/testdata/TestDLCPurge_RequiresForce.stderr.txt
+++ b/acceptance/testdata/TestDLCPurge_RequiresForce.stderr.txt
@@ -1,0 +1,4 @@
+error: Purging DLC for "gh/myorg/myrepo" will discard all cached Docker layers.
+
+Suggestions:
+  • Pass --force (-f) to skip this prompt in non-interactive mode

--- a/acceptance/testdata/TestExtensionRemove_RequiresForce.stderr.txt
+++ b/acceptance/testdata/TestExtensionRemove_RequiresForce.stderr.txt
@@ -1,0 +1,4 @@
+error: Removing extension "circleci-testextension" will delete the binary and manifest.
+
+Suggestions:
+  • Pass --force (-f) to skip this prompt in non-interactive mode

--- a/internal/cmd/certificate/certificate.go
+++ b/internal/cmd/certificate/certificate.go
@@ -300,6 +300,7 @@ func newDeleteCmd() *cobra.Command {
 				%[1]s<cert-id>%[1]s is the ID of the certificate to delete.
 				Find the certificate ID with %[1]scircleci certificate list%[1]s.
 			`, "`"),
+			"destructiveHint": "true",
 		},
 		Long: heredoc.Doc(`
 			Remove an Apple certificate from your organization's secure storage.

--- a/internal/cmd/context/delete.go
+++ b/internal/cmd/context/delete.go
@@ -52,6 +52,7 @@ func newDeleteCmd() *cobra.Command {
 				- By name, for example, %[1]scontext-name%[1]s
 				- By ID, for example, %[1]s849e7902-802f-4082-8a70-da77dcd084e3%[1]s
 			`, "`"),
+			"destructiveHint": "true",
 		},
 		Long: heredoc.Doc(`
 			Delete a CircleCI context by UUID or name.

--- a/internal/cmd/context/restriction.go
+++ b/internal/cmd/context/restriction.go
@@ -197,6 +197,7 @@ func newRestrictionDeleteCmd() *cobra.Command {
 				- By name, for example, %[1]scontext-name%[1]s
 				- By ID, for example, %[1]s849e7902-802f-4082-8a70-da77dcd084e3%[1]s
 			`, "`"),
+			"destructiveHint": "true",
 		},
 		Long: heredoc.Doc(`
 			Remove a restriction from a CircleCI context.

--- a/internal/cmd/context/secret.go
+++ b/internal/cmd/context/secret.go
@@ -290,6 +290,7 @@ func newSecretDeleteCmd() *cobra.Command {
 				- By name, for example, %[1]scontext-name%[1]s
 				- By ID, for example, %[1]s849e7902-802f-4082-8a70-da77dcd084e3%[1]s
 			`, "`"),
+			"destructiveHint": "true",
 		},
 		Long: heredoc.Doc(`
 			Remove an environment variable from a CircleCI context.

--- a/internal/cmd/dlc/purge.go
+++ b/internal/cmd/dlc/purge.go
@@ -40,12 +40,16 @@ import (
 func NewPurgeCmd() *cobra.Command {
 	var (
 		projectSlug string
+		force       bool
 		jsonOut     bool
 	)
 
 	cmd := &cobra.Command{
 		Use:   "purge",
 		Short: "Purge the Docker Layer Cache for a project",
+		Annotations: map[string]string{
+			"destructiveHint": "true",
+		},
 		Long: heredoc.Doc(`
 			Purge the docker layer cache (DLC) for a project.
 
@@ -67,8 +71,11 @@ func NewPurgeCmd() *cobra.Command {
 			# Purge DLC for a specific project
 			$ circleci dlc purge --project gh/myorg/myrepo
 
+			# Skip the confirmation prompt (for scripting)
+			$ circleci dlc purge --project gh/myorg/myrepo --force
+
 			# Purge DLC and output result as JSON
-			$ circleci dlc purge --project gh/myorg/myrepo --json
+			$ circleci dlc purge --project gh/myorg/myrepo --force --json
 
 			# Purge DLC for a Bitbucket project
 			$ circleci dlc purge --project bb/myorg/myrepo
@@ -105,6 +112,18 @@ func NewPurgeCmd() *cobra.Command {
 					"Use 'circleci project list' to see followed projects")
 			}
 
+			if err := cmdutil.ConfirmOrForce(ctx, iostream.Get(ctx), force,
+				fmt.Sprintf("Purge DLC for %q? All cached Docker layers will be discarded.", projectSlug),
+				clierrors.New("dlc.purge_aborted", "Purge aborted",
+					"DLC purge was not confirmed.").
+					WithExitCode(clierrors.ExitCancelled),
+				clierrors.New("dlc.purge_requires_force", "Purge requires --force",
+					fmt.Sprintf("Purging DLC for %q will discard all cached Docker layers.", projectSlug)).
+					WithExitCode(clierrors.ExitBadArguments),
+			); err != nil {
+				return err
+			}
+
 			if err := client.PurgeDLC(ctx, proj.ID.String()); err != nil {
 				if errors.Is(err, apiclient.ErrDLCGone) {
 					return clierrors.New("dlc.gone", "DLC purge unavailable",
@@ -135,6 +154,7 @@ func NewPurgeCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&projectSlug, "project", "", "Project slug (e.g. gh/org/repo); defaults to git remote")
+	cmd.Flags().BoolVarP(&force, "force", "f", false, "Skip confirmation prompt")
 	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output as JSON")
 
 	return cmd

--- a/internal/cmd/extension/remove.go
+++ b/internal/cmd/extension/remove.go
@@ -24,6 +24,7 @@ package extension
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/MakeNowJust/heredoc"
@@ -37,9 +38,14 @@ import (
 )
 
 func newRemoveCmd() *cobra.Command {
+	var force bool
+
 	cmd := &cobra.Command{
 		Use:   "remove <extension>",
 		Short: "Remove an installed extension",
+		Annotations: map[string]string{
+			"destructiveHint": "true",
+		},
 		Long: heredoc.Doc(`
 			Remove an installed CircleCI CLI extension.
 
@@ -53,6 +59,9 @@ func newRemoveCmd() *cobra.Command {
 
 			# Remove using the full binary name
 			$ circleci extension remove circleci-<name>
+
+			# Remove without confirmation prompt
+			$ circleci extension remove <name> --force
 		`),
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -81,6 +90,18 @@ func newRemoveCmd() *cobra.Command {
 				name = "circleci-" + name
 			}
 
+			if err := cmdutil.ConfirmOrForce(ctx, iostream.Get(ctx), force,
+				fmt.Sprintf("Remove extension %q? The binary and manifest will be deleted.", name),
+				clierrors.New("extension.remove_aborted", "Removal aborted",
+					"Extension removal was not confirmed.").
+					WithExitCode(clierrors.ExitCancelled),
+				clierrors.New("extension.remove_requires_force", "Removal requires --force",
+					fmt.Sprintf("Removing extension %q will delete the binary and manifest.", name)).
+					WithExitCode(clierrors.ExitBadArguments),
+			); err != nil {
+				return err
+			}
+
 			err = m.Remove(ctx, name)
 			if err != nil {
 				return removeCLIError(err)
@@ -90,6 +111,8 @@ func newRemoveCmd() *cobra.Command {
 			return nil
 		},
 	}
+
+	cmd.Flags().BoolVarP(&force, "force", "f", false, "Skip confirmation prompt")
 
 	return cmd
 }

--- a/internal/cmd/namespace/delete.go
+++ b/internal/cmd/namespace/delete.go
@@ -47,6 +47,7 @@ func newDeleteCmd() *cobra.Command {
 			"help:arguments": heredoc.Docf(`
 				%[1]s<name>%[1]s is the name of the namespace to delete, for example, "myorg".
 			`, "`"),
+			"destructiveHint": "true",
 		},
 		Long: heredoc.Doc(`
 			Delete a CircleCI orb namespace and all orbs published under it.

--- a/internal/cmd/project/env.go
+++ b/internal/cmd/project/env.go
@@ -244,6 +244,7 @@ func NewEnvDeleteCmd() *cobra.Command {
 				%[1]s<name>%[1]s is the name of the environment variable to delete from
 				the project. This action is irreversible.
 			`, "`"),
+			"destructiveHint": "true",
 		},
 		Long: heredoc.Doc(`
 			Delete an environment variable from a CircleCI project.

--- a/internal/cmd/root/mcp_annotations_test.go
+++ b/internal/cmd/root/mcp_annotations_test.go
@@ -1,0 +1,104 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package root_test
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"gotest.tools/v3/assert"
+
+	"github.com/CircleCI-Public/circleci-cli/internal/cmd/root"
+)
+
+// TestDestructiveHintHasForceFlag enforces that every command marked
+// "destructiveHint": "true" exposes a --force / -f flag. Without this guard a
+// developer could annotate a new destructive command without wiring the
+// confirmation prompt, or remove the flag while leaving the annotation behind.
+func TestDestructiveHintHasForceFlag(t *testing.T) {
+	fakeHome := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", filepath.Join(fakeHome, ".local", "share"))
+	t.Setenv("PATH", fakeHome)
+	t.Setenv("DO_NOT_TRACK", "1")
+
+	cmd := root.NewRootCmd("test")
+
+	var violations []string
+	walkCommands(cmd, func(c *cobra.Command) {
+		if c.Annotations["destructiveHint"] != "true" {
+			return
+		}
+		f := c.Flags().ShorthandLookup("f")
+		if f == nil || f.Name != "force" {
+			violations = append(violations, fmt.Sprintf("%s: has destructiveHint but no --force / -f flag", c.CommandPath()))
+		}
+	})
+
+	assert.Assert(t, len(violations) == 0,
+		"commands with destructiveHint must expose --force (-f):\n%v", violations)
+}
+
+// TestForceFlagHasDestructiveHint is the inverse: every command with a
+// --force / -f flag should be marked destructiveHint so MCP clients know it
+// can mutate state. Commands that use --force for non-destructive purposes
+// (e.g. overwriting a local file) are listed in the allowlist below.
+func TestForceFlagHasDestructiveHint(t *testing.T) {
+	fakeHome := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", filepath.Join(fakeHome, ".local", "share"))
+	t.Setenv("PATH", fakeHome)
+	t.Setenv("DO_NOT_TRACK", "1")
+
+	// Commands whose --force is NOT a destructive API operation (e.g. overwrite
+	// a local config file). Add to this list only with a comment explaining why.
+	allowlist := map[string]bool{
+		"circleci project link": true, // --force overwrites .circleci/config.yml locally, no API mutation
+	}
+
+	cmd := root.NewRootCmd("test")
+
+	var violations []string
+	walkCommands(cmd, func(c *cobra.Command) {
+		f := c.Flags().ShorthandLookup("f")
+		if f == nil || f.Name != "force" {
+			return
+		}
+		if allowlist[c.CommandPath()] {
+			return
+		}
+		if c.Annotations["destructiveHint"] != "true" {
+			violations = append(violations, fmt.Sprintf("%s: has --force but no destructiveHint annotation", c.CommandPath()))
+		}
+	})
+
+	assert.Assert(t, len(violations) == 0,
+		"commands with --force (-f) must have destructiveHint annotation (or be added to the allowlist):\n%v", violations)
+}
+
+func walkCommands(cmd *cobra.Command, fn func(*cobra.Command)) {
+	fn(cmd)
+	for _, sub := range cmd.Commands() {
+		walkCommands(sub, fn)
+	}
+}

--- a/internal/cmd/root/testdata/help/circleci/dlc/purge.txt
+++ b/internal/cmd/root/testdata/help/circleci/dlc/purge.txt
@@ -21,6 +21,7 @@ JSON fields (--json): project_id, project_slug
 
 | Flag               | Description                                             |
 | ------------------ | ------------------------------------------------------- |
+| `-f, --force`      | Skip confirmation prompt                                |
 | `--json`           | Output as JSON                                          |
 | `--project string` | Project slug (e.g. gh/org/repo); defaults to git remote |
 
@@ -39,8 +40,10 @@ JSON fields (--json): project_id, project_slug
   `circleci dlc purge`
 - Purge DLC for a specific project: 
   `circleci dlc purge --project gh/myorg/myrepo`
+- Skip the confirmation prompt (for scripting): 
+  `circleci dlc purge --project gh/myorg/myrepo --force`
 - Purge DLC and output result as JSON: 
-  `circleci dlc purge --project gh/myorg/myrepo --json`
+  `circleci dlc purge --project gh/myorg/myrepo --force --json`
 - Purge DLC for a Bitbucket project: 
   `circleci dlc purge --project bb/myorg/myrepo`
 

--- a/internal/cmd/root/testdata/help/circleci/extension/remove.txt
+++ b/internal/cmd/root/testdata/help/circleci/extension/remove.txt
@@ -10,6 +10,12 @@ CLI command.
 
 `circleci extension remove <extension> [flags]`
 
+## Flags
+
+| Flag          | Description              |
+| ------------- | ------------------------ |
+| `-f, --force` | Skip confirmation prompt |
+
 ## Inherited Flags
 
 | Flag                  | Description                                                  |
@@ -25,6 +31,8 @@ CLI command.
   `circleci extension remove <name>`
 - Remove using the full binary name: 
   `circleci extension remove circleci-<name>`
+- Remove without confirmation prompt: 
+  `circleci extension remove <name> --force`
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/project/dlc/purge.txt
+++ b/internal/cmd/root/testdata/help/circleci/project/dlc/purge.txt
@@ -21,6 +21,7 @@ JSON fields (--json): project_id, project_slug
 
 | Flag               | Description                                             |
 | ------------------ | ------------------------------------------------------- |
+| `-f, --force`      | Skip confirmation prompt                                |
 | `--json`           | Output as JSON                                          |
 | `--project string` | Project slug (e.g. gh/org/repo); defaults to git remote |
 
@@ -39,8 +40,10 @@ JSON fields (--json): project_id, project_slug
   `circleci dlc purge`
 - Purge DLC for a specific project: 
   `circleci dlc purge --project gh/myorg/myrepo`
+- Skip the confirmation prompt (for scripting): 
+  `circleci dlc purge --project gh/myorg/myrepo --force`
 - Purge DLC and output result as JSON: 
-  `circleci dlc purge --project gh/myorg/myrepo --json`
+  `circleci dlc purge --project gh/myorg/myrepo --force --json`
 - Purge DLC for a Bitbucket project: 
   `circleci dlc purge --project bb/myorg/myrepo`
 

--- a/internal/cmd/root/testdata/help/circleci/reference.txt
+++ b/internal/cmd/root/testdata/help/circleci/reference.txt
@@ -762,6 +762,7 @@ Purge the Docker Layer Cache for a project
 
 | Flag               | Description                                             |
 | ------------------ | ------------------------------------------------------- |
+| `-f, --force`      | Skip confirmation prompt                                |
 | `--json`           | Output as JSON                                          |
 | `--project string` | Project slug (e.g. gh/org/repo); defaults to git remote |
 
@@ -1358,6 +1359,7 @@ Purge the Docker Layer Cache for a project
 
 | Flag               | Description                                             |
 | ------------------ | ------------------------------------------------------- |
+| `-f, --force`      | Skip confirmation prompt                                |
 | `--json`           | Output as JSON                                          |
 | `--project string` | Project slug (e.g. gh/org/repo); defaults to git remote |
 
@@ -2070,9 +2072,14 @@ Manage CLI extensions
 
 Install an extension
 
-#### `circleci extension remove <extension>`
+#### `circleci extension remove <extension> [flags]`
 
 Remove an installed extension
+
+| Flag          | Description              |
+| ------------- | ------------------------ |
+| `-f, --force` | Skip confirmation prompt |
+
 
 ### `circleci testsuite`
 

--- a/internal/cmd/root/testdata/usage/circleci/dlc/purge.txt
+++ b/internal/cmd/root/testdata/usage/circleci/dlc/purge.txt
@@ -1,6 +1,7 @@
 Usage:  circleci dlc purge [flags]
 
 Flags:
-  --json             Output as JSON
-  --project string   Project slug (e.g. gh/org/repo); defaults to git remote
+  -f, --force            Skip confirmation prompt
+      --json             Output as JSON
+      --project string   Project slug (e.g. gh/org/repo); defaults to git remote
   

--- a/internal/cmd/root/testdata/usage/circleci/extension/remove.txt
+++ b/internal/cmd/root/testdata/usage/circleci/extension/remove.txt
@@ -1,1 +1,5 @@
-Usage:  circleci extension remove <extension>
+Usage:  circleci extension remove <extension> [flags]
+
+Flags:
+  -f, --force   Skip confirmation prompt
+  

--- a/internal/cmd/root/testdata/usage/circleci/project/dlc/purge.txt
+++ b/internal/cmd/root/testdata/usage/circleci/project/dlc/purge.txt
@@ -1,6 +1,7 @@
 Usage:  circleci project dlc purge [flags]
 
 Flags:
-  --json             Output as JSON
-  --project string   Project slug (e.g. gh/org/repo); defaults to git remote
+  -f, --force            Skip confirmation prompt
+      --json             Output as JSON
+      --project string   Project slug (e.g. gh/org/repo); defaults to git remote
   

--- a/internal/cmd/run/cancel.go
+++ b/internal/cmd/run/cancel.go
@@ -55,6 +55,7 @@ func newCancelCmd() *cobra.Command {
 
 				The project is inferred from the git remote unless overridden with %[1]s--project%[1]s.
 			`, "`"),
+			"destructiveHint": "true",
 		},
 		Long: heredoc.Doc(`
 			Cancel a running CircleCI run by number or UUID.

--- a/internal/cmd/runner/resource_class.go
+++ b/internal/cmd/runner/resource_class.go
@@ -265,6 +265,7 @@ func newResourceClassDeleteCmd() *cobra.Command {
 				The resource class to delete, given in the form %[1]snamespace/name%[1]s,
 				where namespace is your organization name (for example, %[1]smy-org/my-runner%[1]s).
 			`, "`"),
+			"destructiveHint": "true",
 		},
 		Long: heredoc.Doc(`
 			Delete a CircleCI runner resource class.

--- a/internal/cmd/runner/token.go
+++ b/internal/cmd/runner/token.go
@@ -288,6 +288,7 @@ func newTokenDeleteCmd() *cobra.Command {
 				%[1]s<token-id>%[1]s is the ID of the token to delete (a UUID). Find token IDs
 				with: %[1]scircleci runner token list --resource-class <namespace/name>%[1]s
 			`, "`"),
+			"destructiveHint": "true",
 		},
 		Long: heredoc.Docf(`
 			Delete a CircleCI runner authentication token by its ID.

--- a/internal/cmd/signingconfig/signingconfig.go
+++ b/internal/cmd/signingconfig/signingconfig.go
@@ -331,6 +331,7 @@ func newDeleteCmd() *cobra.Command {
 				%[1]s<signing-config-id>%[1]s is the ID of the signing config to delete
 				Use %[1]scircleci signing-config list%[1]s to find the ID.
 			`, "`"),
+			"destructiveHint": "true",
 		},
 		Long: heredoc.Doc(`
 			Permanently remove an iOS signing config from your organization.

--- a/internal/cmd/workflow/cancel.go
+++ b/internal/cmd/workflow/cancel.go
@@ -47,6 +47,7 @@ func newCancelCmd() *cobra.Command {
 				%[1]s<workflow-id>%[1]s is the UUID of the workflow to cancel. Workflow IDs are
 				shown in the output of %[1]scircleci run get%[1]s.
 			`, "`"),
+			"destructiveHint": "true",
 		},
 		Long: heredoc.Doc(`
 			Cancel a running CircleCI workflow.


### PR DESCRIPTION
Also add `--force` to a couple commands that were missing it.

Testing ensures that any command with one of these attributes also has the other.