### PR TITLE
Prefer `gen2` resource class

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ executors:
   linux:
     machine:
       image: ubuntu-2604:current
-    resource_class: large
+    resource_class: large.gen2
 
   macos:
     macos:


### PR DESCRIPTION
This is what we were using before switching to `gen3`.
