### PR TITLE
Override default MCP server name to `circleci-cli`

### DIFF
--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -270,6 +270,30 @@ func NewRootCmd(version string) *cobra.Command {
 				_ = os.Setenv("CIRCLE_MCP", "1")
 				return orig(cmd, args)
 			}
+		default:
+			// Editor groups (claude/cursor/vscode). ophis defaults the
+			// generated MCP server-config key to the executable basename
+			// ("circleci"); override it to "circleci-cli". Setting the flag
+			// value (rather than DefValue, which is help-text only) writes
+			// through the bound variable so it becomes the effective default,
+			// while an explicit `--server-name` from the user still wins.
+			// TODO: Remove this if/when https://github.com/njayp/ophis/pull/49 is released.
+			for _, editorSub := range sub.Commands() {
+				if editorSub.Name() != "enable" && editorSub.Name() != "disable" {
+					continue
+				}
+				if f := editorSub.Flags().Lookup("server-name"); f != nil {
+					_ = f.Value.Set("circleci-cli")
+					f.DefValue = "circleci-cli"
+					// Strip ophis's hand-written "(default: derived from
+					// executable name)" clause — it's no longer accurate and
+					// would sit next to the "(default "circleci-cli")" clause
+					// cobra appends from DefValue, producing a doubled,
+					// contradictory note in the help text. Trim only the clause
+					// so each command keeps its own phrasing (enable vs remove).
+					f.Usage = strings.TrimSuffix(f.Usage, " (default: derived from executable name)")
+				}
+			}
 		}
 	}
 

--- a/internal/cmd/root/testdata/help/circleci/mcp/claude/disable.txt
+++ b/internal/cmd/root/testdata/help/circleci/mcp/claude/disable.txt
@@ -8,10 +8,10 @@ Remove this application from Claude Desktop MCP servers
 
 ## Flags
 
-| Flag                   | Description                                                              |
-| ---------------------- | ------------------------------------------------------------------------ |
-| `--config-path string` | Path to Claude config file                                               |
-| `--server-name string` | Name of the MCP server to remove (default: derived from executable name) |
+| Flag                   | Description                                               |
+| ---------------------- | --------------------------------------------------------- |
+| `--config-path string` | Path to Claude config file                                |
+| `--server-name string` | Name of the MCP server to remove (default "circleci-cli") |
 
 ## Inherited Flags
 

--- a/internal/cmd/root/testdata/help/circleci/mcp/claude/enable.txt
+++ b/internal/cmd/root/testdata/help/circleci/mcp/claude/enable.txt
@@ -13,7 +13,7 @@ Add this application as an MCP server in Claude Desktop
 | `--config-path string`     | Path to Claude config file                                                     |
 | `-e, --env stringToString` | Environment variables (e.g., --env KEY1=value1 --env KEY2=value2) (default []) |
 | `--log-level string`       | Log level (debug, info, warn, error)                                           |
-| `--server-name string`     | Name for the MCP server (default: derived from executable name)                |
+| `--server-name string`     | Name for the MCP server (default "circleci-cli")                               |
 
 ## Inherited Flags
 

--- a/internal/cmd/root/testdata/help/circleci/mcp/cursor/disable.txt
+++ b/internal/cmd/root/testdata/help/circleci/mcp/cursor/disable.txt
@@ -11,7 +11,7 @@ Remove this application from Cursor MCP servers
 | Flag                   | Description                                                                |
 | ---------------------- | -------------------------------------------------------------------------- |
 | `--config-path string` | Path to Cursor config file                                                 |
-| `--server-name string` | Name of the MCP server to remove (default: derived from executable name)   |
+| `--server-name string` | Name of the MCP server to remove (default "circleci-cli")                  |
 | `--workspace`          | Remove from workspace settings (.cursor/mcp.json) instead of user settings |
 
 ## Inherited Flags

--- a/internal/cmd/root/testdata/help/circleci/mcp/cursor/enable.txt
+++ b/internal/cmd/root/testdata/help/circleci/mcp/cursor/enable.txt
@@ -13,7 +13,7 @@ Add this application as an MCP server in Cursor
 | `--config-path string`     | Path to Cursor config file                                                     |
 | `-e, --env stringToString` | Environment variables (e.g., --env KEY1=value1 --env KEY2=value2) (default []) |
 | `--log-level string`       | Log level (debug, info, warn, error)                                           |
-| `--server-name string`     | Name for the MCP server (default: derived from executable name)                |
+| `--server-name string`     | Name for the MCP server (default "circleci-cli")                               |
 | `--workspace`              | Add to workspace settings (.cursor/mcp.json) instead of user settings          |
 
 ## Inherited Flags

--- a/internal/cmd/root/testdata/help/circleci/mcp/vscode/disable.txt
+++ b/internal/cmd/root/testdata/help/circleci/mcp/vscode/disable.txt
@@ -11,7 +11,7 @@ Remove this application from VSCode MCP servers
 | Flag                   | Description                                                                |
 | ---------------------- | -------------------------------------------------------------------------- |
 | `--config-path string` | Path to VSCode config file                                                 |
-| `--server-name string` | Name of the MCP server to remove (default: derived from executable name)   |
+| `--server-name string` | Name of the MCP server to remove (default "circleci-cli")                  |
 | `--workspace`          | Remove from workspace settings (.vscode/mcp.json) instead of user settings |
 
 ## Inherited Flags

--- a/internal/cmd/root/testdata/help/circleci/mcp/vscode/enable.txt
+++ b/internal/cmd/root/testdata/help/circleci/mcp/vscode/enable.txt
@@ -13,7 +13,7 @@ Add this application as an MCP server in VSCode
 | `--config-path string`     | Path to VSCode config file                                                     |
 | `-e, --env stringToString` | Environment variables (e.g., --env KEY1=value1 --env KEY2=value2) (default []) |
 | `--log-level string`       | Log level (debug, info, warn, error)                                           |
-| `--server-name string`     | Name for the MCP server (default: derived from executable name)                |
+| `--server-name string`     | Name for the MCP server (default "circleci-cli")                               |
 | `--workspace`              | Add to workspace settings (.vscode/mcp.json) instead of user settings          |
 
 ## Inherited Flags

--- a/internal/cmd/root/testdata/help/circleci/reference.txt
+++ b/internal/cmd/root/testdata/help/circleci/reference.txt
@@ -1857,10 +1857,10 @@ Manage Claude Desktop MCP servers
 
 Remove server from Claude config
 
-| Flag                   | Description                                                              |
-| ---------------------- | ------------------------------------------------------------------------ |
-| `--config-path string` | Path to Claude config file                                               |
-| `--server-name string` | Name of the MCP server to remove (default: derived from executable name) |
+| Flag                   | Description                                               |
+| ---------------------- | --------------------------------------------------------- |
+| `--config-path string` | Path to Claude config file                                |
+| `--server-name string` | Name of the MCP server to remove (default "circleci-cli") |
 
 
 ##### `circleci mcp claude enable [flags]`
@@ -1872,7 +1872,7 @@ Add server to Claude config
 | `--config-path string`     | Path to Claude config file                                                     |
 | `-e, --env stringToString` | Environment variables (e.g., --env KEY1=value1 --env KEY2=value2) (default []) |
 | `--log-level string`       | Log level (debug, info, warn, error)                                           |
-| `--server-name string`     | Name for the MCP server (default: derived from executable name)                |
+| `--server-name string`     | Name for the MCP server (default "circleci-cli")                               |
 
 
 ##### `circleci mcp claude list [flags]`
@@ -1895,7 +1895,7 @@ Remove server from Cursor config
 | Flag                   | Description                                                                |
 | ---------------------- | -------------------------------------------------------------------------- |
 | `--config-path string` | Path to Cursor config file                                                 |
-| `--server-name string` | Name of the MCP server to remove (default: derived from executable name)   |
+| `--server-name string` | Name of the MCP server to remove (default "circleci-cli")                  |
 | `--workspace`          | Remove from workspace settings (.cursor/mcp.json) instead of user settings |
 
 
@@ -1908,7 +1908,7 @@ Add server to Cursor config
 | `--config-path string`     | Path to Cursor config file                                                     |
 | `-e, --env stringToString` | Environment variables (e.g., --env KEY1=value1 --env KEY2=value2) (default []) |
 | `--log-level string`       | Log level (debug, info, warn, error)                                           |
-| `--server-name string`     | Name for the MCP server (default: derived from executable name)                |
+| `--server-name string`     | Name for the MCP server (default "circleci-cli")                               |
 | `--workspace`              | Add to workspace settings (.cursor/mcp.json) instead of user settings          |
 
 
@@ -1962,7 +1962,7 @@ Remove server from VSCode config
 | Flag                   | Description                                                                |
 | ---------------------- | -------------------------------------------------------------------------- |
 | `--config-path string` | Path to VSCode config file                                                 |
-| `--server-name string` | Name of the MCP server to remove (default: derived from executable name)   |
+| `--server-name string` | Name of the MCP server to remove (default "circleci-cli")                  |
 | `--workspace`          | Remove from workspace settings (.vscode/mcp.json) instead of user settings |
 
 
@@ -1975,7 +1975,7 @@ Add server to VSCode config
 | `--config-path string`     | Path to VSCode config file                                                     |
 | `-e, --env stringToString` | Environment variables (e.g., --env KEY1=value1 --env KEY2=value2) (default []) |
 | `--log-level string`       | Log level (debug, info, warn, error)                                           |
-| `--server-name string`     | Name for the MCP server (default: derived from executable name)                |
+| `--server-name string`     | Name for the MCP server (default "circleci-cli")                               |
 | `--workspace`              | Add to workspace settings (.vscode/mcp.json) instead of user settings          |
 
 

--- a/internal/cmd/root/testdata/usage/circleci/mcp/claude/disable.txt
+++ b/internal/cmd/root/testdata/usage/circleci/mcp/claude/disable.txt
@@ -2,5 +2,5 @@ Usage:  circleci mcp claude disable [flags]
 
 Flags:
   --config-path string   Path to Claude config file
-  --server-name string   Name of the MCP server to remove (default: derived from executable name)
+  --server-name string   Name of the MCP server to remove (default "circleci-cli")
   

--- a/internal/cmd/root/testdata/usage/circleci/mcp/claude/enable.txt
+++ b/internal/cmd/root/testdata/usage/circleci/mcp/claude/enable.txt
@@ -4,5 +4,5 @@ Flags:
       --config-path string   Path to Claude config file
   -e, --env stringToString   Environment variables (e.g., --env KEY1=value1 --env KEY2=value2) (default [])
       --log-level string     Log level (debug, info, warn, error)
-      --server-name string   Name for the MCP server (default: derived from executable name)
+      --server-name string   Name for the MCP server (default "circleci-cli")
   

--- a/internal/cmd/root/testdata/usage/circleci/mcp/cursor/disable.txt
+++ b/internal/cmd/root/testdata/usage/circleci/mcp/cursor/disable.txt
@@ -2,6 +2,6 @@ Usage:  circleci mcp cursor disable [flags]
 
 Flags:
   --config-path string   Path to Cursor config file
-  --server-name string   Name of the MCP server to remove (default: derived from executable name)
+  --server-name string   Name of the MCP server to remove (default "circleci-cli")
   --workspace            Remove from workspace settings (.cursor/mcp.json) instead of user settings
   

--- a/internal/cmd/root/testdata/usage/circleci/mcp/cursor/enable.txt
+++ b/internal/cmd/root/testdata/usage/circleci/mcp/cursor/enable.txt
@@ -4,6 +4,6 @@ Flags:
       --config-path string   Path to Cursor config file
   -e, --env stringToString   Environment variables (e.g., --env KEY1=value1 --env KEY2=value2) (default [])
       --log-level string     Log level (debug, info, warn, error)
-      --server-name string   Name for the MCP server (default: derived from executable name)
+      --server-name string   Name for the MCP server (default "circleci-cli")
       --workspace            Add to workspace settings (.cursor/mcp.json) instead of user settings
   

--- a/internal/cmd/root/testdata/usage/circleci/mcp/vscode/disable.txt
+++ b/internal/cmd/root/testdata/usage/circleci/mcp/vscode/disable.txt
@@ -2,6 +2,6 @@ Usage:  circleci mcp vscode disable [flags]
 
 Flags:
   --config-path string   Path to VSCode config file
-  --server-name string   Name of the MCP server to remove (default: derived from executable name)
+  --server-name string   Name of the MCP server to remove (default "circleci-cli")
   --workspace            Remove from workspace settings (.vscode/mcp.json) instead of user settings
   

--- a/internal/cmd/root/testdata/usage/circleci/mcp/vscode/enable.txt
+++ b/internal/cmd/root/testdata/usage/circleci/mcp/vscode/enable.txt
@@ -4,6 +4,6 @@ Flags:
       --config-path string   Path to VSCode config file
   -e, --env stringToString   Environment variables (e.g., --env KEY1=value1 --env KEY2=value2) (default [])
       --log-level string     Log level (debug, info, warn, error)
-      --server-name string   Name for the MCP server (default: derived from executable name)
+      --server-name string   Name for the MCP server (default "circleci-cli")
       --workspace            Add to workspace settings (.vscode/mcp.json) instead of user settings
   


### PR DESCRIPTION
- This will stop it colliding with the new hosted MCP server that we'd like to name `circleci`.
- Have raised https://github.com/njayp/ophis/pull/49 for official support.
