### PR TITLE
Stop using `gen3`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ executors:
   linux:
     machine:
       image: ubuntu-2604:current
-    resource_class: large.gen3
+    resource_class: large
 
   macos:
     macos:


### PR DESCRIPTION
Builds are currently failing with an error indicating that this is not a valid resource class.