### PR TITLE
Report dynamic config continued workflow failure in run watch

### DIFF
--- a/acceptance/watch_test.go
+++ b/acceptance/watch_test.go
@@ -144,6 +144,79 @@ func TestRunWatch_Latest(t *testing.T) {
 	assert.Check(t, cmp.Contains(result.Stderr, "succeeded"), "stderr: %s", result.Stderr)
 }
 
+// --- dynamic config: setup succeeded but the continued config failed validation →
+// the error is recorded on the run itself (no continued workflow object) → exit 1 ---
+
+func TestRunWatch_DynamicConfig_RunLevelConfigError(t *testing.T) {
+	runID := "f0000000-0000-4000-8000-00000000dc01"
+	setupWfID := "b0000000-0000-4000-8000-0000000dc001"
+
+	v3Run := fakeRunV3(runID, watchProjectID, "ended", "errored", "main", "abc1234def5678")
+	v3Run["attributes"].(map[string]any)["errors"] = []map[string]any{
+		{"type": "config_validation_error", "message": "Continued workflow config is invalid: bad yaml"},
+	}
+
+	fake := fakes.NewCircleCI(t)
+	addProjectBySlug(fake, watchSlug, watchProjectID)
+	fake.AddRunV3(runID, watchProjectID, v3Run)
+	fake.AddRun(runID, fakeRun(runID, 80, "created", watchSlug, "main"))
+	fake.AddProjectRuns(watchSlug, fakeRun(runID, 80, "created", watchSlug, "main"))
+	// Only the setup workflow exists; the continued workflow was never created.
+	fake.AddRunWorkflowsV3(runID,
+		fakeWorkflowV3(setupWfID, "setup", runID, watchProjectID, "ended", "succeeded"),
+	)
+	fake.AddWorkflowJobsV3(setupWfID, fakeJobV3("d0000000-0000-4000-8000-0000000dc001", "generate-config", setupWfID, watchProjectID))
+
+	env := testenv.New(t)
+	env.Token = testToken
+	env.CircleCIURL = fake.URL()
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"run", "watch", "80", "--project", watchSlug},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 1, "stderr: %s", result.Stderr)
+	assert.Check(t, cmp.Contains(result.Stderr, "failed"), "stderr: %s", result.Stderr)
+	assert.Check(t, cmp.Contains(result.Stderr, "Continued workflow config is invalid"), "stderr: %s", result.Stderr)
+}
+
+// --- dynamic config: setup succeeded but continued workflow has a not_run outcome → exit 1 ---
+
+func TestRunWatch_DynamicConfig_ContinuedWorkflowNotRun(t *testing.T) {
+	runID := "f0000000-0000-4000-8000-00000000dc02"
+	setupWfID := "b0000000-0000-4000-8000-0000000dc002"
+	continuedWfID := "b0000000-0000-4000-8000-0000000dc003"
+
+	fake := fakes.NewCircleCI(t)
+	addProjectBySlug(fake, watchSlug, watchProjectID)
+	fake.AddRunV3(runID, watchProjectID, fakeRunV3(runID, watchProjectID, "ended", "errored", "main", "abc1234def5678"))
+	fake.AddRun(runID, fakeRun(runID, 81, "created", watchSlug, "main"))
+	fake.AddProjectRuns(watchSlug, fakeRun(runID, 81, "created", watchSlug, "main"))
+	fake.AddRunWorkflowsV3(runID,
+		fakeWorkflowV3(setupWfID, "setup", runID, watchProjectID, "ended", "succeeded"),
+		fakeWorkflowV3(continuedWfID, "continue", runID, watchProjectID, "ended", "not_run"),
+	)
+	fake.AddWorkflowJobsV3(setupWfID, fakeJobV3("d0000000-0000-4000-8000-0000000dc002", "generate-config", setupWfID, watchProjectID))
+	fake.AddWorkflowJobsV3(continuedWfID)
+
+	env := testenv.New(t)
+	env.Token = testToken
+	env.CircleCIURL = fake.URL()
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"run", "watch", "81", "--project", watchSlug},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 1, "stderr: %s", result.Stderr)
+	assert.Check(t, cmp.Contains(result.Stderr, "failed"), "stderr: %s", result.Stderr)
+}
+
 // --- failed run → exit 1 ---
 
 func TestRunWatch_Failed(t *testing.T) {

--- a/internal/cmd/run/get.go
+++ b/internal/cmd/run/get.go
@@ -48,7 +48,6 @@ import (
 )
 
 const (
-	statusCanceled     = "canceled"
 	maxWorkflowFetches = 8
 
 	// defaultBranchGuess is the branch assumed for latest-run lookup when
@@ -830,26 +829,23 @@ func deriveDisplayStatus(r runGetOutput) string {
 		return apiclient.PhaseOutcomeStatus(r.Phase, r.Outcome, r.CurrentOutcome)
 	}
 	for _, wf := range r.Workflows {
-		if wf.Outcome == "failed" || wf.Outcome == "errored" || wf.CurrentOutcome == "failed" {
-			return "failed"
-		}
-	}
-	for _, wf := range r.Workflows {
 		if wf.Phase != "ended" {
 			return "running"
 		}
 	}
-	for _, wf := range r.Workflows {
-		if wf.Outcome == statusCanceled {
-			return statusCanceled
-		}
+	// Run-level errors (e.g. a dynamic config continued-workflow config
+	// validation failure) are recorded on the run itself and never produce a
+	// workflow object, so checking workflow outcomes alone would miss them.
+	if len(r.Errors) > 0 {
+		return "errored"
 	}
-	for _, wf := range r.Workflows {
-		if wf.Outcome == "succeeded" {
-			return "succeeded"
-		}
-	}
-	return apiclient.PhaseOutcomeStatus(r.Phase, r.Outcome, r.CurrentOutcome)
+	// Use the last workflow's status as the run's overall status. The V3 API
+	// returns workflows in creation order, so the last entry is the most
+	// recently started one. In dynamic config that is the continued workflow —
+	// its outcome is what determines whether the full run succeeded or failed,
+	// not the setup workflow that preceded it.
+	latest := r.Workflows[len(r.Workflows)-1]
+	return apiclient.PhaseOutcomeText(latest.Phase, latest.Outcome, latest.CurrentOutcome)
 }
 
 func printRun(ctx context.Context, r runGetOutput, u string) {

--- a/internal/cmd/run/watch.go
+++ b/internal/cmd/run/watch.go
@@ -530,8 +530,12 @@ func watchFinalResult(ctx context.Context, state runGetOutput, runID uuid.UUID, 
 	default:
 		iostream.ErrPrintf(ctx, "%s Run %s failed (%s)\n",
 			iostream.SymbolFail(ctx), runID, formatElapsed(elapsed))
-		return clierrors.New("run.failed", "Run failed",
-			fmt.Sprintf("Run %s failed.", runID)).
+		var errParts []string
+		errParts = append(errParts, fmt.Sprintf("Run %s failed.", runID))
+		for _, e := range state.Errors {
+			errParts = append(errParts, e.Message)
+		}
+		return clierrors.New("run.failed", "Run failed", strings.Join(errParts, "\n")).
 			WithSuggestions(failedJobLogSuggestions(state)...).
 			WithExitCode(clierrors.ExitGeneralError)
 	}


### PR DESCRIPTION
## Summary

- `deriveDisplayStatus` previously returned `"succeeded"` as soon as it found *any* workflow with `outcome == "succeeded"`, so in a dynamic config pipeline the setup workflow's success masked the continued workflow's failure
- Now uses the **last workflow's status** (the most recently started one) as the overall run status — in dynamic config the continued workflow is always last in the V3 API response
- A `not_run` or other non-succeeded outcome on the continued workflow now correctly causes `run watch` to exit 1

## Test plan

- [ ] New acceptance test `TestRunWatch_DynamicConfig_ContinuedWorkflowValidationError`: setup workflow `ended/succeeded`, continued workflow `ended/not_run` → exit code 1 and "failed" in output
- [ ] Existing watch acceptance tests all pass