### PR TITLE
Add Snyk agent scan for MCP server security

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,34 @@ jobs:
       - run: task ci:test
       - store_results
 
+  agent-scan:
+    executor: linux
+    steps:
+      - setup
+      - run: task build
+      - run:
+          name: Install uv
+          command: |
+            curl -LsSf https://astral.sh/uv/install.sh | sh
+            echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
+      - run:
+          name: Create Claude Desktop config for MCP server discovery
+          command: |
+            mkdir -p "$HOME/.config/Claude"
+            cat > "$HOME/.config/Claude/claude_desktop_config.json" <<'EOF'
+            {
+              "mcpServers": {
+                "circleci": {
+                  "command": "/home/circleci/project/dist/circleci",
+                  "args": ["mcp", "start"]
+                }
+              }
+            }
+            EOF
+      - run:
+          name: Run Snyk agent scan
+          command: uvx snyk-agent-scan@latest
+
   mark-release:
     executor: linux
     steps:
@@ -189,11 +217,19 @@ workflows:
                 - main
                 - gh-pages
 
+      - agent-scan:
+          context:
+            - snyk
+          filters:
+            branches:
+              ignore: gh-pages
+
       - ok-to-deploy:
           requires:
             - check
             - test
             - docs
+            - agent-scan
           filters:
             branches:
               only: main

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -363,6 +363,11 @@ tasks:
       - go run ./cmd/cloudsmith push deb {{if .DRY_RUN}}--dry-run {{end}}--repo '{{.CLOUDSMITH_REPO}}' dist/*.deb
       - go run ./cmd/cloudsmith push rpm {{if .DRY_RUN}}--dry-run {{end}}--repo '{{.CLOUDSMITH_REPO}}' dist/*.rpm
 
+  security:scan:
+    desc: Scan MCP server tool descriptions for security issues with Snyk agent scan
+    cmds:
+      - uvx snyk-agent-scan@latest
+
   ci:build:
     desc: Dry-run a release — build a snapshot (incl. nfpms) and dry-run the packagecloud publish
     vars:


### PR DESCRIPTION
Scans MCP tool descriptions for prompt injection, tool poisoning, and other agent-layer security issues using snyk-agent-scan.

- task security:scan for local runs (uvx snyk-agent-scan@latest)
- agent-scan CI job: builds the binary, writes a Claude Desktop config pointing to it, then runs the scan; gates ok-to-deploy on main

Requires a CircleCI context named 'snyk' with SNYK_TOKEN set.
