### PR TITLE
TEST-212 Update prompt extension to run the command after install

### DIFF
--- a/acceptance/extension_test.go
+++ b/acceptance/extension_test.go
@@ -106,6 +106,10 @@ func TestExtensionInstall_OfficialExtensionNotFound_Interactive(t *testing.T) {
 
 	_, err = console.Send("Y\r")
 	assert.NilError(t, err)
+
+	// expect the test binary to run after installation.
+	_, err = console.ExpectString("args []")
+	assert.NilError(t, err)
 }
 
 func TestExtensionInstall_InvalidExtensionName(t *testing.T) {

--- a/internal/cmd/extension/extension.go
+++ b/internal/cmd/extension/extension.go
@@ -30,6 +30,7 @@
 package extension
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -115,7 +116,12 @@ func newPromptCmd(name string) *cobra.Command {
 			if s.IsInteractive() {
 				prompt := fmt.Sprintf("%q is not installed. Install %q now?", name, name)
 				if s.Confirm(ctx, prompt) {
-					return installExtension(ctx, name)
+					ext, err := installExtension(ctx, name)
+					if err != nil {
+						return err
+					}
+
+					return runExtension(ctx, cmd, ext)
 				}
 			}
 
@@ -168,30 +174,32 @@ func newManagedCmd(ext extension.Manifest) *cobra.Command {
 		DisableFlagParsing: true,
 		SilenceUsage:       true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
-
-			extArgs := ParseRootFlags(cmd)
-
-			// Some extensions do not need a CCI account, load the client and suppress
-			// any errors; extensions are expected to handle any missing vars.
-			client, _ := cmdutil.LoadClient(ctx)
-
-			err := ext.Run(ctx, client, extArgs)
-			if err != nil {
-				if exitErr, ok := errors.AsType[*extension.ErrExited](err); ok {
-					return exitErr
-				}
-
-				return clierrors.New(
-					"extension.exec_failed",
-					"Extension failed",
-					fmt.Sprintf("extension %q could not be executed: %s", ext.BinaryName, err),
-				)
-			}
-
-			return nil
+			return runExtension(cmd.Context(), cmd, ext)
 		},
 	}
+}
+
+func runExtension(ctx context.Context, cmd *cobra.Command, ext extension.Manifest) error {
+	extArgs := ParseRootFlags(cmd)
+
+	// Some extensions do not need a CCI account, load the client and suppress
+	// any errors; extensions are expected to handle any missing vars.
+	client, _ := cmdutil.LoadClient(ctx)
+
+	err := ext.Run(ctx, client, extArgs)
+	if err != nil {
+		if exitErr, ok := errors.AsType[*extension.ErrExited](err); ok {
+			return exitErr
+		}
+
+		return clierrors.New(
+			"extension.exec_failed",
+			"Extension failed",
+			fmt.Sprintf("extension %q could not be executed: %s", ext.BinaryName, err),
+		)
+	}
+
+	return nil
 }
 
 // newUnmanagedCmd returns a cobra command that dispatches to the circleci-<name>

--- a/internal/cmd/extension/install.go
+++ b/internal/cmd/extension/install.go
@@ -62,17 +62,22 @@ func newInstallCmd() *cobra.Command {
 			}
 
 			ctx := cmd.Context()
-			return installExtension(ctx, args[0])
+			_, err := installExtension(ctx, args[0])
+			if err != nil {
+				return err
+			}
+
+			return nil
 		},
 	}
 
 	return cmd
 }
 
-func installExtension(ctx context.Context, name string) error {
+func installExtension(ctx context.Context, name string) (extension.Manifest, error) {
 	extDir, err := config.ExtensionsDir()
 	if err != nil {
-		return err
+		return extension.Manifest{}, err
 	}
 
 	cfg := cmdutil.GetConfig(ctx)
@@ -90,18 +95,18 @@ func installExtension(ctx context.Context, name string) error {
 	}
 	ext, err := m.Get(ctx, n)
 	if err != nil {
-		return installCLIError(err)
+		return extension.Manifest{}, installCLIError(err)
 	}
 
 	iostream.Printf(ctx, "Installing %s version %s...\n", ext.BinaryName, ext.Version)
 
-	err = m.Install(ctx, ext)
+	manifest, err := m.Install(ctx, ext)
 	if err != nil {
-		return installCLIError(err)
+		return extension.Manifest{}, installCLIError(err)
 	}
 
 	iostream.Printf(ctx, "%s Installed %s version %s\n", iostream.SymbolOK(ctx), ext.BinaryName, ext.Version)
-	return nil
+	return manifest, nil
 }
 
 func installCLIError(err error) error {

--- a/internal/extension/manager.go
+++ b/internal/extension/manager.go
@@ -140,7 +140,7 @@ func (m *Manager) Get(ctx context.Context, binaryName string) (Extension, error)
 	}, nil
 }
 
-func (m *Manager) Install(ctx context.Context, ext Extension) error {
+func (m *Manager) Install(ctx context.Context, ext Extension) (Manifest, error) {
 	buf := bytes.NewBuffer(nil)
 
 	hasher := sha256.New()
@@ -156,24 +156,24 @@ func (m *Manager) Install(ctx context.Context, ext Extension) error {
 	_, err := m.client.Call(ctx, req)
 	if err != nil {
 		if httpErr, ok := errors.AsType[*httpcl.HTTPError](err); ok {
-			return &ErrDownloadFailed{StatusCode: httpErr.StatusCode}
+			return Manifest{}, &ErrDownloadFailed{StatusCode: httpErr.StatusCode}
 		}
-		return err
+		return Manifest{}, err
 	}
 
 	got := hex.EncodeToString(hasher.Sum(nil))
 	if got != ext.Sha256 {
-		return &ErrChecksumMismatch{Expected: ext.Sha256, Got: got}
+		return Manifest{}, &ErrChecksumMismatch{Expected: ext.Sha256, Got: got}
 	}
 
 	// Ensure the extensions directory exists.
 	if err := os.MkdirAll(m.extensionsDir, 0750); err != nil {
-		return err
+		return Manifest{}, err
 	}
 
 	fsRoot, err := os.OpenRoot(m.extensionsDir)
 	if err != nil {
-		return err
+		return Manifest{}, err
 	}
 
 	defer func() { _ = fsRoot.Close() }()
@@ -184,41 +184,47 @@ func (m *Manager) Install(ctx context.Context, ext Extension) error {
 	}
 
 	if err := fsRoot.MkdirAll(filepath.Dir(target), 0750); err != nil {
-		return err
+		return Manifest{}, err
 	}
 
 	out, err := fsRoot.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0750)
 	if err != nil {
-		return err
+		return Manifest{}, err
 	}
 	defer func() { _ = out.Close() }()
 
 	zr, err := gzip.NewReader(buf)
 	if err != nil {
 		_ = os.Remove(target)
-		return err
+		return Manifest{}, err
 	}
 	defer func() { _ = zr.Close() }()
 
 	n, err := io.CopyN(out, zr, maxExtensionSize+1)
 	if err != nil {
 		if !errors.Is(err, io.EOF) {
-			return err
+			return Manifest{}, err
 		}
 	}
 
 	if n > maxExtensionSize {
-		return &ErrExtensionTooLarge{Name: ext.BinaryName, MaxSize: maxExtensionSize}
+		return Manifest{}, &ErrExtensionTooLarge{Name: ext.BinaryName, MaxSize: maxExtensionSize}
 	}
 
-	return m.writeManifest(fsRoot, Manifest{
+	manifest := Manifest{
 		Name:       strings.TrimPrefix(ext.BinaryName, "circleci-"),
 		BinaryName: ext.BinaryName,
 		Version:    ext.Version,
 		Sha256:     ext.Sha256,
 		URL:        ext.URL,
 		Path:       filepath.Join(fsRoot.Name(), target),
-	})
+	}
+
+	if err := m.writeManifest(fsRoot, manifest); err != nil {
+		return Manifest{}, err
+	}
+
+	return manifest, nil
 }
 
 // Remove removes the given extension.


### PR DESCRIPTION
When attempting to run an official extension that is not installed, the CLI will prompt on whether to install the extension.

Currently, the CLI will exit after a clean install, requiring the command to be executed again to run.

This changes that to run the intended command after installing it given a successful installation.

```shell
$ circleci testsuite "ci tests"
"testsuite" is not installed. Install "testsuite" now?[y/N] N
error: extension "testsuite" is not installed

Suggestions:
  • Install with: 'circleci extension install testsuite'
```

```shell
$ circleci testsuite "ci tests"      
"testsuite" is not installed. Install "testsuite" now?[y/N] y
Installing circleci-testsuite version 1.0.46717-34655a9...
✓ Installed circleci-testsuite version 1.0.46717-34655a9
==> Running test-suite-subcommand version "1.0.46717-34655a9" built "2026-07-20T14:51:08Z"
...
```

```shell
$ circleci testsuite "ci tests" --doctor
"testsuite" is not installed. Install "testsuite" now?[y/N] y
Installing circleci-testsuite version 1.0.46717-34655a9...
✓ Installed circleci-testsuite version 1.0.46717-34655a9
✓ test-suite configuration exists
✓ detect test runner
✓ test-suite configuration is valid
✓ discover command can discover test atoms
...
```