### PR TITLE
Add GitHub App API client methods and fake server routes

### DIFF
--- a/internal/apiclient/githubapp.go
+++ b/internal/apiclient/githubapp.go
@@ -1,0 +1,121 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package apiclient
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strconv"
+
+	"github.com/CircleCI-Public/circleci-cli/internal/httpcl"
+)
+
+// ErrGitHubAppNotInstalled is returned by GetGitHubAppInstallation when the
+// CircleCI GitHub App is not installed for the organization (the endpoint
+// answers 404). Callers use it to branch into the install flow.
+var ErrGitHubAppNotInstalled = errors.New("CircleCI GitHub App is not installed for this organization")
+
+// GitHubAppInstallation describes a CircleCI GitHub App installation for an
+// organization, as returned by
+// GET /api/v2/github-app/organization/{orgID}/installation.
+type GitHubAppInstallation struct {
+	// ID is the GitHub App installation's external (GitHub) ID.
+	ID int64 `json:"id"`
+	// TargetType is "Organization" or "User".
+	TargetType string `json:"target_type"`
+	// Login is the GitHub account the app is installed on.
+	Login string `json:"login"`
+	// RepositorySelection is "all" or "selected" when present.
+	RepositorySelection string `json:"repository_selection,omitempty"`
+}
+
+// GetGitHubAppInstallation reports the CircleCI GitHub App installation for the
+// organization. orgID must be the organization UUID. It returns
+// ErrGitHubAppNotInstalled when the app is not installed (HTTP 404).
+func (c *Client) GetGitHubAppInstallation(ctx context.Context, orgID string) (*GitHubAppInstallation, error) {
+	var resp GitHubAppInstallation
+	err := c.get(ctx, "/github-app/organization/%s/installation", &resp,
+		routeParams(orgID),
+	)
+	if err != nil {
+		if httpcl.HasStatusCode(err, http.StatusNotFound) {
+			return nil, ErrGitHubAppNotInstalled
+		}
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// InitiateGitHubAppInstall starts a GitHub App installation for the
+// organization and returns the URL the user should open to complete the
+// install on GitHub. orgID must be the organization UUID; returnURL is where
+// GitHub redirects after the install completes and must be an app.circleci.com
+// URL.
+func (c *Client) InitiateGitHubAppInstall(ctx context.Context, orgID, returnURL string) (string, error) {
+	body := map[string]any{
+		"org_id":     orgID,
+		"return_url": returnURL,
+	}
+	var resp struct {
+		RedirectURL string `json:"redirect_url"`
+	}
+	if err := c.post(ctx, "/github-app/install", body, &resp); err != nil {
+		return "", err
+	}
+	return resp.RedirectURL, nil
+}
+
+// GitHubAppRepository is a repository the CircleCI GitHub App can access, as
+// returned by GET /api/v2/github-app/organization/{orgID}/repositories.
+type GitHubAppRepository struct {
+	// ID is the GitHub numeric repository ID — the external ID used as the repo
+	// reference in pipeline definitions and triggers.
+	ID int64 `json:"id"`
+	// FullName is the "owner/repo" name.
+	FullName      string `json:"repo_full_name"`
+	Name          string `json:"repo_name"`
+	Owner         string `json:"owner"`
+	DefaultBranch string `json:"default_branch"`
+	Private       bool   `json:"private"`
+}
+
+// ListGitHubAppRepositories returns one page of repositories the GitHub App can
+// access for the organization, along with the total repository count. orgID
+// must be the organization UUID. page is 1-based; limit is capped at 100 by the
+// server. Passing both page and limit > 0 selects the paginated response shape.
+func (c *Client) ListGitHubAppRepositories(ctx context.Context, orgID string, page, limit int) ([]GitHubAppRepository, int, error) {
+	var resp struct {
+		Items      []GitHubAppRepository `json:"items"`
+		TotalCount int                   `json:"total_count"`
+	}
+	err := c.get(ctx, "/github-app/organization/%s/repositories", &resp,
+		routeParams(orgID),
+		queryParam("page", strconv.Itoa(page)),
+		queryParam("limit", strconv.Itoa(limit)),
+	)
+	if err != nil {
+		return nil, 0, err
+	}
+	return resp.Items, resp.TotalCount, nil
+}

--- a/internal/apiclient/githubapp.go
+++ b/internal/apiclient/githubapp.go
@@ -102,8 +102,8 @@ type GitHubAppRepository struct {
 
 // ListGitHubAppRepositories returns one page of repositories the GitHub App can
 // access for the organization, along with the total repository count. orgID
-// must be the organization UUID. page is 1-based; limit is capped at 100 by the
-// server. Passing both page and limit > 0 selects the paginated response shape.
+// must be the organization UUID. page is 1-based; limit is the page size (max
+// 100 by the server).
 func (c *Client) ListGitHubAppRepositories(ctx context.Context, orgID string, page, limit int) ([]GitHubAppRepository, int, error) {
 	var resp struct {
 		Items      []GitHubAppRepository `json:"items"`

--- a/internal/testing/fakes/circleci.go
+++ b/internal/testing/fakes/circleci.go
@@ -71,9 +71,14 @@ type CircleCI struct {
 	createPipelineDefinitionResponses map[string]any    // projectID → response body
 	createTriggerResponses            map[string]any    // "projectID/pipelineDefinitionID" → response body
 	listTriggerResponses              map[string][]any  // "projectID/pipelineDefinitionID" → list of triggers
-	rerunResponses                    map[string]int    // workflow id → HTTP status to return
-	cancelResponses                   map[string]int    // workflow id → HTTP status to return
-	pipelineCancelResponses           map[string]int    // pipeline id → HTTP status to return
+
+	// GitHub App state.
+	githubAppInstalled      map[string]bool  // orgID → app installed (200) vs not (404)
+	githubAppRepos          map[string][]any // orgID → repositories the app can access
+	githubAppInstallResp    any              // response body for POST /github-app/install
+	rerunResponses          map[string]int   // workflow id → HTTP status to return
+	cancelResponses         map[string]int   // workflow id → HTTP status to return
+	pipelineCancelResponses map[string]int   // pipeline id → HTTP status to return
 
 	// Job (v3) state.
 	jobsV3             map[string]any    // job UUID → V3 response body
@@ -210,6 +215,8 @@ func NewCircleCI(t *testing.T) *CircleCI {
 		createPipelineDefinitionResponses: map[string]any{},
 		createTriggerResponses:            map[string]any{},
 		listTriggerResponses:              map[string][]any{},
+		githubAppInstalled:                map[string]bool{},
+		githubAppRepos:                    map[string][]any{},
 		rerunResponses:                    map[string]int{},
 		cancelResponses:                   map[string]int{},
 		pipelineCancelResponses:           map[string]int{},
@@ -327,6 +334,10 @@ func NewCircleCI(t *testing.T) *CircleCI {
 	r.Post("/api/v2/projects/{projectID}/pipeline-definitions", f.handleCreatePipelineDefinition)
 	r.Get("/api/v2/projects/{projectID}/pipeline-definitions/{pipelineDefinitionID}/triggers", f.handleListTriggers)
 	r.Post("/api/v2/projects/{projectID}/pipeline-definitions/{pipelineDefinitionID}/triggers", f.handleCreateTrigger)
+	// GitHub App routes.
+	r.Get("/api/v2/github-app/organization/{orgID}/installation", f.handleGetGitHubAppInstallation)
+	r.Post("/api/v2/github-app/install", f.handleInstallGitHubApp)
+	r.Get("/api/v2/github-app/organization/{orgID}/repositories", f.handleListGitHubAppRepositories)
 	// Policy routes.
 	r.Route("/api/v2/owner/{ownerID}/context/{policyCtx}", func(r chi.Router) {
 		r.Post("/policy-bundle", f.handleCreatePolicyBundle)
@@ -2322,6 +2333,73 @@ func (f *CircleCI) handleCreateTrigger(w http.ResponseWriter, r *http.Request) {
 	}
 	render.Status(r, http.StatusCreated)
 	render.JSON(w, r, resp)
+}
+
+// SetGitHubAppInstalled controls whether GET
+// /api/v2/github-app/organization/{orgID}/installation returns 200 (installed)
+// or 404 (not installed) for the org.
+func (f *CircleCI) SetGitHubAppInstalled(orgID string, installed bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.githubAppInstalled[orgID] = installed
+}
+
+// AddGitHubAppRepository registers a repository returned by GET
+// /api/v2/github-app/organization/{orgID}/repositories.
+func (f *CircleCI) AddGitHubAppRepository(orgID string, repo any) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.githubAppRepos[orgID] = append(f.githubAppRepos[orgID], repo)
+}
+
+// SetGitHubAppInstallResponse registers the body returned by POST
+// /api/v2/github-app/install.
+func (f *CircleCI) SetGitHubAppInstallResponse(resp any) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.githubAppInstallResp = resp
+}
+
+func (f *CircleCI) handleGetGitHubAppInstallation(w http.ResponseWriter, r *http.Request) {
+	orgID := chi.URLParam(r, "orgID")
+	f.mu.RLock()
+	installed := f.githubAppInstalled[orgID]
+	f.mu.RUnlock()
+
+	if !installed {
+		render.Status(r, http.StatusNotFound)
+		render.JSON(w, r, map[string]any{"message": "not found"})
+		return
+	}
+	render.JSON(w, r, map[string]any{
+		"id":                   12345678,
+		"target_type":          "Organization",
+		"login":                "my-org",
+		"repository_selection": "all",
+	})
+}
+
+func (f *CircleCI) handleInstallGitHubApp(w http.ResponseWriter, r *http.Request) {
+	f.mu.RLock()
+	resp := f.githubAppInstallResp
+	f.mu.RUnlock()
+
+	if resp == nil {
+		resp = map[string]any{"redirect_url": "https://github.com/apps/circleci/installations/new?state=test"}
+	}
+	render.JSON(w, r, resp)
+}
+
+func (f *CircleCI) handleListGitHubAppRepositories(w http.ResponseWriter, r *http.Request) {
+	orgID := chi.URLParam(r, "orgID")
+	f.mu.RLock()
+	repos := f.githubAppRepos[orgID]
+	f.mu.RUnlock()
+
+	if repos == nil {
+		repos = []any{}
+	}
+	render.JSON(w, r, map[string]any{"items": repos, "total_count": len(repos)})
 }
 
 func (f *CircleCI) handleGetProjectInfo(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

- Adds `GetGitHubAppInstallation`, `InitiateGitHubAppInstall`, and `ListGitHubAppRepositories` to `internal/apiclient/`
- Wires matching routes into the fake CircleCI server (`internal/testing/fakes/circleci.go`) with `SetGitHubAppInstalled`, `AddGitHubAppRepository`, and `SetGitHubAppInstallResponse` helpers

These are the three GitHub App endpoints (`/api/v2/github-app/*`) the onboard flow needs for installation check and repo external ID resolution. No behavior changes to existing commands.

**Stack** (merge bottom-up):
1. #1645 — Add GitHub App API client methods and fake server routes **← this PR**
2. #1646 — Add GitHub App domain logic for installation check and repo ID resolution
3. #1647 — Extend onboard to set up first pipeline definition and trigger

## Test plan
- [ ] `task test` passes
- [ ] Review API client methods match the endpoint contracts
- [ ] Review fake routes accurately mirror the real API responses
