### PR TITLE
Paginate run list and my runs transparently

### DIFF
--- a/acceptance/my_test.go
+++ b/acceptance/my_test.go
@@ -24,6 +24,7 @@ package acceptance_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -184,6 +185,40 @@ func TestMyRuns_JSON(t *testing.T) {
 	assert.Check(t, cmp.Equal(out[2]["project"], "acme/api"))
 	assert.Check(t, cmp.Equal(out[2]["project_id"], "a0000000-0000-4000-8000-00000000aa02"))
 	assert.Check(t, cmp.Equal(out[2]["current_outcome"], "failed"))
+}
+
+// TestMyRuns_PaginatesMultiPage verifies that my runs transparently paginates
+// when the requested limit exceeds the API's max page size (20). With 25 user
+// runs in the fake and --limit 25, the client must make two requests and return
+// all 25 results — not just the first page of 20.
+func TestMyRuns_PaginatesMultiPage(t *testing.T) {
+	fake := fakes.NewCircleCI(t)
+	runs := make([]any, 25)
+	for i := range runs {
+		id := fmt.Sprintf("e0000000-0000-4000-8000-%012x", i+1)
+		rev := fmt.Sprintf("%016x", i+1)
+		runs[i] = fakeMyRunV3(id, "a0000000-0000-4000-8000-00000000aa01", "ended", "succeeded",
+			"https://github.com/acme/web", "main", rev, "2026-06-19T10:00:00Z")
+	}
+	fake.SetUserRuns(runs...)
+
+	env := testenv.New(t)
+	env.Token = testToken
+	env.CircleCIURL = fake.URL()
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"my", "runs", "--limit", "25", "--json"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	var out []map[string]any
+	assert.NilError(t, json.Unmarshal([]byte(result.Stdout), &out))
+	assert.Check(t, cmp.Len(out, 25), "expected 25 runs across two pages, got %d", len(out))
+	assert.Check(t, cmp.Equal(out[0]["id"], "e0000000-0000-4000-8000-000000000001"))
+	assert.Check(t, cmp.Equal(out[24]["id"], "e0000000-0000-4000-8000-000000000019"))
 }
 
 func TestMyRuns_NoToken(t *testing.T) {

--- a/acceptance/run_test.go
+++ b/acceptance/run_test.go
@@ -24,6 +24,7 @@ package acceptance_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/url"
 	"runtime"
@@ -1326,6 +1327,70 @@ func TestRunList_NoToken(t *testing.T) {
 
 	assert.Equal(t, result.ExitCode, 3, "stderr: %s", result.Stderr) // ExitAuthError
 	assert.Check(t, golden.String(result.Stderr, t.Name()+".stderr.txt"))
+}
+
+// TestRunList_PaginatesMultiPage verifies that run list transparently paginates
+// when the requested limit exceeds the API's max page size (20). With 25 runs
+// in the fake and --limit 25, the client must make two requests and return all
+// 25 results — not just the first page of 20.
+func TestRunList_PaginatesMultiPage(t *testing.T) {
+	fake := fakes.NewCircleCI(t)
+	slug := watchSlug
+	addProjectBySlug(fake, slug, runTestProjectID)
+	for i := 1; i <= 25; i++ {
+		id := fmt.Sprintf("e0000000-0000-4000-8000-%012x", i)
+		rev := fmt.Sprintf("%016x", i)
+		fake.AddRunV3(id, runTestProjectID, fakeRunV3(id, runTestProjectID, "ended", "succeeded", "main", rev))
+	}
+
+	env := testenv.New(t)
+	env.Token = testToken
+	env.CircleCIURL = fake.URL()
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"run", "list", "--project", slug, "--limit", "25", "--json"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	var out []map[string]any
+	assert.NilError(t, json.Unmarshal([]byte(result.Stdout), &out))
+	assert.Check(t, cmp.Len(out, 25), "expected 25 runs across two pages, got %d", len(out))
+	assert.Check(t, cmp.Equal(out[0]["id"], "e0000000-0000-4000-8000-000000000001"))
+	assert.Check(t, cmp.Equal(out[24]["id"], "e0000000-0000-4000-8000-000000000019"))
+}
+
+// TestRunList_PaginatesExhausted verifies that run list stops fetching pages as
+// soon as the server signals there are no more results, even when the requested
+// limit has not been reached. With 15 runs and --limit 25, a single page covers
+// all results (next is nil) and the client returns 15, not 25.
+func TestRunList_PaginatesExhausted(t *testing.T) {
+	fake := fakes.NewCircleCI(t)
+	slug := watchSlug
+	addProjectBySlug(fake, slug, runTestProjectID)
+	for i := 1; i <= 15; i++ {
+		id := fmt.Sprintf("e0000000-0000-4000-8000-%012x", i)
+		rev := fmt.Sprintf("%016x", i)
+		fake.AddRunV3(id, runTestProjectID, fakeRunV3(id, runTestProjectID, "ended", "succeeded", "main", rev))
+	}
+
+	env := testenv.New(t)
+	env.Token = testToken
+	env.CircleCIURL = fake.URL()
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"run", "list", "--project", slug, "--limit", "25", "--json"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	var out []map[string]any
+	assert.NilError(t, json.Unmarshal([]byte(result.Stdout), &out))
+	assert.Check(t, cmp.Len(out, 15), "expected 15 runs (server exhausted before limit), got %d", len(out))
 }
 
 // --- run trigger (still V2) ---

--- a/internal/apiclient/run.go
+++ b/internal/apiclient/run.go
@@ -216,36 +216,67 @@ type runSearchPage struct {
 	Limit  int    `json:"limit"`
 }
 
+// maxRunsPageSize is the maximum page size accepted by the runs API endpoints.
+// Requests with a larger page size are rejected with 400 "Invalid page size".
+const maxRunsPageSize = 20
+
+// paginateRunsV3 drives the common pagination loop shared by SearchRunsV3 and
+// ListMyRunsV3. fetch is called once per page with the clamped page size and
+// current cursor; it returns the raw response page. The loop stops when the
+// response carries no next cursor, returns an empty page, or the requested
+// total has been collected.
+func paginateRunsV3(
+	limit int,
+	cursor string,
+	fetch func(pageSize int, cursor string) (v3List[runWire], error),
+) ([]RunV3, error) {
+	if limit <= 0 {
+		limit = 10
+	}
+	var allRuns []RunV3
+	remaining := limit
+	for remaining > 0 {
+		pageSize := remaining
+		if pageSize > maxRunsPageSize {
+			pageSize = maxRunsPageSize
+		}
+		resp, err := fetch(pageSize, cursor)
+		if err != nil {
+			return nil, err
+		}
+		for _, w := range resp.Data {
+			allRuns = append(allRuns, *w.toRunV3())
+		}
+		remaining -= len(resp.Data)
+		if resp.Page.Next == nil || len(resp.Data) == 0 {
+			break
+		}
+		cursor = *resp.Page.Next
+	}
+	return allRuns, nil
+}
+
 // SearchRunsV3 searches for runs using the V3 search endpoint.
+// It paginates transparently when params.Limit exceeds maxRunsPageSize.
 func (c *Client) SearchRunsV3(ctx context.Context, params RunSearchParams) ([]RunV3, error) {
-	if params.Limit <= 0 {
-		params.Limit = 10
-	}
-
-	body := runSearchRequest{
-		Scope: runSearchScope{
-			ProjectIDs: params.ProjectIDs,
-			From:       params.From.Format(time.RFC3339),
-			To:         params.To.Format(time.RFC3339),
-		},
-		Filter:  params.Filter,
-		OrderBy: params.OrderBy,
-		Page: runSearchPage{
-			Cursor: params.Cursor,
-			Limit:  params.Limit,
-		},
-	}
-
-	var resp v3List[runWire]
-	if err := c.postV3(ctx, "/runs/search", body, &resp); err != nil {
-		return nil, err
-	}
-
-	runs := make([]RunV3, len(resp.Data))
-	for i, w := range resp.Data {
-		runs[i] = *w.toRunV3()
-	}
-	return runs, nil
+	return paginateRunsV3(params.Limit, params.Cursor, func(pageSize int, cursor string) (v3List[runWire], error) {
+		body := runSearchRequest{
+			Scope: runSearchScope{
+				ProjectIDs: params.ProjectIDs,
+				From:       params.From.Format(time.RFC3339),
+				To:         params.To.Format(time.RFC3339),
+			},
+			Filter:  params.Filter,
+			OrderBy: params.OrderBy,
+			Page: runSearchPage{
+				Cursor: cursor,
+				Limit:  pageSize,
+			},
+		}
+		var resp v3List[runWire]
+		err := c.postV3(ctx, "/runs/search", body, &resp)
+		return resp, err
+	})
 }
 
 // MyRunsParams configures a ListMyRunsV3 request. All fields are optional: the
@@ -264,29 +295,26 @@ type MyRunsParams struct {
 }
 
 // ListMyRunsV3 lists runs triggered by the authenticated user across all
-// projects, via GET /api/v3/runs?filter[user_id]=me.
+// projects, via GET /api/v3/runs?filter[user_id]=me. Paginates transparently
+// when params.Limit exceeds maxRunsPageSize.
 //
 // Unlike the runs/search endpoint, this endpoint has no pipeline.status filter —
 // it filters on the run's own phase and current_outcome — so the status is
 // converted to those via StatusPhaseOutcome.
 func (c *Client) ListMyRunsV3(ctx context.Context, params MyRunsParams) ([]RunV3, error) {
 	phase, currentOutcome := StatusPhaseOutcome(params.Status)
-	var resp v3List[runWire]
-	if err := c.getV3(ctx, "/runs", &resp,
-		filterParam("user_id", "me"),
-		filterParam("phase", phase),
-		filterParam("current_outcome", currentOutcome),
-		filterParam("from", rfc3339OrEmpty(params.From)),
-		filterParam("to", rfc3339OrEmpty(params.To)),
-		pageLimit(params.Limit)); err != nil {
-		return nil, err
-	}
-
-	runs := make([]RunV3, len(resp.Data))
-	for i, w := range resp.Data {
-		runs[i] = *w.toRunV3()
-	}
-	return runs, nil
+	return paginateRunsV3(params.Limit, "", func(pageSize int, cursor string) (v3List[runWire], error) {
+		var resp v3List[runWire]
+		err := c.getV3(ctx, "/runs", &resp,
+			filterParam("user_id", "me"),
+			filterParam("phase", phase),
+			filterParam("current_outcome", currentOutcome),
+			filterParam("from", rfc3339OrEmpty(params.From)),
+			filterParam("to", rfc3339OrEmpty(params.To)),
+			pageLimit(pageSize),
+			pageCursor(cursor))
+		return resp, err
+	})
 }
 
 // Pipeline status values, as reported by the V3 runs API and accepted by the

--- a/internal/testing/fakes/circleci.go
+++ b/internal/testing/fakes/circleci.go
@@ -1031,13 +1031,23 @@ func (f *CircleCI) handleListMyRunsV3(w http.ResponseWriter, r *http.Request) {
 	}
 	f.mu.RUnlock()
 
-	if size, err := strconv.Atoi(r.URL.Query().Get("page[limit]")); err == nil && size > 0 && len(results) > size {
-		results = results[:size]
+	offset, _ := strconv.Atoi(r.URL.Query().Get("page[cursor]"))
+	if offset > len(results) {
+		offset = len(results)
+	}
+	page := results[offset:]
+	if size, err := strconv.Atoi(r.URL.Query().Get("page[limit]")); err == nil && size > 0 && len(page) > size {
+		page = page[:size]
+	}
+
+	var next any
+	if nextOff := offset + len(page); nextOff < len(results) {
+		next = strconv.Itoa(nextOff)
 	}
 
 	render.JSON(w, r, map[string]any{
-		"data": results,
-		"page": map[string]any{"next": nil, "prev": nil},
+		"data": page,
+		"page": map[string]any{"next": next, "prev": nil},
 	})
 }
 
@@ -1062,7 +1072,8 @@ func (f *CircleCI) handleSearchRunsV3(w http.ResponseWriter, r *http.Request) {
 		} `json:"scope"`
 		Filter string `json:"filter"`
 		Page   struct {
-			Limit int `json:"limit"`
+			Cursor string `json:"cursor"`
+			Limit  int    `json:"limit"`
 		} `json:"page"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -1075,7 +1086,7 @@ func (f *CircleCI) handleSearchRunsV3(w http.ResponseWriter, r *http.Request) {
 	status := runStatusFilterExpr(body.Filter)
 
 	f.mu.RLock()
-	var results []any
+	var all []any
 	for _, pid := range body.Scope.ProjectIDs {
 		for _, run := range f.runsV3ByProject[pid] {
 			if branch != "" && runBranch(run) != branch {
@@ -1084,18 +1095,29 @@ func (f *CircleCI) handleSearchRunsV3(w http.ResponseWriter, r *http.Request) {
 			if status != "" && runStatus(run) != status {
 				continue
 			}
-			results = append(results, run)
+			all = append(all, run)
 		}
 	}
 	f.mu.RUnlock()
 
-	if body.Page.Limit > 0 && len(results) > body.Page.Limit {
-		results = results[:body.Page.Limit]
+	offset, _ := strconv.Atoi(body.Page.Cursor)
+	if offset > len(all) {
+		offset = len(all)
+	}
+	page := all[offset:]
+	if body.Page.Limit > 0 && len(page) > body.Page.Limit {
+		page = page[:body.Page.Limit]
+	}
+
+	var next any
+	if nextOff := offset + len(page); nextOff < len(all) {
+		s := strconv.Itoa(nextOff)
+		next = s
 	}
 
 	render.JSON(w, r, map[string]any{
-		"data": results,
-		"page": map[string]any{"next": nil, "prev": nil},
+		"data": page,
+		"page": map[string]any{"next": next, "prev": nil},
 	})
 }
 


### PR DESCRIPTION
Both SearchRunsV3 and ListMyRunsV3 passed the raw --limit value directly to the API as the page size, which rejects anything above 20 with 400 "Invalid page size". Both functions now cap each request at maxRunsPageSize (20) and follow page.next cursors until the requested limit is satisfied. The fake server gains cursor support for both endpoints so tests with limits > 20 work correctly.