### PR TITLE
Address a project link by the slug its project type accepts

### DIFF
--- a/acceptance/link_test.go
+++ b/acceptance/link_test.go
@@ -145,27 +145,28 @@ func TestProjectLink_NoToken(t *testing.T) {
 	assert.Check(t, os.IsNotExist(statErr), "info.yml should not be written without a token")
 }
 
-// Once a checkout is linked, subsequent commands should resolve the project
-// from info.yml — using the canonical "circleci/<orgID>/<projectID>" slug
-// when info.yml carries the UUIDs, even though the git remote (if any)
-// would have produced a "gh/org/repo"-style slug.
+// Once a checkout is linked, subsequent commands resolve the project from
+// info.yml. For a CircleCI-native project that means the canonical
+// "circleci/<orgID>/<projectID>" slug built from the recorded IDs, so resolution
+// survives a slug change on the CircleCI side.
 func TestProjectGet_UsesLinkedUUIDs(t *testing.T) {
-	const standaloneSlug = "circleci/E6i3yYZeWZhcf8UNqcKfjN/13c8F7nusayivoSxC6GMsw"
+	const canonicalSlug = "circleci/E6i3yYZeWZhcf8UNqcKfjN/13c8F7nusayivoSxC6GMsw"
+	const linkedSlug = "circleci/OldOrgShortId/OldProjShortId"
 
 	fake := fakes.NewCircleCI(t)
-	// Only register the standalone (UUID-form) slug. If `project get` falls
-	// back to a VCS-style slug for any reason, the API will return 404.
-	fake.AddProjectInfo(standaloneSlug, map[string]any{
+	// Only register the ID-form slug for the lookup under test. If `project get`
+	// used the stored slug instead, the fake would 404.
+	fake.AddProjectInfo(canonicalSlug, map[string]any{
 		"id":              "13c8F7nusayivoSxC6GMsw",
-		"slug":            standaloneSlug,
+		"slug":            canonicalSlug,
 		"name":            "linked",
 		"organization_id": "E6i3yYZeWZhcf8UNqcKfjN",
 	})
-	// Also register the VCS slug used during link, so the initial link call succeeds.
-	fake.AddProjectInfo("gh/myorg/alpha", map[string]any{
+	// Register the slug passed to link, so the initial link call succeeds.
+	fake.AddProjectInfo(linkedSlug, map[string]any{
 		"id":              "13c8F7nusayivoSxC6GMsw",
-		"slug":            "gh/myorg/alpha",
-		"name":            "alpha",
+		"slug":            linkedSlug,
+		"name":            "linked",
 		"organization_id": "E6i3yYZeWZhcf8UNqcKfjN",
 	})
 
@@ -177,14 +178,14 @@ func TestProjectGet_UsesLinkedUUIDs(t *testing.T) {
 
 	link := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
-		Args:    []string{"project", "link", "--project", "gh/myorg/alpha"},
+		Args:    []string{"project", "link", "--project", linkedSlug},
 		Env:     env.Environ(),
 		WorkDir: workDir,
 	})
 	assert.Equal(t, link.ExitCode, 0, "link stderr: %s", link.Stderr)
 
-	// Now run `project get` with no --project flag. It must resolve via
-	// info.yml and hit the standalone (UUID) endpoint, NOT the VCS slug.
+	// `project get` with no --project must resolve via info.yml, rebuilding the
+	// ID-form slug rather than reusing the one that was linked.
 	get := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
 		Args:    []string{"project", "get", "--json"},
@@ -192,7 +193,52 @@ func TestProjectGet_UsesLinkedUUIDs(t *testing.T) {
 		WorkDir: workDir,
 	})
 	assert.Equal(t, get.ExitCode, 0, "get stderr: %s", get.Stderr)
-	assert.Check(t, strings.Contains(get.Stdout, standaloneSlug), "stdout: %s", get.Stdout)
+	assert.Check(t, strings.Contains(get.Stdout, canonicalSlug), "stdout: %s", get.Stdout)
+}
+
+// TestProjectGet_ClassicLinkUsesOwnSlug is the counterpart: a classic VCS project
+// resolves by its own "<vcs>/<org>/<repo>" slug.
+//
+// `circleci project link` records org and project IDs for every project type, but
+// the "circleci/<orgID>/<projectID>" form addresses CircleCI-native projects only.
+// The real API answers 404 for a classic project addressed that way, whatever its
+// recorded IDs are — so rebuilding the slug there breaks every command that
+// resolves a project from a linked checkout.
+func TestProjectGet_ClassicLinkUsesOwnSlug(t *testing.T) {
+	const classicSlug = "gh/myorg/alpha"
+
+	fake := fakes.NewCircleCI(t)
+	// Only the classic slug is registered, mirroring the real API: an ID-form
+	// lookup for this project 404s.
+	fake.AddProjectInfo(classicSlug, map[string]any{
+		"id":              "52404b72-02fb-482e-9bd8-846bbc048eea",
+		"slug":            classicSlug,
+		"name":            "alpha",
+		"organization_id": "c1e89d5c-d2e5-4db2-b2d7-a35cf73160ad",
+	})
+
+	env := testenv.New(t)
+	env.Token = testToken
+	env.CircleCIURL = fake.URL()
+
+	workDir := t.TempDir()
+
+	link := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"project", "link", "--project", classicSlug},
+		Env:     env.Environ(),
+		WorkDir: workDir,
+	})
+	assert.Equal(t, link.ExitCode, 0, "link stderr: %s", link.Stderr)
+
+	get := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"project", "get", "--json"},
+		Env:     env.Environ(),
+		WorkDir: workDir,
+	})
+	assert.Equal(t, get.ExitCode, 0, "get stderr: %s", get.Stderr)
+	assert.Check(t, strings.Contains(get.Stdout, classicSlug), "stdout: %s", get.Stdout)
 }
 
 // Refuses to overwrite an existing info.yml without --force.

--- a/internal/gitremote/detect.go
+++ b/internal/gitremote/detect.go
@@ -79,18 +79,34 @@ func DetectNamespace() (string, error) {
 	return parts[1], nil
 }
 
-// DetectRepoName returns the repository name from the git remote, or "" if it
-// cannot be detected.
+// DetectRepoName returns a human-readable name for the checkout in the working
+// directory, or "" when none can be determined. Callers use it as the suggested
+// project name.
+//
+// The git remote is preferred. It is read directly rather than through Detect,
+// which prefers .circleci/info.yml: a linked standalone project's slug is
+// "circleci/<orgID>/<projectID>", so its last segment is an opaque ID — useless as
+// a name to show a user.
+//
+// When the remote cannot be read — no origin, no origin/HEAD, an unsupported host
+// — the name recorded by `circleci project link` is used instead. That is the only
+// other place a readable name for this checkout exists, and without it a linked
+// repository with no usable remote would offer no name at all.
 func DetectRepoName() string {
-	info, err := Detect()
+	if info, err := DetectFromRemote(); err == nil {
+		if parts := strings.Split(info.Slug, "/"); len(parts) == 3 {
+			return parts[2]
+		}
+	}
+	cwd, err := os.Getwd()
 	if err != nil {
 		return ""
 	}
-	parts := strings.Split(info.Slug, "/")
-	if len(parts) == 3 {
-		return parts[2]
+	ref, err := projectref.Read(cwd)
+	if err != nil {
+		return ""
 	}
-	return ""
+	return ref.Project.Name
 }
 
 // Detect resolves the CircleCI project for the current working directory.
@@ -164,10 +180,20 @@ func gitBranches() (branch, defaultBranch string) {
 // — reading info.yml there would short-circuit the very write that link is
 // about to perform.
 func DetectFromRemote() (_ *ProjectInfo, err error) {
+	return DetectFromRemoteIn("")
+}
+
+// DetectFromRemoteIn is DetectFromRemote scoped to the repository containing dir.
+// An empty dir means the process working directory.
+//
+// Commands that accept a directory argument must use this: reading the process
+// working directory instead would describe a different repository than the one
+// being operated on — or an enclosing one, since detection walks upward.
+func DetectFromRemoteIn(dir string) (_ *ProjectInfo, err error) {
 	// Both "not a git repo" and "repo without an origin remote" surface as the
 	// same user-facing failure, matching the previous `git remote get-url`
 	// behaviour.
-	repo, err := openRepo()
+	repo, err := openRepoIn(dir)
 	if err != nil {
 		return nil, fmt.Errorf("could not read git remote: %w", err)
 	}
@@ -252,11 +278,41 @@ func buildSlug(host, org, repo string) (string, error) {
 // extra option. Callers must Close the returned repository to release its file
 // handles (Windows cannot delete files with open handles — see the tests).
 func openRepo() (*git.Repository, error) {
-	cwd, err := os.Getwd()
+	return openRepoIn("")
+}
+
+// RepoRootIn returns the root of the working tree containing dir, or an error
+// when dir is not inside a git repository. An empty dir means the process working
+// directory.
+//
+// Callers that write files describing the repository use this so that running
+// from a subdirectory records them at the root, where they belong, rather than
+// wherever the command happened to be invoked.
+func RepoRootIn(dir string) (_ string, err error) {
+	repo, err := openRepoIn(dir)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
-	return git.PlainOpenWithOptions(cwd, &git.PlainOpenOptions{DetectDotGit: true})
+	defer closer.ErrorHandler(repo, &err)
+
+	wt, err := repo.Worktree()
+	if err != nil {
+		return "", err
+	}
+	return wt.Filesystem().Root(), nil
+}
+
+// openRepoIn opens the repository containing dir, walking upward to find it. An
+// empty dir means the process working directory.
+func openRepoIn(dir string) (*git.Repository, error) {
+	if dir == "" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return nil, err
+		}
+		dir = cwd
+	}
+	return git.PlainOpenWithOptions(dir, &git.PlainOpenOptions{DetectDotGit: true})
 }
 
 // gitOriginURL returns the first configured URL for the "origin" remote,

--- a/internal/gitremote/detect_test.go
+++ b/internal/gitremote/detect_test.go
@@ -115,16 +115,31 @@ func TestDetect_PrefersInfoYml(t *testing.T) {
 		wantOrgID string
 	}{
 		{
-			name: "uuids present yields canonical slug",
+			name: "circleci slug with uuids yields canonical slug",
 			info: projectref.Info{
 				Organization: projectref.Organization{ID: "E6i3yYZeWZhcf8UNqcKfjN"},
 				Project: projectref.Project{
-					Slug: "gh/myorg/myrepo",
+					Slug: "circleci/OrgShortId/ProjShortId",
 					ID:   "13c8F7nusayivoSxC6GMsw",
 				},
 			},
 			wantSlug:  "circleci/E6i3yYZeWZhcf8UNqcKfjN/13c8F7nusayivoSxC6GMsw",
 			wantOrgID: "E6i3yYZeWZhcf8UNqcKfjN",
+		},
+		{
+			// The ID form addresses CircleCI-native projects only — the API answers
+			// 404 for a classic project addressed that way, even though
+			// `circleci project link` records both IDs for one.
+			name: "classic slug with uuids keeps its own slug",
+			info: projectref.Info{
+				Organization: projectref.Organization{ID: "c1e89d5c-d2e5-4db2-b2d7-a35cf73160ad"},
+				Project: projectref.Project{
+					Slug: "gh/myorg/myrepo",
+					ID:   "52404b72-02fb-482e-9bd8-846bbc048eea",
+				},
+			},
+			wantSlug:  "gh/myorg/myrepo",
+			wantOrgID: "c1e89d5c-d2e5-4db2-b2d7-a35cf73160ad",
 		},
 		{
 			name:     "slug-only falls through verbatim",
@@ -173,6 +188,83 @@ func TestDetect_SurfacesMalformedInfoYml(t *testing.T) {
 
 	_, err = Detect()
 	assert.Check(t, err != nil, "expected Detect to surface a malformed info.yml rather than fall back")
+}
+
+// TestDetectRepoName_IgnoresInfoYml pins DetectRepoName to the git remote. A
+// linked standalone project records "circleci/<orgID>/<projectID>" in info.yml,
+// so resolving through Detect would hand callers an opaque project ID where they
+// show the user a suggested project name (onboard, `project create`).
+func TestDetectRepoName_IgnoresInfoYml(t *testing.T) {
+	dir := t.TempDir()
+	repo, err := git.PlainInit(dir, false)
+	assert.NilError(t, err)
+	_, err = repo.CreateRemote(&config.RemoteConfig{
+		Name: "origin",
+		URLs: []string{"https://github.com/myorg/my-repo.git"},
+	})
+	assert.NilError(t, err)
+
+	// Detection needs a resolvable HEAD and an origin/HEAD symref. Signing is
+	// disabled locally so an ambient commit.gpgSign=true cannot fail the commit.
+	cfg, err := repo.Config()
+	assert.NilError(t, err)
+	cfg.Raw.Section("commit").SetOption("gpgsign", "false")
+	assert.NilError(t, repo.SetConfig(cfg))
+
+	wt, err := repo.Worktree()
+	assert.NilError(t, err)
+	commit, err := wt.Commit("init", &git.CommitOptions{
+		AllowEmptyCommits: true,
+		Author:            &object.Signature{Name: "test", Email: "test@test.com"},
+	})
+	assert.NilError(t, err)
+	assert.NilError(t, repo.Storer.SetReference(
+		plumbing.NewHashReference("refs/remotes/origin/main", commit)))
+	assert.NilError(t, repo.Storer.SetReference(
+		plumbing.NewSymbolicReference("refs/remotes/origin/HEAD", "refs/remotes/origin/main")))
+
+	assert.NilError(t, projectref.Write(dir, &projectref.Info{
+		Organization: projectref.Organization{ID: "3b524838-a95e-44eb-bc56-deb0af23ef19"},
+		Project: projectref.Project{
+			Slug: "circleci/8KsBMffqgArk2xVzYAC5ag/Y5nuJ5ZzavVEhGCEjV2rfA",
+			ID:   "fbb68fb9-71c3-4b79-a9be-68721332e871",
+			Name: "my-repo",
+		},
+	}))
+
+	cwd, err := os.Getwd()
+	assert.NilError(t, err)
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	assert.NilError(t, os.Chdir(dir))
+
+	assert.Check(t, cmp.Equal(DetectRepoName(), "my-repo"))
+}
+
+// TestDetectRepoName_FallsBackToLinkedName pins the fallback for a checkout whose
+// remote cannot be read — no origin, no origin/HEAD, or a host the slug parser does
+// not recognise. The name recorded by `circleci project link` is the only other
+// readable name for the checkout, and without it callers would have no default at
+// all: `project create` fails with a missing-name error and onboard abandons
+// project setup.
+func TestDetectRepoName_FallsBackToLinkedName(t *testing.T) {
+	dir := t.TempDir() // no git repository at all, so the remote is unreadable
+	writeErr := projectref.Write(dir, &projectref.Info{
+		Organization: projectref.Organization{ID: "org-uuid"},
+		Project: projectref.Project{
+			Slug: "gh/myorg/api",
+			ID:   "proj-uuid",
+			Name: "api",
+		},
+	})
+	assert.NilError(t, writeErr)
+
+	cwd, err := os.Getwd()
+	assert.NilError(t, err)
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	chdirErr := os.Chdir(dir)
+	assert.NilError(t, chdirErr)
+
+	assert.Check(t, cmp.Equal(DetectRepoName(), "api"))
 }
 
 // Sanity check that DetectFromRemote does not consult info.yml — used by

--- a/internal/projectref/projectref.go
+++ b/internal/projectref/projectref.go
@@ -33,6 +33,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -75,15 +76,21 @@ type Project struct {
 }
 
 // EffectiveSlug returns the slug to use when calling the CircleCI API.
-// When both Project.ID and Organization.ID are known, the canonical
-// "circleci/<orgID>/<projectID>" form is returned so the lookup is stable
-// across VCS-side renames; otherwise the stored Project.Slug is returned
-// as-is.
+//
+// For a CircleCI-native project — one whose stored slug is already a "circleci/"
+// slug — the canonical "circleci/<orgID>/<projectID>" form is returned when both
+// IDs are known, so the lookup is stable across renames. Anything else returns
+// the stored Project.Slug as-is.
+//
+// The ID form addresses CircleCI-native projects only. A classic VCS project must
+// be addressed by its own "<vcs>/<org>/<repo>" slug: the API answers 404 for the
+// ID form even though both IDs are valid and `circleci project link` records them
+// for every project type.
 func (i *Info) EffectiveSlug() string {
 	if i == nil {
 		return ""
 	}
-	if i.Project.ID != "" && i.Organization.ID != "" {
+	if strings.HasPrefix(i.Project.Slug, "circleci/") && i.Project.ID != "" && i.Organization.ID != "" {
 		return "circleci/" + i.Organization.ID + "/" + i.Project.ID
 	}
 	return i.Project.Slug


### PR DESCRIPTION
## Summary

`projectref.EffectiveSlug` rebuilt `circleci/<orgID>/<projectID>` whenever `.circleci/info.yml` carried both IDs. That form addresses **CircleCI-native projects only** — the API answers 404 for a classic VCS project addressed that way — and `circleci project link` records IDs for *every* project type.

Since `gitremote.Detect` goes through `EffectiveSlug`, **project resolution was broken for every command run in a checkout linked to a classic project**, not just onboarding.

Verified against the API on a single real project:

| Slug form | Result |
|---|---|
| `gh/<org>/<repo>` | **200** |
| `circleci/<orgUUID>/<projectUUID>` (same project) | **404** |

The ID form is now built only when the recorded slug is itself a `circleci/` slug. Native projects keep resolution that survives a slug change; everything else uses the slug that was validated when it was written.

## Two tests were asserting the bug

`TestProjectGet_UsesLinkedUUIDs` linked a **classic** `gh/…` slug and demanded the ID form back — the exact combination the API rejects — with a fake registered to serve it. Both project types are now covered explicitly, so the fake stops agreeing with an assumption the API does not share.

## Also here

- **`DetectRepoName`** reads the git remote directly, as its documentation always claimed, instead of going through `Detect` and returning the last segment of an opaque linked slug. When the remote cannot be read at all — no origin, no `origin/HEAD`, an unrecognised host — it falls back to the name recorded by `project link`. Without that fallback, `circleci project create` fails with a missing-name error in a repository that was linked the whole time.
- **`DetectFromRemoteIn` / `RepoRootIn`** — directory-scoped detection, for callers that take a path argument and must describe *that* checkout rather than the process working directory. Unused by production code in this PR; the consumer arrives in the next one.

## Test plan

- [ ] `task test` passes
- [ ] Linked classic project resolves by its own slug; linked native project still resolves by rebuilt IDs — both verified failing before the fix
- [ ] `DetectRepoName` prefers the remote, and falls back to the recorded name when there is none
- [ ] Existing `project get` / `project link` suites unaffected

Second of four stacked PRs from #1647. Fixes behaviour already on `main`, independent of the onboarding work.