### PR TITLE
Feat(Factory-II): Add `--failure-report` flag to `run get` for condensed failure output

### DIFF
--- a/acceptance/run_failed_context_test.go
+++ b/acceptance/run_failed_context_test.go
@@ -43,12 +43,12 @@ const (
 	fcJob3ID = "d0000000-0000-4000-8000-0000000000f3" // succeeded, no failures — should not appear
 )
 
-// --- run get --log-failed ---
+// --- run get --failure-report ---
 
 // TestRunGet_FailedContext prints condensed output for every failed step across
 // a run's workflows and jobs, organised as workflow -> job -> step headers, and
 // bypasses the interactive TUI even in a TTY-less run (the default acceptance
-// invocation is already non-interactive, but --log-failed is what forces it).
+// invocation is already non-interactive, but --failure-report is what forces it).
 func TestRunGet_FailedContext(t *testing.T) {
 	fake := fakes.NewCircleCI(t)
 	fake.AddRunV3(fcRunID, runTestProjectID, fakeRunV3(fcRunID, runTestProjectID, "ended", "failed", "main", "abc1234def5678"))
@@ -102,7 +102,7 @@ func TestRunGet_FailedContext(t *testing.T) {
 
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    []string{"run", "get", fcRunID, "--log-failed"},
+		Args:    []string{"run", "get", fcRunID, "--failure-report"},
 		Env:     env.Environ(),
 		WorkDir: t.TempDir(),
 	})
@@ -154,7 +154,7 @@ func TestRunGet_FailedContext_ParallelExecution(t *testing.T) {
 
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    []string{"run", "get", fcRunID, "--log-failed"},
+		Args:    []string{"run", "get", fcRunID, "--failure-report"},
 		Env:     env.Environ(),
 		WorkDir: t.TempDir(),
 	})
@@ -198,7 +198,7 @@ func TestRunGet_FailedContext_NoFailures(t *testing.T) {
 
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    []string{"run", "get", fcRunID, "--log-failed"},
+		Args:    []string{"run", "get", fcRunID, "--failure-report"},
 		Env:     env.Environ(),
 		WorkDir: t.TempDir(),
 	})
@@ -208,22 +208,22 @@ func TestRunGet_FailedContext_NoFailures(t *testing.T) {
 	assert.Check(t, cmp.Equal(result.Stderr, ""))
 }
 
-// TestRunGet_LogFailed_RejectsJSON verifies that combining --log-failed with
+// TestRunGet_FailureReport_RejectsJSON verifies that combining --failure-report with
 // --json exits non-zero with a user-facing error.
-func TestRunGet_LogFailed_RejectsJSON(t *testing.T) {
+func TestRunGet_FailureReport_RejectsJSON(t *testing.T) {
 	env := testenv.New(t)
 	env.Token = testToken
 	env.CircleCIURL = "https://circleci.com" // never reached
 
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    []string{"run", "get", fcRunID, "--log-failed", "--json"},
+		Args:    []string{"run", "get", fcRunID, "--failure-report", "--json"},
 		Env:     env.Environ(),
 		WorkDir: t.TempDir(),
 	})
 
 	assert.Check(t, cmp.Equal(result.ExitCode, 2))
-	assert.Check(t, cmp.Contains(result.Stderr, "run.log_failed_no_json"))
+	assert.Check(t, cmp.Contains(result.Stderr, "run.failure_report_no_json"))
 }
 
 // TestRunGet_FailedContext_WorkflowsNotFound exits 0 with no output when the
@@ -239,7 +239,7 @@ func TestRunGet_FailedContext_WorkflowsNotFound(t *testing.T) {
 
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    []string{"run", "get", fcRunID, "--log-failed"},
+		Args:    []string{"run", "get", fcRunID, "--failure-report"},
 		Env:     env.Environ(),
 		WorkDir: t.TempDir(),
 	})

--- a/acceptance/run_failed_context_test.go
+++ b/acceptance/run_failed_context_test.go
@@ -1,0 +1,227 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package acceptance_test
+
+import (
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/golden"
+
+	"github.com/CircleCI-Public/circleci-cli/internal/testing/binary"
+	testenv "github.com/CircleCI-Public/circleci-cli/internal/testing/env"
+	"github.com/CircleCI-Public/circleci-cli/internal/testing/fakes"
+)
+
+const (
+	fcRunID  = "e0000000-0000-4000-8000-0000000000f1"
+	fcWfID   = "b0000000-0000-4000-8000-0000000000f1"
+	fcJob1ID = "d0000000-0000-4000-8000-0000000000f1" // single execution, one failed step
+	fcJob2ID = "d0000000-0000-4000-8000-0000000000f2" // parallel job, one of two executions failed
+	fcJob3ID = "d0000000-0000-4000-8000-0000000000f3" // succeeded, no failures — should not appear
+)
+
+// --- run get --log-failed ---
+
+// TestRunGet_FailedContext prints condensed output for every failed step across
+// a run's workflows and jobs, organised as workflow -> job -> step headers, and
+// bypasses the interactive TUI even in a TTY-less run (the default acceptance
+// invocation is already non-interactive, but --log-failed is what forces it).
+func TestRunGet_FailedContext(t *testing.T) {
+	fake := fakes.NewCircleCI(t)
+	fake.AddRunV3(fcRunID, runTestProjectID, fakeRunV3(fcRunID, runTestProjectID, "ended", "failed", "main", "abc1234def5678"))
+	fake.AddRunWorkflowsV3(fcRunID, fakeWorkflowV3(fcWfID, "build", fcRunID, runTestProjectID, "ended", "failed"))
+	fake.AddWorkflowJobsV3(fcWfID,
+		fakeJobV3(fcJob1ID, "run-tests", fcWfID, runTestProjectID),
+		fakeJobV3(fcJob3ID, "lint", fcWfID, runTestProjectID),
+	)
+
+	now := time.Date(2020, 1, 1, 12, 0, 0, 0, time.UTC).Format(v3TimeFormat)
+	fake.AddJobV3(fcJob1ID, map[string]any{"data": map[string]any{
+		"id": fcJob1ID,
+		"attributes": map[string]any{
+			"name": "run-tests", "type": "build", "phase": "ended", "outcome": "failed",
+			"started_at": now, "ended_at": now,
+			"parallel_executions": []map[string]any{{
+				"steps": []map[string]any{
+					{"name": "Spin up environment", "type": "spinup_environment", "num": 0, "phase": "ended", "outcome": "succeeded", "started_at": now, "ended_at": now},
+					{"name": "run tests", "type": "run", "num": 101, "phase": "ended", "outcome": "failed", "exit_code": 1, "started_at": now, "ended_at": now},
+				},
+			}},
+		},
+		"references": map[string]any{
+			"workflow": map[string]any{"id": fcWfID},
+			"project":  map[string]any{"id": runTestProjectID},
+		},
+	}})
+	fake.AddJobStdoutCondensed(fcJob1ID, 0, 101, []byte("FAILURE: 2 tests failed\n"))
+
+	// A succeeded job in the same workflow contributes no output at all.
+	fake.AddJobV3(fcJob3ID, map[string]any{"data": map[string]any{
+		"id": fcJob3ID,
+		"attributes": map[string]any{
+			"name": "lint", "type": "build", "phase": "ended", "outcome": "succeeded",
+			"started_at": now, "ended_at": now,
+			"parallel_executions": []map[string]any{{
+				"steps": []map[string]any{
+					{"name": "run lint", "type": "run", "num": 100, "phase": "ended", "outcome": "succeeded", "exit_code": 0, "started_at": now, "ended_at": now},
+				},
+			}},
+		},
+		"references": map[string]any{
+			"workflow": map[string]any{"id": fcWfID},
+			"project":  map[string]any{"id": runTestProjectID},
+		},
+	}})
+
+	env := testenv.New(t)
+	env.Token = testToken
+	env.CircleCIURL = fake.URL()
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"run", "get", fcRunID, "--log-failed"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 0)
+	assert.Check(t, golden.String(result.Stdout, t.Name()+".txt"))
+}
+
+// TestRunGet_FailedContext_ParallelExecution exercises a parallel job (two
+// executions) where only one execution failed: the job header includes the
+// execution index and an "N of M failed" count, and only the failed execution's
+// steps are printed.
+func TestRunGet_FailedContext_ParallelExecution(t *testing.T) {
+	fake := fakes.NewCircleCI(t)
+	fake.AddRunV3(fcRunID, runTestProjectID, fakeRunV3(fcRunID, runTestProjectID, "ended", "failed", "main", "abc1234def5678"))
+	fake.AddRunWorkflowsV3(fcRunID, fakeWorkflowV3(fcWfID, "build", fcRunID, runTestProjectID, "ended", "failed"))
+	fake.AddWorkflowJobsV3(fcWfID,
+		fakeJobV3(fcJob2ID, "deploy", fcWfID, runTestProjectID),
+	)
+
+	now := time.Date(2020, 1, 1, 12, 0, 0, 0, time.UTC).Format(v3TimeFormat)
+	deployStep := func(outcome string, exit int) []map[string]any {
+		return []map[string]any{
+			{"name": "Spin up environment", "type": "spinup_environment", "num": 0, "phase": "ended", "outcome": "succeeded", "started_at": now, "ended_at": now},
+			{"name": "deploy", "type": "run", "num": 50, "phase": "ended", "outcome": outcome, "exit_code": exit, "started_at": now, "ended_at": now},
+		}
+	}
+	fake.AddJobV3(fcJob2ID, map[string]any{"data": map[string]any{
+		"id": fcJob2ID,
+		"attributes": map[string]any{
+			"name": "deploy", "type": "build", "phase": "ended", "outcome": "failed",
+			"started_at": now, "ended_at": now,
+			"parallel_executions": []map[string]any{
+				{"steps": deployStep("succeeded", 0)},
+				{"steps": deployStep("failed", 1)},
+			},
+		},
+		"references": map[string]any{
+			"workflow": map[string]any{"id": fcWfID},
+			"project":  map[string]any{"id": runTestProjectID},
+		},
+	}})
+	fake.AddJobStdoutCondensed(fcJob2ID, 1, 50, []byte("deploy failed\n"))
+
+	env := testenv.New(t)
+	env.Token = testToken
+	env.CircleCIURL = fake.URL()
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"run", "get", fcRunID, "--log-failed"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 0)
+	assert.Check(t, golden.String(result.Stdout, t.Name()+".txt"))
+}
+
+// TestRunGet_FailedContext_NoFailures exits 0 with no output when the run has no
+// failed steps.
+func TestRunGet_FailedContext_NoFailures(t *testing.T) {
+	fake := fakes.NewCircleCI(t)
+	fake.AddRunV3(fcRunID, runTestProjectID, fakeRunV3(fcRunID, runTestProjectID, "ended", "succeeded", "main", "abc1234def5678"))
+	fake.AddRunWorkflowsV3(fcRunID, fakeWorkflowV3(fcWfID, "build", fcRunID, runTestProjectID, "ended", "succeeded"))
+	fake.AddWorkflowJobsV3(fcWfID,
+		fakeJobV3(fcJob3ID, "lint", fcWfID, runTestProjectID),
+	)
+
+	now := time.Date(2020, 1, 1, 12, 0, 0, 0, time.UTC).Format(v3TimeFormat)
+	fake.AddJobV3(fcJob3ID, map[string]any{"data": map[string]any{
+		"id": fcJob3ID,
+		"attributes": map[string]any{
+			"name": "lint", "type": "build", "phase": "ended", "outcome": "succeeded",
+			"started_at": now, "ended_at": now,
+			"parallel_executions": []map[string]any{{
+				"steps": []map[string]any{
+					{"name": "run lint", "type": "run", "num": 100, "phase": "ended", "outcome": "succeeded", "exit_code": 0, "started_at": now, "ended_at": now},
+				},
+			}},
+		},
+		"references": map[string]any{
+			"workflow": map[string]any{"id": fcWfID},
+			"project":  map[string]any{"id": runTestProjectID},
+		},
+	}})
+
+	env := testenv.New(t)
+	env.Token = testToken
+	env.CircleCIURL = fake.URL()
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"run", "get", fcRunID, "--log-failed"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 0)
+	assert.Equal(t, result.Stdout, "")
+}
+
+// TestRunGet_FailedContext_WorkflowsNotFound exits 0 with no output when the
+// run's workflows have not materialised yet (404).
+func TestRunGet_FailedContext_WorkflowsNotFound(t *testing.T) {
+	fake := fakes.NewCircleCI(t)
+	fake.AddRunV3(fcRunID, runTestProjectID, fakeRunV3(fcRunID, runTestProjectID, "created", "", "main", "abc1234def5678"))
+	fake.SetRunWorkflowsV3NotFound(fcRunID)
+
+	env := testenv.New(t)
+	env.Token = testToken
+	env.CircleCIURL = fake.URL()
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"run", "get", fcRunID, "--log-failed"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 0)
+	assert.Equal(t, result.Stdout, "")
+}

--- a/acceptance/run_failed_context_test.go
+++ b/acceptance/run_failed_context_test.go
@@ -208,6 +208,24 @@ func TestRunGet_FailedContext_NoFailures(t *testing.T) {
 	assert.Check(t, cmp.Equal(result.Stderr, ""))
 }
 
+// TestRunGet_LogFailed_RejectsJSON verifies that combining --log-failed with
+// --json exits non-zero with a user-facing error.
+func TestRunGet_LogFailed_RejectsJSON(t *testing.T) {
+	env := testenv.New(t)
+	env.Token = testToken
+	env.CircleCIURL = "https://circleci.com" // never reached
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"run", "get", fcRunID, "--log-failed", "--json"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Check(t, cmp.Equal(result.ExitCode, 2))
+	assert.Check(t, cmp.Contains(result.Stderr, "run.log_failed_no_json"))
+}
+
 // TestRunGet_FailedContext_WorkflowsNotFound exits 0 with no output when the
 // run's workflows have not materialised yet (404).
 func TestRunGet_FailedContext_WorkflowsNotFound(t *testing.T) {

--- a/acceptance/run_failed_context_test.go
+++ b/acceptance/run_failed_context_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/golden"
 
 	"github.com/CircleCI-Public/circleci-cli/internal/testing/binary"
@@ -106,8 +107,9 @@ func TestRunGet_FailedContext(t *testing.T) {
 		WorkDir: t.TempDir(),
 	})
 
-	assert.Equal(t, result.ExitCode, 0)
+	assert.Check(t, cmp.Equal(result.ExitCode, 0))
 	assert.Check(t, golden.String(result.Stdout, t.Name()+".txt"))
+	assert.Check(t, cmp.Equal(result.Stderr, ""))
 }
 
 // TestRunGet_FailedContext_ParallelExecution exercises a parallel job (two
@@ -157,8 +159,9 @@ func TestRunGet_FailedContext_ParallelExecution(t *testing.T) {
 		WorkDir: t.TempDir(),
 	})
 
-	assert.Equal(t, result.ExitCode, 0)
+	assert.Check(t, cmp.Equal(result.ExitCode, 0))
 	assert.Check(t, golden.String(result.Stdout, t.Name()+".txt"))
+	assert.Check(t, cmp.Equal(result.Stderr, ""))
 }
 
 // TestRunGet_FailedContext_NoFailures exits 0 with no output when the run has no
@@ -200,8 +203,9 @@ func TestRunGet_FailedContext_NoFailures(t *testing.T) {
 		WorkDir: t.TempDir(),
 	})
 
-	assert.Equal(t, result.ExitCode, 0)
-	assert.Equal(t, result.Stdout, "")
+	assert.Check(t, cmp.Equal(result.ExitCode, 0))
+	assert.Check(t, cmp.Equal(result.Stdout, ""))
+	assert.Check(t, cmp.Equal(result.Stderr, ""))
 }
 
 // TestRunGet_FailedContext_WorkflowsNotFound exits 0 with no output when the
@@ -222,6 +226,7 @@ func TestRunGet_FailedContext_WorkflowsNotFound(t *testing.T) {
 		WorkDir: t.TempDir(),
 	})
 
-	assert.Equal(t, result.ExitCode, 0)
-	assert.Equal(t, result.Stdout, "")
+	assert.Check(t, cmp.Equal(result.ExitCode, 0))
+	assert.Check(t, cmp.Equal(result.Stdout, ""))
+	assert.Check(t, cmp.Equal(result.Stderr, ""))
 }

--- a/acceptance/testdata/TestRunGet_FailedContext.txt
+++ b/acceptance/testdata/TestRunGet_FailedContext.txt
@@ -1,0 +1,8 @@
+## workflow: build
+
+### job: run-tests
+
+#### step 101: run tests [exit: 1]
+
+FAILURE: 2 tests failed
+

--- a/acceptance/testdata/TestRunGet_FailedContext_ParallelExecution.txt
+++ b/acceptance/testdata/TestRunGet_FailedContext_ParallelExecution.txt
@@ -1,0 +1,8 @@
+## workflow: build
+
+### job: deploy (execution 1, 1 of 2 failed)
+
+#### step 50: deploy [exit: 1]
+
+deploy failed
+

--- a/internal/cmd/root/testdata/help/circleci/reference.txt
+++ b/internal/cmd/root/testdata/help/circleci/reference.txt
@@ -248,14 +248,15 @@ The project is inferred from the git remote unless overridden with `--project`.
 
 Get a run's status
 
-| Flag                  | Description                                                                 |
-| --------------------- | --------------------------------------------------------------------------- |
-| `-b, --branch string` | Branch name (defaults to the current branch, or main when --project is set) |
-| `--jq string`         | Process values from the response using jq syntax                            |
-| `--json`              | Output as JSON                                                              |
-| `-m, --mine`          | Filter to runs owned by you.                                                |
-| `--no-interactive`    | Skip the interactive picker and resolve the latest run directly             |
-| `--project string`    | Project slug (e.g. gh/org/repo); used for latest-run lookup                 |
+| Flag                  | Description                                                                  |
+| --------------------- | ---------------------------------------------------------------------------- |
+| `-b, --branch string` | Branch name (defaults to the current branch, or main when --project is set)  |
+| `--jq string`         | Process values from the response using jq syntax                             |
+| `--json`              | Output as JSON                                                               |
+| `--log-failed`        | Print condensed output for every failed step; intended for agent consumption |
+| `-m, --mine`          | Filter to runs owned by you.                                                 |
+| `--no-interactive`    | Skip the interactive picker and resolve the latest run directly              |
+| `--project string`    | Project slug (e.g. gh/org/repo); used for latest-run lookup                  |
 
 
 **Arguments:**

--- a/internal/cmd/root/testdata/help/circleci/reference.txt
+++ b/internal/cmd/root/testdata/help/circleci/reference.txt
@@ -251,9 +251,9 @@ Get a run's status
 | Flag                  | Description                                                                  |
 | --------------------- | ---------------------------------------------------------------------------- |
 | `-b, --branch string` | Branch name (defaults to the current branch, or main when --project is set)  |
+| `--failure-report`    | Print condensed output for every failed step; intended for agent consumption |
 | `--jq string`         | Process values from the response using jq syntax                             |
 | `--json`              | Output as JSON                                                               |
-| `--log-failed`        | Print condensed output for every failed step; intended for agent consumption |
 | `-m, --mine`          | Filter to runs owned by you.                                                 |
 | `--no-interactive`    | Skip the interactive picker and resolve the latest run directly              |
 | `--project string`    | Project slug (e.g. gh/org/repo); used for latest-run lookup                  |

--- a/internal/cmd/root/testdata/help/circleci/run/get.txt
+++ b/internal/cmd/root/testdata/help/circleci/run/get.txt
@@ -32,9 +32,9 @@ For more information about output formatting flags, see `circleci help formattin
 | Flag                  | Description                                                                  |
 | --------------------- | ---------------------------------------------------------------------------- |
 | `-b, --branch string` | Branch name (defaults to the current branch, or main when --project is set)  |
+| `--failure-report`    | Print condensed output for every failed step; intended for agent consumption |
 | `--jq string`         | Process values from the response using jq syntax                             |
 | `--json`              | Output as JSON                                                               |
-| `--log-failed`        | Print condensed output for every failed step; intended for agent consumption |
 | `-m, --mine`          | Filter to runs owned by you.                                                 |
 | `--no-interactive`    | Skip the interactive picker and resolve the latest run directly              |
 | `--project string`    | Project slug (e.g. gh/org/repo); used for latest-run lookup                  |

--- a/internal/cmd/root/testdata/help/circleci/run/get.txt
+++ b/internal/cmd/root/testdata/help/circleci/run/get.txt
@@ -29,14 +29,15 @@ For more information about output formatting flags, see `circleci help formattin
 
 ## Flags
 
-| Flag                  | Description                                                                 |
-| --------------------- | --------------------------------------------------------------------------- |
-| `-b, --branch string` | Branch name (defaults to the current branch, or main when --project is set) |
-| `--jq string`         | Process values from the response using jq syntax                            |
-| `--json`              | Output as JSON                                                              |
-| `-m, --mine`          | Filter to runs owned by you.                                                |
-| `--no-interactive`    | Skip the interactive picker and resolve the latest run directly             |
-| `--project string`    | Project slug (e.g. gh/org/repo); used for latest-run lookup                 |
+| Flag                  | Description                                                                  |
+| --------------------- | ---------------------------------------------------------------------------- |
+| `-b, --branch string` | Branch name (defaults to the current branch, or main when --project is set)  |
+| `--jq string`         | Process values from the response using jq syntax                             |
+| `--json`              | Output as JSON                                                               |
+| `--log-failed`        | Print condensed output for every failed step; intended for agent consumption |
+| `-m, --mine`          | Filter to runs owned by you.                                                 |
+| `--no-interactive`    | Skip the interactive picker and resolve the latest run directly              |
+| `--project string`    | Project slug (e.g. gh/org/repo); used for latest-run lookup                  |
 
 ## Inherited Flags
 

--- a/internal/cmd/root/testdata/usage/circleci/run/get.txt
+++ b/internal/cmd/root/testdata/usage/circleci/run/get.txt
@@ -2,9 +2,9 @@ Usage:  circleci run get [<run-id>] [flags]
 
 Flags:
   -b, --branch string    Branch name (defaults to the current branch, or main when --project is set)
+      --failure-report   Print condensed output for every failed step; intended for agent consumption
       --jq string        Process values from the response using jq syntax
       --json             Output as JSON
-      --log-failed       Print condensed output for every failed step; intended for agent consumption
   -m, --mine             Filter to runs owned by you.
       --no-interactive   Skip the interactive picker and resolve the latest run directly
       --project string   Project slug (e.g. gh/org/repo); used for latest-run lookup

--- a/internal/cmd/root/testdata/usage/circleci/run/get.txt
+++ b/internal/cmd/root/testdata/usage/circleci/run/get.txt
@@ -4,6 +4,7 @@ Flags:
   -b, --branch string    Branch name (defaults to the current branch, or main when --project is set)
       --jq string        Process values from the response using jq syntax
       --json             Output as JSON
+      --log-failed       Print condensed output for every failed step; intended for agent consumption
   -m, --mine             Filter to runs owned by you.
       --no-interactive   Skip the interactive picker and resolve the latest run directly
       --project string   Project slug (e.g. gh/org/repo); used for latest-run lookup

--- a/internal/cmd/run/failed_context.go
+++ b/internal/cmd/run/failed_context.go
@@ -1,0 +1,143 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package run
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/CircleCI-Public/circleci-cli/internal/apiclient"
+	"github.com/CircleCI-Public/circleci-cli/internal/httpcl"
+	"github.com/CircleCI-Public/circleci-cli/internal/iostream"
+)
+
+// runLogFailed prints condensed output for every failed step in the run,
+// organised as workflow → job → execution → step headers. It is the output path
+// for --log-failed and never enters the TUI.
+//
+// Output is written to stdout so it can be piped directly into an agent's
+// context window. Empty output (no failed steps, or run not in a failed state)
+// is valid and exits 0.
+func runLogFailed(ctx context.Context, client *apiclient.Client, r *apiclient.RunV3) error {
+	workflows, err := client.GetRunWorkflowsV3(ctx, r.ID)
+	if err != nil {
+		if httpcl.HasStatusCode(err, http.StatusNotFound) {
+			return nil // no workflows yet — nothing to report
+		}
+		return apiErr(err, r.ID.String())
+	}
+
+	var out strings.Builder
+
+	for _, wf := range workflows {
+		wfWritten := false
+
+		jobs, err := client.GetWorkflowJobsV3(ctx, wf.ID)
+		if err != nil {
+			return apiErr(err, wf.ID.String())
+		}
+
+		for _, j := range jobs {
+			jobDetail, err := client.GetJobV3(ctx, j.ID)
+			if err != nil {
+				return apiErr(err, j.ID.String())
+			}
+
+			// Collect executions that contain at least one failed step.
+			type failedExec struct {
+				exec  apiclient.JobV3Execution
+				steps []apiclient.JobV3Step // only the failed steps
+			}
+			var failed []failedExec
+			for _, exec := range jobDetail.Executions {
+				var failedSteps []apiclient.JobV3Step
+				for _, step := range exec.Steps {
+					if step.Outcome == "failed" {
+						failedSteps = append(failedSteps, step)
+					}
+				}
+				if len(failedSteps) > 0 {
+					failed = append(failed, failedExec{exec: exec, steps: failedSteps})
+				}
+			}
+			if len(failed) == 0 {
+				continue
+			}
+
+			// Lazy-write the workflow header the first time we have output for it.
+			if !wfWritten {
+				fmt.Fprintf(&out, "## workflow: %s\n\n", wf.Name)
+				wfWritten = true
+			}
+
+			totalExecs := len(jobDetail.Executions)
+			failedCount := len(failed)
+
+			for _, fe := range failed {
+				// Job header: include execution index and failure count only for
+				// parallel jobs (more than one execution total).
+				if totalExecs > 1 {
+					fmt.Fprintf(&out, "### job: %s (execution %d, %d of %d failed)\n\n",
+						j.Name, fe.exec.Index, failedCount, totalExecs)
+				} else {
+					fmt.Fprintf(&out, "### job: %s\n\n", j.Name)
+				}
+
+				for _, step := range fe.steps {
+					if step.ExitCode != nil {
+						fmt.Fprintf(&out, "#### step %d: %s [exit: %d]\n\n", step.Num, step.Name, *step.ExitCode)
+					} else {
+						fmt.Fprintf(&out, "#### step %d: %s\n\n", step.Num, step.Name)
+					}
+
+					condensed, err := client.GetJobStdoutCondensed(ctx, j.ID, fe.exec.Index, step.Num)
+					if err != nil {
+						if httpcl.HasStatusCode(err, http.StatusNotFound) {
+							condensed = nil
+						} else {
+							return apiErr(err, fmt.Sprintf("step %d of job %s", step.Num, j.ID))
+						}
+					}
+
+					if len(bytes.TrimSpace(condensed)) == 0 {
+						out.WriteString("(no output)\n\n")
+					} else {
+						out.Write(condensed)
+						if !bytes.HasSuffix(condensed, []byte("\n")) {
+							out.WriteString("\n")
+						}
+						out.WriteString("\n")
+					}
+				}
+			}
+		}
+	}
+
+	if out.Len() > 0 {
+		iostream.Print(ctx, out.String())
+	}
+	return nil
+}

--- a/internal/cmd/run/failed_context.go
+++ b/internal/cmd/run/failed_context.go
@@ -34,14 +34,14 @@ import (
 	"github.com/CircleCI-Public/circleci-cli/internal/iostream"
 )
 
-// runLogFailed prints condensed output for every failed step in the run,
+// runFailureReport prints condensed output for every failed step in the run,
 // organised as workflow → job → execution → step headers. It is the output path
-// for --log-failed and never enters the TUI.
+// for --failure-report and never enters the TUI.
 //
 // Output is written to stdout so it can be piped directly into an agent's
 // context window. Empty output (no failed steps, or run not in a failed state)
 // is valid and exits 0.
-func runLogFailed(ctx context.Context, client *apiclient.Client, r *apiclient.RunV3) error {
+func runFailureReport(ctx context.Context, client *apiclient.Client, r *apiclient.RunV3) error {
 	workflows, err := client.GetRunWorkflowsV3(ctx, r.ID)
 	if err != nil {
 		if httpcl.HasStatusCode(err, http.StatusNotFound) {

--- a/internal/cmd/run/get.go
+++ b/internal/cmd/run/get.go
@@ -40,6 +40,7 @@ import (
 	"github.com/CircleCI-Public/circleci-cli/internal/cmd/job"
 	"github.com/CircleCI-Public/circleci-cli/internal/cmd/workflow"
 	"github.com/CircleCI-Public/circleci-cli/internal/cmdutil"
+	clierrors "github.com/CircleCI-Public/circleci-cli/internal/errors"
 	"github.com/CircleCI-Public/circleci-cli/internal/gitremote"
 	"github.com/CircleCI-Public/circleci-cli/internal/httpcl"
 	"github.com/CircleCI-Public/circleci-cli/internal/iostream"
@@ -121,6 +122,12 @@ func newGetCmd() *cobra.Command {
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+			if logFailed && (jsonOut || cmd.Flags().Changed("jq")) {
+				return clierrors.New("run.log_failed_no_json",
+					"--log-failed cannot be combined with --json or --jq",
+					"--log-failed prints plain-text output for agent consumption and does not support JSON formatting.").
+					WithExitCode(clierrors.ExitBadArguments)
+			}
 			client, err := cmdutil.LoadClient(ctx)
 			if err != nil {
 				return err

--- a/internal/cmd/run/get.go
+++ b/internal/cmd/run/get.go
@@ -66,7 +66,7 @@ func newGetCmd() *cobra.Command {
 		jsonOut       bool
 		mine          bool
 		noInteractive bool
-		logFailed     bool
+		failureReport bool
 	)
 
 	cmd := &cobra.Command{
@@ -122,17 +122,17 @@ func newGetCmd() *cobra.Command {
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
-			if logFailed && (jsonOut || cmd.Flags().Changed("jq")) {
-				return clierrors.New("run.log_failed_no_json",
-					"--log-failed cannot be combined with --json or --jq",
-					"--log-failed prints plain-text output for agent consumption and does not support JSON formatting.").
+			if failureReport && (jsonOut || cmd.Flags().Changed("jq")) {
+				return clierrors.New("run.failure_report_no_json",
+					"--failure-report cannot be combined with --json or --jq",
+					"--failure-report prints plain-text output for agent consumption and does not support JSON formatting.").
 					WithExitCode(clierrors.ExitBadArguments)
 			}
 			client, err := cmdutil.LoadClient(ctx)
 			if err != nil {
 				return err
 			}
-			return runGet(ctx, client, args, projectSlug, branch, jsonOut, mine, noInteractive, logFailed)
+			return runGet(ctx, client, args, projectSlug, branch, jsonOut, mine, noInteractive, failureReport)
 		},
 	}
 
@@ -140,7 +140,7 @@ func newGetCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&branch, "branch", "b", "", "Branch name (defaults to the current branch, or main when --project is set)")
 	cmd.Flags().BoolVarP(&mine, "mine", "m", false, "Filter to runs owned by you.")
 	cmd.Flags().BoolVar(&noInteractive, "no-interactive", false, "Skip the interactive picker and resolve the latest run directly")
-	cmd.Flags().BoolVar(&logFailed, "log-failed", false, "Print condensed output for every failed step; intended for agent consumption")
+	cmd.Flags().BoolVar(&failureReport, "failure-report", false, "Print condensed output for every failed step; intended for agent consumption")
 	cmdutil.AddJSONFlag(cmd, &jsonOut)
 	cmdutil.AddJQFlag(cmd)
 
@@ -210,13 +210,13 @@ type jobOutput struct {
 	Type           string    `json:"type,omitempty"`
 }
 
-func runGet(ctx context.Context, client *apiclient.Client, args []string, projectSlug, branch string, jsonOut, mine, noInteractive, logFailed bool) error {
-	// --log-failed always bypasses the TUI — it is an output-mode flag.
+func runGet(ctx context.Context, client *apiclient.Client, args []string, projectSlug, branch string, jsonOut, mine, noInteractive, failureReport bool) error {
+	// --failure-report always bypasses the TUI — it is an output-mode flag.
 	// With no run ID and an interactive terminal, walk the user through a series
 	// of pickers (run → workflow → job) instead of silently resolving the latest
 	// run. JSON output stays non-interactive so scripting is unaffected, and
 	// --no-interactive forces the same direct latest-run lookup in a TTY.
-	if len(args) == 0 && !jsonOut && !noInteractive && !logFailed && iostream.IsInteractive(ctx) {
+	if len(args) == 0 && !jsonOut && !noInteractive && !failureReport && iostream.IsInteractive(ctx) {
 		return runGetInteractive(ctx, client, projectSlug, branch, mine)
 	}
 
@@ -276,8 +276,8 @@ func runGet(ctx context.Context, client *apiclient.Client, args []string, projec
 		r = &runs[0]
 	}
 
-	if logFailed {
-		return runLogFailed(ctx, client, r)
+	if failureReport {
+		return runFailureReport(ctx, client, r)
 	}
 	return displayRun(ctx, client, r, jsonOut)
 }

--- a/internal/cmd/run/get.go
+++ b/internal/cmd/run/get.go
@@ -65,6 +65,7 @@ func newGetCmd() *cobra.Command {
 		jsonOut       bool
 		mine          bool
 		noInteractive bool
+		logFailed     bool
 	)
 
 	cmd := &cobra.Command{
@@ -124,7 +125,7 @@ func newGetCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return runGet(ctx, client, args, projectSlug, branch, jsonOut, mine, noInteractive)
+			return runGet(ctx, client, args, projectSlug, branch, jsonOut, mine, noInteractive, logFailed)
 		},
 	}
 
@@ -132,6 +133,7 @@ func newGetCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&branch, "branch", "b", "", "Branch name (defaults to the current branch, or main when --project is set)")
 	cmd.Flags().BoolVarP(&mine, "mine", "m", false, "Filter to runs owned by you.")
 	cmd.Flags().BoolVar(&noInteractive, "no-interactive", false, "Skip the interactive picker and resolve the latest run directly")
+	cmd.Flags().BoolVar(&logFailed, "log-failed", false, "Print condensed output for every failed step; intended for agent consumption")
 	cmdutil.AddJSONFlag(cmd, &jsonOut)
 	cmdutil.AddJQFlag(cmd)
 
@@ -201,12 +203,13 @@ type jobOutput struct {
 	Type           string    `json:"type,omitempty"`
 }
 
-func runGet(ctx context.Context, client *apiclient.Client, args []string, projectSlug, branch string, jsonOut, mine, noInteractive bool) error {
+func runGet(ctx context.Context, client *apiclient.Client, args []string, projectSlug, branch string, jsonOut, mine, noInteractive, logFailed bool) error {
+	// --log-failed always bypasses the TUI — it is an output-mode flag.
 	// With no run ID and an interactive terminal, walk the user through a series
 	// of pickers (run → workflow → job) instead of silently resolving the latest
 	// run. JSON output stays non-interactive so scripting is unaffected, and
 	// --no-interactive forces the same direct latest-run lookup in a TTY.
-	if len(args) == 0 && !jsonOut && !noInteractive && iostream.IsInteractive(ctx) {
+	if len(args) == 0 && !jsonOut && !noInteractive && !logFailed && iostream.IsInteractive(ctx) {
 		return runGetInteractive(ctx, client, projectSlug, branch, mine)
 	}
 
@@ -266,6 +269,9 @@ func runGet(ctx context.Context, client *apiclient.Client, args []string, projec
 		r = &runs[0]
 	}
 
+	if logFailed {
+		return runLogFailed(ctx, client, r)
+	}
 	return displayRun(ctx, client, r, jsonOut)
 }
 


### PR DESCRIPTION
Prints condensed output for every failed step in a run, organized as workflow -> job -> execution -> step, and always bypasses the interactive TUI. Intended for piping run failures into an agent's context window.

<!--
  Thank you for contributing to CircleCI CLI!
  For PRs adding new features, please raise an issue first.
-->
