### PR TITLE
Add api_path property to command_invocation telemetry for circleci api

### DIFF
--- a/acceptance/api_test.go
+++ b/acceptance/api_test.go
@@ -23,17 +23,27 @@
 package acceptance_test
 
 import (
+	"context"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/segmentio/analytics-go/v3"
+	"github.com/shirou/gopsutil/v4/host"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/golden"
+	"gotest.tools/v3/poll"
 
+	"github.com/CircleCI-Public/circleci-cli/internal/config"
+	"github.com/CircleCI-Public/circleci-cli/internal/iostream"
+	"github.com/CircleCI-Public/circleci-cli/internal/telemetry"
 	"github.com/CircleCI-Public/circleci-cli/internal/testing/binary"
 	testenv "github.com/CircleCI-Public/circleci-cli/internal/testing/env"
+	"github.com/CircleCI-Public/circleci-cli/internal/testing/fakesegment"
 	"github.com/CircleCI-Public/circleci-cli/internal/testing/fakes"
 )
 
@@ -371,6 +381,80 @@ func TestAPI_ProjectIDSubstitution_NoProject(t *testing.T) {
 	// The git-detect failure embeds git's own (version/platform-dependent)
 	// message, so match a stable substring rather than golden the whole thing.
 	assert.Check(t, cmp.Contains(result.Stderr, "could not read git remote"))
+}
+
+// TestAPI_Telemetry verifies that a circleci api call emits a command_invocation
+// event with the api_path property set to the raw path the user typed.
+func TestAPI_Telemetry(t *testing.T) {
+	ctx := iostream.Testing(context.Background())
+
+	fake := fakes.NewCircleCI(t)
+	fake.AddRunV3(getRunID, runTestProjectID,
+		fakeRunV3(getRunID, runTestProjectID, "ended", "succeeded", "main", "abc1234def5678"))
+
+	env := testenv.New(t)
+	env.Token = testToken
+	env.CircleCIURL = fake.URL()
+	env.Telemetry = true
+	fs := fakesegment.New(ctx, telemetry.SegmentKey)
+	fsSrv := httptest.NewServer(fs)
+	t.Cleanup(fsSrv.Close)
+	env.Extra["CIRCLE_TELEMETRY_ENDPOINT"] = fsSrv.URL
+
+	const apiPath = "api/v3/runs/" + getRunID
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"api", apiPath},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+	assert.Check(t, cmp.Equal(result.ExitCode, 0))
+
+	cfg, err := config.Load(ctx, env.ConfigDir()+"/circleci/config.yml", false)
+	assert.NilError(t, err)
+
+	hostInfo, err := host.Info()
+	assert.NilError(t, err)
+
+	poll.WaitOn(t, func(t poll.LogT) poll.Result {
+		batches := fs.Batches()
+		now := time.Now()
+		return poll.Compare(cmp.DeepEqual(batches, []fakesegment.Batch{
+			{
+				SentAt: now,
+				Messages: []analytics.Track{
+					{
+						Type:      "track",
+						MessageId: "ignored",
+						Timestamp: now,
+						UserId:    telemetry.AnonymousID.String(),
+						Event:     "command_invocation",
+						Properties: analytics.Properties{
+							"command":  "circleci api",
+							"flags":    "debug,insecure-storage,theme",
+							"api_path": apiPath,
+						},
+						Context: &analytics.Context{
+							App: analytics.AppInfo{Name: "circleci-cli", Version: "dev"},
+							Device: analytics.DeviceInfo{
+								Id:    cfg.DeviceID().String(),
+								Model: hostInfo.KernelArch,
+								Type:  hostInfo.PlatformFamily,
+							},
+							OS: analytics.OSInfo{Name: hostInfo.OS, Version: hostInfo.PlatformVersion},
+							Traits: map[string]any{
+								"agent":          "",
+								"is_self_hosted": true, // fake server URL is not https://circleci.com
+								"is_tty":         false,
+							},
+						},
+						Integrations: analytics.NewIntegrations().Enable("Amplitude"),
+					},
+				},
+			},
+		}, fakesegment.CompareTrack, fakesegment.CompareTime))
+	})
 }
 
 // When the project lookup itself fails (slug resolves but the API has no such

--- a/acceptance/api_test.go
+++ b/acceptance/api_test.go
@@ -43,8 +43,8 @@ import (
 	"github.com/CircleCI-Public/circleci-cli/internal/telemetry"
 	"github.com/CircleCI-Public/circleci-cli/internal/testing/binary"
 	testenv "github.com/CircleCI-Public/circleci-cli/internal/testing/env"
-	"github.com/CircleCI-Public/circleci-cli/internal/testing/fakesegment"
 	"github.com/CircleCI-Public/circleci-cli/internal/testing/fakes"
+	"github.com/CircleCI-Public/circleci-cli/internal/testing/fakesegment"
 )
 
 // IDs used by the {project-id}/{org-id} substitution tests.

--- a/internal/cmd/api/api.go
+++ b/internal/cmd/api/api.go
@@ -117,6 +117,8 @@ func NewAPICmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 
+			cmdutil.SetTelemetryProp(cmd, "api_path", args[0])
+
 			client, cliErr := cmdutil.LoadClient(ctx)
 			if cliErr != nil {
 				return cliErr

--- a/internal/cmdutil/telemetry.go
+++ b/internal/cmdutil/telemetry.go
@@ -30,6 +30,17 @@ import (
 	"github.com/spf13/pflag"
 )
 
+const telemetryPropPrefix = "telemetry_prop:"
+
+// SetTelemetryProp attaches an extra property to cmd that RecordTelemetryNow
+// will include in the command_invocation event.
+func SetTelemetryProp(cmd *cobra.Command, key, value string) {
+	if cmd.Annotations == nil {
+		cmd.Annotations = map[string]string{}
+	}
+	cmd.Annotations[telemetryPropPrefix+key] = value
+}
+
 func DisableEverything(cmd *cobra.Command) {
 	if cmd.Annotations == nil {
 		cmd.Annotations = map[string]string{}
@@ -101,10 +112,16 @@ func RecordTelemetryNow(cmd *cobra.Command) {
 	if tc == nil {
 		return
 	}
-	_ = tc.Track("command_invocation",
-		map[string]any{
-			"command": cmd.CommandPath(),
-			"flags":   strings.Join(flags, ","),
-		},
-	)
+
+	props := map[string]any{
+		"command": cmd.CommandPath(),
+		"flags":   strings.Join(flags, ","),
+	}
+	for k, v := range cmd.Annotations {
+		if after, ok := strings.CutPrefix(k, telemetryPropPrefix); ok {
+			props[after] = v
+		}
+	}
+
+	_ = tc.Track("command_invocation", props)
 }

--- a/internal/cmdutil/telemetry_test.go
+++ b/internal/cmdutil/telemetry_test.go
@@ -249,6 +249,48 @@ func TestRecordTelemetry(t *testing.T) {
 		assert.NilError(t, cmd.RunE(cmd, nil))
 		assert.Check(t, cmp.Len(recorder.Tracks(), 0))
 	})
+
+	t.Run("includes extra props set via SetTelemetryProp", func(t *testing.T) {
+		recorder, client := newTelemetry(t)
+		cmd := &cobra.Command{
+			Use: "api",
+			RunE: func(cmd *cobra.Command, args []string) error {
+				cmdutil.SetTelemetryProp(cmd, "api_path", "api/v2/me")
+				return nil
+			},
+		}
+		cmd.SetContext(cmdutil.WithTelemetry(context.Background(), client))
+		cmdutil.RecordTelemetry(cmd)
+		assert.NilError(t, cmd.RunE(cmd, nil))
+		assert.NilError(t, client.Close())
+
+		now := time.Now()
+		assert.Check(t, cmp.DeepEqual(recorder.Tracks(), []analytics.Track{
+			{
+				Timestamp: now,
+				UserId:    userID,
+				Event:     "command_invocation",
+				Properties: analytics.Properties{
+					"command":  "api",
+					"flags":    "",
+					"api_path": "api/v2/me",
+				},
+				Context: &analytics.Context{
+					App: analytics.AppInfo{
+						Name:    "circleci-cli",
+						Version: "1.2.3",
+					},
+					Device: analytics.DeviceInfo{
+						Id:    instanceID,
+						Model: "x86_64",
+						Type:  "debian",
+					},
+					OS: analytics.OSInfo{Name: "linux", Version: "24.04"},
+				},
+				Integrations: analytics.NewIntegrations().Enable("Amplitude"),
+			},
+		}, fakesegment.CompareTrack, fakesegment.CompareTime))
+	})
 }
 
 func TestRecordTelemetryForSubcommands(t *testing.T) {


### PR DESCRIPTION
## Summary

- Adds a `SetTelemetryProp` helper to `cmdutil` that stores extra properties on a cobra command via annotations
- `RecordTelemetryNow` picks up any properties set this way and merges them into the `command_invocation` event
- The `circleci api` command sets `api_path` to the raw path argument so we can see which endpoints users are calling

## Test plan

- [ ] New unit test in `cmdutil/telemetry_test.go` covers the `SetTelemetryProp` → `RecordTelemetryNow` flow
- [ ] `go test ./internal/cmdutil/...` passes