### PR TITLE
Surface API deprecation headers and 410 Gone responses

### DIFF
--- a/acceptance/deprecation_test.go
+++ b/acceptance/deprecation_test.go
@@ -1,0 +1,131 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package acceptance_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/CircleCI-Public/circleci-cli/internal/testing/binary"
+	testenv "github.com/CircleCI-Public/circleci-cli/internal/testing/env"
+	"github.com/CircleCI-Public/circleci-cli/internal/testing/fakes"
+)
+
+// TestDeprecationWarning_SunsetInOutput checks that Deprecation + Sunset response
+// headers produce a warning on stderr while the command still succeeds.
+func TestDeprecationWarning_SunsetInOutput(t *testing.T) {
+	fake := fakes.NewCircleCI(t)
+	fake.AddResourceClass(map[string]any{
+		"id":             "rc-1",
+		"resource_class": "myns/myclass",
+		"description":    "test class",
+	})
+	fake.ExtraHeaders = http.Header{
+		"Deprecation": []string{"true"},
+		"Sunset":      []string{"Sat, 01 Jan 2028 00:00:00 GMT"},
+	}
+
+	env := testenv.New(t)
+	env.Token = testToken
+	env.CircleCIURL = fake.URL()
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"runner", "resource-class", "list", "--namespace", "myns"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	// Command succeeds — endpoint still works during the sunset window.
+	assert.Check(t, result.ExitCode == 0, "expected exit 0, stderr: %s", result.Stderr)
+	assert.Check(t, strings.Contains(result.Stdout, "myns/myclass"), "expected resource class in stdout: %s", result.Stdout)
+
+	// Warning appears on stderr.
+	assert.Check(t, strings.Contains(result.Stderr, "deprecated"), "expected deprecation warning on stderr: %s", result.Stderr)
+	assert.Check(t, strings.Contains(result.Stderr, "days"), "expected days-remaining in warning: %s", result.Stderr)
+	assert.Check(t, strings.Contains(result.Stderr, "upgrade"), "expected upgrade hint in warning: %s", result.Stderr)
+}
+
+// TestGone_410ProducesUpgradeError checks that a 410 response causes the CLI to
+// exit non-zero with a clear "out of date" message.
+func TestGone_410ProducesUpgradeError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusGone)
+	}))
+	t.Cleanup(srv.Close)
+
+	env := testenv.New(t)
+	env.Token = testToken
+	env.CircleCIURL = srv.URL
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"runner", "resource-class", "list", "--namespace", "myns"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Check(t, result.ExitCode != 0, "expected non-zero exit on 410")
+	assert.Check(t, strings.Contains(result.Stderr, "out of date"), "expected 'out of date' in stderr: %s", result.Stderr)
+	assert.Check(t, strings.Contains(result.Stderr, "pgrade"), "expected upgrade suggestion in stderr: %s", result.Stderr)
+}
+
+// TestGone_410WithServerMessageInOutput checks that the server-provided message
+// in the 410 body is surfaced in the CLI error output.
+func TestGone_410WithServerMessageInOutput(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusGone)
+		body, _ := json.Marshal(map[string]string{"error": "upgrade circleci CLI to v2.x or later"})
+		_, _ = w.Write(body)
+	}))
+	t.Cleanup(srv.Close)
+
+	env := testenv.New(t)
+	env.Token = testToken
+	env.CircleCIURL = srv.URL
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"runner", "resource-class", "list", "--namespace", "myns"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Check(t, result.ExitCode != 0, "expected non-zero exit on 410")
+	assert.Check(t, strings.Contains(result.Stderr, "out of date"), "expected 'out of date' in stderr: %s", result.Stderr)
+	assert.Check(t, strings.Contains(result.Stderr, "upgrade circleci CLI to v2.x"), "expected server message in stderr: %s", result.Stderr)
+}

--- a/cmd/circleci/main.go
+++ b/cmd/circleci/main.go
@@ -26,13 +26,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
 
+	"github.com/CircleCI-Public/circleci-cli/internal/apiclient"
 	"github.com/CircleCI-Public/circleci-cli/internal/cmd/root"
 	clierrors "github.com/CircleCI-Public/circleci-cli/internal/errors"
 	"github.com/CircleCI-Public/circleci-cli/internal/extension"
+	"github.com/CircleCI-Public/circleci-cli/internal/httpcl"
 	"github.com/CircleCI-Public/circleci-cli/internal/jq"
 )
 
@@ -88,6 +91,20 @@ func run() int {
 					"See the jq manual: https://jqlang.github.io/jq/manual/",
 				).
 				WithExitCode(clierrors.ExitBadArguments)
+		}
+		// A 410 anywhere means the server dropped this API version — override
+		// before display so it renders as a "CLI out of date" error.
+		if httpcl.HasStatusCode(err, http.StatusGone) {
+			he, _ := errors.AsType[*httpcl.HTTPError](err)
+			detail := "This version of circleci CLI is out of date."
+			if he != nil {
+				if msg := apiclient.ParseServerMessage(he.Body); msg != "" {
+					detail = "This version of circleci CLI is out of date. " + msg
+				}
+			}
+			err = clierrors.New("api.gone", "CLI out of date", detail).
+				WithSuggestions("Upgrade to the latest version: https://circleci.com/docs/local-cli/").
+				WithExitCode(clierrors.ExitAPIError)
 		}
 		if cliErr, ok := errors.AsType[*clierrors.CLIError](err); ok {
 			if jsonFlagPresent() {

--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -46,6 +46,9 @@ type Config struct {
 	Agent   string
 
 	Transport http.RoundTripper
+	// OnWarn, when non-nil, is called with a plain-text deprecation warning.
+	// See httpcl.Config.OnWarn for details.
+	OnWarn func(msg string)
 }
 
 // New creates a Client. baseURL should be the CircleCI host, e.g. "https://circleci.com".
@@ -61,6 +64,7 @@ func New(cfg Config) *Client {
 		AuthHeader: "Authorization",
 		UserAgent:  httpcl.UserAgent(runtime.GOOS, runtime.GOARCH, cfg.Version, cfg.Agent),
 		Transport:  cfg.Transport,
+		OnWarn:     cfg.OnWarn,
 	}
 
 	mainCfg := baseCfg

--- a/internal/apiclient/error.go
+++ b/internal/apiclient/error.go
@@ -79,6 +79,28 @@ func (e *Error) Message() string {
 	return b.String()
 }
 
+// ParseServerMessage tries to extract a human-readable message from an error
+// response body. It checks "error" and "message" JSON fields, falling back to
+// the raw body string. Returns "" for an empty body.
+func ParseServerMessage(body []byte) string {
+	if len(body) == 0 {
+		return ""
+	}
+	var payload struct {
+		Error   string `json:"error"`
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(body, &payload); err == nil {
+		if payload.Error != "" {
+			return payload.Error
+		}
+		if payload.Message != "" {
+			return payload.Message
+		}
+	}
+	return string(body)
+}
+
 // ParseError extracts the v3 error envelope from the response body of an
 // *httpcl.HTTPError. It returns false when err is not an HTTP error or the
 // body does not carry the envelope (e.g. v1/v2 endpoints, HTML error pages).

--- a/internal/cmdutil/client.go
+++ b/internal/cmdutil/client.go
@@ -39,6 +39,7 @@ import (
 	"github.com/CircleCI-Public/circleci-cli/internal/config"
 	clierrors "github.com/CircleCI-Public/circleci-cli/internal/errors"
 	"github.com/CircleCI-Public/circleci-cli/internal/httpcl"
+	"github.com/CircleCI-Public/circleci-cli/internal/iostream"
 	"github.com/CircleCI-Public/circleci-cli/internal/keyring"
 	"github.com/CircleCI-Public/circleci-cli/internal/telemetry"
 )
@@ -172,6 +173,9 @@ func LoadClient(ctx context.Context) (*apiclient.Client, error) {
 		Token:   token,
 		Version: GetVersion(ctx),
 		Agent:   GetAgentName(ctx),
+		OnWarn: func(msg string) {
+			iostream.ErrPrintf(ctx, "warning: %s\n", msg)
+		},
 	}), nil
 }
 
@@ -195,6 +199,18 @@ func AppURL(ctx context.Context) (string, error) {
 // Optional notFoundSuggestions are appended to the 404 error (useful for
 // pointing users toward a list command, for example).
 func APIErr(err error, subject, notFoundCode, notFoundMsg string, notFoundSuggestions ...string) *clierrors.CLIError {
+	if httpcl.HasStatusCode(err, http.StatusGone) {
+		he, _ := errors.AsType[*httpcl.HTTPError](err)
+		detail := "This version of circleci CLI is out of date."
+		if he != nil {
+			if msg := apiclient.ParseServerMessage(he.Body); msg != "" {
+				detail = "This version of circleci CLI is out of date. " + msg
+			}
+		}
+		return clierrors.New("api.gone", "CLI out of date", detail).
+			WithSuggestions("Upgrade to the latest version: https://circleci.com/docs/local-cli/").
+			WithExitCode(clierrors.ExitAPIError)
+	}
 	if httpcl.HasStatusCode(err, http.StatusUnauthorized) {
 		return clierrors.New("auth.token_invalid", "Authentication failed",
 			"The API token was rejected by CircleCI.").

--- a/internal/httpcl/client.go
+++ b/internal/httpcl/client.go
@@ -60,6 +60,10 @@ type Config struct {
 	DisableRetries bool
 	// Transport overrides the HTTP transport (useful for testing).
 	Transport http.RoundTripper
+	// OnWarn, when non-nil, is called with a plain-text warning message when the
+	// server signals endpoint removal via Deprecation or Sunset response headers.
+	// The caller controls formatting (prefix, newline, colour).
+	OnWarn func(msg string)
 }
 
 // Client is a simple HTTP client with JSON defaults and automatic retries.
@@ -69,6 +73,7 @@ type Client struct {
 	authHeader string
 	userAgent  string
 	timeout    time.Duration
+	onWarn     func(string)
 	http       *retryablehttp.Client
 }
 
@@ -99,6 +104,7 @@ func New(cfg Config) *Client {
 		authHeader: cfg.AuthHeader,
 		userAgent:  cfg.UserAgent,
 		timeout:    timeout,
+		onWarn:     cfg.OnWarn,
 		http:       rc,
 	}
 }
@@ -197,6 +203,9 @@ func (c *Client) Call(ctx context.Context, r Request) (status int, err error) {
 	status = resp.StatusCode
 
 	if status >= 200 && status < 300 {
+		if c.onWarn != nil {
+			checkDeprecation(c.onWarn, resp.Header)
+		}
 		if r.respHeader != nil {
 			*r.respHeader = resp.Header
 		}
@@ -222,4 +231,29 @@ func UserAgent(goos, goarch, version, agent string) string {
 		return fmt.Sprintf("circleci-cli (%s/%s; %s; %s)", goos, goarch, version, agent)
 	}
 	return fmt.Sprintf("circleci-cli (%s/%s; %s)", goos, goarch, version)
+}
+
+// checkDeprecation calls onWarn when the response carries Deprecation or Sunset
+// headers signalling that the endpoint will be removed. The message is plain
+// text — no prefix or newline — so the caller controls formatting.
+func checkDeprecation(onWarn func(string), h http.Header) {
+	dep := h.Get("Deprecation")
+	sunset := h.Get("Sunset")
+	if dep == "" && sunset == "" {
+		return
+	}
+	if sunset != "" {
+		if t, err := http.ParseTime(sunset); err == nil {
+			days := int(time.Until(t).Hours() / 24)
+			if days > 0 {
+				onWarn(fmt.Sprintf("this API endpoint is deprecated and will be removed in %d days — upgrade circleci CLI", days))
+			} else {
+				onWarn("this API endpoint is deprecated and removal is imminent — upgrade circleci CLI")
+			}
+		} else {
+			onWarn(fmt.Sprintf("this API endpoint is deprecated and will be removed on %s — upgrade circleci CLI", sunset))
+		}
+	} else {
+		onWarn("this API endpoint is deprecated and will be removed — upgrade circleci CLI")
+	}
 }

--- a/internal/httpcl/client_test.go
+++ b/internal/httpcl/client_test.go
@@ -203,3 +203,68 @@ func TestClient_Call(t *testing.T) {
 	})
 
 }
+
+func TestDeprecationWarning_SunsetHeader(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Deprecation", "true")
+		w.Header().Set("Sunset", "Sat, 01 Jan 2028 00:00:00 GMT")
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	var msgs []string
+	c := httpcl.New(httpcl.Config{BaseURL: srv.URL, OnWarn: func(msg string) { msgs = append(msgs, msg) }})
+
+	ctx := iostream.Testing(context.Background())
+	_, err := c.Call(ctx, httpcl.NewRequest(http.MethodGet, "/"))
+	assert.NilError(t, err)
+	assert.Check(t, cmp.Equal(len(msgs), 1), "expected one warning, got %v", msgs)
+	assert.Check(t, cmp.Contains(msgs[0], "deprecated"))
+	assert.Check(t, cmp.Contains(msgs[0], "days"))
+}
+
+func TestDeprecationWarning_DeprecationOnly(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Deprecation", "true")
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	var msgs []string
+	c := httpcl.New(httpcl.Config{BaseURL: srv.URL, OnWarn: func(msg string) { msgs = append(msgs, msg) }})
+
+	ctx := iostream.Testing(context.Background())
+	_, err := c.Call(ctx, httpcl.NewRequest(http.MethodGet, "/"))
+	assert.NilError(t, err)
+	assert.Check(t, cmp.Equal(len(msgs), 1), "expected one warning, got %v", msgs)
+	assert.Check(t, cmp.Contains(msgs[0], "deprecated"))
+}
+
+func TestDeprecationWarning_NoCallback(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Deprecation", "true")
+		w.Header().Set("Sunset", "Sat, 01 Jan 2027 00:00:00 GMT")
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	// no OnWarn — must not panic
+	c := httpcl.New(httpcl.Config{BaseURL: srv.URL})
+	ctx := iostream.Testing(context.Background())
+	_, err := c.Call(ctx, httpcl.NewRequest(http.MethodGet, "/"))
+	assert.NilError(t, err)
+}
+
+func TestDeprecationWarning_NoHeadersNoCallback(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	called := false
+	c := httpcl.New(httpcl.Config{BaseURL: srv.URL, OnWarn: func(string) { called = true }})
+	ctx := iostream.Testing(context.Background())
+	_, err := c.Call(ctx, httpcl.NewRequest(http.MethodGet, "/"))
+	assert.NilError(t, err)
+	assert.Check(t, cmp.Equal(called, false), "OnWarn should not fire without deprecation headers")
+}

--- a/internal/testing/fakes/circleci.go
+++ b/internal/testing/fakes/circleci.go
@@ -47,11 +47,10 @@ import (
 type CircleCI struct {
 	*httprecorder.RequestRecorder
 
-	server  *httptest.Server
-	handler http.Handler
+	server *httptest.Server
 
-	// ExtraHeaders are added to every response. Use to inject Deprecation/Sunset
-	// headers without changing individual handler logic.
+	// ExtraHeaders are added to every response via middleware. Use to inject
+	// Deprecation/Sunset headers without changing individual handler logic.
 	ExtraHeaders http.Header
 
 	mu                                sync.RWMutex
@@ -276,6 +275,18 @@ func NewCircleCI(t *testing.T) *CircleCI {
 
 	r := newRouter()
 	r.Use(chirecorder.Middleware(f.RequestRecorder))
+	r.Use(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			f.mu.RLock()
+			for k, vals := range f.ExtraHeaders {
+				for _, v := range vals {
+					w.Header().Add(k, v)
+				}
+			}
+			f.mu.RUnlock()
+			next.ServeHTTP(w, req)
+		})
+	})
 	r.Get("/api/v2/pipeline/{id}", f.handleGetPipeline)
 	r.Post("/api/v2/pipeline/{id}/cancel", f.handleCancelPipeline)
 	r.Post("/api/v3/workflows/{id}/rerun", f.handleRerunWorkflow)
@@ -402,23 +413,9 @@ func NewCircleCI(t *testing.T) *CircleCI {
 	// GraphQL endpoint — dispatches by operation within the request body.
 	r.Post("/graphql-unstable", f.handleGraphQL)
 
-	f.handler = r
-	f.server = httptest.NewServer(f)
+	f.server = httptest.NewServer(r)
 	t.Cleanup(f.server.Close)
 	return f
-}
-
-// ServeHTTP injects ExtraHeaders into every response before delegating to the
-// chi router. Headers must be set before the first Write/WriteHeader call.
-func (f *CircleCI) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	f.mu.RLock()
-	for k, vals := range f.ExtraHeaders {
-		for _, v := range vals {
-			w.Header().Add(k, v)
-		}
-	}
-	f.mu.RUnlock()
-	f.handler.ServeHTTP(w, r)
 }
 
 // URL returns the base URL of the fake server.

--- a/internal/testing/fakes/circleci.go
+++ b/internal/testing/fakes/circleci.go
@@ -47,7 +47,12 @@ import (
 type CircleCI struct {
 	*httprecorder.RequestRecorder
 
-	server *httptest.Server
+	server  *httptest.Server
+	handler http.Handler
+
+	// ExtraHeaders are added to every response. Use to inject Deprecation/Sunset
+	// headers without changing individual handler logic.
+	ExtraHeaders http.Header
 
 	mu                                sync.RWMutex
 	pipelines                         map[string]any
@@ -397,9 +402,23 @@ func NewCircleCI(t *testing.T) *CircleCI {
 	// GraphQL endpoint — dispatches by operation within the request body.
 	r.Post("/graphql-unstable", f.handleGraphQL)
 
-	f.server = httptest.NewServer(r)
+	f.handler = r
+	f.server = httptest.NewServer(f)
 	t.Cleanup(f.server.Close)
 	return f
+}
+
+// ServeHTTP injects ExtraHeaders into every response before delegating to the
+// chi router. Headers must be set before the first Write/WriteHeader call.
+func (f *CircleCI) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	f.mu.RLock()
+	for k, vals := range f.ExtraHeaders {
+		for _, v := range vals {
+			w.Header().Add(k, v)
+		}
+	}
+	f.mu.RUnlock()
+	f.handler.ServeHTTP(w, r)
 }
 
 // URL returns the base URL of the fake server.


### PR DESCRIPTION
## Summary

- Checks `Deprecation`/`Sunset` response headers on 2xx responses in the httpcl layer; calls an `OnWarn` callback with a plain-text message including days remaining until sunset. Commands receive the callback via `LoadClient`, writing `warning: ...` to stderr.
- 410 Gone responses are converted to a structured "CLI out of date" `CLIError` in both `cmdutil.APIErr` (typed commands) and `main.go` (catch-all). Server-provided error body is extracted and appended to the message.
- `apiclient.ParseServerMessage` extracts `error`/`message` JSON fields or falls back to raw body, used by both 410 handling sites.
- `ExtraHeaders http.Header` field added to the test fake with a `ServeHTTP` override that injects headers on every response without modifying individual handlers.
- Three acceptance tests and four httpcl unit tests cover: sunset warning output, empty-body 410, and body-provided 410 message.