### PR TITLE
Extend onboard to set up first pipeline definition and trigger

### DIFF
--- a/acceptance/link_test.go
+++ b/acceptance/link_test.go
@@ -145,27 +145,28 @@ func TestProjectLink_NoToken(t *testing.T) {
 	assert.Check(t, os.IsNotExist(statErr), "info.yml should not be written without a token")
 }
 
-// Once a checkout is linked, subsequent commands should resolve the project
-// from info.yml — using the canonical "circleci/<orgID>/<projectID>" slug
-// when info.yml carries the UUIDs, even though the git remote (if any)
-// would have produced a "gh/org/repo"-style slug.
+// Once a checkout is linked, subsequent commands resolve the project from
+// info.yml. For a CircleCI-native project that means the canonical
+// "circleci/<orgID>/<projectID>" slug built from the recorded IDs, so resolution
+// survives a slug change on the CircleCI side.
 func TestProjectGet_UsesLinkedUUIDs(t *testing.T) {
-	const standaloneSlug = "circleci/E6i3yYZeWZhcf8UNqcKfjN/13c8F7nusayivoSxC6GMsw"
+	const canonicalSlug = "circleci/E6i3yYZeWZhcf8UNqcKfjN/13c8F7nusayivoSxC6GMsw"
+	const linkedSlug = "circleci/OldOrgShortId/OldProjShortId"
 
 	fake := fakes.NewCircleCI(t)
-	// Only register the standalone (UUID-form) slug. If `project get` falls
-	// back to a VCS-style slug for any reason, the API will return 404.
-	fake.AddProjectInfo(standaloneSlug, map[string]any{
+	// Only register the ID-form slug for the lookup under test. If `project get`
+	// used the stored slug instead, the fake would 404.
+	fake.AddProjectInfo(canonicalSlug, map[string]any{
 		"id":              "13c8F7nusayivoSxC6GMsw",
-		"slug":            standaloneSlug,
+		"slug":            canonicalSlug,
 		"name":            "linked",
 		"organization_id": "E6i3yYZeWZhcf8UNqcKfjN",
 	})
-	// Also register the VCS slug used during link, so the initial link call succeeds.
-	fake.AddProjectInfo("gh/myorg/alpha", map[string]any{
+	// Register the slug passed to link, so the initial link call succeeds.
+	fake.AddProjectInfo(linkedSlug, map[string]any{
 		"id":              "13c8F7nusayivoSxC6GMsw",
-		"slug":            "gh/myorg/alpha",
-		"name":            "alpha",
+		"slug":            linkedSlug,
+		"name":            "linked",
 		"organization_id": "E6i3yYZeWZhcf8UNqcKfjN",
 	})
 
@@ -177,14 +178,14 @@ func TestProjectGet_UsesLinkedUUIDs(t *testing.T) {
 
 	link := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    []string{"project", "link", "--project", "gh/myorg/alpha"},
+		Args:    []string{"project", "link", "--project", linkedSlug},
 		Env:     env.Environ(),
 		WorkDir: workDir,
 	})
 	assert.Equal(t, link.ExitCode, 0, "link stderr: %s", link.Stderr)
 
-	// Now run `project get` with no --project flag. It must resolve via
-	// info.yml and hit the standalone (UUID) endpoint, NOT the VCS slug.
+	// `project get` with no --project must resolve via info.yml, rebuilding the
+	// ID-form slug rather than reusing the one that was linked.
 	get := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
 		Args:    []string{"project", "get", "--json"},
@@ -192,7 +193,52 @@ func TestProjectGet_UsesLinkedUUIDs(t *testing.T) {
 		WorkDir: workDir,
 	})
 	assert.Equal(t, get.ExitCode, 0, "get stderr: %s", get.Stderr)
-	assert.Check(t, strings.Contains(get.Stdout, standaloneSlug), "stdout: %s", get.Stdout)
+	assert.Check(t, strings.Contains(get.Stdout, canonicalSlug), "stdout: %s", get.Stdout)
+}
+
+// TestProjectGet_ClassicLinkUsesOwnSlug is the counterpart: a classic VCS project
+// resolves by its own "<vcs>/<org>/<repo>" slug.
+//
+// `circleci project link` records org and project IDs for every project type, but
+// the "circleci/<orgID>/<projectID>" form addresses CircleCI-native projects only.
+// The real API answers 404 for a classic project addressed that way, whatever its
+// recorded IDs are — so rebuilding the slug there breaks every command that
+// resolves a project from a linked checkout.
+func TestProjectGet_ClassicLinkUsesOwnSlug(t *testing.T) {
+	const classicSlug = "gh/myorg/alpha"
+
+	fake := fakes.NewCircleCI(t)
+	// Only the classic slug is registered, mirroring the real API: an ID-form
+	// lookup for this project 404s.
+	fake.AddProjectInfo(classicSlug, map[string]any{
+		"id":              "52404b72-02fb-482e-9bd8-846bbc048eea",
+		"slug":            classicSlug,
+		"name":            "alpha",
+		"organization_id": "c1e89d5c-d2e5-4db2-b2d7-a35cf73160ad",
+	})
+
+	env := testenv.New(t)
+	env.Token = testToken
+	env.CircleCIURL = fake.URL()
+
+	workDir := t.TempDir()
+
+	link := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"project", "link", "--project", classicSlug},
+		Env:     env.Environ(),
+		WorkDir: workDir,
+	})
+	assert.Equal(t, link.ExitCode, 0, "link stderr: %s", link.Stderr)
+
+	get := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"project", "get", "--json"},
+		Env:     env.Environ(),
+		WorkDir: workDir,
+	})
+	assert.Equal(t, get.ExitCode, 0, "get stderr: %s", get.Stderr)
+	assert.Check(t, strings.Contains(get.Stdout, classicSlug), "stdout: %s", get.Stdout)
 }
 
 // Refuses to overwrite an existing info.yml without --force.

--- a/acceptance/onboard_test.go
+++ b/acceptance/onboard_test.go
@@ -468,6 +468,14 @@ func TestOnboard_PostSignup_FirstPipeline_GitHubAppResolvesRepo(t *testing.T) {
 	assert.Check(t, strings.Contains(result.Stdout, "Your project is ready!"))
 }
 
+// TestOnboard_PostSignup_Rerun_Idempotent runs onboard twice over the same
+// repository. The first run creates the project and records it in
+// .circleci/info.yml; the second resolves it from that file instead of
+// attempting a create that could only conflict.
+//
+// That local record is what makes a re-run recoverable at all: a CircleCI-native
+// project slug is circleci/<orgID>/<projectID> — opaque IDs, not the repository
+// name — and no API maps a project name to its ID within an org.
 func TestOnboard_PostSignup_Rerun_Idempotent(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("test runner uses sh -c")
@@ -477,17 +485,6 @@ func TestOnboard_PostSignup_Rerun_Idempotent(t *testing.T) {
 	initGitRepoWithRemote(t, dir, "https://github.com/myorg/my-repo.git")
 
 	fake, env := onboardStandaloneEnv(t, "testuser")
-	// Simulate a prior onboard run: project creation now conflicts, and the
-	// project already has its pipeline definition + trigger.
-	fake.SetCreateProjectResponse(nil) // create fails → resolve the existing project
-	fake.AddProjectInfo("circleci/myorg/my-repo", map[string]any{
-		"id":                "proj-uuid-5678",
-		"slug":              "circleci/myorg/my-repo",
-		"name":              "my-repo",
-		"organization_name": "myorg",
-		"organization_slug": "circleci/myorg",
-		"organization_id":   "org-uuid-1234",
-	})
 	fake.SetGitHubAppInstalled("org-uuid-1234", true)
 	fake.AddGitHubAppRepository("org-uuid-1234", map[string]any{
 		"id":             987654321,
@@ -495,6 +492,40 @@ func TestOnboard_PostSignup_Rerun_Idempotent(t *testing.T) {
 		"repo_name":      "my-repo",
 		"owner":          "myorg",
 	})
+	fake.SetCreatePipelineDefinitionResponse("proj-uuid-5678", map[string]any{
+		"id":   "pdef-uuid-1",
+		"name": "my-repo",
+	})
+	fake.SetCreateTriggerResponse("proj-uuid-5678", "pdef-uuid-1", map[string]any{
+		"id":           "trig-uuid-1",
+		"event_preset": "all-pushes",
+	})
+	// The second run looks the project up by the slug projectref derives from the
+	// recorded UUIDs. The real API accepts that form and canonicalises it to the
+	// short-ID slug.
+	fake.AddProjectInfo("circleci/org-uuid-1234/proj-uuid-5678", map[string]any{
+		"id":                "proj-uuid-5678",
+		"slug":              "circleci/Org1234ShortId/Proj5678ShortId",
+		"name":              "my-repo",
+		"organization_name": "myorg",
+		"organization_slug": "circleci/Org1234ShortId",
+		"organization_id":   "org-uuid-1234",
+	})
+	addFakeDotnet(t, env, false)
+
+	first := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"onboard", "--scan"},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+	assert.Equal(t, first.ExitCode, 0, "stderr: %s", first.Stderr)
+	assert.Check(t, strings.Contains(first.Stdout, "Project created: my-repo"))
+	assert.Check(t, strings.Contains(first.Stdout, "Linked this repository to the project"))
+	_, err := os.Stat(filepath.Join(dir, ".circleci", "info.yml"))
+	assert.NilError(t, err, "first run should record the project locally")
+
+	// The project now has its pipeline definition and trigger.
 	fake.AddPipelineDefinition("proj-uuid-5678", map[string]any{
 		"id":   "pdef-uuid-1",
 		"name": "my-repo",
@@ -507,7 +538,38 @@ func TestOnboard_PostSignup_Rerun_Idempotent(t *testing.T) {
 		"id":           "trig-uuid-1",
 		"event_preset": "all-pushes",
 	})
+
+	second := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"onboard", "--scan"},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+	assert.Equal(t, second.ExitCode, 0, "stderr: %s", second.Stderr)
+	assert.Check(t, strings.Contains(second.Stdout, "Using existing project: my-repo"))
+	assert.Check(t, strings.Contains(second.Stdout, "Pipeline definition already exists: my-repo"))
+	assert.Check(t, strings.Contains(second.Stdout, "Trigger already exists"))
+	assert.Check(t, !strings.Contains(second.Stdout, "Project created"), "re-run should not create a second project")
+	assert.Check(t, !strings.Contains(second.Stderr, "already exists"), "re-run should not surface a conflict")
+}
+
+// TestOnboard_PostSignup_ProjectNameConflict covers a name collision that onboard
+// cannot resolve: the org already has a project with this name, but the checkout
+// has no .circleci/info.yml recording its ID. Since a project cannot be looked up
+// by name, onboard points at `circleci project link` rather than reporting a raw
+// HTTP conflict.
+func TestOnboard_PostSignup_ProjectNameConflict(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test runner uses sh -c")
+	}
+	dir := t.TempDir()
+	copyFixture(t, "testdata/test-run/dotnet", dir)
+	initGitRepoWithRemote(t, dir, "https://github.com/myorg/my-repo.git")
+
+	fake, env := onboardStandaloneEnv(t, "testuser")
+	fake.SetCreateProjectConflict()
 	addFakeDotnet(t, env, false)
+
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
 		Args:    []string{"onboard", "--scan"},
@@ -516,10 +578,11 @@ func TestOnboard_PostSignup_Rerun_Idempotent(t *testing.T) {
 	})
 
 	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
-	assert.Check(t, strings.Contains(result.Stdout, "Using existing project: my-repo"))
-	assert.Check(t, strings.Contains(result.Stdout, "Pipeline definition already exists: my-repo"))
-	assert.Check(t, strings.Contains(result.Stdout, "Trigger already exists"))
-	assert.Check(t, !strings.Contains(result.Stderr, "Could not create project"), "re-run should not surface a creation error")
+	assert.Check(t, strings.Contains(result.Stderr, `project named "my-repo" already exists`))
+	assert.Check(t, strings.Contains(result.Stdout, "circleci project link"))
+	// No raw HTTP internals for a conflict the user can resolve with one command.
+	assert.Check(t, !strings.Contains(result.Stderr, "409"), "stderr should not leak an HTTP status")
+	assert.Check(t, !strings.Contains(result.Stderr, "/api/v2/"), "stderr should not leak an API path")
 }
 
 func TestOnboard_PostSignup_FirstPipeline_RepoNotAccessible(t *testing.T) {
@@ -664,12 +727,16 @@ func onboardStandaloneEnv(t *testing.T, login string) (*fakes.CircleCI, *testenv
 	fake.SetCollaborations([]any{
 		map[string]any{"id": "org-uuid-1234", "name": "myorg", "slug": "circleci/myorg", "vcs_type": "circleci"},
 	})
+	// A CircleCI-native project slug embeds opaque org and project short IDs, not
+	// the repository name — mirroring the real API, where a name-based slug is
+	// rejected outright. The UUIDs are separate values used by the pipeline
+	// definition and GitHub App calls.
 	fake.SetCreateProjectResponse(map[string]any{
 		"id":                "proj-uuid-5678",
-		"slug":              "circleci/myorg/my-repo",
+		"slug":              "circleci/Org1234ShortId/Proj5678ShortId",
 		"name":              "my-repo",
 		"organization_name": "myorg",
-		"organization_slug": "circleci/myorg",
+		"organization_slug": "circleci/Org1234ShortId",
 		"organization_id":   "org-uuid-1234",
 	})
 

--- a/acceptance/onboard_test.go
+++ b/acceptance/onboard_test.go
@@ -304,6 +304,92 @@ func TestOnboard_PostSignup_ProjectCreated(t *testing.T) {
 	assert.Check(t, strings.Contains(result.Stdout, "Commit .circleci/config.yml"))
 }
 
+// TestOnboard_PostSignup_FreshSignup_ContinuesToProjectSetup is a regression test
+// for a fresh signup dead-ending at "Run 'circleci project create'" instead of
+// continuing into project, pipeline, and trigger setup.
+//
+// Signup writes the token to disk part-way through the run, but the config cached
+// in the context was loaded during bootstrap — before that write — so without a
+// reload LoadClient sees no token and the whole setup chain degrades to manual
+// guidance on the one run where it matters most.
+//
+// This test must NOT set env.Token: CIRCLE_TOKEN is read ahead of the cached
+// config, which masks the bug — and is why the other PostSignup tests, which all
+// pass a token through the environment, never caught it.
+func TestOnboard_PostSignup_FreshSignup_ContinuesToProjectSetup(t *testing.T) {
+	dir := t.TempDir()
+	initGitRepoWithRemote(t, dir, "https://github.com/myorg/my-repo.git")
+
+	fake := fakes.NewCircleCI(t)
+	fake.SetMe(map[string]any{
+		"id": "e4a72497-7c55-400d-a72d-dadc4b92255d",
+		"attributes": map[string]any{
+			"name":  "New User",
+			"login": "newuser",
+		},
+	})
+	fake.SetOAuthTokenResponse(map[string]any{
+		"access_token": "test-signup-token",
+		"token_type":   "Bearer",
+		"expires_in":   int64(7776000),
+	})
+	fake.SetCollaborations([]any{
+		map[string]any{"id": "org-uuid-1234", "name": "myorg", "slug": "circleci/myorg", "vcs_type": "circleci"},
+	})
+	fake.SetCreateProjectResponse(map[string]any{
+		"id":                "proj-uuid-5678",
+		"slug":              "circleci/myorg/my-repo",
+		"name":              "my-repo",
+		"organization_name": "myorg",
+		"organization_slug": "circleci/myorg",
+		"organization_id":   "org-uuid-1234",
+	})
+	fake.SetCreatePipelineDefinitionResponse("proj-uuid-5678", map[string]any{
+		"id":   "pdef-uuid-1",
+		"name": "my-repo",
+	})
+	fake.SetCreateTriggerResponse("proj-uuid-5678", "pdef-uuid-1", map[string]any{
+		"id":           "trig-uuid-1",
+		"event_preset": "all-pushes",
+	})
+
+	env := testenv.New(t)
+	env.CircleCIURL = fake.URL()
+	// Deliberately no env.Token — see the note above.
+	env.Extra["CIRCLE_LOGIN_TIMEOUT"] = "20s"
+	// Suppress the project-name prompt so the run completes without further input.
+	env.Extra["CIRCLE_NO_INTERACTIVE"] = "true"
+
+	console := binary.RunCLIInteractive(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"onboard", "--signup", "--no-browser", "--repo-id", "123456789"},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	assert.Assert(t, t.Run("waits for browser callback", func(t *testing.T) {
+		_, err := console.ExpectString("Waiting for browser authentication")
+		assert.NilError(t, err)
+	}))
+
+	assert.Assert(t, t.Run("browser callback", func(t *testing.T) {
+		callbackViaPAR(t, fake)
+	}))
+
+	assert.Assert(t, t.Run("continues into project and pipeline setup", func(t *testing.T) {
+		_, err := console.ExpectString("Logged in as newuser")
+		assert.NilError(t, err)
+		_, err = console.ExpectString("Project created: my-repo")
+		assert.NilError(t, err)
+		_, err = console.ExpectString("Pipeline definition created: my-repo")
+		assert.NilError(t, err)
+		_, err = console.ExpectString("Trigger created: all-pushes")
+		assert.NilError(t, err)
+		_, err = console.ExpectString("Your project is ready!")
+		assert.NilError(t, err)
+	}))
+}
+
 func TestOnboard_PostSignup_FirstPipelineCreated(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("test runner uses sh -c")

--- a/acceptance/onboard_test.go
+++ b/acceptance/onboard_test.go
@@ -40,6 +40,16 @@ import (
 	"github.com/CircleCI-Public/circleci-cli/internal/testing/fakes"
 )
 
+// Fixture IDs shared by the onboard tests. The slug segments are deliberately
+// opaque short IDs rather than names, mirroring a real CircleCI-native project,
+// whose slug the API will not accept in name form.
+const (
+	onboardOrgID          = "org-uuid-1234"
+	onboardProjectID      = "proj-uuid-5678"
+	onboardPipelineDefID  = "pdef-uuid-1"
+	onboardRepoExternalID = "123456789"
+)
+
 func TestOnboard_PathInvalid(t *testing.T) {
 	cases := []struct {
 		name        string
@@ -283,14 +293,7 @@ func TestOnboard_ScanFlag_ExplicitSameAsDefault(t *testing.T) {
 }
 
 func TestOnboard_PostSignup_ProjectCreated(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("test runner uses sh -c")
-	}
-	dir := t.TempDir()
-	copyFixture(t, "testdata/test-run/dotnet", dir)
-	initGitRepoWithRemote(t, dir, "https://github.com/myorg/my-repo.git")
-
-	_, env := onboardStandaloneEnv(t, "testuser")
+	dir, _, env := onboardDotnetRepo(t)
 	addFakeDotnet(t, env, false)
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
@@ -300,9 +303,9 @@ func TestOnboard_PostSignup_ProjectCreated(t *testing.T) {
 	})
 
 	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
-	assert.Check(t, strings.Contains(result.Stdout, "Project created: my-repo"))
-	assert.Check(t, strings.Contains(result.Stdout, "Organization: myorg"))
-	assert.Check(t, strings.Contains(result.Stdout, "Commit .circleci/config.yml"))
+	assert.Check(t, cmp.Contains(result.Stdout, "Project created: my-repo"))
+	assert.Check(t, cmp.Contains(result.Stdout, "Organization: myorg"))
+	assert.Check(t, cmp.Contains(result.Stdout, "Commit .circleci/config.yml"))
 }
 
 // TestOnboard_PostSignup_FreshSignup_ContinuesToProjectSetup is a regression test
@@ -335,24 +338,17 @@ func TestOnboard_PostSignup_FreshSignup_ContinuesToProjectSetup(t *testing.T) {
 		"expires_in":   int64(7776000),
 	})
 	fake.SetCollaborations([]any{
-		map[string]any{"id": "org-uuid-1234", "name": "myorg", "slug": "circleci/myorg", "vcs_type": "circleci"},
+		map[string]any{"id": onboardOrgID, "name": "myorg", "slug": "circleci/myorg", "vcs_type": "circleci"},
 	})
 	fake.SetCreateProjectResponse(map[string]any{
-		"id":                "proj-uuid-5678",
+		"id":                onboardProjectID,
 		"slug":              "circleci/myorg/my-repo",
 		"name":              "my-repo",
 		"organization_name": "myorg",
 		"organization_slug": "circleci/myorg",
-		"organization_id":   "org-uuid-1234",
+		"organization_id":   onboardOrgID,
 	})
-	fake.SetCreatePipelineDefinitionResponse("proj-uuid-5678", map[string]any{
-		"id":   "pdef-uuid-1",
-		"name": "my-repo",
-	})
-	fake.SetCreateTriggerResponse("proj-uuid-5678", "pdef-uuid-1", map[string]any{
-		"id":           "trig-uuid-1",
-		"event_preset": "all-pushes",
-	})
+	addFirstPipelineResponses(fake)
 
 	env := testenv.New(t)
 	env.CircleCIURL = fake.URL()
@@ -363,7 +359,7 @@ func TestOnboard_PostSignup_FreshSignup_ContinuesToProjectSetup(t *testing.T) {
 
 	console := binary.RunCLIInteractive(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    []string{"onboard", "--signup", "--no-browser", "--repo-id", "123456789"},
+		Args:    []string{"onboard", "--signup", "--no-browser", "--repo-id", onboardRepoExternalID},
 		Env:     env.Environ(),
 		WorkDir: dir,
 	})
@@ -438,28 +434,21 @@ func TestOnboard_PostSignup_KeepsExistingProjectRef(t *testing.T) {
 // trigger would otherwise be reported as ready, and the push onboard tells the
 // user to make would build nothing.
 func TestOnboard_PostSignup_AddsPushTriggerAlongsideOthers(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("test runner uses sh -c")
-	}
-	dir := t.TempDir()
-	copyFixture(t, "testdata/test-run/dotnet", dir)
-	initGitRepoWithRemote(t, dir, "https://github.com/myorg/my-repo.git")
-
-	fake, env := onboardStandaloneEnv(t, "testuser")
-	fake.AddPipelineDefinition("proj-uuid-5678", map[string]any{
-		"id":   "pdef-uuid-1",
+	dir, fake, env := onboardDotnetRepo(t)
+	fake.AddPipelineDefinition(onboardProjectID, map[string]any{
+		"id":   onboardPipelineDefID,
 		"name": "my-repo",
 		"config_source": map[string]any{
 			"provider": "github_app",
-			"repo":     map[string]any{"external_id": "123456789"},
+			"repo":     map[string]any{"external_id": onboardRepoExternalID},
 		},
 	})
 	// Only a schedule trigger exists — no push would build anything.
-	fake.AddTrigger("proj-uuid-5678", "pdef-uuid-1", map[string]any{
+	fake.AddTrigger(onboardProjectID, onboardPipelineDefID, map[string]any{
 		"id":           "trig-schedule",
 		"event_preset": "schedule",
 	})
-	fake.SetCreateTriggerResponse("proj-uuid-5678", "pdef-uuid-1", map[string]any{
+	fake.SetCreateTriggerResponse(onboardProjectID, onboardPipelineDefID, map[string]any{
 		"id":           "trig-uuid-1",
 		"event_preset": "all-pushes",
 	})
@@ -467,7 +456,7 @@ func TestOnboard_PostSignup_AddsPushTriggerAlongsideOthers(t *testing.T) {
 
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    []string{"onboard", "--scan", "--repo-id", "123456789"},
+		Args:    []string{"onboard", "--scan", "--repo-id", onboardRepoExternalID},
 		Env:     env.Environ(),
 		WorkDir: dir,
 	})
@@ -546,19 +535,12 @@ func TestOnboard_PathArgument_UsesGivenDirectory(t *testing.T) {
 	initGitRepoWithRemote(t, otherDir, "https://github.com/myorg/wrong-repo.git")
 
 	fake, env := onboardStandaloneEnv(t, "testuser")
-	fake.SetCreatePipelineDefinitionResponse("proj-uuid-5678", map[string]any{
-		"id":   "pdef-uuid-1",
-		"name": "my-repo",
-	})
-	fake.SetCreateTriggerResponse("proj-uuid-5678", "pdef-uuid-1", map[string]any{
-		"id":           "trig-uuid-1",
-		"event_preset": "all-pushes",
-	})
+	addFirstPipelineResponses(fake)
 	addFakeDotnet(t, env, false)
 
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    []string{"onboard", "--scan", "--repo-id", "123456789", dir},
+		Args:    []string{"onboard", "--scan", "--repo-id", onboardRepoExternalID, dir},
 		Env:     env.Environ(),
 		WorkDir: otherDir,
 	})
@@ -576,20 +558,13 @@ func TestOnboard_PathArgument_UsesGivenDirectory(t *testing.T) {
 }
 
 func TestOnboard_PostSignup_FirstPipelineCreated(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("test runner uses sh -c")
-	}
-	dir := t.TempDir()
-	copyFixture(t, "testdata/test-run/dotnet", dir)
-	initGitRepoWithRemote(t, dir, "https://github.com/myorg/my-repo.git")
-
-	fake, env := onboardStandaloneEnv(t, "testuser")
-	fake.SetCreatePipelineDefinitionResponse("proj-uuid-5678", map[string]any{
-		"id":         "pdef-uuid-1",
+	dir, fake, env := onboardDotnetRepo(t)
+	fake.SetCreatePipelineDefinitionResponse(onboardProjectID, map[string]any{
+		"id":         onboardPipelineDefID,
 		"name":       "my-repo",
 		"created_at": "2026-07-23T00:00:00Z",
 	})
-	fake.SetCreateTriggerResponse("proj-uuid-5678", "pdef-uuid-1", map[string]any{
+	fake.SetCreateTriggerResponse(onboardProjectID, onboardPipelineDefID, map[string]any{
 		"id":           "trig-uuid-1",
 		"created_at":   "2026-07-23T00:00:00Z",
 		"event_preset": "all-pushes",
@@ -597,32 +572,25 @@ func TestOnboard_PostSignup_FirstPipelineCreated(t *testing.T) {
 	addFakeDotnet(t, env, false)
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    []string{"onboard", "--scan", "--repo-id", "123456789"},
+		Args:    []string{"onboard", "--scan", "--repo-id", onboardRepoExternalID},
 		Env:     env.Environ(),
 		WorkDir: dir,
 	})
 
 	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
-	assert.Check(t, strings.Contains(result.Stdout, "Project created: my-repo"))
-	assert.Check(t, strings.Contains(result.Stdout, "Pipeline definition created: my-repo"))
-	assert.Check(t, strings.Contains(result.Stdout, "Trigger created: all-pushes"))
-	assert.Check(t, strings.Contains(result.Stdout, "Your project is ready!"))
-	assert.Check(t, strings.Contains(result.Stdout, "git push"))
+	assert.Check(t, cmp.Contains(result.Stdout, "Project created: my-repo"))
+	assert.Check(t, cmp.Contains(result.Stdout, "Pipeline definition created: my-repo"))
+	assert.Check(t, cmp.Contains(result.Stdout, "Trigger created: all-pushes"))
+	assert.Check(t, cmp.Contains(result.Stdout, "Your project is ready!"))
+	assert.Check(t, cmp.Contains(result.Stdout, "git push"))
 }
 
 func TestOnboard_PostSignup_FirstPipeline_GitHubAppResolvesRepo(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("test runner uses sh -c")
-	}
-	dir := t.TempDir()
-	copyFixture(t, "testdata/test-run/dotnet", dir)
-	initGitRepoWithRemote(t, dir, "https://github.com/myorg/my-repo.git")
-
-	fake, env := onboardStandaloneEnv(t, "testuser")
+	dir, fake, env := onboardDotnetRepo(t)
 	// GitHub App is installed for the org and can access the repo, so the repo's
 	// external ID is resolved automatically — no --repo-id needed.
-	fake.SetGitHubAppInstalled("org-uuid-1234", true)
-	fake.AddGitHubAppRepository("org-uuid-1234", map[string]any{
+	fake.SetGitHubAppInstalled(onboardOrgID, true)
+	fake.AddGitHubAppRepository(onboardOrgID, map[string]any{
 		"id":             987654321,
 		"repo_full_name": "myorg/my-repo",
 		"repo_name":      "my-repo",
@@ -630,14 +598,7 @@ func TestOnboard_PostSignup_FirstPipeline_GitHubAppResolvesRepo(t *testing.T) {
 		"default_branch": "main",
 		"private":        false,
 	})
-	fake.SetCreatePipelineDefinitionResponse("proj-uuid-5678", map[string]any{
-		"id":   "pdef-uuid-1",
-		"name": "my-repo",
-	})
-	fake.SetCreateTriggerResponse("proj-uuid-5678", "pdef-uuid-1", map[string]any{
-		"id":           "trig-uuid-1",
-		"event_preset": "all-pushes",
-	})
+	addFirstPipelineResponses(fake)
 	addFakeDotnet(t, env, false)
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
@@ -647,10 +608,10 @@ func TestOnboard_PostSignup_FirstPipeline_GitHubAppResolvesRepo(t *testing.T) {
 	})
 
 	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
-	assert.Check(t, strings.Contains(result.Stdout, "Found repository myorg/my-repo"))
-	assert.Check(t, strings.Contains(result.Stdout, "Pipeline definition created: my-repo"))
-	assert.Check(t, strings.Contains(result.Stdout, "Trigger created: all-pushes"))
-	assert.Check(t, strings.Contains(result.Stdout, "Your project is ready!"))
+	assert.Check(t, cmp.Contains(result.Stdout, "Found repository myorg/my-repo"))
+	assert.Check(t, cmp.Contains(result.Stdout, "Pipeline definition created: my-repo"))
+	assert.Check(t, cmp.Contains(result.Stdout, "Trigger created: all-pushes"))
+	assert.Check(t, cmp.Contains(result.Stdout, "Your project is ready!"))
 }
 
 // TestOnboard_PostSignup_Rerun_Idempotent runs onboard twice over the same
@@ -662,39 +623,25 @@ func TestOnboard_PostSignup_FirstPipeline_GitHubAppResolvesRepo(t *testing.T) {
 // project slug is circleci/<orgID>/<projectID> — opaque IDs, not the repository
 // name — and no API maps a project name to its ID within an org.
 func TestOnboard_PostSignup_Rerun_Idempotent(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("test runner uses sh -c")
-	}
-	dir := t.TempDir()
-	copyFixture(t, "testdata/test-run/dotnet", dir)
-	initGitRepoWithRemote(t, dir, "https://github.com/myorg/my-repo.git")
-
-	fake, env := onboardStandaloneEnv(t, "testuser")
-	fake.SetGitHubAppInstalled("org-uuid-1234", true)
-	fake.AddGitHubAppRepository("org-uuid-1234", map[string]any{
+	dir, fake, env := onboardDotnetRepo(t)
+	fake.SetGitHubAppInstalled(onboardOrgID, true)
+	fake.AddGitHubAppRepository(onboardOrgID, map[string]any{
 		"id":             987654321,
 		"repo_full_name": "myorg/my-repo",
 		"repo_name":      "my-repo",
 		"owner":          "myorg",
 	})
-	fake.SetCreatePipelineDefinitionResponse("proj-uuid-5678", map[string]any{
-		"id":   "pdef-uuid-1",
-		"name": "my-repo",
-	})
-	fake.SetCreateTriggerResponse("proj-uuid-5678", "pdef-uuid-1", map[string]any{
-		"id":           "trig-uuid-1",
-		"event_preset": "all-pushes",
-	})
+	addFirstPipelineResponses(fake)
 	// The second run looks the project up by the slug projectref derives from the
 	// recorded UUIDs. The real API accepts that form and canonicalises it to the
 	// short-ID slug.
 	fake.AddProjectInfo("circleci/org-uuid-1234/proj-uuid-5678", map[string]any{
-		"id":                "proj-uuid-5678",
+		"id":                onboardProjectID,
 		"slug":              "circleci/Org1234ShortId/Proj5678ShortId",
 		"name":              "my-repo",
 		"organization_name": "myorg",
 		"organization_slug": "circleci/Org1234ShortId",
-		"organization_id":   "org-uuid-1234",
+		"organization_id":   onboardOrgID,
 	})
 	addFakeDotnet(t, env, false)
 
@@ -705,26 +652,26 @@ func TestOnboard_PostSignup_Rerun_Idempotent(t *testing.T) {
 		WorkDir: dir,
 	})
 	assert.Equal(t, first.ExitCode, 0, "stderr: %s", first.Stderr)
-	assert.Check(t, strings.Contains(first.Stdout, "Project created: my-repo"))
-	assert.Check(t, strings.Contains(first.Stdout, "Linked this repository to the project"))
+	assert.Check(t, cmp.Contains(first.Stdout, "Project created: my-repo"))
+	assert.Check(t, cmp.Contains(first.Stdout, "Linked this repository to the project"))
 	_, err := os.Stat(filepath.Join(dir, ".circleci", "info.yml"))
 	assert.NilError(t, err, "first run should record the project locally")
 	// The recorded ID is unrecoverable from the project name, so the next steps
 	// have to stage info.yml, not just config.yml.
-	assert.Check(t, strings.Contains(first.Stdout, "git add .circleci/"))
+	assert.Check(t, cmp.Contains(first.Stdout, "git add .circleci/"))
 	assert.Check(t, !strings.Contains(first.Stdout, "git add .circleci/config.yml"),
 		"staging only config.yml would leave the project ID uncommitted")
 
 	// The project now has its pipeline definition and trigger.
-	fake.AddPipelineDefinition("proj-uuid-5678", map[string]any{
-		"id":   "pdef-uuid-1",
+	fake.AddPipelineDefinition(onboardProjectID, map[string]any{
+		"id":   onboardPipelineDefID,
 		"name": "my-repo",
 		"config_source": map[string]any{
 			"provider": "github_app",
 			"repo":     map[string]any{"external_id": "987654321"},
 		},
 	})
-	fake.AddTrigger("proj-uuid-5678", "pdef-uuid-1", map[string]any{
+	fake.AddTrigger(onboardProjectID, onboardPipelineDefID, map[string]any{
 		"id":           "trig-uuid-1",
 		"event_preset": "all-pushes",
 	})
@@ -736,9 +683,9 @@ func TestOnboard_PostSignup_Rerun_Idempotent(t *testing.T) {
 		WorkDir: dir,
 	})
 	assert.Equal(t, second.ExitCode, 0, "stderr: %s", second.Stderr)
-	assert.Check(t, strings.Contains(second.Stdout, "Using existing project: my-repo"))
-	assert.Check(t, strings.Contains(second.Stdout, "Pipeline definition already exists: my-repo"))
-	assert.Check(t, strings.Contains(second.Stdout, "Trigger already exists"))
+	assert.Check(t, cmp.Contains(second.Stdout, "Using existing project: my-repo"))
+	assert.Check(t, cmp.Contains(second.Stdout, "Pipeline definition already exists: my-repo"))
+	assert.Check(t, cmp.Contains(second.Stdout, "Trigger already exists"))
 	assert.Check(t, !strings.Contains(second.Stdout, "Project created"), "re-run should not create a second project")
 	assert.Check(t, !strings.Contains(second.Stderr, "already exists"), "re-run should not surface a conflict")
 }
@@ -790,7 +737,7 @@ func TestOnboard_PostSignup_LinkedProjectInAnotherOrg(t *testing.T) {
 	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
 	assert.Check(t, !strings.Contains(result.Stdout, "Using existing project"),
 		"a project in another organization must not be reused")
-	assert.Check(t, strings.Contains(result.Stderr, `project named "my-repo" already exists`))
+	assert.Check(t, cmp.Contains(result.Stderr, `project named "my-repo" already exists`))
 	// The guidance has to terminate: --force because info.yml exists, and --project
 	// because otherwise link re-derives the same foreign slug from the git remote.
 	assert.Check(t, strings.Contains(result.Stdout,
@@ -804,14 +751,7 @@ func TestOnboard_PostSignup_LinkedProjectInAnotherOrg(t *testing.T) {
 // by name, onboard points at `circleci project link` rather than reporting a raw
 // HTTP conflict.
 func TestOnboard_PostSignup_ProjectNameConflict(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("test runner uses sh -c")
-	}
-	dir := t.TempDir()
-	copyFixture(t, "testdata/test-run/dotnet", dir)
-	initGitRepoWithRemote(t, dir, "https://github.com/myorg/my-repo.git")
-
-	fake, env := onboardStandaloneEnv(t, "testuser")
+	dir, fake, env := onboardDotnetRepo(t)
 	fake.SetCreateProjectConflict()
 	addFakeDotnet(t, env, false)
 
@@ -823,8 +763,8 @@ func TestOnboard_PostSignup_ProjectNameConflict(t *testing.T) {
 	})
 
 	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
-	assert.Check(t, strings.Contains(result.Stderr, `project named "my-repo" already exists`))
-	assert.Check(t, strings.Contains(result.Stdout, "circleci project link --project circleci/myorg/<projectID>"))
+	assert.Check(t, cmp.Contains(result.Stderr, `project named "my-repo" already exists`))
+	assert.Check(t, cmp.Contains(result.Stdout, "circleci project link --project circleci/myorg/<projectID>"))
 	assert.Check(t, !strings.Contains(result.Stdout, "--force"), "no info.yml to overwrite")
 	// No raw HTTP internals for a conflict the user can resolve with one command.
 	assert.Check(t, !strings.Contains(result.Stderr, "409"), "stderr should not leak an HTTP status")
@@ -832,17 +772,10 @@ func TestOnboard_PostSignup_ProjectNameConflict(t *testing.T) {
 }
 
 func TestOnboard_PostSignup_FirstPipeline_RepoNotAccessible(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("test runner uses sh -c")
-	}
-	dir := t.TempDir()
-	copyFixture(t, "testdata/test-run/dotnet", dir)
-	initGitRepoWithRemote(t, dir, "https://github.com/myorg/my-repo.git")
-
-	fake, env := onboardStandaloneEnv(t, "testuser")
+	dir, fake, env := onboardDotnetRepo(t)
 	// App is installed, but the repo the user is in was not granted to it.
-	fake.SetGitHubAppInstalled("org-uuid-1234", true)
-	fake.AddGitHubAppRepository("org-uuid-1234", map[string]any{
+	fake.SetGitHubAppInstalled(onboardOrgID, true)
+	fake.AddGitHubAppRepository(onboardOrgID, map[string]any{
 		"id":             111,
 		"repo_full_name": "myorg/some-other-repo",
 		"repo_name":      "some-other-repo",
@@ -857,22 +790,15 @@ func TestOnboard_PostSignup_FirstPipeline_RepoNotAccessible(t *testing.T) {
 	})
 
 	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
-	assert.Check(t, strings.Contains(result.Stderr, "can't access myorg/my-repo"))
-	assert.Check(t, strings.Contains(result.Stdout, "Commit .circleci/config.yml"))
+	assert.Check(t, cmp.Contains(result.Stderr, "can't access myorg/my-repo"))
+	assert.Check(t, cmp.Contains(result.Stdout, "Commit .circleci/config.yml"))
 	assert.Check(t, !strings.Contains(result.Stdout, "Pipeline definition created"), "no pipeline def without a repo ID")
 }
 
 func TestOnboard_PostSignup_FirstPipeline_TriggerFails(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("test runner uses sh -c")
-	}
-	dir := t.TempDir()
-	copyFixture(t, "testdata/test-run/dotnet", dir)
-	initGitRepoWithRemote(t, dir, "https://github.com/myorg/my-repo.git")
-
-	fake, env := onboardStandaloneEnv(t, "testuser")
-	fake.SetCreatePipelineDefinitionResponse("proj-uuid-5678", map[string]any{
-		"id":   "pdef-uuid-1",
+	dir, fake, env := onboardDotnetRepo(t)
+	fake.SetCreatePipelineDefinitionResponse(onboardProjectID, map[string]any{
+		"id":   onboardPipelineDefID,
 		"name": "my-repo",
 	})
 	// No trigger response registered → the trigger create returns 404 and the
@@ -880,15 +806,15 @@ func TestOnboard_PostSignup_FirstPipeline_TriggerFails(t *testing.T) {
 	addFakeDotnet(t, env, false)
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    []string{"onboard", "--scan", "--repo-id", "123456789"},
+		Args:    []string{"onboard", "--scan", "--repo-id", onboardRepoExternalID},
 		Env:     env.Environ(),
 		WorkDir: dir,
 	})
 
 	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
-	assert.Check(t, strings.Contains(result.Stdout, "Pipeline definition created: my-repo"))
-	assert.Check(t, strings.Contains(result.Stderr, "Could not create trigger"))
-	assert.Check(t, strings.Contains(result.Stdout, "Commit .circleci/config.yml"))
+	assert.Check(t, cmp.Contains(result.Stdout, "Pipeline definition created: my-repo"))
+	assert.Check(t, cmp.Contains(result.Stderr, "Could not create trigger"))
+	assert.Check(t, cmp.Contains(result.Stdout, "Commit .circleci/config.yml"))
 }
 
 func TestOnboard_PostSignup_ClassicOrg_FollowsProject(t *testing.T) {
@@ -909,9 +835,9 @@ func TestOnboard_PostSignup_ClassicOrg_FollowsProject(t *testing.T) {
 	})
 
 	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
-	assert.Check(t, strings.Contains(result.Stdout, "Project connected: my-repo"))
-	assert.Check(t, strings.Contains(result.Stdout, "Organization: myorg"))
-	assert.Check(t, strings.Contains(result.Stdout, "Commit and push .circleci/config.yml"))
+	assert.Check(t, cmp.Contains(result.Stdout, "Project connected: my-repo"))
+	assert.Check(t, cmp.Contains(result.Stdout, "Organization: myorg"))
+	assert.Check(t, cmp.Contains(result.Stdout, "Commit and push .circleci/config.yml"))
 }
 
 func TestOnboard_PostSignup_NoOrgs(t *testing.T) {
@@ -933,18 +859,11 @@ func TestOnboard_PostSignup_NoOrgs(t *testing.T) {
 	})
 
 	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
-	assert.Check(t, strings.Contains(result.Stdout, "circleci project create"))
+	assert.Check(t, cmp.Contains(result.Stdout, "circleci project create"))
 }
 
 func TestOnboard_PostSignup_CreateFails(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("test runner uses sh -c")
-	}
-	dir := t.TempDir()
-	copyFixture(t, "testdata/test-run/dotnet", dir)
-	initGitRepoWithRemote(t, dir, "https://github.com/myorg/my-repo.git")
-
-	fake, env := onboardStandaloneEnv(t, "testuser")
+	dir, fake, env := onboardDotnetRepo(t)
 	fake.SetCreateProjectResponse(nil)
 	addFakeDotnet(t, env, false)
 	result := binary.RunCLI(t, binary.RunOpts{
@@ -955,8 +874,39 @@ func TestOnboard_PostSignup_CreateFails(t *testing.T) {
 	})
 
 	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
-	assert.Check(t, strings.Contains(result.Stderr, "Could not create project"))
-	assert.Check(t, strings.Contains(result.Stdout, "circleci project create"))
+	assert.Check(t, cmp.Contains(result.Stderr, "Could not create project"))
+	assert.Check(t, cmp.Contains(result.Stdout, "circleci project create"))
+}
+
+// onboardDotnetRepo builds the fixture shared by the post-signup tests: a dotnet
+// checkout with a GitHub remote, a fake CircleCI serving a CircleCI-native
+// organization, and an isolated environment pointed at it.
+//
+// Callers still wire their own fake dotnet binary, since whether the tests pass or
+// fail is the variable under test in some of them.
+func onboardDotnetRepo(t *testing.T) (string, *fakes.CircleCI, *testenv.TestEnv) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("test runner uses sh -c")
+	}
+	dir := t.TempDir()
+	copyFixture(t, "testdata/test-run/dotnet", dir)
+	initGitRepoWithRemote(t, dir, "https://github.com/myorg/my-repo.git")
+	fake, env := onboardStandaloneEnv(t, "testuser")
+	return dir, fake, env
+}
+
+// addFirstPipelineResponses registers the create responses for the pipeline
+// definition and all-pushes trigger that onboard wires up on the happy path.
+func addFirstPipelineResponses(fake *fakes.CircleCI) {
+	fake.SetCreatePipelineDefinitionResponse(onboardProjectID, map[string]any{
+		"id":   onboardPipelineDefID,
+		"name": "my-repo",
+	})
+	fake.SetCreateTriggerResponse(onboardProjectID, onboardPipelineDefID, map[string]any{
+		"id":           "trig-uuid-1",
+		"event_preset": "all-pushes",
+	})
 }
 
 func onboardStandaloneEnv(t *testing.T, login string) (*fakes.CircleCI, *testenv.TestEnv) {
@@ -971,19 +921,19 @@ func onboardStandaloneEnv(t *testing.T, login string) (*fakes.CircleCI, *testenv
 		},
 	})
 	fake.SetCollaborations([]any{
-		map[string]any{"id": "org-uuid-1234", "name": "myorg", "slug": "circleci/myorg", "vcs_type": "circleci"},
+		map[string]any{"id": onboardOrgID, "name": "myorg", "slug": "circleci/myorg", "vcs_type": "circleci"},
 	})
 	// A CircleCI-native project slug embeds opaque org and project short IDs, not
 	// the repository name — mirroring the real API, where a name-based slug is
 	// rejected outright. The UUIDs are separate values used by the pipeline
 	// definition and GitHub App calls.
 	fake.SetCreateProjectResponse(map[string]any{
-		"id":                "proj-uuid-5678",
+		"id":                onboardProjectID,
 		"slug":              "circleci/Org1234ShortId/Proj5678ShortId",
 		"name":              "my-repo",
 		"organization_name": "myorg",
 		"organization_slug": "circleci/Org1234ShortId",
-		"organization_id":   "org-uuid-1234",
+		"organization_id":   onboardOrgID,
 	})
 
 	env := testenv.New(t)
@@ -1004,15 +954,15 @@ func onboardAuthenticatedEnv(t *testing.T, login string) (*fakes.CircleCI, *test
 		},
 	})
 	fake.SetCollaborations([]any{
-		map[string]any{"id": "org-uuid-1234", "name": "myorg", "slug": "gh/myorg", "vcs_type": "github"},
+		map[string]any{"id": onboardOrgID, "name": "myorg", "slug": "gh/myorg", "vcs_type": "github"},
 	})
 	fake.SetCreateProjectResponse(map[string]any{
-		"id":                "proj-uuid-5678",
+		"id":                onboardProjectID,
 		"slug":              "gh/myorg/my-repo",
 		"name":              "my-repo",
 		"organization_name": "myorg",
 		"organization_slug": "gh/myorg",
-		"organization_id":   "org-uuid-1234",
+		"organization_id":   onboardOrgID,
 		"vcs_info": map[string]any{
 			"provider":       "GitHub",
 			"default_branch": "main",

--- a/acceptance/onboard_test.go
+++ b/acceptance/onboard_test.go
@@ -524,6 +524,11 @@ func TestOnboard_PostSignup_Rerun_Idempotent(t *testing.T) {
 	assert.Check(t, strings.Contains(first.Stdout, "Linked this repository to the project"))
 	_, err := os.Stat(filepath.Join(dir, ".circleci", "info.yml"))
 	assert.NilError(t, err, "first run should record the project locally")
+	// The recorded ID is unrecoverable from the project name, so the next steps
+	// have to stage info.yml, not just config.yml.
+	assert.Check(t, strings.Contains(first.Stdout, "git add .circleci/"))
+	assert.Check(t, !strings.Contains(first.Stdout, "git add .circleci/config.yml"),
+		"staging only config.yml would leave the project ID uncommitted")
 
 	// The project now has its pipeline definition and trigger.
 	fake.AddPipelineDefinition("proj-uuid-5678", map[string]any{

--- a/acceptance/onboard_test.go
+++ b/acceptance/onboard_test.go
@@ -32,6 +32,7 @@ import (
 	"testing"
 
 	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/golden"
 
 	"github.com/CircleCI-Public/circleci-cli/internal/testing/binary"
@@ -388,6 +389,190 @@ func TestOnboard_PostSignup_FreshSignup_ContinuesToProjectSetup(t *testing.T) {
 		_, err = console.ExpectString("Your project is ready!")
 		assert.NilError(t, err)
 	}))
+}
+
+// TestOnboard_PostSignup_KeepsExistingProjectRef pins that onboard never rewrites
+// an existing .circleci/info.yml.
+//
+// The file is meant to be committed, and it may record a project in another
+// organization that this run has no mandate to replace — `circleci project link`
+// requires --force for exactly that reason.
+func TestOnboard_PostSignup_KeepsExistingProjectRef(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test runner uses sh -c")
+	}
+	dir := t.TempDir()
+	copyFixture(t, "testdata/test-run/dotnet", dir)
+	initGitRepoWithRemote(t, dir, "https://github.com/myorg/my-repo.git")
+
+	// A link to a project in a different organization, so it is ignored and onboard
+	// proceeds to create — the path that reaches the write.
+	existing := "organization:\n  id: other-org-uuid\n" +
+		"project:\n  id: other-proj-uuid\n  slug: gh/myorg/my-repo\n  name: my-repo\n"
+	refPath := filepath.Join(dir, ".circleci", "info.yml")
+	mkErr := os.MkdirAll(filepath.Dir(refPath), 0o755)
+	assert.NilError(t, mkErr)
+	writeErr := os.WriteFile(refPath, []byte(existing), 0o644)
+	assert.NilError(t, writeErr)
+
+	_, env := onboardStandaloneEnv(t, "testuser")
+	addFakeDotnet(t, env, false)
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"onboard", "--scan"},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	body, readErr := os.ReadFile(refPath)
+	assert.NilError(t, readErr)
+	assert.Check(t, cmp.Equal(string(body), existing), "info.yml must be left byte-for-byte alone")
+	assert.Check(t, cmp.Contains(result.Stderr, "already records a different project"))
+	assert.Check(t, cmp.Contains(result.Stderr, "circleci project link --force --project"))
+}
+
+// TestOnboard_PostSignup_AddsPushTriggerAlongsideOthers pins that only an
+// all-pushes trigger satisfies onboard. A definition carrying just a schedule
+// trigger would otherwise be reported as ready, and the push onboard tells the
+// user to make would build nothing.
+func TestOnboard_PostSignup_AddsPushTriggerAlongsideOthers(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test runner uses sh -c")
+	}
+	dir := t.TempDir()
+	copyFixture(t, "testdata/test-run/dotnet", dir)
+	initGitRepoWithRemote(t, dir, "https://github.com/myorg/my-repo.git")
+
+	fake, env := onboardStandaloneEnv(t, "testuser")
+	fake.AddPipelineDefinition("proj-uuid-5678", map[string]any{
+		"id":   "pdef-uuid-1",
+		"name": "my-repo",
+		"config_source": map[string]any{
+			"provider": "github_app",
+			"repo":     map[string]any{"external_id": "123456789"},
+		},
+	})
+	// Only a schedule trigger exists — no push would build anything.
+	fake.AddTrigger("proj-uuid-5678", "pdef-uuid-1", map[string]any{
+		"id":           "trig-schedule",
+		"event_preset": "schedule",
+	})
+	fake.SetCreateTriggerResponse("proj-uuid-5678", "pdef-uuid-1", map[string]any{
+		"id":           "trig-uuid-1",
+		"event_preset": "all-pushes",
+	})
+	addFakeDotnet(t, env, false)
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"onboard", "--scan", "--repo-id", "123456789"},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Check(t, cmp.Contains(result.Stdout, "Trigger created: all-pushes"))
+	assert.Check(t, !strings.Contains(result.Stdout, "Trigger already exists"),
+		"a schedule-only definition is not ready for a push")
+	assert.Check(t, cmp.Contains(result.Stdout, "Your project is ready!"))
+}
+
+// TestOnboard_SignupFlag_RecordsProjectRefAtRepoRoot pins where --signup records
+// the project link when run from a subdirectory.
+//
+// info.yml belongs beside config.yml at the top of the checkout. Writing it into
+// whatever directory the command was invoked from would leave it unreachable to
+// every command that looks for it at the root — and, run somewhere that is not a
+// repository at all, would litter a home directory.
+func TestOnboard_SignupFlag_RecordsProjectRefAtRepoRoot(t *testing.T) {
+	root := t.TempDir()
+	initGitRepoWithRemote(t, root, "https://github.com/myorg/my-repo.git")
+	sub := filepath.Join(root, "services", "api")
+	mkErr := os.MkdirAll(sub, 0o755)
+	assert.NilError(t, mkErr)
+
+	_, env := onboardStandaloneEnv(t, "testuser")
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"onboard", "--signup"},
+		Env:     env.Environ(),
+		WorkDir: sub,
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	_, rootErr := os.Stat(filepath.Join(root, ".circleci", "info.yml"))
+	assert.NilError(t, rootErr, "the link belongs at the repository root")
+	_, subErr := os.Stat(filepath.Join(sub, ".circleci", "info.yml"))
+	assert.Check(t, os.IsNotExist(subErr), "must not record the link in the invocation directory")
+}
+
+// TestOnboard_SignupFlag_WritesNoProjectRefOutsideRepo is the other half: with no
+// repository there is nothing to link, so nothing is written.
+func TestOnboard_SignupFlag_WritesNoProjectRefOutsideRepo(t *testing.T) {
+	dir := t.TempDir() // deliberately not a git checkout
+
+	_, env := onboardStandaloneEnv(t, "testuser")
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"onboard", "--signup"},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	_, statErr := os.Stat(filepath.Join(dir, ".circleci"))
+	assert.Check(t, os.IsNotExist(statErr), "must not create .circleci outside a repository")
+}
+
+// TestOnboard_PathArgument_UsesGivenDirectory pins that a path argument selects
+// the repository onboard describes.
+//
+// The process runs from a *different* checkout with a different remote, so any
+// detection that reads the working directory instead of the argument would name
+// the project after the wrong repository and wire the pipeline to the wrong repo —
+// silently, since every step still reports success.
+func TestOnboard_PathArgument_UsesGivenDirectory(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test runner uses sh -c")
+	}
+	dir := t.TempDir()
+	copyFixture(t, "testdata/test-run/dotnet", dir)
+	initGitRepoWithRemote(t, dir, "https://github.com/myorg/my-repo.git")
+
+	// A second, unrelated checkout to run from.
+	otherDir := t.TempDir()
+	initGitRepoWithRemote(t, otherDir, "https://github.com/myorg/wrong-repo.git")
+
+	fake, env := onboardStandaloneEnv(t, "testuser")
+	fake.SetCreatePipelineDefinitionResponse("proj-uuid-5678", map[string]any{
+		"id":   "pdef-uuid-1",
+		"name": "my-repo",
+	})
+	fake.SetCreateTriggerResponse("proj-uuid-5678", "pdef-uuid-1", map[string]any{
+		"id":           "trig-uuid-1",
+		"event_preset": "all-pushes",
+	})
+	addFakeDotnet(t, env, false)
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"onboard", "--scan", "--repo-id", "123456789", dir},
+		Env:     env.Environ(),
+		WorkDir: otherDir,
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Check(t, cmp.Contains(result.Stdout, "Project created: my-repo"))
+	assert.Check(t, cmp.Contains(result.Stdout, "Your project is ready!"))
+	assert.Check(t, !strings.Contains(result.Stdout, "wrong-repo"),
+		"the working directory's repository must not leak into the run")
+	// The link belongs to the directory that was onboarded, not the cwd.
+	_, err := os.Stat(filepath.Join(dir, ".circleci", "info.yml"))
+	assert.NilError(t, err)
+	_, err = os.Stat(filepath.Join(otherDir, ".circleci", "info.yml"))
+	assert.Check(t, os.IsNotExist(err), "must not write into the working directory")
 }
 
 func TestOnboard_PostSignup_FirstPipelineCreated(t *testing.T) {

--- a/acceptance/onboard_test.go
+++ b/acceptance/onboard_test.go
@@ -553,6 +553,61 @@ func TestOnboard_PostSignup_Rerun_Idempotent(t *testing.T) {
 	assert.Check(t, !strings.Contains(second.Stderr, "already exists"), "re-run should not surface a conflict")
 }
 
+// TestOnboard_PostSignup_LinkedProjectInAnotherOrg covers a repository already
+// linked to a project in a different organization — a classic VCS project being
+// onboarded into a CircleCI-native org, which is what a migration looks like.
+//
+// The link must not be reused: it would set up pipelines in an organization the
+// user did not choose. It is ignored, onboard proceeds to create, and the name
+// collision that follows points at `project link --force`, since plain
+// `project link` refuses while .circleci/info.yml exists.
+func TestOnboard_PostSignup_LinkedProjectInAnotherOrg(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test runner uses sh -c")
+	}
+	dir := t.TempDir()
+	copyFixture(t, "testdata/test-run/dotnet", dir)
+	initGitRepoWithRemote(t, dir, "https://github.com/myorg/my-repo.git")
+
+	// A resolvable link, but to a project owned by a different org. Both IDs are
+	// recorded against a classic slug, exactly as `circleci project link` writes
+	// it — the slug must be used as-is rather than rebuilt into the circleci/ form.
+	assert.NilError(t, os.MkdirAll(filepath.Join(dir, ".circleci"), 0o755))
+	assert.NilError(t, os.WriteFile(filepath.Join(dir, ".circleci", "info.yml"), []byte(
+		"organization:\n  id: other-org-uuid\n  name: myorg\n"+
+			"project:\n  id: other-proj-uuid\n  slug: gh/myorg/my-repo\n  name: my-repo\n",
+	), 0o644))
+
+	fake, env := onboardStandaloneEnv(t, "testuser")
+	fake.AddProjectInfo("gh/myorg/my-repo", map[string]any{
+		"id":                "other-proj-uuid",
+		"slug":              "gh/myorg/my-repo",
+		"name":              "my-repo",
+		"organization_name": "myorg",
+		"organization_slug": "gh/myorg",
+		"organization_id":   "other-org-uuid",
+	})
+	fake.SetCreateProjectConflict()
+	addFakeDotnet(t, env, false)
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"onboard", "--scan"},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Check(t, !strings.Contains(result.Stdout, "Using existing project"),
+		"a project in another organization must not be reused")
+	assert.Check(t, strings.Contains(result.Stderr, `project named "my-repo" already exists`))
+	// The guidance has to terminate: --force because info.yml exists, and --project
+	// because otherwise link re-derives the same foreign slug from the git remote.
+	assert.Check(t, strings.Contains(result.Stdout,
+		"circleci project link --force --project circleci/myorg/<projectID>"))
+	assert.Check(t, !strings.Contains(result.Stderr, "409"), "stderr should not leak an HTTP status")
+}
+
 // TestOnboard_PostSignup_ProjectNameConflict covers a name collision that onboard
 // cannot resolve: the org already has a project with this name, but the checkout
 // has no .circleci/info.yml recording its ID. Since a project cannot be looked up
@@ -579,7 +634,8 @@ func TestOnboard_PostSignup_ProjectNameConflict(t *testing.T) {
 
 	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
 	assert.Check(t, strings.Contains(result.Stderr, `project named "my-repo" already exists`))
-	assert.Check(t, strings.Contains(result.Stdout, "circleci project link"))
+	assert.Check(t, strings.Contains(result.Stdout, "circleci project link --project circleci/myorg/<projectID>"))
+	assert.Check(t, !strings.Contains(result.Stdout, "--force"), "no info.yml to overwrite")
 	// No raw HTTP internals for a conflict the user can resolve with one command.
 	assert.Check(t, !strings.Contains(result.Stderr, "409"), "stderr should not leak an HTTP status")
 	assert.Check(t, !strings.Contains(result.Stderr, "/api/v2/"), "stderr should not leak an API path")

--- a/acceptance/onboard_test.go
+++ b/acceptance/onboard_test.go
@@ -304,6 +304,198 @@ func TestOnboard_PostSignup_ProjectCreated(t *testing.T) {
 	assert.Check(t, strings.Contains(result.Stdout, "Commit .circleci/config.yml"))
 }
 
+func TestOnboard_PostSignup_FirstPipelineCreated(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test runner uses sh -c")
+	}
+	dir := t.TempDir()
+	copyFixture(t, "testdata/test-run/dotnet", dir)
+	initGitRepoWithRemote(t, dir, "https://github.com/myorg/my-repo.git")
+
+	fake, env := onboardStandaloneEnv(t, "testuser")
+	fake.SetCreatePipelineDefinitionResponse("proj-uuid-5678", map[string]any{
+		"id":         "pdef-uuid-1",
+		"name":       "my-repo",
+		"created_at": "2026-07-23T00:00:00Z",
+	})
+	fake.SetCreateTriggerResponse("proj-uuid-5678", "pdef-uuid-1", map[string]any{
+		"id":           "trig-uuid-1",
+		"created_at":   "2026-07-23T00:00:00Z",
+		"event_preset": "all-pushes",
+	})
+	addFakeDotnet(t, env, false)
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"onboard", "--scan", "--repo-id", "123456789"},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Check(t, strings.Contains(result.Stdout, "Project created: my-repo"))
+	assert.Check(t, strings.Contains(result.Stdout, "Pipeline definition created: my-repo"))
+	assert.Check(t, strings.Contains(result.Stdout, "Trigger created: all-pushes"))
+	assert.Check(t, strings.Contains(result.Stdout, "Your project is ready!"))
+	assert.Check(t, strings.Contains(result.Stdout, "git push"))
+}
+
+func TestOnboard_PostSignup_FirstPipeline_GitHubAppResolvesRepo(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test runner uses sh -c")
+	}
+	dir := t.TempDir()
+	copyFixture(t, "testdata/test-run/dotnet", dir)
+	initGitRepoWithRemote(t, dir, "https://github.com/myorg/my-repo.git")
+
+	fake, env := onboardStandaloneEnv(t, "testuser")
+	// GitHub App is installed for the org and can access the repo, so the repo's
+	// external ID is resolved automatically — no --repo-id needed.
+	fake.SetGitHubAppInstalled("org-uuid-1234", true)
+	fake.AddGitHubAppRepository("org-uuid-1234", map[string]any{
+		"id":             987654321,
+		"repo_full_name": "myorg/my-repo",
+		"repo_name":      "my-repo",
+		"owner":          "myorg",
+		"default_branch": "main",
+		"private":        false,
+	})
+	fake.SetCreatePipelineDefinitionResponse("proj-uuid-5678", map[string]any{
+		"id":   "pdef-uuid-1",
+		"name": "my-repo",
+	})
+	fake.SetCreateTriggerResponse("proj-uuid-5678", "pdef-uuid-1", map[string]any{
+		"id":           "trig-uuid-1",
+		"event_preset": "all-pushes",
+	})
+	addFakeDotnet(t, env, false)
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"onboard", "--scan"},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Check(t, strings.Contains(result.Stdout, "Found repository myorg/my-repo"))
+	assert.Check(t, strings.Contains(result.Stdout, "Pipeline definition created: my-repo"))
+	assert.Check(t, strings.Contains(result.Stdout, "Trigger created: all-pushes"))
+	assert.Check(t, strings.Contains(result.Stdout, "Your project is ready!"))
+}
+
+func TestOnboard_PostSignup_Rerun_Idempotent(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test runner uses sh -c")
+	}
+	dir := t.TempDir()
+	copyFixture(t, "testdata/test-run/dotnet", dir)
+	initGitRepoWithRemote(t, dir, "https://github.com/myorg/my-repo.git")
+
+	fake, env := onboardStandaloneEnv(t, "testuser")
+	// Simulate a prior onboard run: project creation now conflicts, and the
+	// project already has its pipeline definition + trigger.
+	fake.SetCreateProjectResponse(nil) // create fails → resolve the existing project
+	fake.AddProjectInfo("circleci/myorg/my-repo", map[string]any{
+		"id":                "proj-uuid-5678",
+		"slug":              "circleci/myorg/my-repo",
+		"name":              "my-repo",
+		"organization_name": "myorg",
+		"organization_slug": "circleci/myorg",
+		"organization_id":   "org-uuid-1234",
+	})
+	fake.SetGitHubAppInstalled("org-uuid-1234", true)
+	fake.AddGitHubAppRepository("org-uuid-1234", map[string]any{
+		"id":             987654321,
+		"repo_full_name": "myorg/my-repo",
+		"repo_name":      "my-repo",
+		"owner":          "myorg",
+	})
+	fake.AddPipelineDefinition("proj-uuid-5678", map[string]any{
+		"id":   "pdef-uuid-1",
+		"name": "my-repo",
+		"config_source": map[string]any{
+			"provider": "github_app",
+			"repo":     map[string]any{"external_id": "987654321"},
+		},
+	})
+	fake.AddTrigger("proj-uuid-5678", "pdef-uuid-1", map[string]any{
+		"id":           "trig-uuid-1",
+		"event_preset": "all-pushes",
+	})
+	addFakeDotnet(t, env, false)
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"onboard", "--scan"},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Check(t, strings.Contains(result.Stdout, "Using existing project: my-repo"))
+	assert.Check(t, strings.Contains(result.Stdout, "Pipeline definition already exists: my-repo"))
+	assert.Check(t, strings.Contains(result.Stdout, "Trigger already exists"))
+	assert.Check(t, !strings.Contains(result.Stderr, "Could not create project"), "re-run should not surface a creation error")
+}
+
+func TestOnboard_PostSignup_FirstPipeline_RepoNotAccessible(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test runner uses sh -c")
+	}
+	dir := t.TempDir()
+	copyFixture(t, "testdata/test-run/dotnet", dir)
+	initGitRepoWithRemote(t, dir, "https://github.com/myorg/my-repo.git")
+
+	fake, env := onboardStandaloneEnv(t, "testuser")
+	// App is installed, but the repo the user is in was not granted to it.
+	fake.SetGitHubAppInstalled("org-uuid-1234", true)
+	fake.AddGitHubAppRepository("org-uuid-1234", map[string]any{
+		"id":             111,
+		"repo_full_name": "myorg/some-other-repo",
+		"repo_name":      "some-other-repo",
+		"owner":          "myorg",
+	})
+	addFakeDotnet(t, env, false)
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"onboard", "--scan"},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Check(t, strings.Contains(result.Stderr, "can't access myorg/my-repo"))
+	assert.Check(t, strings.Contains(result.Stdout, "Commit .circleci/config.yml"))
+	assert.Check(t, !strings.Contains(result.Stdout, "Pipeline definition created"), "no pipeline def without a repo ID")
+}
+
+func TestOnboard_PostSignup_FirstPipeline_TriggerFails(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test runner uses sh -c")
+	}
+	dir := t.TempDir()
+	copyFixture(t, "testdata/test-run/dotnet", dir)
+	initGitRepoWithRemote(t, dir, "https://github.com/myorg/my-repo.git")
+
+	fake, env := onboardStandaloneEnv(t, "testuser")
+	fake.SetCreatePipelineDefinitionResponse("proj-uuid-5678", map[string]any{
+		"id":   "pdef-uuid-1",
+		"name": "my-repo",
+	})
+	// No trigger response registered → the trigger create returns 404 and the
+	// flow degrades to manual guidance.
+	addFakeDotnet(t, env, false)
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"onboard", "--scan", "--repo-id", "123456789"},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Check(t, strings.Contains(result.Stdout, "Pipeline definition created: my-repo"))
+	assert.Check(t, strings.Contains(result.Stderr, "Could not create trigger"))
+	assert.Check(t, strings.Contains(result.Stdout, "Commit .circleci/config.yml"))
+}
+
 func TestOnboard_PostSignup_ClassicOrg_FollowsProject(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("test runner uses sh -c")

--- a/acceptance/testdata/TestOnboard_FailingTests_ShortCircuits.stderr.txt
+++ b/acceptance/testdata/TestOnboard_FailingTests_ShortCircuits.stderr.txt
@@ -3,4 +3,4 @@ error: Test command exited with status 9.
 
 Suggestions:
   • Paste the prompt above into your AI assistant
-  • Re-run circleci onboard once tests pass
+  • Re-run circleci test run once tests pass

--- a/acceptance/testdata/TestOnboard_FailingTests_ShortCircuits.txt
+++ b/acceptance/testdata/TestOnboard_FailingTests_ShortCircuits.txt
@@ -4,7 +4,7 @@
 Running tests ...
 fake dotnet test --framework net8.0 --filter FullyQualifiedName!~BufferErroringWithInvalidSize&FullyQualifiedName!~MemoryTraceWriter&FullyQualifiedName!~Issue1619&FullyQualifiedName!~SerializeFormattedDateTimeNewZealandCulture
 
-My tests failed when running `circleci onboard`.
+My tests failed when running `circleci test run`.
 
 Project stack: dotnet
 Image: mcr.microsoft.com/dotnet/sdk:8.0
@@ -16,4 +16,4 @@ fake dotnet test --framework net8.0 --filter FullyQualifiedName!~BufferErroringW
 fake failure details
 
 Please diagnose the failure from the output above and propose a fix.
-Once fixed, I will re-run `circleci onboard`.
+Once fixed, I will re-run `circleci test run`.

--- a/acceptance/watch_test.go
+++ b/acceptance/watch_test.go
@@ -158,6 +158,7 @@ func TestRunWatch_Failed(t *testing.T) {
 
 	assert.Equal(t, result.ExitCode, 1, "stderr: %s", result.Stderr)
 	assert.Check(t, cmp.Contains(result.Stderr, "failed"), "stderr: %s", result.Stderr)
+	assert.Check(t, cmp.Contains(result.Stderr, "circleci logs --last-failed"), "stderr: %s", result.Stderr)
 }
 
 // --- failed pipeline with a failed job → suggests viewing logs ---
@@ -195,6 +196,7 @@ func TestRunWatch_Failed_SuggestsJobLogs(t *testing.T) {
 	assert.Equal(t, result.ExitCode, 1, "stderr: %s", result.Stderr)
 	assert.Check(t, cmp.Contains(result.Stderr, `"integration-test"`), "stderr: %s", result.Stderr)
 	assert.Check(t, cmp.Contains(result.Stderr, "circleci job get <job-id>"), "stderr: %s", result.Stderr)
+	assert.Check(t, cmp.Contains(result.Stderr, "circleci logs --last-failed"), "stderr: %s", result.Stderr)
 }
 
 // --- cancelled run → exit 6 ---

--- a/internal/cmd/cmdauth/auth.go
+++ b/internal/cmd/cmdauth/auth.go
@@ -68,7 +68,7 @@ func NewAuthCmd() *cobra.Command {
 // "Saved token to <path>" status line on stderr. Shared by `auth login`
 // (after OAuth token exchange) and `auth token` (after the TUI prompt).
 func persistToken(ctx context.Context, host, token string, userID uuid.UUID, secureStorage bool, path string) error {
-	res, err := config.SetLogin(ctx, host, token, userID, secureStorage)
+	res, err := config.SetLogin(ctx, path, host, token, userID, secureStorage)
 	if err != nil {
 		return clierrors.New("auth.save_failed", "Failed to save token", err.Error()).
 			WithExitCode(clierrors.ExitGeneralError)

--- a/internal/cmd/onboard/onboard.go
+++ b/internal/cmd/onboard/onboard.go
@@ -61,10 +61,11 @@ func NewOnboardCmd() *cobra.Command {
 			When run interactively without --scan or --signup, a prompt lets you
 			choose between scanning the current repo or signing up directly.
 
-			Setting up the pipeline needs your GitHub repository's numeric ID.
-			Pass it with --repo-id to skip the prompt (required in non-interactive
-			sessions); without it, project creation still completes and prints the
-			steps to finish setup by hand.
+			Setting up the pipeline needs your repository's numeric ID. For a GitHub
+			repository it is resolved through the CircleCI GitHub App. Pass --repo-id
+			to skip that lookup, or when the repository is not on GitHub. Without an
+			ID the project is still created and the steps to finish setup by hand are
+			printed.
 		`),
 		Example: heredoc.Doc(`
 			# Interactive mode: choose scan or signup
@@ -115,6 +116,6 @@ func NewOnboardCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&noBrowser, "no-browser", false, "Print the signup URL instead of opening a browser")
 	cmd.Flags().BoolVar(&scan, "scan", false, "Skip prompt: scan the repo and generate config")
 	cmd.Flags().BoolVar(&signup, "signup", false, "Skip prompt: sign up for CircleCI")
-	cmd.Flags().StringVar(&repoID, "repo-id", "", "GitHub repository external ID (numeric) for the pipeline definition and trigger")
+	cmd.Flags().StringVar(&repoID, "repo-id", "", "Repository external ID (numeric) for the pipeline")
 	return cmd
 }

--- a/internal/cmd/onboard/onboard.go
+++ b/internal/cmd/onboard/onboard.go
@@ -38,6 +38,7 @@ func NewOnboardCmd() *cobra.Command {
 		noBrowser bool
 		scan      bool
 		signup    bool
+		repoID    string
 	)
 
 	cmd := &cobra.Command{
@@ -52,10 +53,18 @@ func NewOnboardCmd() *cobra.Command {
 		},
 		Long: heredoc.Doc(`
 			Guided onboarding: scan a local repository, run its detected tests,
-			generate a starter .circleci/config.yml, and sign up for CircleCI.
+			generate a starter .circleci/config.yml, sign up for CircleCI, and —
+			for CircleCI-native organizations — create the project along with a
+			pipeline definition and an all-pushes trigger so your next push starts
+			a build.
 
 			When run interactively without --scan or --signup, a prompt lets you
 			choose between scanning the current repo or signing up directly.
+
+			Setting up the pipeline needs your GitHub repository's numeric ID.
+			Pass it with --repo-id to skip the prompt (required in non-interactive
+			sessions); without it, project creation still completes and prints the
+			steps to finish setup by hand.
 		`),
 		Example: heredoc.Doc(`
 			# Interactive mode: choose scan or signup
@@ -63,6 +72,9 @@ func NewOnboardCmd() *cobra.Command {
 
 			# Scan the current directory (skip the choice prompt)
 			$ circleci onboard --scan
+
+			# Scan and wire up the first pipeline without prompts
+			$ circleci onboard --scan --repo-id 123456789
 
 			# Sign up for CircleCI (no repo needed)
 			$ circleci onboard --signup
@@ -95,6 +107,7 @@ func NewOnboardCmd() *cobra.Command {
 				ConfigPath:    configPath,
 				Scan:          scan,
 				Signup:        signup,
+				RepoID:        repoID,
 			})
 		},
 	}
@@ -102,5 +115,6 @@ func NewOnboardCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&noBrowser, "no-browser", false, "Print the signup URL instead of opening a browser")
 	cmd.Flags().BoolVar(&scan, "scan", false, "Skip prompt: scan the repo and generate config")
 	cmd.Flags().BoolVar(&signup, "signup", false, "Skip prompt: sign up for CircleCI")
+	cmd.Flags().StringVar(&repoID, "repo-id", "", "GitHub repository external ID (numeric) for the pipeline definition and trigger")
 	return cmd
 }

--- a/internal/cmd/org/settings.go
+++ b/internal/cmd/org/settings.go
@@ -207,13 +207,13 @@ func newOrgSettingsGetCmd() *cobra.Command {
 		`, orgSettingTable()),
 		Example: heredoc.Doc(`
 			# Get a setting for the current org
-			$ circleci org setting get private-orbs
+			$ circleci org settings get private-orbs
 
 			# Get a setting for a specific org
-			$ circleci org setting get private-orbs --org gh/myorg
+			$ circleci org settings get private-orbs --org gh/myorg
 
 			# Output as JSON
-			$ circleci org setting get private-orbs --json
+			$ circleci org settings get private-orbs --json
 		`),
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -221,7 +221,7 @@ func newOrgSettingsGetCmd() *cobra.Command {
 			if !ok {
 				return clierrors.New("settings.unknown", "Unknown setting",
 					fmt.Sprintf("%q is not a known org setting.", args[0])).
-					WithSuggestions("Run 'circleci org setting list' to see all available settings",
+					WithSuggestions("Run 'circleci org settings list' to see all available settings",
 						"Valid settings: "+orgSettingNames()).
 					WithExitCode(clierrors.ExitBadArguments)
 			}
@@ -231,7 +231,7 @@ func newOrgSettingsGetCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			orgID, err := cmdutil.ResolveOrgSlugOrID(ctx, client, orgSlug, "circleci org setting get")
+			orgID, err := cmdutil.ResolveOrgSlugOrID(ctx, client, orgSlug, "circleci org settings get")
 			if err != nil {
 				return err
 			}
@@ -267,13 +267,13 @@ func newOrgSettingsSetCmd() *cobra.Command {
 		`, orgSettingTable()),
 		Example: heredoc.Doc(`
 			# Enable a setting for the current org
-			$ circleci org setting set private-orbs true
+			$ circleci org settings set private-orbs true
 
 			# Disable a setting for a specific org
-			$ circleci org setting set private-orbs false --org gh/myorg
+			$ circleci org settings set private-orbs false --org gh/myorg
 
 			# Output the updated value as JSON
-			$ circleci org setting set ai-error-summarization true --json
+			$ circleci org settings set ai-error-summarization true --json
 		`),
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -281,7 +281,7 @@ func newOrgSettingsSetCmd() *cobra.Command {
 			if !ok {
 				return clierrors.New("settings.unknown", "Unknown setting",
 					fmt.Sprintf("%q is not a known org setting.", args[0])).
-					WithSuggestions("Run 'circleci org setting list' to see all available settings",
+					WithSuggestions("Run 'circleci org settings list' to see all available settings",
 						"Valid settings: "+orgSettingNames()).
 					WithExitCode(clierrors.ExitBadArguments)
 			}
@@ -296,7 +296,7 @@ func newOrgSettingsSetCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			orgID, err := cmdutil.ResolveOrgSlugOrID(ctx, client, orgSlug, "circleci org setting set")
+			orgID, err := cmdutil.ResolveOrgSlugOrID(ctx, client, orgSlug, "circleci org settings set")
 			if err != nil {
 				return err
 			}
@@ -421,13 +421,13 @@ func newOrgSettingsListCmd() *cobra.Command {
 		`),
 		Example: heredoc.Doc(`
 			# List settings for the current org
-			$ circleci org setting list
+			$ circleci org settings list
 
 			# List settings for a specific org
-			$ circleci org setting list --org gh/myorg
+			$ circleci org settings list --org gh/myorg
 
 			# Output as JSON
-			$ circleci org setting list --json
+			$ circleci org settings list --json
 		`),
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -436,7 +436,7 @@ func newOrgSettingsListCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			orgID, err := cmdutil.ResolveOrgSlugOrID(ctx, client, orgSlug, "circleci org setting list")
+			orgID, err := cmdutil.ResolveOrgSlugOrID(ctx, client, orgSlug, "circleci org settings list")
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/project/project.go
+++ b/internal/cmd/project/project.go
@@ -42,7 +42,7 @@ func NewProjectCmd() *cobra.Command {
 			A project corresponds to a version-control repository connected
 			to CircleCI. Use 'circleci project list' to see all followed projects,
 			'circleci project follow' to start following a new project, and
-			'circleci project envvar' to manage environment variables.
+			'circleci project env' to manage environment variables.
 
 			To manage environment variables directly, use the top-level alias:
 			  circleci envvar list --project gh/org/repo

--- a/internal/cmd/project/settings.go
+++ b/internal/cmd/project/settings.go
@@ -205,13 +205,13 @@ func newSettingsGetCmd() *cobra.Command {
 		`, projectSettingTable()),
 		Example: heredoc.Doc(`
 			# Get a setting for the current project
-			$ circleci project setting get build-forked-pull-requests
+			$ circleci project settings get build-forked-pull-requests
 
 			# Get a setting for a specific project
-			$ circleci project setting get build-forked-pull-requests --project gh/myorg/myrepo
+			$ circleci project settings get build-forked-pull-requests --project gh/myorg/myrepo
 
 			# Output as JSON
-			$ circleci project setting get build-forked-pull-requests --json
+			$ circleci project settings get build-forked-pull-requests --json
 		`),
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -219,7 +219,7 @@ func newSettingsGetCmd() *cobra.Command {
 			if !ok {
 				return clierrors.New("settings.unknown", "Unknown setting",
 					fmt.Sprintf("%q is not a known project setting.", args[0])).
-					WithSuggestions("Run 'circleci project setting list' to see all available settings",
+					WithSuggestions("Run 'circleci project settings list' to see all available settings",
 						"Valid settings: "+projectSettingNames()).
 					WithExitCode(clierrors.ExitBadArguments)
 			}
@@ -265,13 +265,13 @@ func newSettingsSetCmd() *cobra.Command {
 		`, projectSettingTable()),
 		Example: heredoc.Doc(`
 			# Enable a setting for the current project
-			$ circleci project setting set build-forked-pull-requests true
+			$ circleci project settings set build-forked-pull-requests true
 
 			# Disable a setting for a specific project
-			$ circleci project setting set build-forked-pull-requests false --project gh/myorg/myrepo
+			$ circleci project settings set build-forked-pull-requests false --project gh/myorg/myrepo
 
 			# Output the updated value as JSON
-			$ circleci project setting set auto-cancel-builds true --json
+			$ circleci project settings set auto-cancel-builds true --json
 		`),
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -279,7 +279,7 @@ func newSettingsSetCmd() *cobra.Command {
 			if !ok {
 				return clierrors.New("settings.unknown", "Unknown setting",
 					fmt.Sprintf("%q is not a known project setting.", args[0])).
-					WithSuggestions("Run 'circleci project setting list' to see all available settings",
+					WithSuggestions("Run 'circleci project settings list' to see all available settings",
 						"Valid settings: "+projectSettingNames()).
 					WithExitCode(clierrors.ExitBadArguments)
 			}
@@ -415,13 +415,13 @@ func newSettingsListCmd() *cobra.Command {
 		`),
 		Example: heredoc.Doc(`
 			# List settings for the current project
-			$ circleci project setting list
+			$ circleci project settings list
 
 			# List settings for a specific project
-			$ circleci project setting list --project gh/myorg/myrepo
+			$ circleci project settings list --project gh/myorg/myrepo
 
 			# Output as JSON
-			$ circleci project setting list --json
+			$ circleci project settings list --json
 		`),
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/root/testdata/help/circleci/onboard.txt
+++ b/internal/cmd/root/testdata/help/circleci/onboard.txt
@@ -1,10 +1,18 @@
 # CircleCI CLI
 
 Guided onboarding: scan a local repository, run its detected tests,
-generate a starter .circleci/config.yml, and sign up for CircleCI.
+generate a starter .circleci/config.yml, sign up for CircleCI, and —
+for CircleCI-native organizations — create the project along with a
+pipeline definition and an all-pushes trigger so your next push starts
+a build.
 
 When run interactively without --scan or --signup, a prompt lets you
 choose between scanning the current repo or signing up directly.
+
+Setting up the pipeline needs your GitHub repository's numeric ID.
+Pass it with --repo-id to skip the prompt (required in non-interactive
+sessions); without it, project creation still completes and prints the
+steps to finish setup by hand.
 
 ## Usage
 
@@ -12,11 +20,12 @@ choose between scanning the current repo or signing up directly.
 
 ## Flags
 
-| Flag           | Description                                       |
-| -------------- | ------------------------------------------------- |
-| `--no-browser` | Print the signup URL instead of opening a browser |
-| `--scan`       | Skip prompt: scan the repo and generate config    |
-| `--signup`     | Skip prompt: sign up for CircleCI                 |
+| Flag               | Description                                                                     |
+| ------------------ | ------------------------------------------------------------------------------- |
+| `--no-browser`     | Print the signup URL instead of opening a browser                               |
+| `--repo-id string` | GitHub repository external ID (numeric) for the pipeline definition and trigger |
+| `--scan`           | Skip prompt: scan the repo and generate config                                  |
+| `--signup`         | Skip prompt: sign up for CircleCI                                               |
 
 ## Inherited Flags
 
@@ -38,6 +47,8 @@ the current directory.
   `circleci onboard`
 - Scan the current directory (skip the choice prompt): 
   `circleci onboard --scan`
+- Scan and wire up the first pipeline without prompts: 
+  `circleci onboard --scan --repo-id 123456789`
 - Sign up for CircleCI (no repo needed): 
   `circleci onboard --signup`
 - Onboard a specific project path: 

--- a/internal/cmd/root/testdata/help/circleci/onboard.txt
+++ b/internal/cmd/root/testdata/help/circleci/onboard.txt
@@ -9,10 +9,11 @@ a build.
 When run interactively without --scan or --signup, a prompt lets you
 choose between scanning the current repo or signing up directly.
 
-Setting up the pipeline needs your GitHub repository's numeric ID.
-Pass it with --repo-id to skip the prompt (required in non-interactive
-sessions); without it, project creation still completes and prints the
-steps to finish setup by hand.
+Setting up the pipeline needs your repository's numeric ID. For a GitHub
+repository it is resolved through the CircleCI GitHub App. Pass --repo-id
+to skip that lookup, or when the repository is not on GitHub. Without an
+ID the project is still created and the steps to finish setup by hand are
+printed.
 
 ## Usage
 
@@ -20,12 +21,12 @@ steps to finish setup by hand.
 
 ## Flags
 
-| Flag               | Description                                                                     |
-| ------------------ | ------------------------------------------------------------------------------- |
-| `--no-browser`     | Print the signup URL instead of opening a browser                               |
-| `--repo-id string` | GitHub repository external ID (numeric) for the pipeline definition and trigger |
-| `--scan`           | Skip prompt: scan the repo and generate config                                  |
-| `--signup`         | Skip prompt: sign up for CircleCI                                               |
+| Flag               | Description                                       |
+| ------------------ | ------------------------------------------------- |
+| `--no-browser`     | Print the signup URL instead of opening a browser |
+| `--repo-id string` | Repository external ID (numeric) for the pipeline |
+| `--scan`           | Skip prompt: scan the repo and generate config    |
+| `--signup`         | Skip prompt: sign up for CircleCI                 |
 
 ## Inherited Flags
 

--- a/internal/cmd/root/testdata/help/circleci/org/setting/get.txt
+++ b/internal/cmd/root/testdata/help/circleci/org/setting/get.txt
@@ -49,11 +49,11 @@ For more information about output formatting flags, see `circleci help formattin
 ## Examples
 
 - Get a setting for the current org: 
-  `circleci org setting get private-orbs`
+  `circleci org settings get private-orbs`
 - Get a setting for a specific org: 
-  `circleci org setting get private-orbs --org gh/myorg`
+  `circleci org settings get private-orbs --org gh/myorg`
 - Output as JSON: 
-  `circleci org setting get private-orbs --json`
+  `circleci org settings get private-orbs --json`
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/org/setting/list.txt
+++ b/internal/cmd/root/testdata/help/circleci/org/setting/list.txt
@@ -44,11 +44,11 @@ For more information about output formatting flags, see `circleci help formattin
 ## Examples
 
 - List settings for the current org: 
-  `circleci org setting list`
+  `circleci org settings list`
 - List settings for a specific org: 
-  `circleci org setting list --org gh/myorg`
+  `circleci org settings list --org gh/myorg`
 - Output as JSON: 
-  `circleci org setting list --json`
+  `circleci org settings list --json`
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/org/setting/set.txt
+++ b/internal/cmd/root/testdata/help/circleci/org/setting/set.txt
@@ -49,11 +49,11 @@ For more information about output formatting flags, see `circleci help formattin
 ## Examples
 
 - Enable a setting for the current org: 
-  `circleci org setting set private-orbs true`
+  `circleci org settings set private-orbs true`
 - Disable a setting for a specific org: 
-  `circleci org setting set private-orbs false --org gh/myorg`
+  `circleci org settings set private-orbs false --org gh/myorg`
 - Output the updated value as JSON: 
-  `circleci org setting set ai-error-summarization true --json`
+  `circleci org settings set ai-error-summarization true --json`
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/org/settings.txt
+++ b/internal/cmd/root/testdata/help/circleci/org/settings.txt
@@ -1,0 +1,34 @@
+# CircleCI CLI
+
+View and update advanced settings for a CircleCI organization.
+
+Use 'get' to read a setting's current value and 'set' to change it.
+Use 'list' to see all settings at once.
+
+## Usage
+
+`circleci org settings <command> [flags]`
+
+## Available Commands
+
+| Command | Description                             |
+| ------- | --------------------------------------- |
+| `get`   | Get the current value of an org setting |
+| `list`  | List all advanced settings for an org   |
+| `set`   | Set an org setting                      |
+
+## Inherited Flags
+
+| Flag                  | Description                                                  |
+| --------------------- | ------------------------------------------------------------ |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
+
+## Learn More
+
+- Use `circleci <command> <subcommand> --help` for more information about a command.
+- Read the manual at <https://cli.circleci.com/reference/>
+- Support at <https://github.com/CircleCI-Public/circleci-cli/issues>
+

--- a/internal/cmd/root/testdata/help/circleci/project.txt
+++ b/internal/cmd/root/testdata/help/circleci/project.txt
@@ -5,7 +5,7 @@ List, follow, and manage settings for CircleCI projects.
 A project corresponds to a version-control repository connected
 to CircleCI. Use 'circleci project list' to see all followed projects,
 'circleci project follow' to start following a new project, and
-'circleci project envvar' to manage environment variables.
+'circleci project env' to manage environment variables.
 
 To manage environment variables directly, use the top-level alias:
   circleci envvar list --project gh/org/repo

--- a/internal/cmd/root/testdata/help/circleci/project/setting/get.txt
+++ b/internal/cmd/root/testdata/help/circleci/project/setting/get.txt
@@ -46,11 +46,11 @@ For more information about output formatting flags, see `circleci help formattin
 ## Examples
 
 - Get a setting for the current project: 
-  `circleci project setting get build-forked-pull-requests`
+  `circleci project settings get build-forked-pull-requests`
 - Get a setting for a specific project: 
-  `circleci project setting get build-forked-pull-requests --project gh/myorg/myrepo`
+  `circleci project settings get build-forked-pull-requests --project gh/myorg/myrepo`
 - Output as JSON: 
-  `circleci project setting get build-forked-pull-requests --json`
+  `circleci project settings get build-forked-pull-requests --json`
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/project/setting/list.txt
+++ b/internal/cmd/root/testdata/help/circleci/project/setting/list.txt
@@ -41,11 +41,11 @@ For more information about output formatting flags, see `circleci help formattin
 ## Examples
 
 - List settings for the current project: 
-  `circleci project setting list`
+  `circleci project settings list`
 - List settings for a specific project: 
-  `circleci project setting list --project gh/myorg/myrepo`
+  `circleci project settings list --project gh/myorg/myrepo`
 - Output as JSON: 
-  `circleci project setting list --json`
+  `circleci project settings list --json`
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/project/setting/set.txt
+++ b/internal/cmd/root/testdata/help/circleci/project/setting/set.txt
@@ -46,11 +46,11 @@ For more information about output formatting flags, see `circleci help formattin
 ## Examples
 
 - Enable a setting for the current project: 
-  `circleci project setting set build-forked-pull-requests true`
+  `circleci project settings set build-forked-pull-requests true`
 - Disable a setting for a specific project: 
-  `circleci project setting set build-forked-pull-requests false --project gh/myorg/myrepo`
+  `circleci project settings set build-forked-pull-requests false --project gh/myorg/myrepo`
 - Output the updated value as JSON: 
-  `circleci project setting set auto-cancel-builds true --json`
+  `circleci project settings set auto-cancel-builds true --json`
 
 ## Learn More
 

--- a/internal/cmd/root/testdata/help/circleci/project/settings.txt
+++ b/internal/cmd/root/testdata/help/circleci/project/settings.txt
@@ -1,0 +1,34 @@
+# CircleCI CLI
+
+View and update advanced settings for a CircleCI project.
+
+Use 'get' to read a setting's current value and 'set' to change it.
+Use 'list' to see all settings at once.
+
+## Usage
+
+`circleci project settings <command> [flags]`
+
+## Available Commands
+
+| Command | Description                                |
+| ------- | ------------------------------------------ |
+| `get`   | Get the current value of a project setting |
+| `list`  | List all advanced settings for a project   |
+| `set`   | Set a project setting                      |
+
+## Inherited Flags
+
+| Flag                  | Description                                                  |
+| --------------------- | ------------------------------------------------------------ |
+| `-c, --config string` | Path to config file (default: ~/.config/circleci/config.yml) |
+| `--debug`             | Enable debug logging                                         |
+| `--no-color`          | Disable ANSI color output (same as setting NO_COLOR)         |
+| `-q, --quiet`         | Suppress informational output. Data on stdout is unaffected  |
+
+## Learn More
+
+- Use `circleci <command> <subcommand> --help` for more information about a command.
+- Read the manual at <https://cli.circleci.com/reference/>
+- Support at <https://github.com/CircleCI-Public/circleci-cli/issues>
+

--- a/internal/cmd/root/testdata/help/circleci/reference.txt
+++ b/internal/cmd/root/testdata/help/circleci/reference.txt
@@ -2013,12 +2013,12 @@ List your recent runs grouped by project
 
 Guided onboarding: scan, test, generate config, sign up
 
-| Flag               | Description                                                                     |
-| ------------------ | ------------------------------------------------------------------------------- |
-| `--no-browser`     | Print the signup URL instead of opening a browser                               |
-| `--repo-id string` | GitHub repository external ID (numeric) for the pipeline definition and trigger |
-| `--scan`           | Skip prompt: scan the repo and generate config                                  |
-| `--signup`         | Skip prompt: sign up for CircleCI                                               |
+| Flag               | Description                                       |
+| ------------------ | ------------------------------------------------- |
+| `--no-browser`     | Print the signup URL instead of opening a browser |
+| `--repo-id string` | Repository external ID (numeric) for the pipeline |
+| `--scan`           | Skip prompt: scan the repo and generate config    |
+| `--signup`         | Skip prompt: sign up for CircleCI                 |
 
 
 **Arguments:**

--- a/internal/cmd/root/testdata/help/circleci/reference.txt
+++ b/internal/cmd/root/testdata/help/circleci/reference.txt
@@ -2013,11 +2013,12 @@ List your recent runs grouped by project
 
 Guided onboarding: scan, test, generate config, sign up
 
-| Flag           | Description                                       |
-| -------------- | ------------------------------------------------- |
-| `--no-browser` | Print the signup URL instead of opening a browser |
-| `--scan`       | Skip prompt: scan the repo and generate config    |
-| `--signup`     | Skip prompt: sign up for CircleCI                 |
+| Flag               | Description                                                                     |
+| ------------------ | ------------------------------------------------------------------------------- |
+| `--no-browser`     | Print the signup URL instead of opening a browser                               |
+| `--repo-id string` | GitHub repository external ID (numeric) for the pipeline definition and trigger |
+| `--scan`           | Skip prompt: scan the repo and generate config                                  |
+| `--signup`         | Skip prompt: sign up for CircleCI                                               |
 
 
 **Arguments:**

--- a/internal/cmd/root/testdata/usage/circleci/onboard.txt
+++ b/internal/cmd/root/testdata/usage/circleci/onboard.txt
@@ -2,7 +2,7 @@ Usage:  circleci onboard [path] [flags]
 
 Flags:
   --no-browser       Print the signup URL instead of opening a browser
-  --repo-id string   GitHub repository external ID (numeric) for the pipeline definition and trigger
+  --repo-id string   Repository external ID (numeric) for the pipeline
   --scan             Skip prompt: scan the repo and generate config
   --signup           Skip prompt: sign up for CircleCI
   

--- a/internal/cmd/root/testdata/usage/circleci/onboard.txt
+++ b/internal/cmd/root/testdata/usage/circleci/onboard.txt
@@ -1,7 +1,8 @@
 Usage:  circleci onboard [path] [flags]
 
 Flags:
-  --no-browser   Print the signup URL instead of opening a browser
-  --scan         Skip prompt: scan the repo and generate config
-  --signup       Skip prompt: sign up for CircleCI
+  --no-browser       Print the signup URL instead of opening a browser
+  --repo-id string   GitHub repository external ID (numeric) for the pipeline definition and trigger
+  --scan             Skip prompt: scan the repo and generate config
+  --signup           Skip prompt: sign up for CircleCI
   

--- a/internal/cmd/root/testdata/usage/circleci/org/settings.txt
+++ b/internal/cmd/root/testdata/usage/circleci/org/settings.txt
@@ -1,0 +1,6 @@
+Usage:  circleci org settings <command>
+
+Available commands:
+  get
+  list
+  set

--- a/internal/cmd/root/testdata/usage/circleci/project/settings.txt
+++ b/internal/cmd/root/testdata/usage/circleci/project/settings.txt
@@ -1,0 +1,6 @@
+Usage:  circleci project settings <command>
+
+Available commands:
+  get
+  list
+  set

--- a/internal/cmd/run/watch.go
+++ b/internal/cmd/run/watch.go
@@ -547,6 +547,8 @@ func failedJobLogSuggestions(state runGetOutput) []string {
 			}
 		}
 	}
+	suggestions = append(suggestions,
+		"Or fetch logs for the latest failed job: circleci logs --last-failed")
 	return suggestions
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -201,8 +201,14 @@ type SaveResult struct {
 	KeyringErr error
 }
 
-func SetLogin(ctx context.Context, host, token string, userID uuid.UUID, secureStorage bool) (SaveResult, error) {
-	return saveToIncludingToken(ctx, "", secureStorage, func(cfg *Config) error {
+// SetLogin persists the host, token, and user ID to path, or to the default XDG
+// location when path is empty.
+//
+// Honouring path matters because the caller reports it as the save location and
+// may re-read it afterwards; writing elsewhere makes both the message and the
+// re-read describe a file that was never written.
+func SetLogin(ctx context.Context, path, host, token string, userID uuid.UUID, secureStorage bool) (SaveResult, error) {
+	return saveToIncludingToken(ctx, path, secureStorage, func(cfg *Config) error {
 		cfg.state.Host = host
 		cfg.state.Token = token
 		cfg.state.UserID = &userID

--- a/internal/githubapp/githubapp.go
+++ b/internal/githubapp/githubapp.go
@@ -121,10 +121,22 @@ func pollInstalled(ctx context.Context, client *apiclient.Client, orgID string) 
 	}
 }
 
+// ErrTooManyRepositories reports that the search reached its page cap before
+// examining every repository, so the target may well be accessible.
+//
+// Callers must not report this as "the app cannot access that repository": the
+// advice that follows from it — grant access and re-run — can never help, because
+// re-running searches the same bounded prefix again.
+var ErrTooManyRepositories = errors.New("too many repositories to search for a match")
+
 // ResolveRepoID returns the external (numeric) ID of the repository named
 // repoFullName ("owner/repo") among the repositories the GitHub App can access
-// for the organization. It returns "" (with no error) when the repository is
-// not found — e.g. it exists but was not granted to the app.
+// for the organization.
+//
+// It returns "" with no error only when the whole list was examined and held no
+// match — the repository exists but was not granted to the app. Reaching the page
+// cap first returns ErrTooManyRepositories instead, because that is not the same
+// answer. The endpoint offers no name filter, so the list has to be walked.
 func ResolveRepoID(ctx context.Context, client *apiclient.Client, orgID, repoFullName string) (string, error) {
 	if repoFullName == "" {
 		return "", nil
@@ -143,8 +155,8 @@ func ResolveRepoID(ctx context.Context, client *apiclient.Client, orgID, repoFul
 		}
 		seen += len(repos)
 		if len(repos) == 0 || (total > 0 && seen >= total) {
-			break
+			return "", nil // whole list examined, genuinely no match
 		}
 	}
-	return "", nil
+	return "", ErrTooManyRepositories
 }

--- a/internal/githubapp/githubapp_test.go
+++ b/internal/githubapp/githubapp_test.go
@@ -25,12 +25,14 @@ package githubapp_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
 	"testing"
 
 	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
 
 	"github.com/CircleCI-Public/circleci-cli/internal/apiclient"
 	"github.com/CircleCI-Public/circleci-cli/internal/githubapp"
@@ -81,6 +83,36 @@ func pagedReposServer(t *testing.T, fullNames []string) *apiclient.Client {
 	t.Cleanup(srv.Close)
 
 	return apiclient.New(apiclient.Config{BaseURL: srv.URL, Token: "test-token"})
+}
+
+// TestResolveRepoID_PageCap pins that exhausting the page cap is reported as its
+// own condition rather than as "no match".
+//
+// Conflating them makes onboard tell the user the GitHub App cannot access a
+// repository it may well have access to, and the advice that follows — grant
+// access, then re-run — can never help, because the next run searches the same
+// bounded prefix.
+func TestResolveRepoID_PageCap(t *testing.T) {
+	// A server that always has more pages: total_count never gets satisfied, so
+	// the loop can only end by hitting its cap.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"items": []map[string]any{
+				{"id": 1, "repo_full_name": "myorg/filler-a"},
+				{"id": 2, "repo_full_name": "myorg/filler-b"},
+			},
+			"total_count": 1_000_000,
+		})
+	}))
+	t.Cleanup(srv.Close)
+	client := apiclient.New(apiclient.Config{BaseURL: srv.URL, Token: "test-token"})
+
+	id, err := githubapp.ResolveRepoID(testCtx(), client, "org-1", "myorg/needle")
+
+	assert.Check(t, cmp.Equal(id, ""))
+	assert.Check(t, errors.Is(err, githubapp.ErrTooManyRepositories),
+		"hitting the page cap must be distinguishable from an absent repository, got: %v", err)
 }
 
 func TestResolveRepoID(t *testing.T) {

--- a/internal/gitremote/detect.go
+++ b/internal/gitremote/detect.go
@@ -169,10 +169,20 @@ func gitBranches() (branch, defaultBranch string) {
 // — reading info.yml there would short-circuit the very write that link is
 // about to perform.
 func DetectFromRemote() (_ *ProjectInfo, err error) {
+	return DetectFromRemoteIn("")
+}
+
+// DetectFromRemoteIn is DetectFromRemote scoped to the repository containing dir.
+// An empty dir means the process working directory.
+//
+// Commands that accept a directory argument must use this: reading the process
+// working directory instead would describe a different repository than the one
+// being operated on — or an enclosing one, since detection walks upward.
+func DetectFromRemoteIn(dir string) (_ *ProjectInfo, err error) {
 	// Both "not a git repo" and "repo without an origin remote" surface as the
 	// same user-facing failure, matching the previous `git remote get-url`
 	// behaviour.
-	repo, err := openRepo()
+	repo, err := openRepoIn(dir)
 	if err != nil {
 		return nil, fmt.Errorf("could not read git remote: %w", err)
 	}
@@ -257,11 +267,41 @@ func buildSlug(host, org, repo string) (string, error) {
 // extra option. Callers must Close the returned repository to release its file
 // handles (Windows cannot delete files with open handles — see the tests).
 func openRepo() (*git.Repository, error) {
-	cwd, err := os.Getwd()
+	return openRepoIn("")
+}
+
+// RepoRootIn returns the root of the working tree containing dir, or an error
+// when dir is not inside a git repository. An empty dir means the process working
+// directory.
+//
+// Callers that write files describing the repository use this so that running
+// from a subdirectory records them at the root, where they belong, rather than
+// wherever the command happened to be invoked.
+func RepoRootIn(dir string) (_ string, err error) {
+	repo, err := openRepoIn(dir)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
-	return git.PlainOpenWithOptions(cwd, &git.PlainOpenOptions{DetectDotGit: true})
+	defer closer.ErrorHandler(repo, &err)
+
+	wt, err := repo.Worktree()
+	if err != nil {
+		return "", err
+	}
+	return wt.Filesystem().Root(), nil
+}
+
+// openRepoIn opens the repository containing dir, walking upward to find it. An
+// empty dir means the process working directory.
+func openRepoIn(dir string) (*git.Repository, error) {
+	if dir == "" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return nil, err
+		}
+		dir = cwd
+	}
+	return git.PlainOpenWithOptions(dir, &git.PlainOpenOptions{DetectDotGit: true})
 }
 
 // gitOriginURL returns the first configured URL for the "origin" remote,

--- a/internal/gitremote/detect.go
+++ b/internal/gitremote/detect.go
@@ -81,8 +81,13 @@ func DetectNamespace() (string, error) {
 
 // DetectRepoName returns the repository name from the git remote, or "" if it
 // cannot be detected.
+//
+// This reads the remote directly rather than going through Detect, which prefers
+// .circleci/info.yml. A linked standalone project's slug is
+// "circleci/<orgID>/<projectID>", so its last segment is an opaque ID — useless
+// as the repository name callers want to show a user.
 func DetectRepoName() string {
-	info, err := Detect()
+	info, err := DetectFromRemote()
 	if err != nil {
 		return ""
 	}

--- a/internal/gitremote/detect.go
+++ b/internal/gitremote/detect.go
@@ -79,23 +79,34 @@ func DetectNamespace() (string, error) {
 	return parts[1], nil
 }
 
-// DetectRepoName returns the repository name from the git remote, or "" if it
-// cannot be detected.
+// DetectRepoName returns a human-readable name for the checkout in the working
+// directory, or "" when none can be determined. Callers use it as the suggested
+// project name.
 //
-// This reads the remote directly rather than going through Detect, which prefers
-// .circleci/info.yml. A linked standalone project's slug is
-// "circleci/<orgID>/<projectID>", so its last segment is an opaque ID — useless
-// as the repository name callers want to show a user.
+// The git remote is preferred. It is read directly rather than through Detect,
+// which prefers .circleci/info.yml: a linked standalone project's slug is
+// "circleci/<orgID>/<projectID>", so its last segment is an opaque ID — useless as
+// a name to show a user.
+//
+// When the remote cannot be read — no origin, no origin/HEAD, an unsupported host
+// — the name recorded by `circleci project link` is used instead. That is the only
+// other place a readable name for this checkout exists, and without it a linked
+// repository with no usable remote would offer no name at all.
 func DetectRepoName() string {
-	info, err := DetectFromRemote()
+	if info, err := DetectFromRemote(); err == nil {
+		if parts := strings.Split(info.Slug, "/"); len(parts) == 3 {
+			return parts[2]
+		}
+	}
+	cwd, err := os.Getwd()
 	if err != nil {
 		return ""
 	}
-	parts := strings.Split(info.Slug, "/")
-	if len(parts) == 3 {
-		return parts[2]
+	ref, err := projectref.Read(cwd)
+	if err != nil {
+		return ""
 	}
-	return ""
+	return ref.Project.Name
 }
 
 // Detect resolves the CircleCI project for the current working directory.

--- a/internal/gitremote/detect_test.go
+++ b/internal/gitremote/detect_test.go
@@ -175,6 +175,56 @@ func TestDetect_SurfacesMalformedInfoYml(t *testing.T) {
 	assert.Check(t, err != nil, "expected Detect to surface a malformed info.yml rather than fall back")
 }
 
+// TestDetectRepoName_IgnoresInfoYml pins DetectRepoName to the git remote. A
+// linked standalone project records "circleci/<orgID>/<projectID>" in info.yml,
+// so resolving through Detect would hand callers an opaque project ID where they
+// show the user a suggested project name (onboard, `project create`).
+func TestDetectRepoName_IgnoresInfoYml(t *testing.T) {
+	dir := t.TempDir()
+	repo, err := git.PlainInit(dir, false)
+	assert.NilError(t, err)
+	_, err = repo.CreateRemote(&config.RemoteConfig{
+		Name: "origin",
+		URLs: []string{"https://github.com/myorg/my-repo.git"},
+	})
+	assert.NilError(t, err)
+
+	// Detection needs a resolvable HEAD and an origin/HEAD symref. Signing is
+	// disabled locally so an ambient commit.gpgSign=true cannot fail the commit.
+	cfg, err := repo.Config()
+	assert.NilError(t, err)
+	cfg.Raw.Section("commit").SetOption("gpgsign", "false")
+	assert.NilError(t, repo.SetConfig(cfg))
+
+	wt, err := repo.Worktree()
+	assert.NilError(t, err)
+	commit, err := wt.Commit("init", &git.CommitOptions{
+		AllowEmptyCommits: true,
+		Author:            &object.Signature{Name: "test", Email: "test@test.com"},
+	})
+	assert.NilError(t, err)
+	assert.NilError(t, repo.Storer.SetReference(
+		plumbing.NewHashReference("refs/remotes/origin/main", commit)))
+	assert.NilError(t, repo.Storer.SetReference(
+		plumbing.NewSymbolicReference("refs/remotes/origin/HEAD", "refs/remotes/origin/main")))
+
+	assert.NilError(t, projectref.Write(dir, &projectref.Info{
+		Organization: projectref.Organization{ID: "3b524838-a95e-44eb-bc56-deb0af23ef19"},
+		Project: projectref.Project{
+			Slug: "circleci/8KsBMffqgArk2xVzYAC5ag/Y5nuJ5ZzavVEhGCEjV2rfA",
+			ID:   "fbb68fb9-71c3-4b79-a9be-68721332e871",
+			Name: "my-repo",
+		},
+	}))
+
+	cwd, err := os.Getwd()
+	assert.NilError(t, err)
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	assert.NilError(t, os.Chdir(dir))
+
+	assert.Check(t, cmp.Equal(DetectRepoName(), "my-repo"))
+}
+
 // Sanity check that DetectFromRemote does not consult info.yml — used by
 // `project link` to avoid short-circuiting against an existing entry.
 func TestDetectFromRemote_IgnoresInfoYml(t *testing.T) {

--- a/internal/gitremote/detect_test.go
+++ b/internal/gitremote/detect_test.go
@@ -115,16 +115,31 @@ func TestDetect_PrefersInfoYml(t *testing.T) {
 		wantOrgID string
 	}{
 		{
-			name: "uuids present yields canonical slug",
+			name: "circleci slug with uuids yields canonical slug",
 			info: projectref.Info{
 				Organization: projectref.Organization{ID: "E6i3yYZeWZhcf8UNqcKfjN"},
 				Project: projectref.Project{
-					Slug: "gh/myorg/myrepo",
+					Slug: "circleci/OrgShortId/ProjShortId",
 					ID:   "13c8F7nusayivoSxC6GMsw",
 				},
 			},
 			wantSlug:  "circleci/E6i3yYZeWZhcf8UNqcKfjN/13c8F7nusayivoSxC6GMsw",
 			wantOrgID: "E6i3yYZeWZhcf8UNqcKfjN",
+		},
+		{
+			// The ID form addresses CircleCI-native projects only — the API answers
+			// 404 for a classic project addressed that way, even though
+			// `circleci project link` records both IDs for one.
+			name: "classic slug with uuids keeps its own slug",
+			info: projectref.Info{
+				Organization: projectref.Organization{ID: "c1e89d5c-d2e5-4db2-b2d7-a35cf73160ad"},
+				Project: projectref.Project{
+					Slug: "gh/myorg/myrepo",
+					ID:   "52404b72-02fb-482e-9bd8-846bbc048eea",
+				},
+			},
+			wantSlug:  "gh/myorg/myrepo",
+			wantOrgID: "c1e89d5c-d2e5-4db2-b2d7-a35cf73160ad",
 		},
 		{
 			name:     "slug-only falls through verbatim",

--- a/internal/gitremote/detect_test.go
+++ b/internal/gitremote/detect_test.go
@@ -240,6 +240,33 @@ func TestDetectRepoName_IgnoresInfoYml(t *testing.T) {
 	assert.Check(t, cmp.Equal(DetectRepoName(), "my-repo"))
 }
 
+// TestDetectRepoName_FallsBackToLinkedName pins the fallback for a checkout whose
+// remote cannot be read — no origin, no origin/HEAD, or a host the slug parser does
+// not recognise. The name recorded by `circleci project link` is the only other
+// readable name for the checkout, and without it callers would have no default at
+// all: `project create` fails with a missing-name error and onboard abandons
+// project setup.
+func TestDetectRepoName_FallsBackToLinkedName(t *testing.T) {
+	dir := t.TempDir() // no git repository at all, so the remote is unreadable
+	writeErr := projectref.Write(dir, &projectref.Info{
+		Organization: projectref.Organization{ID: "org-uuid"},
+		Project: projectref.Project{
+			Slug: "gh/myorg/api",
+			ID:   "proj-uuid",
+			Name: "api",
+		},
+	})
+	assert.NilError(t, writeErr)
+
+	cwd, err := os.Getwd()
+	assert.NilError(t, err)
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	chdirErr := os.Chdir(dir)
+	assert.NilError(t, chdirErr)
+
+	assert.Check(t, cmp.Equal(DetectRepoName(), "api"))
+}
+
 // Sanity check that DetectFromRemote does not consult info.yml — used by
 // `project link` to avoid short-circuiting against an existing entry.
 func TestDetectFromRemote_IgnoresInfoYml(t *testing.T) {

--- a/internal/onboarder/onboarder.go
+++ b/internal/onboarder/onboarder.go
@@ -25,6 +25,7 @@ package onboarder
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -408,6 +409,13 @@ func resolveLinkedProject(ctx context.Context, client *apiclient.Client, workDir
 	}
 	info, err := projectref.Read(workDir)
 	if err != nil {
+		// An absent file just means "not linked". Anything else is a file the user
+		// can fix, and every other command reports it rather than proceeding as if
+		// the checkout were unlinked.
+		if !errors.Is(err, projectref.ErrNotFound) {
+			iostream.ErrPrintf(ctx, "%s Ignoring %s: %s\n",
+				iostream.SymbolWarn(ctx), projectref.FilePath, err)
+		}
 		return nil
 	}
 	// Compare the recorded org before spending a request: a link to another org is
@@ -601,6 +609,12 @@ func resolveRepoID(ctx context.Context, client *apiclient.Client, pipelinesURL, 
 	}
 
 	id, err := githubapp.ResolveRepoID(ctx, client, proj.OrganizationID, fullName)
+	if errors.Is(err, githubapp.ErrTooManyRepositories) {
+		iostream.ErrPrintf(ctx, "%s This organization has too many repositories to find %s automatically.\n",
+			iostream.SymbolWarn(ctx), fullName)
+		iostream.ErrPrintf(ctx, "  Re-run with --repo-id <id> to set up the pipeline.\n")
+		return ""
+	}
 	if err != nil {
 		iostream.ErrPrintf(ctx, "%s Could not list GitHub App repositories: %s\n", iostream.SymbolWarn(ctx), err)
 		return ""

--- a/internal/onboarder/onboarder.go
+++ b/internal/onboarder/onboarder.go
@@ -35,6 +35,7 @@ import (
 	"github.com/CircleCI-Public/circleci-cli/internal/apiclient"
 	"github.com/CircleCI-Public/circleci-cli/internal/cmd/cmdauth"
 	"github.com/CircleCI-Public/circleci-cli/internal/cmdutil"
+	"github.com/CircleCI-Public/circleci-cli/internal/config"
 	"github.com/CircleCI-Public/circleci-cli/internal/configgen"
 	clierrors "github.com/CircleCI-Public/circleci-cli/internal/errors"
 	"github.com/CircleCI-Public/circleci-cli/internal/githubapp"
@@ -175,6 +176,8 @@ func Run(ctx context.Context, dir string, opts Options) error {
 // Errors are handled gracefully: any failure falls through to manual guidance
 // rather than failing the onboard command.
 func postSignupGuidance(ctx context.Context, opts Options) error {
+	ctx = refreshConfig(ctx, opts)
+
 	client, err := cmdutil.LoadClient(ctx)
 	if err != nil {
 		printManualGuidance(ctx)
@@ -266,6 +269,28 @@ func postSignupGuidance(ctx context.Context, opts Options) error {
 	}
 
 	return setupFirstPipeline(ctx, client, appURL, proj, name, repoFullName(), opts.RepoID, opts.NoBrowser)
+}
+
+// refreshConfig re-reads the config from disk when the cached copy carries no
+// token.
+//
+// A fresh signup persists the token to the keyring (or the config file), but the
+// *config.Config in ctx was loaded during root's bootstrap — before that write —
+// so it still looks unauthenticated. Without this reload, LoadClient fails with
+// auth.token_missing on the very run that just signed the user up, and the whole
+// project setup degrades to manual guidance.
+//
+// A reload failure is not fatal: returning the unchanged ctx degrades exactly as
+// it would have anyway.
+func refreshConfig(ctx context.Context, opts Options) context.Context {
+	if cmdutil.GetConfig(ctx).EffectiveToken() != "" {
+		return ctx
+	}
+	cfg, err := config.Load(ctx, opts.ConfigPath, opts.SecureStorage)
+	if err != nil {
+		return ctx
+	}
+	return cmdutil.WithConfig(ctx, cfg)
 }
 
 // createOrResolveProject creates the project, or resolves the existing one when

--- a/internal/onboarder/onboarder.go
+++ b/internal/onboarder/onboarder.go
@@ -233,7 +233,7 @@ func postSignupGuidance(ctx context.Context, dir string, opts Options) error {
 	// opaque IDs rather than a repository name.
 	var proj *apiclient.ProjectInfo
 	if selectedOrg.VCSType == "circleci" {
-		proj = resolveLinkedProject(ctx, client, dir)
+		proj = resolveLinkedProject(ctx, client, dir, selectedOrg.ID)
 	}
 
 	if proj == nil {
@@ -250,10 +250,9 @@ func postSignupGuidance(ctx context.Context, dir string, opts Options) error {
 		created, err := client.CreateProject(ctx, vcs, orgName, name)
 		if err != nil {
 			if httpcl.HasStatusCode(err, http.StatusConflict) {
-				iostream.ErrPrintf(ctx,
-					"%s A project named %q already exists in %s, but this repository is not linked to it.\n",
+				iostream.ErrPrintf(ctx, "%s A project named %q already exists in %s.\n",
 					iostream.SymbolWarn(ctx), name, selectedOrg.Slug)
-				printLinkGuidance(ctx)
+				printLinkGuidance(ctx, dir, selectedOrg.Slug)
 				return nil
 			}
 			iostream.ErrPrintf(ctx, "%s Could not create project: %s\n", iostream.SymbolWarn(ctx), err)
@@ -315,16 +314,20 @@ func refreshConfig(ctx context.Context, opts Options) context.Context {
 	return cmdutil.WithConfig(ctx, cfg)
 }
 
-// resolveLinkedProject returns the project this repository is already linked to,
-// or nil when there is no usable link.
+// resolveLinkedProject returns the project recorded in .circleci/info.yml, or nil
+// when this checkout has no link onboard can use.
 //
-// The link comes from .circleci/info.yml, written by a previous onboard run or by
-// `circleci project link`. That local record is the only way to find an existing
-// project: a CircleCI-native slug is "circleci/<orgID>/<projectID>" — opaque IDs,
-// not the repository name — and no API maps a name to a project within an org.
-// Resolving before creating also means a re-run never attempts a create that
-// could only conflict.
-func resolveLinkedProject(ctx context.Context, client *apiclient.Client, workDir string) *apiclient.ProjectInfo {
+// That local record is the only way to find an existing project: a CircleCI-native
+// slug is "circleci/<orgID>/<projectID>" — opaque IDs, not the repository name —
+// and no API maps a name to a project within an org. Resolving before creating
+// keeps a re-run from attempting a create that could only conflict.
+//
+// A link only counts when its project belongs to orgID. A repository linked
+// elsewhere — a classic VCS project being migrated to a CircleCI-native org, say —
+// is ignored, so onboard sets up the organization the user actually chose. An
+// unresolvable link is ignored the same way; the create path below handles
+// everything a link cannot supply.
+func resolveLinkedProject(ctx context.Context, client *apiclient.Client, workDir, orgID string) *apiclient.ProjectInfo {
 	if workDir == "" {
 		return nil
 	}
@@ -332,12 +335,8 @@ func resolveLinkedProject(ctx context.Context, client *apiclient.Client, workDir
 	if err != nil {
 		return nil
 	}
-	slug := info.EffectiveSlug()
-	if slug == "" {
-		return nil
-	}
-	proj, err := client.GetProjectInfo(ctx, slug)
-	if err != nil {
+	proj, err := client.GetProjectInfo(ctx, info.EffectiveSlug())
+	if err != nil || proj.OrganizationID != orgID {
 		return nil
 	}
 	return proj
@@ -551,12 +550,23 @@ func printManualGuidance(ctx context.Context) {
 	iostream.Printf(ctx, "\nRun 'circleci project create' to connect this repo to CircleCI.\n")
 }
 
-// printLinkGuidance covers the case where the project exists but this checkout
-// has no record of it. A project cannot be looked up by name, so linking is the
-// step that recovers the ID — after which onboard can finish the job.
-func printLinkGuidance(ctx context.Context) {
-	iostream.Printf(ctx, "\nRun 'circleci project link' to connect this repository to that project,\n")
-	iostream.Printf(ctx, "then re-run 'circleci onboard' to finish setting up your pipeline.\n")
+// printLinkGuidance covers a project that exists in the organization but is not
+// the one this checkout resolves to. No API maps a project name to its ID, so the
+// ID has to come from the user — the same conclusion `circleci project link`
+// reaches when it cannot resolve a slug on its own.
+//
+// The command is spelled out with the organization already filled in. --project is
+// load-bearing: without it, link re-derives the slug from the git remote and a
+// repository linked elsewhere lands straight back where it started. --force is
+// added when .circleci/info.yml is present, since plain link refuses while it is.
+func printLinkGuidance(ctx context.Context, workDir, orgSlug string) {
+	args := "--project " + orgSlug + "/<projectID>"
+	if _, err := os.Stat(projectref.Path(workDir)); err == nil {
+		args = "--force " + args
+	}
+	iostream.Printf(ctx, "\nCopy that project's ID from its settings in CircleCI, then run:\n")
+	iostream.Printf(ctx, "  circleci project link %s\n", args)
+	iostream.Printf(ctx, "  circleci onboard\n")
 }
 
 func trackOnboard(ctx context.Context, event string, props map[string]any) {

--- a/internal/onboarder/onboarder.go
+++ b/internal/onboarder/onboarder.go
@@ -28,6 +28,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	tea "charm.land/bubbletea/v2"
 
@@ -36,6 +37,7 @@ import (
 	"github.com/CircleCI-Public/circleci-cli/internal/cmdutil"
 	"github.com/CircleCI-Public/circleci-cli/internal/configgen"
 	clierrors "github.com/CircleCI-Public/circleci-cli/internal/errors"
+	"github.com/CircleCI-Public/circleci-cli/internal/githubapp"
 	"github.com/CircleCI-Public/circleci-cli/internal/gitremote"
 	"github.com/CircleCI-Public/circleci-cli/internal/iostream"
 	"github.com/CircleCI-Public/circleci-cli/internal/org"
@@ -58,6 +60,11 @@ type Options struct {
 	SecureStorage bool
 	Scan          bool
 	Signup        bool
+	// RepoID is the VCS repository external ID (the numeric GitHub repo ID) used
+	// to wire up the first pipeline definition and trigger. When empty, it is
+	// prompted for interactively; in non-interactive mode an empty value falls
+	// back to manual guidance.
+	RepoID string
 }
 
 // Run scans a repository, verifies its tests, generates a starter config when
@@ -81,7 +88,7 @@ func Run(ctx context.Context, dir string, opts Options) error {
 			"mode":    "signup",
 			"outcome": string(result.Outcome),
 		})
-		return postSignupGuidance(ctx)
+		return postSignupGuidance(ctx, opts)
 	}
 
 	dir, err = filepath.Abs(dir)
@@ -157,15 +164,17 @@ func Run(ctx context.Context, dir string, opts Options) error {
 		"outcome": string(signupResult.Outcome),
 	})
 
-	return postSignupGuidance(ctx)
+	return postSignupGuidance(ctx, opts)
 }
 
 // postSignupGuidance offers inline project creation and prints a follow-up
-// message after the user has authenticated.
+// message after the user has authenticated. For modern (CircleCI-native) orgs
+// it continues past project creation to set up the first pipeline definition
+// and trigger, so a subsequent push starts a build.
 //
-// Errors are handled gracefully: project creation failure falls through to
-// manual guidance rather than failing the onboard command.
-func postSignupGuidance(ctx context.Context) error {
+// Errors are handled gracefully: any failure falls through to manual guidance
+// rather than failing the onboard command.
+func postSignupGuidance(ctx context.Context, opts Options) error {
 	client, err := cmdutil.LoadClient(ctx)
 	if err != nil {
 		printManualGuidance(ctx)
@@ -239,20 +248,205 @@ func postSignupGuidance(ctx context.Context) error {
 		return followClassicProject(ctx, client, appURL, vcs, orgName, name)
 	}
 
-	proj, err := client.CreateProject(ctx, vcs, orgName, name)
+	proj, created, err := createOrResolveProject(ctx, client, vcs, orgName, name)
 	if err != nil {
 		iostream.ErrPrintf(ctx, "%s Could not create project: %s\n", iostream.SymbolWarn(ctx), err)
 		printManualGuidance(ctx)
 		return nil
 	}
 
-	iostream.Printf(ctx, "%s Project created: %s\n", iostream.SymbolOK(ctx), proj.Name)
+	if created {
+		iostream.Printf(ctx, "%s Project created: %s\n", iostream.SymbolOK(ctx), proj.Name)
+	} else {
+		iostream.Printf(ctx, "%s Using existing project: %s\n", iostream.SymbolOK(ctx), proj.Name)
+	}
 	iostream.Printf(ctx, "  Organization: %s\n", proj.OrganizationName)
 	if pipelinesURL, err := cmdutil.RunSlugURL(appURL, proj.Slug); err == nil {
 		iostream.Printf(ctx, "  Pipelines: %s\n", pipelinesURL)
 	}
-	iostream.Printf(ctx, "\nCommit .circleci/config.yml. After your project is connected in CircleCI, pushing will start your first pipeline.\n")
+
+	return setupFirstPipeline(ctx, client, appURL, proj, name, repoFullName(), opts.RepoID, opts.NoBrowser)
+}
+
+// createOrResolveProject creates the project, or resolves the existing one when
+// creation fails because it was already created by a previous onboard run. The
+// returned bool reports whether the project was newly created. Only the original
+// creation error is surfaced when the project genuinely does not exist.
+func createOrResolveProject(ctx context.Context, client *apiclient.Client, vcs, orgName, name string) (*apiclient.ProjectInfo, bool, error) {
+	proj, err := client.CreateProject(ctx, vcs, orgName, name)
+	if err == nil {
+		return proj, true, nil
+	}
+
+	slug := fmt.Sprintf("%s/%s/%s", vcs, orgName, name)
+	if existing, rerr := client.GetProjectInfo(ctx, slug); rerr == nil {
+		return existing, false, nil
+	}
+	return nil, false, err
+}
+
+// repoFullName returns "owner/repo" from the git remote URL, or "" when not detectable.
+func repoFullName() string {
+	info, err := gitremote.DetectFromRemote()
+	if err != nil {
+		return ""
+	}
+	parts := strings.Split(info.Slug, "/")
+	if len(parts) != 3 {
+		return ""
+	}
+	return parts[1] + "/" + parts[2]
+}
+
+// setupFirstPipeline wires up a pipeline definition and an all-pushes trigger
+// for a freshly created project so the first push starts a build. It uses the
+// same v2 endpoints as `circleci pipeline create` and `circleci project trigger
+// create`, with sensible zero-prompt defaults (config at .circleci/config.yml,
+// the github_app provider, and the repo's external ID for both config and
+// checkout sources).
+//
+// Every step degrades gracefully: the project already exists, so any failure
+// prints manual guidance rather than returning an error.
+func setupFirstPipeline(ctx context.Context, client *apiclient.Client, appURL string, proj *apiclient.ProjectInfo, repoName, fullName, repoID string, noBrowser bool) error {
+	repoID = resolveRepoID(ctx, client, appURL, proj, fullName, repoID, noBrowser)
+	if repoID == "" {
+		// Without the repo's external ID we can't create the pipeline
+		// definition. The project still exists; guide the user to finish setup.
+		trackOnboard(ctx, "onboard_project_setup", map[string]any{"outcome": "skipped_no_repo_id"})
+		printManualPipelineGuidance(ctx)
+		return nil
+	}
+
+	def, err := ensurePipelineDefinition(ctx, client, proj.ID, repoName, repoID)
+	if err != nil {
+		iostream.ErrPrintf(ctx, "%s Could not create pipeline definition: %s\n", iostream.SymbolWarn(ctx), err)
+		trackOnboard(ctx, "onboard_project_setup", map[string]any{"outcome": "pipeline_definition_failed"})
+		printManualPipelineGuidance(ctx)
+		return nil
+	}
+
+	if err := ensureTrigger(ctx, client, proj.ID, def.ID, repoID); err != nil {
+		iostream.ErrPrintf(ctx, "%s Could not create trigger: %s\n", iostream.SymbolWarn(ctx), err)
+		trackOnboard(ctx, "onboard_project_setup", map[string]any{"outcome": "trigger_failed"})
+		printManualPipelineGuidance(ctx)
+		return nil
+	}
+
+	trackOnboard(ctx, "onboard_project_setup", map[string]any{"outcome": "created"})
+	printPipelineReadyGuidance(ctx, appURL, proj.Slug)
 	return nil
+}
+
+// ensurePipelineDefinition returns the pipeline definition already configured
+// for the repo, or creates one. Reusing an existing definition keeps re-runs of
+// onboard from creating duplicates.
+func ensurePipelineDefinition(ctx context.Context, client *apiclient.Client, projectID, name, repoID string) (*apiclient.PipelineDefinition, error) {
+	if defs, err := client.ListPipelineDefinitions(ctx, projectID); err == nil {
+		for i := range defs {
+			cs := defs[i].ConfigSource
+			if cs != nil && cs.Repo != nil && cs.Repo.ExternalID == repoID {
+				iostream.Printf(ctx, "%s Pipeline definition already exists: %s\n", iostream.SymbolOK(ctx), defs[i].Name)
+				return &defs[i], nil
+			}
+		}
+	}
+
+	def, err := client.CreatePipelineDefinition(ctx, projectID, apiclient.CreatePipelineDefinitionInput{
+		Name:             name,
+		ConfigProvider:   "github_app",
+		ConfigRepoID:     repoID,
+		ConfigFilePath:   ".circleci/config.yml",
+		CheckoutProvider: "github_app",
+		CheckoutRepoID:   repoID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	iostream.Printf(ctx, "%s Pipeline definition created: %s\n", iostream.SymbolOK(ctx), def.Name)
+	return def, nil
+}
+
+// ensureTrigger creates an all-pushes trigger for the pipeline definition unless
+// one already exists, so re-runs of onboard don't add duplicate triggers.
+func ensureTrigger(ctx context.Context, client *apiclient.Client, projectID, definitionID, repoID string) error {
+	if trigs, err := client.ListTriggers(ctx, projectID, definitionID); err == nil && len(trigs) > 0 {
+		iostream.Printf(ctx, "%s Trigger already exists\n", iostream.SymbolOK(ctx))
+		return nil
+	}
+
+	trig, err := client.CreateTrigger(ctx, projectID, definitionID, "github_app", repoID, "all-pushes", "", "")
+	if err != nil {
+		return err
+	}
+	preset := trig.EventPreset
+	if preset == "" {
+		preset = "all-pushes"
+	}
+	iostream.Printf(ctx, "%s Trigger created: %s\n", iostream.SymbolOK(ctx), preset)
+	return nil
+}
+
+// resolveRepoID determines the repo external ID for the pipeline definition and
+// trigger. An explicit --repo-id wins. Otherwise it ensures the CircleCI GitHub
+// App is installed for the org and matches the git remote against the app's
+// accessible repositories. Any failure returns "" so the caller degrades to
+// manual guidance rather than prompting for an opaque numeric ID.
+func resolveRepoID(ctx context.Context, client *apiclient.Client, appURL string, proj *apiclient.ProjectInfo, fullName, repoID string, noBrowser bool) string {
+	if repoID != "" {
+		return repoID
+	}
+	if proj.OrganizationID == "" || fullName == "" {
+		return ""
+	}
+
+	returnURL := appURL
+	if u, err := cmdutil.RunSlugURL(appURL, proj.Slug); err == nil {
+		returnURL = u
+	}
+
+	installed, err := githubapp.EnsureInstalled(ctx, client, proj.OrganizationID, returnURL, noBrowser)
+	if err != nil {
+		iostream.ErrPrintf(ctx, "%s Could not check GitHub App installation: %s\n", iostream.SymbolWarn(ctx), err)
+		return ""
+	}
+	if !installed {
+		return ""
+	}
+
+	id, err := githubapp.ResolveRepoID(ctx, client, proj.OrganizationID, fullName)
+	if err != nil {
+		iostream.ErrPrintf(ctx, "%s Could not list GitHub App repositories: %s\n", iostream.SymbolWarn(ctx), err)
+		return ""
+	}
+	if id == "" {
+		iostream.ErrPrintf(ctx, "%s The GitHub App can't access %s yet. Grant it access to this repository, then re-run.\n",
+			iostream.SymbolWarn(ctx), fullName)
+		return ""
+	}
+
+	iostream.Printf(ctx, "%s Found repository %s\n", iostream.SymbolOK(ctx), fullName)
+	return id
+}
+
+// printPipelineReadyGuidance prints the happy-path next steps once the pipeline
+// definition and trigger have been created.
+func printPipelineReadyGuidance(ctx context.Context, appURL, slug string) {
+	iostream.Printf(ctx, "\nYour project is ready! Next steps:\n")
+	iostream.Printf(ctx, "  1. git add .circleci/config.yml\n")
+	iostream.Printf(ctx, "  2. git commit -m \"Add CircleCI config\"\n")
+	iostream.Printf(ctx, "  3. git push\n")
+	iostream.Printf(ctx, "\nPushing will trigger your first pipeline.\n")
+	if url, err := cmdutil.RunSlugURL(appURL, slug); err == nil {
+		iostream.Printf(ctx, "%s\n", url)
+	}
+}
+
+// printManualPipelineGuidance is the fallback when the pipeline definition or
+// trigger could not be created. The project exists, so point the user at the
+// commands that finish the job.
+func printManualPipelineGuidance(ctx context.Context) {
+	iostream.Printf(ctx, "\nCommit .circleci/config.yml. After your project is connected in CircleCI, pushing will start your first pipeline.\n")
+	iostream.Printf(ctx, "To set up a trigger now, run 'circleci pipeline create' then 'circleci project trigger create'.\n")
 }
 
 func followClassicProject(ctx context.Context, client *apiclient.Client, appURL, vcs, orgName, repoName string) error {
@@ -349,6 +543,8 @@ func displayPreamble(ctx context.Context, dir string) error {
 			"Run your tests locally",
 			"Generate a starter .circleci/config.yml",
 			"Sign you up for CircleCI",
+			"Create your project and connect it to GitHub",
+			"Set up your first pipeline trigger",
 		},
 	)
 	p := tea.NewProgram(model,

--- a/internal/onboarder/onboarder.go
+++ b/internal/onboarder/onboarder.go
@@ -26,6 +26,7 @@ package onboarder
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -40,8 +41,10 @@ import (
 	clierrors "github.com/CircleCI-Public/circleci-cli/internal/errors"
 	"github.com/CircleCI-Public/circleci-cli/internal/githubapp"
 	"github.com/CircleCI-Public/circleci-cli/internal/gitremote"
+	"github.com/CircleCI-Public/circleci-cli/internal/httpcl"
 	"github.com/CircleCI-Public/circleci-cli/internal/iostream"
 	"github.com/CircleCI-Public/circleci-cli/internal/org"
+	"github.com/CircleCI-Public/circleci-cli/internal/projectref"
 	"github.com/CircleCI-Public/circleci-cli/internal/reposcan"
 	"github.com/CircleCI-Public/circleci-cli/internal/testrunner"
 	"github.com/CircleCI-Public/circleci-cli/internal/ui"
@@ -89,7 +92,7 @@ func Run(ctx context.Context, dir string, opts Options) error {
 			"mode":    "signup",
 			"outcome": string(result.Outcome),
 		})
-		return postSignupGuidance(ctx, opts)
+		return postSignupGuidance(ctx, dir, opts)
 	}
 
 	dir, err = filepath.Abs(dir)
@@ -165,7 +168,7 @@ func Run(ctx context.Context, dir string, opts Options) error {
 		"outcome": string(signupResult.Outcome),
 	})
 
-	return postSignupGuidance(ctx, opts)
+	return postSignupGuidance(ctx, dir, opts)
 }
 
 // postSignupGuidance offers inline project creation and prints a follow-up
@@ -175,7 +178,7 @@ func Run(ctx context.Context, dir string, opts Options) error {
 //
 // Errors are handled gracefully: any failure falls through to manual guidance
 // rather than failing the onboard command.
-func postSignupGuidance(ctx context.Context, opts Options) error {
+func postSignupGuidance(ctx context.Context, dir string, opts Options) error {
 	ctx = refreshConfig(ctx, opts)
 
 	client, err := cmdutil.LoadClient(ctx)
@@ -224,51 +227,70 @@ func postSignupGuidance(ctx context.Context, opts Options) error {
 		return nil
 	}
 
-	defaultName := gitremote.DetectRepoName()
-	var name string
-	if iostream.IsInteractive(ctx) {
-		name, err = iostream.PromptText(ctx, "Project name", defaultName)
+	// Resolve a project this repository is already linked to before asking for a
+	// name. On a re-run the answer would be discarded, and offering one is
+	// actively misleading: the recorded slug of a standalone project carries
+	// opaque IDs rather than a repository name.
+	var proj *apiclient.ProjectInfo
+	if selectedOrg.VCSType == "circleci" {
+		proj = resolveLinkedProject(ctx, client, dir)
+	}
+
+	if proj == nil {
+		name, ok := promptProjectName(ctx)
+		if !ok {
+			printManualGuidance(ctx)
+			return nil
+		}
+
+		if selectedOrg.VCSType != "circleci" {
+			return followClassicProject(ctx, client, appURL, vcs, orgName, name)
+		}
+
+		created, err := client.CreateProject(ctx, vcs, orgName, name)
 		if err != nil {
+			if httpcl.HasStatusCode(err, http.StatusConflict) {
+				iostream.ErrPrintf(ctx,
+					"%s A project named %q already exists in %s, but this repository is not linked to it.\n",
+					iostream.SymbolWarn(ctx), name, selectedOrg.Slug)
+				printLinkGuidance(ctx)
+				return nil
+			}
+			iostream.ErrPrintf(ctx, "%s Could not create project: %s\n", iostream.SymbolWarn(ctx), err)
 			printManualGuidance(ctx)
 			return nil
 		}
-		if name == "" {
-			name = defaultName
-		}
-		if name == "" {
-			printManualGuidance(ctx)
-			return nil
-		}
-	} else {
-		name = defaultName
-		if name == "" {
-			printManualGuidance(ctx)
-			return nil
-		}
-	}
-
-	if selectedOrg.VCSType != "circleci" {
-		return followClassicProject(ctx, client, appURL, vcs, orgName, name)
-	}
-
-	proj, created, err := createOrResolveProject(ctx, client, vcs, orgName, name)
-	if err != nil {
-		iostream.ErrPrintf(ctx, "%s Could not create project: %s\n", iostream.SymbolWarn(ctx), err)
-		printManualGuidance(ctx)
-		return nil
-	}
-
-	if created {
+		proj = created
 		iostream.Printf(ctx, "%s Project created: %s\n", iostream.SymbolOK(ctx), proj.Name)
+		writeProjectRef(ctx, dir, proj)
 	} else {
 		iostream.Printf(ctx, "%s Using existing project: %s\n", iostream.SymbolOK(ctx), proj.Name)
 	}
+
 	iostream.Printf(ctx, "  Organization: %s\n", proj.OrganizationName)
 	if pipelinesURL, err := cmdutil.RunSlugURL(appURL, proj.Slug); err == nil {
 		iostream.Printf(ctx, "  Pipelines: %s\n", pipelinesURL)
 	}
 
-	return setupFirstPipeline(ctx, client, appURL, proj, name, repoFullName(), opts.RepoID, opts.NoBrowser)
+	return setupFirstPipeline(ctx, client, appURL, proj, proj.Name, repoFullName(), opts.RepoID, opts.NoBrowser)
+}
+
+// promptProjectName asks for the project name, defaulting to the repository name
+// from the git remote. It reports false when no name could be determined, which
+// callers treat as "fall back to manual guidance".
+func promptProjectName(ctx context.Context) (string, bool) {
+	defaultName := gitremote.DetectRepoName()
+	if !iostream.IsInteractive(ctx) {
+		return defaultName, defaultName != ""
+	}
+	name, err := iostream.PromptText(ctx, "Project name", defaultName)
+	if err != nil {
+		return "", false
+	}
+	if name == "" {
+		name = defaultName
+	}
+	return name, name != ""
 }
 
 // refreshConfig re-reads the config from disk when the cached copy carries no
@@ -293,21 +315,55 @@ func refreshConfig(ctx context.Context, opts Options) context.Context {
 	return cmdutil.WithConfig(ctx, cfg)
 }
 
-// createOrResolveProject creates the project, or resolves the existing one when
-// creation fails because it was already created by a previous onboard run. The
-// returned bool reports whether the project was newly created. Only the original
-// creation error is surfaced when the project genuinely does not exist.
-func createOrResolveProject(ctx context.Context, client *apiclient.Client, vcs, orgName, name string) (*apiclient.ProjectInfo, bool, error) {
-	proj, err := client.CreateProject(ctx, vcs, orgName, name)
-	if err == nil {
-		return proj, true, nil
+// resolveLinkedProject returns the project this repository is already linked to,
+// or nil when there is no usable link.
+//
+// The link comes from .circleci/info.yml, written by a previous onboard run or by
+// `circleci project link`. That local record is the only way to find an existing
+// project: a CircleCI-native slug is "circleci/<orgID>/<projectID>" — opaque IDs,
+// not the repository name — and no API maps a name to a project within an org.
+// Resolving before creating also means a re-run never attempts a create that
+// could only conflict.
+func resolveLinkedProject(ctx context.Context, client *apiclient.Client, workDir string) *apiclient.ProjectInfo {
+	if workDir == "" {
+		return nil
 	}
+	info, err := projectref.Read(workDir)
+	if err != nil {
+		return nil
+	}
+	slug := info.EffectiveSlug()
+	if slug == "" {
+		return nil
+	}
+	proj, err := client.GetProjectInfo(ctx, slug)
+	if err != nil {
+		return nil
+	}
+	return proj
+}
 
-	slug := fmt.Sprintf("%s/%s/%s", vcs, orgName, name)
-	if existing, rerr := client.GetProjectInfo(ctx, slug); rerr == nil {
-		return existing, false, nil
+// writeProjectRef records the new project in .circleci/info.yml so a re-run of
+// onboard — and every other command in this repository — can resolve it without
+// asking the user for an opaque project ID.
+//
+// Failure is not fatal: the project exists and setup continues using the ID
+// already in hand. Only the next run loses the shortcut.
+func writeProjectRef(ctx context.Context, workDir string, proj *apiclient.ProjectInfo) {
+	if workDir == "" {
+		return
 	}
-	return nil, false, err
+	err := projectref.Write(workDir, &projectref.Info{
+		Organization: projectref.Organization{ID: proj.OrganizationID, Name: proj.OrganizationName},
+		Project:      projectref.Project{ID: proj.ID, Slug: proj.Slug, Name: proj.Name},
+	})
+	if err != nil {
+		iostream.ErrPrintf(ctx, "%s Could not write %s: %s\n",
+			iostream.SymbolWarn(ctx), projectref.FilePath, err)
+		return
+	}
+	iostream.Printf(ctx, "%s Linked this repository to the project in %s\n",
+		iostream.SymbolOK(ctx), projectref.FilePath)
 }
 
 // repoFullName returns "owner/repo" from the git remote URL, or "" when not detectable.
@@ -493,6 +549,14 @@ func followClassicProject(ctx context.Context, client *apiclient.Client, appURL,
 
 func printManualGuidance(ctx context.Context) {
 	iostream.Printf(ctx, "\nRun 'circleci project create' to connect this repo to CircleCI.\n")
+}
+
+// printLinkGuidance covers the case where the project exists but this checkout
+// has no record of it. A project cannot be looked up by name, so linking is the
+// step that recovers the ID — after which onboard can finish the job.
+func printLinkGuidance(ctx context.Context) {
+	iostream.Printf(ctx, "\nRun 'circleci project link' to connect this repository to that project,\n")
+	iostream.Printf(ctx, "then re-run 'circleci onboard' to finish setting up your pipeline.\n")
 }
 
 func trackOnboard(ctx context.Context, event string, props map[string]any) {

--- a/internal/onboarder/onboarder.go
+++ b/internal/onboarder/onboarder.go
@@ -57,6 +57,10 @@ const (
 	modeSignup             // sign up only — no repo required
 )
 
+// allPushesPreset is the trigger event preset that starts a pipeline on every
+// push, which is what onboard sets up.
+const allPushesPreset = "all-pushes"
+
 // Options configures the onboarding flow.
 type Options struct {
 	ConfigPath    string
@@ -65,9 +69,10 @@ type Options struct {
 	Scan          bool
 	Signup        bool
 	// RepoID is the VCS repository external ID (the numeric GitHub repo ID) used
-	// to wire up the first pipeline definition and trigger. When empty, it is
-	// prompted for interactively; in non-interactive mode an empty value falls
-	// back to manual guidance.
+	// to wire up the first pipeline definition and trigger. When empty it is
+	// resolved through the CircleCI GitHub App; if that cannot resolve it, pipeline
+	// setup is skipped with manual guidance. It is never prompted for — an opaque
+	// numeric ID is not something a user can be expected to know.
 	RepoID string
 }
 
@@ -92,7 +97,11 @@ func Run(ctx context.Context, dir string, opts Options) error {
 			"mode":    "signup",
 			"outcome": string(result.Outcome),
 		})
-		return postSignupGuidance(ctx, dir, opts)
+		// --signup may be run anywhere — it needs no repository — so the directory
+		// has been through none of the validation below. repoDir yields "" unless it
+		// really is a checkout, which keeps a run from a home directory out of
+		// ~/.circleci/info.yml.
+		return postSignupGuidance(ctx, repoDir(dir), opts)
 	}
 
 	dir, err = filepath.Abs(dir)
@@ -171,10 +180,30 @@ func Run(ctx context.Context, dir string, opts Options) error {
 	return postSignupGuidance(ctx, dir, opts)
 }
 
+// repoDir returns the root of the repository containing dir, and "" when dir is
+// not inside one. A "" result disables everything that reads or writes repository
+// state, which is the right behaviour when there is no repository to describe.
+//
+// Resolving to the root matters: run from a subdirectory, .circleci/info.yml
+// belongs beside .circleci/config.yml at the top of the checkout, not wherever the
+// command was invoked.
+func repoDir(dir string) string {
+	root, err := gitremote.RepoRootIn(dir)
+	if err != nil {
+		return ""
+	}
+	return root
+}
+
 // postSignupGuidance offers inline project creation and prints a follow-up
 // message after the user has authenticated. For modern (CircleCI-native) orgs
 // it continues past project creation to set up the first pipeline definition
 // and trigger, so a subsequent push starts a build.
+//
+// dir is the checkout being onboarded, or "" when there is none. Every read of
+// repository state — the git remote and .circleci/info.yml — is scoped to it, so
+// that `circleci onboard <path>` describes the directory it was given rather than
+// the one the process happens to be sitting in.
 //
 // Errors are handled gracefully: any failure falls through to manual guidance
 // rather than failing the onboard command.
@@ -227,6 +256,10 @@ func postSignupGuidance(ctx context.Context, dir string, opts Options) error {
 		return nil
 	}
 
+	// One read of the checkout's remote serves both the suggested project name and
+	// the owner/repo the GitHub App lookup needs.
+	remote := detectRemote(dir)
+
 	// Resolve a project this repository is already linked to before asking for a
 	// name. On a re-run the answer would be discarded, and offering one is
 	// actively misleading: the recorded slug of a standalone project carries
@@ -237,14 +270,15 @@ func postSignupGuidance(ctx context.Context, dir string, opts Options) error {
 	}
 
 	if proj == nil {
-		name, ok := promptProjectName(ctx)
-		if !ok {
+		name := promptProjectName(ctx, remote.Repo)
+		if name == "" {
 			printManualGuidance(ctx)
 			return nil
 		}
 
 		if selectedOrg.VCSType != "circleci" {
-			return followClassicProject(ctx, client, appURL, vcs, orgName, name)
+			followClassicProject(ctx, client, appURL, vcs, orgName, name)
+			return nil
 		}
 
 		created, err := client.CreateProject(ctx, vcs, orgName, name)
@@ -266,30 +300,71 @@ func postSignupGuidance(ctx context.Context, dir string, opts Options) error {
 		iostream.Printf(ctx, "%s Using existing project: %s\n", iostream.SymbolOK(ctx), proj.Name)
 	}
 
+	pipelinesURL, _ := cmdutil.RunSlugURL(appURL, proj.Slug)
 	iostream.Printf(ctx, "  Organization: %s\n", proj.OrganizationName)
-	if pipelinesURL, err := cmdutil.RunSlugURL(appURL, proj.Slug); err == nil {
+	if pipelinesURL != "" {
 		iostream.Printf(ctx, "  Pipelines: %s\n", pipelinesURL)
 	}
 
-	return setupFirstPipeline(ctx, client, appURL, proj, proj.Name, repoFullName(), opts.RepoID, opts.NoBrowser)
+	setupFirstPipeline(ctx, client, pipelinesURL, appURL, proj, remote, opts)
+	return nil
 }
 
-// promptProjectName asks for the project name, defaulting to the repository name
-// from the git remote. It reports false when no name could be determined, which
-// callers treat as "fall back to manual guidance".
-func promptProjectName(ctx context.Context) (string, bool) {
-	defaultName := gitremote.DetectRepoName()
+// promptProjectName asks for the project name, offering defaultName. It returns
+// "" when no name could be determined, which callers treat as "fall back to
+// manual guidance".
+func promptProjectName(ctx context.Context, defaultName string) string {
 	if !iostream.IsInteractive(ctx) {
-		return defaultName, defaultName != ""
+		return defaultName
 	}
 	name, err := iostream.PromptText(ctx, "Project name", defaultName)
 	if err != nil {
-		return "", false
+		return ""
 	}
 	if name == "" {
-		name = defaultName
+		return defaultName
 	}
-	return name, name != ""
+	return name
+}
+
+// gitRemote is what onboard needs to know about a checkout's origin remote.
+type gitRemote struct {
+	// VCS is the provider segment of the slug ("gh", "bb", "gl"), or "" when the
+	// remote could not be read.
+	VCS string
+	// Owner and Repo name the repository, e.g. "acme" and "web".
+	Owner, Repo string
+}
+
+// FullName is the "owner/repo" form used as the GitHub App's repository key, or
+// "" when the remote could not be read.
+func (r gitRemote) FullName() string {
+	if r.Owner == "" || r.Repo == "" {
+		return ""
+	}
+	return r.Owner + "/" + r.Repo
+}
+
+// IsGitHub reports whether this is a GitHub repository — the only provider the
+// CircleCI GitHub App can resolve.
+func (r gitRemote) IsGitHub() bool { return r.VCS == "gh" }
+
+// detectRemote reads the origin remote of the checkout at dir. A failure yields
+// the zero value rather than an error: onboard degrades to prompting for a name
+// and to manual pipeline guidance.
+func detectRemote(dir string) gitRemote {
+	if dir == "" {
+		return gitRemote{}
+	}
+	info, err := gitremote.DetectFromRemoteIn(dir)
+	if err != nil {
+		return gitRemote{}
+	}
+	parts := strings.Split(info.Slug, "/")
+	if len(parts) != 3 {
+		return gitRemote{}
+	}
+	return gitRemote{VCS: parts[0], Owner: parts[1], Repo: parts[2]}
 }
 
 // refreshConfig re-reads the config from disk when the cached copy carries no
@@ -335,6 +410,12 @@ func resolveLinkedProject(ctx context.Context, client *apiclient.Client, workDir
 	if err != nil {
 		return nil
 	}
+	// Compare the recorded org before spending a request: a link to another org is
+	// rejected for free. Both IDs must be present — treating two empty strings as
+	// a match would reuse a foreign project while appearing to have checked.
+	if orgID == "" || (info.Organization.ID != "" && info.Organization.ID != orgID) {
+		return nil
+	}
 	proj, err := client.GetProjectInfo(ctx, info.EffectiveSlug())
 	if err != nil || proj.OrganizationID != orgID {
 		return nil
@@ -346,10 +427,21 @@ func resolveLinkedProject(ctx context.Context, client *apiclient.Client, workDir
 // onboard — and every other command in this repository — can resolve it without
 // asking the user for an opaque project ID.
 //
+// An existing file is never overwritten. It may be committed, and it may record a
+// project in another organization that this run has no mandate to replace —
+// `circleci project link` itself demands --force for exactly that reason.
+//
 // Failure is not fatal: the project exists and setup continues using the ID
 // already in hand. Only the next run loses the shortcut.
 func writeProjectRef(ctx context.Context, workDir string, proj *apiclient.ProjectInfo) {
 	if workDir == "" {
+		return
+	}
+	if _, err := os.Stat(projectref.Path(workDir)); err == nil {
+		iostream.ErrPrintf(ctx, "%s %s already records a different project; leaving it as it is.\n",
+			iostream.SymbolWarn(ctx), projectref.FilePath)
+		iostream.ErrPrintf(ctx, "  To point it at %s: circleci project link --force --project %s\n",
+			proj.Name, proj.Slug)
 		return
 	}
 	err := projectref.Write(workDir, &projectref.Info{
@@ -365,19 +457,6 @@ func writeProjectRef(ctx context.Context, workDir string, proj *apiclient.Projec
 		iostream.SymbolOK(ctx), projectref.FilePath)
 }
 
-// repoFullName returns "owner/repo" from the git remote URL, or "" when not detectable.
-func repoFullName() string {
-	info, err := gitremote.DetectFromRemote()
-	if err != nil {
-		return ""
-	}
-	parts := strings.Split(info.Slug, "/")
-	if len(parts) != 3 {
-		return ""
-	}
-	return parts[1] + "/" + parts[2]
-}
-
 // setupFirstPipeline wires up a pipeline definition and an all-pushes trigger
 // for a freshly created project so the first push starts a build. It uses the
 // same v2 endpoints as `circleci pipeline create` and `circleci project trigger
@@ -386,48 +465,51 @@ func repoFullName() string {
 // checkout sources).
 //
 // Every step degrades gracefully: the project already exists, so any failure
-// prints manual guidance rather than returning an error.
-func setupFirstPipeline(ctx context.Context, client *apiclient.Client, appURL string, proj *apiclient.ProjectInfo, repoName, fullName, repoID string, noBrowser bool) error {
-	repoID = resolveRepoID(ctx, client, appURL, proj, fullName, repoID, noBrowser)
+// prints manual guidance rather than failing the command.
+func setupFirstPipeline(ctx context.Context, client *apiclient.Client, pipelinesURL, appURL string, proj *apiclient.ProjectInfo, remote gitRemote, opts Options) {
+	repoID := resolveRepoID(ctx, client, pipelinesURL, appURL, proj, remote, opts)
 	if repoID == "" {
 		// Without the repo's external ID we can't create the pipeline
 		// definition. The project still exists; guide the user to finish setup.
 		trackOnboard(ctx, "onboard_project_setup", map[string]any{"outcome": "skipped_no_repo_id"})
 		printManualPipelineGuidance(ctx)
-		return nil
+		return
 	}
 
-	def, err := ensurePipelineDefinition(ctx, client, proj.ID, repoName, repoID)
+	def, err := ensurePipelineDefinition(ctx, client, proj.ID, proj.Name, repoID)
 	if err != nil {
 		iostream.ErrPrintf(ctx, "%s Could not create pipeline definition: %s\n", iostream.SymbolWarn(ctx), err)
 		trackOnboard(ctx, "onboard_project_setup", map[string]any{"outcome": "pipeline_definition_failed"})
 		printManualPipelineGuidance(ctx)
-		return nil
+		return
 	}
 
 	if err := ensureTrigger(ctx, client, proj.ID, def.ID, repoID); err != nil {
 		iostream.ErrPrintf(ctx, "%s Could not create trigger: %s\n", iostream.SymbolWarn(ctx), err)
 		trackOnboard(ctx, "onboard_project_setup", map[string]any{"outcome": "trigger_failed"})
 		printManualPipelineGuidance(ctx)
-		return nil
+		return
 	}
 
 	trackOnboard(ctx, "onboard_project_setup", map[string]any{"outcome": "created"})
-	printPipelineReadyGuidance(ctx, appURL, proj.Slug)
-	return nil
+	printPipelineReadyGuidance(ctx)
 }
 
 // ensurePipelineDefinition returns the pipeline definition already configured
 // for the repo, or creates one. Reusing an existing definition keeps re-runs of
 // onboard from creating duplicates.
 func ensurePipelineDefinition(ctx context.Context, client *apiclient.Client, projectID, name, repoID string) (*apiclient.PipelineDefinition, error) {
-	if defs, err := client.ListPipelineDefinitions(ctx, projectID); err == nil {
-		for i := range defs {
-			cs := defs[i].ConfigSource
-			if cs != nil && cs.Repo != nil && cs.Repo.ExternalID == repoID {
-				iostream.Printf(ctx, "%s Pipeline definition already exists: %s\n", iostream.SymbolOK(ctx), defs[i].Name)
-				return &defs[i], nil
-			}
+	defs, err := client.ListPipelineDefinitions(ctx, projectID)
+	if err != nil {
+		// Creating blindly after a failed lookup risks a duplicate definition, so
+		// report the lookup failure instead of guessing.
+		return nil, err
+	}
+	for i := range defs {
+		cs := defs[i].ConfigSource
+		if cs != nil && cs.Repo != nil && cs.Repo.ExternalID == repoID {
+			iostream.Printf(ctx, "%s Pipeline definition already exists: %s\n", iostream.SymbolOK(ctx), defs[i].Name)
+			return &defs[i], nil
 		}
 	}
 
@@ -448,19 +530,29 @@ func ensurePipelineDefinition(ctx context.Context, client *apiclient.Client, pro
 
 // ensureTrigger creates an all-pushes trigger for the pipeline definition unless
 // one already exists, so re-runs of onboard don't add duplicate triggers.
+//
+// Only an all-pushes trigger counts. A definition carrying just a schedule or
+// webhook trigger would otherwise be reported as ready, and the push onboard tells
+// the user to make would build nothing.
 func ensureTrigger(ctx context.Context, client *apiclient.Client, projectID, definitionID, repoID string) error {
-	if trigs, err := client.ListTriggers(ctx, projectID, definitionID); err == nil && len(trigs) > 0 {
-		iostream.Printf(ctx, "%s Trigger already exists\n", iostream.SymbolOK(ctx))
-		return nil
+	trigs, err := client.ListTriggers(ctx, projectID, definitionID)
+	if err != nil {
+		return err
+	}
+	for _, t := range trigs {
+		if t.EventPreset == allPushesPreset {
+			iostream.Printf(ctx, "%s Trigger already exists: %s\n", iostream.SymbolOK(ctx), t.EventPreset)
+			return nil
+		}
 	}
 
-	trig, err := client.CreateTrigger(ctx, projectID, definitionID, "github_app", repoID, "all-pushes", "", "")
+	trig, err := client.CreateTrigger(ctx, projectID, definitionID, "github_app", repoID, allPushesPreset, "", "")
 	if err != nil {
 		return err
 	}
 	preset := trig.EventPreset
 	if preset == "" {
-		preset = "all-pushes"
+		preset = allPushesPreset
 	}
 	iostream.Printf(ctx, "%s Trigger created: %s\n", iostream.SymbolOK(ctx), preset)
 	return nil
@@ -471,20 +563,35 @@ func ensureTrigger(ctx context.Context, client *apiclient.Client, projectID, def
 // App is installed for the org and matches the git remote against the app's
 // accessible repositories. Any failure returns "" so the caller degrades to
 // manual guidance rather than prompting for an opaque numeric ID.
-func resolveRepoID(ctx context.Context, client *apiclient.Client, appURL string, proj *apiclient.ProjectInfo, fullName, repoID string, noBrowser bool) string {
-	if repoID != "" {
-		return repoID
+func resolveRepoID(ctx context.Context, client *apiclient.Client, pipelinesURL, appURL string, proj *apiclient.ProjectInfo, remote gitRemote, opts Options) string {
+	if opts.RepoID != "" {
+		return opts.RepoID
 	}
-	if proj.OrganizationID == "" || fullName == "" {
+	if proj.OrganizationID == "" {
+		return ""
+	}
+	fullName := remote.FullName()
+	if fullName == "" {
+		iostream.ErrPrintf(ctx, "%s Could not read this repository's git remote, so the pipeline was not set up.\n",
+			iostream.SymbolWarn(ctx))
+		return ""
+	}
+	// The GitHub App resolves GitHub repositories only. Sending a GitLab or
+	// Bitbucket remote through it produces an install prompt that cannot help and
+	// a "grant access to this repository" message that can never be satisfied.
+	if !remote.IsGitHub() {
+		iostream.ErrPrintf(ctx, "%s %s is not a GitHub repository, so its ID cannot be looked up automatically.\n",
+			iostream.SymbolWarn(ctx), fullName)
+		iostream.ErrPrintf(ctx, "  Re-run with --repo-id <id> to set up the pipeline.\n")
 		return ""
 	}
 
-	returnURL := appURL
-	if u, err := cmdutil.RunSlugURL(appURL, proj.Slug); err == nil {
-		returnURL = u
+	returnURL := pipelinesURL
+	if returnURL == "" {
+		returnURL = appURL
 	}
 
-	installed, err := githubapp.EnsureInstalled(ctx, client, proj.OrganizationID, returnURL, noBrowser)
+	installed, err := githubapp.EnsureInstalled(ctx, client, proj.OrganizationID, returnURL, opts.NoBrowser)
 	if err != nil {
 		iostream.ErrPrintf(ctx, "%s Could not check GitHub App installation: %s\n", iostream.SymbolWarn(ctx), err)
 		return ""
@@ -509,8 +616,9 @@ func resolveRepoID(ctx context.Context, client *apiclient.Client, appURL string,
 }
 
 // printPipelineReadyGuidance prints the happy-path next steps once the pipeline
-// definition and trigger have been created.
-func printPipelineReadyGuidance(ctx context.Context, appURL, slug string) {
+// definition and trigger have been created. The pipelines URL is not repeated
+// here; the caller has already printed it alongside the project details.
+func printPipelineReadyGuidance(ctx context.Context) {
 	// Stage the whole directory rather than just config.yml: info.yml records the
 	// project's ID, and that ID is not recoverable from its name — no API maps one
 	// to the other. Committing it is what lets a fresh clone, a teammate, or a
@@ -520,9 +628,6 @@ func printPipelineReadyGuidance(ctx context.Context, appURL, slug string) {
 	iostream.Printf(ctx, "  2. git commit -m \"Add CircleCI config\"\n")
 	iostream.Printf(ctx, "  3. git push\n")
 	iostream.Printf(ctx, "\nPushing will trigger your first pipeline.\n")
-	if url, err := cmdutil.RunSlugURL(appURL, slug); err == nil {
-		iostream.Printf(ctx, "%s\n", url)
-	}
 }
 
 // printManualPipelineGuidance is the fallback when the pipeline definition or
@@ -533,11 +638,11 @@ func printManualPipelineGuidance(ctx context.Context) {
 	iostream.Printf(ctx, "To set up a trigger now, run 'circleci pipeline create' then 'circleci project trigger create'.\n")
 }
 
-func followClassicProject(ctx context.Context, client *apiclient.Client, appURL, vcs, orgName, repoName string) error {
+func followClassicProject(ctx context.Context, client *apiclient.Client, appURL, vcs, orgName, repoName string) {
 	if err := client.FollowProject(ctx, vcs, orgName, repoName); err != nil {
 		iostream.ErrPrintf(ctx, "%s Could not connect project: %s\n", iostream.SymbolWarn(ctx), err)
 		printManualGuidance(ctx)
-		return nil
+		return
 	}
 
 	slug := fmt.Sprintf("%s/%s/%s", vcs, orgName, repoName)
@@ -547,7 +652,6 @@ func followClassicProject(ctx context.Context, client *apiclient.Client, appURL,
 		iostream.Printf(ctx, "  Pipelines: %s\n", pipelinesURL)
 	}
 	iostream.Printf(ctx, "\nCommit and push .circleci/config.yml to start your first pipeline.\n")
-	return nil
 }
 
 func printManualGuidance(ctx context.Context) {

--- a/internal/onboarder/onboarder.go
+++ b/internal/onboarder/onboarder.go
@@ -511,8 +511,12 @@ func resolveRepoID(ctx context.Context, client *apiclient.Client, appURL string,
 // printPipelineReadyGuidance prints the happy-path next steps once the pipeline
 // definition and trigger have been created.
 func printPipelineReadyGuidance(ctx context.Context, appURL, slug string) {
+	// Stage the whole directory rather than just config.yml: info.yml records the
+	// project's ID, and that ID is not recoverable from its name — no API maps one
+	// to the other. Committing it is what lets a fresh clone, a teammate, or a
+	// later onboard run find this project instead of colliding with it.
 	iostream.Printf(ctx, "\nYour project is ready! Next steps:\n")
-	iostream.Printf(ctx, "  1. git add .circleci/config.yml\n")
+	iostream.Printf(ctx, "  1. git add .circleci/\n")
 	iostream.Printf(ctx, "  2. git commit -m \"Add CircleCI config\"\n")
 	iostream.Printf(ctx, "  3. git push\n")
 	iostream.Printf(ctx, "\nPushing will trigger your first pipeline.\n")

--- a/internal/projectref/projectref.go
+++ b/internal/projectref/projectref.go
@@ -33,6 +33,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -75,15 +76,21 @@ type Project struct {
 }
 
 // EffectiveSlug returns the slug to use when calling the CircleCI API.
-// When both Project.ID and Organization.ID are known, the canonical
-// "circleci/<orgID>/<projectID>" form is returned so the lookup is stable
-// across VCS-side renames; otherwise the stored Project.Slug is returned
-// as-is.
+//
+// For a CircleCI-native project — one whose stored slug is already a "circleci/"
+// slug — the canonical "circleci/<orgID>/<projectID>" form is returned when both
+// IDs are known, so the lookup is stable across renames. Anything else returns
+// the stored Project.Slug as-is.
+//
+// The ID form addresses CircleCI-native projects only. A classic VCS project must
+// be addressed by its own "<vcs>/<org>/<repo>" slug: the API answers 404 for the
+// ID form even though both IDs are valid and `circleci project link` records them
+// for every project type.
 func (i *Info) EffectiveSlug() string {
 	if i == nil {
 		return ""
 	}
-	if i.Project.ID != "" && i.Organization.ID != "" {
+	if strings.HasPrefix(i.Project.Slug, "circleci/") && i.Project.ID != "" && i.Organization.ID != "" {
 		return "circleci/" + i.Organization.ID + "/" + i.Project.ID
 	}
 	return i.Project.Slug

--- a/internal/testing/fakes/circleci.go
+++ b/internal/testing/fakes/circleci.go
@@ -106,16 +106,17 @@ type CircleCI struct {
 	deletedRCs      map[string]bool  // resource class → deleted
 
 	// Project / env-var state.
-	followedProjects  []any            // list of project objects for GET /api/v1.1/projects
-	followedSlugs     map[string]bool  // vcs+org+repo → true (for follow idempotency)
-	envVars           map[string][]any // project slug → env vars
-	deletedEnvVars    map[string]bool  // "slug/name" → deleted
-	projectInfos      map[string]any   // project slug → project info response
-	projectsByID      map[string]any   // project UUID → V3 project response (GET /api/v3/projects/{id})
-	projectsBySlug    map[string]any   // project slug → V3 project entity (GET /api/v3/projects?filter[slug]=)
-	projectSettings   map[string]any   // project UUID → advanced settings attributes
-	createProjectResp any              // preset response for POST /organization/{vcs}/{org}/project
-	createOrgResp     any              // preset response for POST /organization
+	followedProjects    []any            // list of project objects for GET /api/v1.1/projects
+	followedSlugs       map[string]bool  // vcs+org+repo → true (for follow idempotency)
+	envVars             map[string][]any // project slug → env vars
+	deletedEnvVars      map[string]bool  // "slug/name" → deleted
+	projectInfos        map[string]any   // project slug → project info response
+	projectsByID        map[string]any   // project UUID → V3 project response (GET /api/v3/projects/{id})
+	projectsBySlug      map[string]any   // project slug → V3 project entity (GET /api/v3/projects?filter[slug]=)
+	projectSettings     map[string]any   // project UUID → advanced settings attributes
+	createProjectResp   any              // preset response for POST /organization/{vcs}/{org}/project
+	createProjectStatus int              // HTTP status for that POST (0 → 201 Created)
+	createOrgResp       any              // preset response for POST /organization
 
 	// Context state.
 	contexts                   map[string]any   // context id → context object
@@ -1838,6 +1839,16 @@ func (f *CircleCI) SetCreateProjectResponse(resp any) {
 	f.createProjectResp = resp
 }
 
+// SetCreateProjectConflict makes POST /api/v2/organization/{vcs}/{org}/project
+// answer 409, as the real API does when the organization already has a project
+// with that name.
+func (f *CircleCI) SetCreateProjectConflict() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.createProjectStatus = http.StatusConflict
+	f.createProjectResp = map[string]any{"message": "A project with this name already exists"}
+}
+
 // AddEnvVar registers an env var for a project.
 // slug should be in "vcs/org/repo" form.
 func (f *CircleCI) AddEnvVar(slug, name, value string, createdAt *time.Time) {
@@ -1901,8 +1912,14 @@ func (f *CircleCI) handleCreateOrg(w http.ResponseWriter, r *http.Request) {
 func (f *CircleCI) handleCreateProject(w http.ResponseWriter, r *http.Request) {
 	f.mu.RLock()
 	resp := f.createProjectResp
+	status := f.createProjectStatus
 	f.mu.RUnlock()
 
+	if status != 0 {
+		render.Status(r, status)
+		render.JSON(w, r, resp)
+		return
+	}
 	if resp == nil {
 		render.Status(r, http.StatusUnprocessableEntity)
 		render.JSON(w, r, map[string]any{"message": "project creation not configured"})

--- a/internal/testing/fakes/circleci.go
+++ b/internal/testing/fakes/circleci.go
@@ -1925,6 +1925,22 @@ func (f *CircleCI) handleCreateProject(w http.ResponseWriter, r *http.Request) {
 		render.JSON(w, r, map[string]any{"message": "project creation not configured"})
 		return
 	}
+	// Echo the requested name, as the real API does. Returning a canned name
+	// regardless of the request would let a caller send the wrong one and still
+	// look correct in the output a test asserts on.
+	if body, ok := resp.(map[string]any); ok {
+		var req struct {
+			Name string `json:"name"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err == nil && req.Name != "" {
+			echoed := make(map[string]any, len(body))
+			for k, v := range body {
+				echoed[k] = v
+			}
+			echoed["name"] = req.Name
+			resp = echoed
+		}
+	}
 	render.Status(r, http.StatusCreated)
 	render.JSON(w, r, resp)
 }

--- a/internal/testrunner/prompt.go
+++ b/internal/testrunner/prompt.go
@@ -27,7 +27,7 @@ import (
 	"strings"
 )
 
-const agentPromptTemplate = `My tests failed when running ` + "`circleci onboard`" + `.
+const agentPromptTemplate = `My tests failed when running ` + "`circleci test run`" + `.
 
 Project stack: %s
 Image: %s
@@ -38,7 +38,7 @@ Failing test output:
 %s
 
 Please diagnose the failure from the output above and propose a fix.
-Once fixed, I will re-run ` + "`circleci onboard`" + `.
+Once fixed, I will re-run ` + "`circleci test run`" + `.
 `
 
 // RenderPrompt returns the hardcoded POC prompt shown after local tests fail.

--- a/internal/testrunner/testdata/TestRenderPrompt.txt
+++ b/internal/testrunner/testdata/TestRenderPrompt.txt
@@ -1,4 +1,4 @@
-My tests failed when running `circleci onboard`.
+My tests failed when running `circleci test run`.
 
 Project stack: go
 Image: cimg/go:1.22
@@ -10,4 +10,4 @@ Failing test output:
     nope
 
 Please diagnose the failure from the output above and propose a fix.
-Once fixed, I will re-run `circleci onboard`.
+Once fixed, I will re-run `circleci test run`.

--- a/internal/testrunner/testdata/TestRenderPrompt_NoOutputCaptured.txt
+++ b/internal/testrunner/testdata/TestRenderPrompt_NoOutputCaptured.txt
@@ -1,4 +1,4 @@
-My tests failed when running `circleci onboard`.
+My tests failed when running `circleci test run`.
 
 Project stack: go
 Image: cimg/go:1.22
@@ -9,4 +9,4 @@ Failing test output:
 (no output captured)
 
 Please diagnose the failure from the output above and propose a fix.
-Once fixed, I will re-run `circleci onboard`.
+Once fixed, I will re-run `circleci test run`.

--- a/internal/testrunner/testrunner.go
+++ b/internal/testrunner/testrunner.go
@@ -82,7 +82,7 @@ func Run(ctx context.Context, dir string, result *reposcan.Result) error {
 				fmt.Sprintf("Test command exited with status %d.", exitCode),
 			).WithSuggestions(
 				"Paste the prompt above into your AI assistant",
-				"Re-run circleci onboard once tests pass",
+				"Re-run circleci test run once tests pass",
 			).WithExitCode(clierrors.ExitGeneralError)
 		}
 		return clierrors.New(

--- a/internal/testrunner/testrunner_test.go
+++ b/internal/testrunner/testrunner_test.go
@@ -91,7 +91,7 @@ func TestRun_TestFails_PrintsPromptAndReturnsStructuredError(t *testing.T) {
 	})
 
 	assertCLIError(t, err, "test.tests_failed", clierrors.ExitGeneralError)
-	assert.Check(t, cmp.Contains(outBuf.String(), "My tests failed when running `circleci onboard`."))
+	assert.Check(t, cmp.Contains(outBuf.String(), "My tests failed when running `circleci test run`."))
 	assert.Check(t, cmp.Contains(outBuf.String(), "Command run: printf 'boom\\n'; printf 'details\\n' >&2; exit 7"))
 	assert.Check(t, cmp.Contains(outBuf.String(), "Exit code: 7"))
 	assert.Check(t, cmp.Contains(outBuf.String(), "boom"))


### PR DESCRIPTION
## Summary

`circleci onboard` now finishes the job for a CircleCI-native organization. After creating the project it creates a pipeline definition and an all-pushes trigger, so the next push starts a build. It uses the same v2 endpoints as `circleci pipeline create` and `circleci project trigger create`, with zero-prompt defaults: config at `.circleci/config.yml`, the `github_app` provider, and the repository's external ID as both the config and checkout source.

Every step degrades to printed guidance rather than failing the command. By the time pipeline setup runs the project exists, and a half-finished pipeline is not worth a non-zero exit.

## The constraint that shapes the design

**No API maps a project name to its ID.** Verified against the API:

| Attempt | Result |
|---|---|
| `GET /api/v2/organization/{org}/project` | 404 — POST only |
| `GET /api/v2/organizations/{orgID}/projects` | 404 |
| `GET /api/v3/organizations/{orgID}/projects` | 404 |
| `/api/v3/projects` bare, or `?limit=` | 400 — a filter is required |
| `filter[org_id]` · `[organization_id]` · `[name]` | 400 |
| `GET /api/v2/project/circleci/<org>/<name>` | 400 |
| `/api/v1.1/projects` | 200, but **followed** projects only — a project created through the API is not followed |

And a CircleCI-native project's slug is `circleci/<orgID>/<projectID>` — opaque IDs, not the repository name.

So a second run cannot rediscover the project the first run created unless the ID was written down. Onboard records it in `.circleci/info.yml` through `projectref` — the same file `circleci project link` writes — and resolves from it *before* attempting a create, so a re-run never provokes a conflict it cannot recover from. That also links the repository for every other command, which is what the file is for, and the next-steps output stages `.circleci/` so the ID is committed rather than lost on the next clone.

## Behavior worth reviewing

- **Everything is scoped to the directory onboard was given.** `circleci onboard <path>` reads that checkout's remote and link, not the process working directory. Run from a subdirectory, the link is recorded at the repository root.
- **An existing `.circleci/info.yml` is never overwritten.** It may be committed, and it may record a project this run has no mandate to replace — `circleci project link` demands `--force` for the same reason. Onboard prints the command that would replace it.
- **A link only counts if its project belongs to the selected organization.** A repository linked elsewhere is ignored rather than reused, so the pipeline is never set up under an organization the user did not choose.
- **Only an all-pushes trigger satisfies the trigger step.** A definition carrying just a schedule would otherwise be announced as ready while the push built nothing.
- **`--repo-id`** takes the external ID directly, for a repository that is not on GitHub or an organization the GitHub App cannot enumerate. It is never prompted for; an opaque numeric ID is not something a user can be expected to know.

## Changes outside onboard

Three fixes this feature depends on, each affecting other commands:

- **`projectref.EffectiveSlug`** rebuilt `circleci/<orgID>/<projectID>` whenever both IDs were recorded, but that form addresses CircleCI-native projects only — the API answers 404 for a classic VCS project addressed that way, and `project link` records IDs for every project type. Since `gitremote.Detect` goes through `EffectiveSlug`, **project resolution was broken for every command in a checkout linked to a classic project.** This is the one commit worth reviewing independently of the onboarding work.
- **`config.SetLogin`** ignored the path it was given, so a token was written to the default location while the caller reported, and re-read, somewhere else. Its siblings share the bug but have no caller that re-reads, so they are left alone.
- **`gitremote`** gains directory-scoped detection (`DetectFromRemoteIn`, `RepoRootIn`), and `DetectRepoName` falls back to the name recorded by `project link` when the remote cannot be read.

## Test plan

- [ ] `task test` passes
- [ ] Happy path: `--scan --repo-id <id>` creates the definition and trigger and prints "Your project is ready!"
- [ ] GitHub App resolution: `--scan` with the app installed finds the repository and wires the pipeline without `--repo-id`
- [ ] Re-run: two consecutive runs reuse the project, definition and trigger; the first records the link
- [ ] Fresh signup with no `CIRCLE_TOKEN`: drives the real OAuth callback and continues to a ready project
- [ ] Path argument: run from an unrelated checkout, the project is named after the directory given, and the link is written there
- [ ] `--signup` from a subdirectory records the link at the repository root; outside a repository it records nothing
- [ ] An existing link is left byte-for-byte alone, with the replacing command printed
- [ ] A link to another organization is not reused
- [ ] A schedule-only definition still gets an all-pushes trigger
- [ ] Name collision with no local record points at `circleci project link --project`, with no HTTP status or API path in stderr
- [ ] Linked classic project resolves by its own slug; linked native project resolves by rebuilt IDs
- [ ] Repository not accessible, trigger failure, and a host without the GitHub App endpoints each degrade to guidance and exit 0

Each of the eight commits builds and vets on its own.
