### PR TITLE
Reload config after signup so project setup continues

### DIFF
--- a/acceptance/onboard_test.go
+++ b/acceptance/onboard_test.go
@@ -372,6 +372,77 @@ func TestOnboard_PostSignup_CreateFails(t *testing.T) {
 	assert.Check(t, strings.Contains(result.Stdout, "circleci project create"))
 }
 
+// TestOnboard_PostSignup_FreshSignup_ContinuesToProjectSetup is a regression test
+// for a fresh signup dead-ending before project creation.
+//
+// Signup writes the token to disk part-way through the run, but the config cached
+// in the context was loaded during bootstrap — before that write — so without a
+// reload LoadClient sees no token and project creation degrades to manual
+// guidance, on the one run where the user just signed up.
+//
+// This test must NOT set env.Token: CIRCLE_TOKEN is read ahead of the cached
+// config, which masks the bug, and is why the other post-signup tests never
+// caught it.
+func TestOnboard_PostSignup_FreshSignup_ContinuesToProjectSetup(t *testing.T) {
+	dir := t.TempDir()
+	initGitRepoWithRemote(t, dir, "https://github.com/myorg/my-repo.git")
+
+	fake := fakes.NewCircleCI(t)
+	fake.SetMe(map[string]any{
+		"id": "e4a72497-7c55-400d-a72d-dadc4b92255d",
+		"attributes": map[string]any{
+			"name":  "New User",
+			"login": "newuser",
+		},
+	})
+	fake.SetOAuthTokenResponse(map[string]any{
+		"access_token": "test-signup-token",
+		"token_type":   "Bearer",
+		"expires_in":   int64(7776000),
+	})
+	fake.SetCollaborations([]any{
+		map[string]any{"id": "org-uuid-1234", "name": "myorg", "slug": "circleci/myorg", "vcs_type": "circleci"},
+	})
+	fake.SetCreateProjectResponse(map[string]any{
+		"id":                "proj-uuid-5678",
+		"slug":              "circleci/Org1234ShortId/Proj5678ShortId",
+		"name":              "my-repo",
+		"organization_name": "myorg",
+		"organization_slug": "circleci/Org1234ShortId",
+		"organization_id":   "org-uuid-1234",
+	})
+
+	env := testenv.New(t)
+	env.CircleCIURL = fake.URL()
+	// Deliberately no env.Token — see the note above.
+	env.Extra["CIRCLE_LOGIN_TIMEOUT"] = "20s"
+	// Suppress the project-name prompt so the run completes without further input.
+	env.Extra["CIRCLE_NO_INTERACTIVE"] = "true"
+
+	console := binary.RunCLIInteractive(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"onboard", "--signup", "--no-browser"},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	assert.Assert(t, t.Run("waits for browser callback", func(t *testing.T) {
+		_, err := console.ExpectString("Waiting for browser authentication")
+		assert.NilError(t, err)
+	}))
+
+	assert.Assert(t, t.Run("browser callback", func(t *testing.T) {
+		callbackViaPAR(t, fake)
+	}))
+
+	assert.Assert(t, t.Run("continues into project creation", func(t *testing.T) {
+		_, err := console.ExpectString("Logged in as newuser")
+		assert.NilError(t, err)
+		_, err = console.ExpectString("Project created: my-repo")
+		assert.NilError(t, err)
+	}))
+}
+
 func onboardStandaloneEnv(t *testing.T, login string) (*fakes.CircleCI, *testenv.TestEnv) {
 	t.Helper()
 

--- a/internal/cmd/cmdauth/auth.go
+++ b/internal/cmd/cmdauth/auth.go
@@ -68,7 +68,7 @@ func NewAuthCmd() *cobra.Command {
 // "Saved token to <path>" status line on stderr. Shared by `auth login`
 // (after OAuth token exchange) and `auth token` (after the TUI prompt).
 func persistToken(ctx context.Context, host, token string, userID uuid.UUID, secureStorage bool, path string) error {
-	res, err := config.SetLogin(ctx, host, token, userID, secureStorage)
+	res, err := config.SetLogin(ctx, path, host, token, userID, secureStorage)
 	if err != nil {
 		return clierrors.New("auth.save_failed", "Failed to save token", err.Error()).
 			WithExitCode(clierrors.ExitGeneralError)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -201,8 +201,14 @@ type SaveResult struct {
 	KeyringErr error
 }
 
-func SetLogin(ctx context.Context, host, token string, userID uuid.UUID, secureStorage bool) (SaveResult, error) {
-	return saveToIncludingToken(ctx, "", secureStorage, func(cfg *Config) error {
+// SetLogin persists the host, token, and user ID to path, or to the default XDG
+// location when path is empty.
+//
+// Honouring path matters because the caller reports it as the save location and
+// may re-read it afterwards; writing elsewhere makes both the message and the
+// re-read describe a file that was never written.
+func SetLogin(ctx context.Context, path, host, token string, userID uuid.UUID, secureStorage bool) (SaveResult, error) {
+	return saveToIncludingToken(ctx, path, secureStorage, func(cfg *Config) error {
 		cfg.state.Host = host
 		cfg.state.Token = token
 		cfg.state.UserID = &userID

--- a/internal/onboarder/onboarder.go
+++ b/internal/onboarder/onboarder.go
@@ -34,6 +34,7 @@ import (
 	"github.com/CircleCI-Public/circleci-cli/internal/apiclient"
 	"github.com/CircleCI-Public/circleci-cli/internal/cmd/cmdauth"
 	"github.com/CircleCI-Public/circleci-cli/internal/cmdutil"
+	"github.com/CircleCI-Public/circleci-cli/internal/config"
 	"github.com/CircleCI-Public/circleci-cli/internal/configgen"
 	clierrors "github.com/CircleCI-Public/circleci-cli/internal/errors"
 	"github.com/CircleCI-Public/circleci-cli/internal/gitremote"
@@ -81,7 +82,7 @@ func Run(ctx context.Context, dir string, opts Options) error {
 			"mode":    "signup",
 			"outcome": string(result.Outcome),
 		})
-		return postSignupGuidance(ctx)
+		return postSignupGuidance(ctx, opts)
 	}
 
 	dir, err = filepath.Abs(dir)
@@ -157,7 +158,29 @@ func Run(ctx context.Context, dir string, opts Options) error {
 		"outcome": string(signupResult.Outcome),
 	})
 
-	return postSignupGuidance(ctx)
+	return postSignupGuidance(ctx, opts)
+}
+
+// refreshConfig re-reads the config from disk when the cached copy carries no
+// token.
+//
+// A fresh signup persists the token to the keyring (or the config file), but the
+// *config.Config in ctx was loaded during root's bootstrap — before that write —
+// so it still looks unauthenticated. Without this reload, LoadClient fails with
+// auth.token_missing on the very run that just signed the user up, and project
+// creation degrades to manual guidance.
+//
+// A reload failure is not fatal: returning the unchanged ctx degrades exactly as
+// it would have anyway.
+func refreshConfig(ctx context.Context, opts Options) context.Context {
+	if cmdutil.GetConfig(ctx).EffectiveToken() != "" {
+		return ctx
+	}
+	cfg, err := config.Load(ctx, opts.ConfigPath, opts.SecureStorage)
+	if err != nil {
+		return ctx
+	}
+	return cmdutil.WithConfig(ctx, cfg)
 }
 
 // postSignupGuidance offers inline project creation and prints a follow-up
@@ -165,7 +188,9 @@ func Run(ctx context.Context, dir string, opts Options) error {
 //
 // Errors are handled gracefully: project creation failure falls through to
 // manual guidance rather than failing the onboard command.
-func postSignupGuidance(ctx context.Context) error {
+func postSignupGuidance(ctx context.Context, opts Options) error {
+	ctx = refreshConfig(ctx, opts)
+
 	client, err := cmdutil.LoadClient(ctx)
 	if err != nil {
 		printManualGuidance(ctx)


### PR DESCRIPTION
## Summary

A fresh signup dead-ends before project creation. Signup persists the token to the keyring or the config file, but the `*config.Config` carried in the context was loaded during root's bootstrap — before that write — so `postSignupGuidance` calls `LoadClient` against a config with no token, gets `auth.token_missing`, and swallows it into manual guidance.

The run that just signed a user up is therefore the one run that never goes on to create their project.

The config is now re-read from disk when the cached copy has no token. The already-authenticated path is untouched and pays no extra keyring read.

`config.SetLogin` ignored the path it was given and always wrote to the default XDG location, so under `--config` the reload above would read a file the token was never written to. Fixed here because the reload depends on it. Its siblings (`SetToken`, `SetLogout`) share the bug but have no caller that re-reads, so they are left for a separate change.

## Why no existing test caught it

Every pre-existing post-signup test supplies a token via `CIRCLE_TOKEN`, and `EffectiveToken` reads that env var *ahead of* the cached config — which masks the bug entirely. The new test deliberately sets no token and drives the real OAuth flow (PAR → loopback callback → token exchange) against the fake server, so the mid-run token write is genuinely exercised.

## Test plan

- [ ] `task test` passes
- [ ] Fresh signup with no `CIRCLE_TOKEN` continues to "Project created" — verified failing before the fix (`EOF` waiting for that line), passing after
- [ ] Existing onboard and auth suites unaffected

First of four stacked PRs extracted from #1647; this one is independent of the rest and fixes behaviour already on `main`.