### PR TITLE
Record and resolve the project link so onboard re-runs cleanly

### DIFF
--- a/acceptance/onboard_test.go
+++ b/acceptance/onboard_test.go
@@ -32,11 +32,18 @@ import (
 	"testing"
 
 	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/golden"
 
 	"github.com/CircleCI-Public/circleci-cli/internal/testing/binary"
 	testenv "github.com/CircleCI-Public/circleci-cli/internal/testing/env"
 	"github.com/CircleCI-Public/circleci-cli/internal/testing/fakes"
+)
+
+// Fixture IDs shared by the onboard tests.
+const (
+	onboardOrgID     = "org-uuid-1234"
+	onboardProjectID = "proj-uuid-5678"
 )
 
 func TestOnboard_PathInvalid(t *testing.T) {
@@ -301,7 +308,7 @@ func TestOnboard_PostSignup_ProjectCreated(t *testing.T) {
 	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
 	assert.Check(t, strings.Contains(result.Stdout, "Project created: my-repo"))
 	assert.Check(t, strings.Contains(result.Stdout, "Organization: myorg"))
-	assert.Check(t, strings.Contains(result.Stdout, "Commit .circleci/config.yml"))
+	assert.Check(t, cmp.Contains(result.Stdout, "Commit .circleci/"))
 }
 
 func TestOnboard_PostSignup_ClassicOrg_FollowsProject(t *testing.T) {
@@ -443,6 +450,163 @@ func TestOnboard_PostSignup_FreshSignup_ContinuesToProjectSetup(t *testing.T) {
 	}))
 }
 
+// onboardDotnetRepo builds the fixture shared by the post-signup tests: a dotnet
+// checkout with a GitHub remote, a fake CircleCI serving a CircleCI-native
+// organization, and an isolated environment pointed at it.
+//
+// Callers still wire their own fake dotnet binary, since whether the tests pass or
+// fail is the variable under test in some of them.
+// TestOnboard_PostSignup_Rerun_ReusesProject runs onboard twice over the same
+// repository. The first run creates the project and records it in
+// .circleci/info.yml; the second resolves it from that file instead of attempting
+// a create that could only conflict.
+//
+// That local record is what makes a re-run recoverable at all: a CircleCI-native
+// project slug is circleci/<orgID>/<projectID> — opaque IDs, not the repository
+// name — and no API maps a project name to its ID within an organization.
+func TestOnboard_PostSignup_Rerun_ReusesProject(t *testing.T) {
+	dir, fake, env := onboardDotnetRepo(t)
+	// The second run looks the project up by the slug projectref derives from the
+	// recorded UUIDs. The real API accepts that form and canonicalises it.
+	fake.AddProjectInfo("circleci/"+onboardOrgID+"/"+onboardProjectID, map[string]any{
+		"id":                onboardProjectID,
+		"slug":              "circleci/Org1234ShortId/Proj5678ShortId",
+		"name":              "my-repo",
+		"organization_name": "myorg",
+		"organization_slug": "circleci/Org1234ShortId",
+		"organization_id":   onboardOrgID,
+	})
+	addFakeDotnet(t, env, false)
+
+	first := binary.RunCLI(t, binary.RunOpts{
+		Binary: binaryPath, Args: []string{"onboard", "--scan"},
+		Env: env.Environ(), WorkDir: dir,
+	})
+	assert.Equal(t, first.ExitCode, 0, "stderr: %s", first.Stderr)
+	assert.Check(t, cmp.Contains(first.Stdout, "Project created: my-repo"))
+	assert.Check(t, cmp.Contains(first.Stdout, "Linked this repository to the project"))
+	_, statErr := os.Stat(filepath.Join(dir, ".circleci", "info.yml"))
+	assert.NilError(t, statErr, "first run should record the project locally")
+
+	second := binary.RunCLI(t, binary.RunOpts{
+		Binary: binaryPath, Args: []string{"onboard", "--scan"},
+		Env: env.Environ(), WorkDir: dir,
+	})
+	assert.Equal(t, second.ExitCode, 0, "stderr: %s", second.Stderr)
+	assert.Check(t, cmp.Contains(second.Stdout, "Using existing project: my-repo"))
+	assert.Check(t, !strings.Contains(second.Stdout, "Project created"),
+		"re-run should not create a second project")
+}
+
+// TestOnboard_PostSignup_KeepsExistingProjectRef pins that onboard never rewrites
+// an existing .circleci/info.yml. The file is meant to be committed, and it may
+// record a project in another organization that this run has no mandate to
+// replace — `circleci project link` requires --force for exactly that reason.
+func TestOnboard_PostSignup_KeepsExistingProjectRef(t *testing.T) {
+	dir, _, env := onboardDotnetRepo(t)
+
+	// A link to a project in a different organization, so it is ignored and onboard
+	// proceeds to create — the path that reaches the write.
+	existing := "organization:\n  id: other-org-uuid\n" +
+		"project:\n  id: other-proj-uuid\n  slug: gh/myorg/my-repo\n  name: my-repo\n"
+	refPath := filepath.Join(dir, ".circleci", "info.yml")
+	mkErr := os.MkdirAll(filepath.Dir(refPath), 0o755)
+	assert.NilError(t, mkErr)
+	writeErr := os.WriteFile(refPath, []byte(existing), 0o644)
+	assert.NilError(t, writeErr)
+	addFakeDotnet(t, env, false)
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary: binaryPath, Args: []string{"onboard", "--scan"},
+		Env: env.Environ(), WorkDir: dir,
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	body, readErr := os.ReadFile(refPath)
+	assert.NilError(t, readErr)
+	assert.Check(t, cmp.Equal(string(body), existing), "info.yml must be left byte-for-byte alone")
+	assert.Check(t, cmp.Contains(result.Stderr, "already records a different project"))
+	assert.Check(t, cmp.Contains(result.Stderr, "circleci project link --force --project"))
+	assert.Check(t, !strings.Contains(result.Stdout, "Using existing project"),
+		"a project in another organization must not be reused")
+}
+
+// TestOnboard_PostSignup_ProjectNameConflict covers a name collision onboard cannot
+// resolve: the organization already has a project with this name, but the checkout
+// has no info.yml recording its ID. Since a project cannot be looked up by name,
+// onboard points at `circleci project link` rather than reporting a raw conflict.
+func TestOnboard_PostSignup_ProjectNameConflict(t *testing.T) {
+	dir, fake, env := onboardDotnetRepo(t)
+	fake.SetCreateProjectConflict()
+	addFakeDotnet(t, env, false)
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary: binaryPath, Args: []string{"onboard", "--scan"},
+		Env: env.Environ(), WorkDir: dir,
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Check(t, cmp.Contains(result.Stderr, `project named "my-repo" already exists`))
+	assert.Check(t, cmp.Contains(result.Stdout, "circleci project link --project circleci/myorg/<projectID>"))
+	assert.Check(t, !strings.Contains(result.Stdout, "--force"), "no info.yml to overwrite")
+	// No raw HTTP internals for a conflict one command can resolve.
+	assert.Check(t, !strings.Contains(result.Stderr, "409"), "stderr should not leak an HTTP status")
+	assert.Check(t, !strings.Contains(result.Stderr, "/api/v2/"), "stderr should not leak an API path")
+}
+
+// TestOnboard_SignupFlag_RecordsProjectRefAtRepoRoot pins where --signup records the
+// link when run from a subdirectory. info.yml belongs beside config.yml at the top
+// of the checkout; writing it into the invocation directory would leave it
+// unreachable to every command that looks for it at the root.
+func TestOnboard_SignupFlag_RecordsProjectRefAtRepoRoot(t *testing.T) {
+	root := t.TempDir()
+	initGitRepoWithRemote(t, root, "https://github.com/myorg/my-repo.git")
+	sub := filepath.Join(root, "services", "api")
+	mkErr := os.MkdirAll(sub, 0o755)
+	assert.NilError(t, mkErr)
+
+	_, env := onboardStandaloneEnv(t, "testuser")
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary: binaryPath, Args: []string{"onboard", "--signup"},
+		Env: env.Environ(), WorkDir: sub,
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	_, rootErr := os.Stat(filepath.Join(root, ".circleci", "info.yml"))
+	assert.NilError(t, rootErr, "the link belongs at the repository root")
+	_, subErr := os.Stat(filepath.Join(sub, ".circleci", "info.yml"))
+	assert.Check(t, os.IsNotExist(subErr), "must not record the link in the invocation directory")
+}
+
+// TestOnboard_SignupFlag_WritesNoProjectRefOutsideRepo is the other half: with no
+// repository there is nothing to link, so nothing is written — a home directory
+// must not acquire a .circleci/info.yml.
+func TestOnboard_SignupFlag_WritesNoProjectRefOutsideRepo(t *testing.T) {
+	dir := t.TempDir() // deliberately not a git checkout
+
+	_, env := onboardStandaloneEnv(t, "testuser")
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary: binaryPath, Args: []string{"onboard", "--signup"},
+		Env: env.Environ(), WorkDir: dir,
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	_, statErr := os.Stat(filepath.Join(dir, ".circleci"))
+	assert.Check(t, os.IsNotExist(statErr), "must not create .circleci outside a repository")
+}
+
+func onboardDotnetRepo(t *testing.T) (string, *fakes.CircleCI, *testenv.TestEnv) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("test runner uses sh -c")
+	}
+	dir := t.TempDir()
+	copyFixture(t, "testdata/test-run/dotnet", dir)
+	initGitRepoWithRemote(t, dir, "https://github.com/myorg/my-repo.git")
+	fake, env := onboardStandaloneEnv(t, "testuser")
+	return dir, fake, env
+}
+
 func onboardStandaloneEnv(t *testing.T, login string) (*fakes.CircleCI, *testenv.TestEnv) {
 	t.Helper()
 
@@ -457,13 +621,16 @@ func onboardStandaloneEnv(t *testing.T, login string) (*fakes.CircleCI, *testenv
 	fake.SetCollaborations([]any{
 		map[string]any{"id": "org-uuid-1234", "name": "myorg", "slug": "circleci/myorg", "vcs_type": "circleci"},
 	})
+	// A CircleCI-native project slug embeds opaque org and project short IDs, not
+	// the repository name — mirroring the real API, which rejects a name-based slug
+	// outright. The UUIDs are separate values used for project lookups.
 	fake.SetCreateProjectResponse(map[string]any{
-		"id":                "proj-uuid-5678",
-		"slug":              "circleci/myorg/my-repo",
+		"id":                onboardProjectID,
+		"slug":              "circleci/Org1234ShortId/Proj5678ShortId",
 		"name":              "my-repo",
 		"organization_name": "myorg",
-		"organization_slug": "circleci/myorg",
-		"organization_id":   "org-uuid-1234",
+		"organization_slug": "circleci/Org1234ShortId",
+		"organization_id":   onboardOrgID,
 	})
 
 	env := testenv.New(t)

--- a/internal/onboarder/onboarder.go
+++ b/internal/onboarder/onboarder.go
@@ -25,9 +25,12 @@ package onboarder
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 
 	tea "charm.land/bubbletea/v2"
 
@@ -38,8 +41,10 @@ import (
 	"github.com/CircleCI-Public/circleci-cli/internal/configgen"
 	clierrors "github.com/CircleCI-Public/circleci-cli/internal/errors"
 	"github.com/CircleCI-Public/circleci-cli/internal/gitremote"
+	"github.com/CircleCI-Public/circleci-cli/internal/httpcl"
 	"github.com/CircleCI-Public/circleci-cli/internal/iostream"
 	"github.com/CircleCI-Public/circleci-cli/internal/org"
+	"github.com/CircleCI-Public/circleci-cli/internal/projectref"
 	"github.com/CircleCI-Public/circleci-cli/internal/reposcan"
 	"github.com/CircleCI-Public/circleci-cli/internal/testrunner"
 	"github.com/CircleCI-Public/circleci-cli/internal/ui"
@@ -82,7 +87,11 @@ func Run(ctx context.Context, dir string, opts Options) error {
 			"mode":    "signup",
 			"outcome": string(result.Outcome),
 		})
-		return postSignupGuidance(ctx, opts)
+		// --signup may be run anywhere — it needs no repository — so the directory
+		// has been through none of the validation below. repoDir yields "" unless it
+		// really is a checkout, which keeps a run from a home directory out of
+		// ~/.circleci/info.yml.
+		return postSignupGuidance(ctx, repoDir(dir), opts)
 	}
 
 	dir, err = filepath.Abs(dir)
@@ -158,7 +167,7 @@ func Run(ctx context.Context, dir string, opts Options) error {
 		"outcome": string(signupResult.Outcome),
 	})
 
-	return postSignupGuidance(ctx, opts)
+	return postSignupGuidance(ctx, dir, opts)
 }
 
 // refreshConfig re-reads the config from disk when the cached copy carries no
@@ -183,12 +192,27 @@ func refreshConfig(ctx context.Context, opts Options) context.Context {
 	return cmdutil.WithConfig(ctx, cfg)
 }
 
+// repoDir returns the root of the repository containing dir, and "" when dir is
+// not inside one. A "" result disables everything that reads or writes repository
+// state, which is the right behaviour when there is no repository to describe.
+//
+// Resolving to the root matters: run from a subdirectory, .circleci/info.yml
+// belongs beside .circleci/config.yml at the top of the checkout, not wherever the
+// command was invoked.
+func repoDir(dir string) string {
+	root, err := gitremote.RepoRootIn(dir)
+	if err != nil {
+		return ""
+	}
+	return root
+}
+
 // postSignupGuidance offers inline project creation and prints a follow-up
 // message after the user has authenticated.
 //
 // Errors are handled gracefully: project creation failure falls through to
 // manual guidance rather than failing the onboard command.
-func postSignupGuidance(ctx context.Context, opts Options) error {
+func postSignupGuidance(ctx context.Context, dir string, opts Options) error {
 	ctx = refreshConfig(ctx, opts)
 
 	client, err := cmdutil.LoadClient(ctx)
@@ -237,54 +261,191 @@ func postSignupGuidance(ctx context.Context, opts Options) error {
 		return nil
 	}
 
-	defaultName := gitremote.DetectRepoName()
-	var name string
-	if iostream.IsInteractive(ctx) {
-		name, err = iostream.PromptText(ctx, "Project name", defaultName)
+	// Resolve a project this repository is already linked to before asking for a
+	// name. On a re-run the answer would be discarded, and offering one is
+	// actively misleading: the recorded slug of a standalone project carries
+	// opaque IDs rather than a repository name.
+	var proj *apiclient.ProjectInfo
+	if selectedOrg.VCSType == "circleci" {
+		proj = resolveLinkedProject(ctx, client, dir, selectedOrg.ID)
+	}
+
+	if proj == nil {
+		name := promptProjectName(ctx, repoNameIn(dir))
+		if name == "" {
+			printManualGuidance(ctx)
+			return nil
+		}
+
+		if selectedOrg.VCSType != "circleci" {
+			followClassicProject(ctx, client, appURL, vcs, orgName, name)
+			return nil
+		}
+
+		created, err := client.CreateProject(ctx, vcs, orgName, name)
 		if err != nil {
+			if httpcl.HasStatusCode(err, http.StatusConflict) {
+				iostream.ErrPrintf(ctx, "%s A project named %q already exists in %s.\n",
+					iostream.SymbolWarn(ctx), name, selectedOrg.Slug)
+				printLinkGuidance(ctx, dir, selectedOrg.Slug)
+				return nil
+			}
+			iostream.ErrPrintf(ctx, "%s Could not create project: %s\n", iostream.SymbolWarn(ctx), err)
 			printManualGuidance(ctx)
 			return nil
 		}
-		if name == "" {
-			name = defaultName
-		}
-		if name == "" {
-			printManualGuidance(ctx)
-			return nil
-		}
+		proj = created
+		iostream.Printf(ctx, "%s Project created: %s\n", iostream.SymbolOK(ctx), proj.Name)
+		writeProjectRef(ctx, dir, proj)
 	} else {
-		name = defaultName
-		if name == "" {
-			printManualGuidance(ctx)
-			return nil
-		}
+		iostream.Printf(ctx, "%s Using existing project: %s\n", iostream.SymbolOK(ctx), proj.Name)
 	}
 
-	if selectedOrg.VCSType != "circleci" {
-		return followClassicProject(ctx, client, appURL, vcs, orgName, name)
-	}
-
-	proj, err := client.CreateProject(ctx, vcs, orgName, name)
-	if err != nil {
-		iostream.ErrPrintf(ctx, "%s Could not create project: %s\n", iostream.SymbolWarn(ctx), err)
-		printManualGuidance(ctx)
-		return nil
-	}
-
-	iostream.Printf(ctx, "%s Project created: %s\n", iostream.SymbolOK(ctx), proj.Name)
 	iostream.Printf(ctx, "  Organization: %s\n", proj.OrganizationName)
 	if pipelinesURL, err := cmdutil.RunSlugURL(appURL, proj.Slug); err == nil {
 		iostream.Printf(ctx, "  Pipelines: %s\n", pipelinesURL)
 	}
-	iostream.Printf(ctx, "\nCommit .circleci/config.yml. After your project is connected in CircleCI, pushing will start your first pipeline.\n")
+	// Stage the whole directory: info.yml records the project's ID, and that ID is
+	// not recoverable from its name — no API maps one to the other. Committing it is
+	// what lets a fresh clone, a teammate, or a later run find this project instead
+	// of colliding with it.
+	iostream.Printf(ctx, "\nCommit .circleci/ (config.yml and info.yml). After your project is connected in CircleCI, pushing will start your first pipeline.\n")
 	return nil
 }
 
-func followClassicProject(ctx context.Context, client *apiclient.Client, appURL, vcs, orgName, repoName string) error {
+// promptProjectName asks for the project name, offering defaultName. It returns
+// "" when no name could be determined, which callers treat as "fall back to
+// manual guidance".
+func promptProjectName(ctx context.Context, defaultName string) string {
+	if !iostream.IsInteractive(ctx) {
+		return defaultName
+	}
+	name, err := iostream.PromptText(ctx, "Project name", defaultName)
+	if err != nil {
+		return ""
+	}
+	if name == "" {
+		return defaultName
+	}
+	return name
+}
+
+// repoNameIn returns the repository name of the checkout at dir, or "" when there
+// is no readable remote there.
+func repoNameIn(dir string) string {
+	if dir == "" {
+		return ""
+	}
+	info, err := gitremote.DetectFromRemoteIn(dir)
+	if err != nil {
+		return ""
+	}
+	parts := strings.Split(info.Slug, "/")
+	if len(parts) != 3 {
+		return ""
+	}
+	return parts[2]
+}
+
+// resolveLinkedProject returns the project recorded in .circleci/info.yml, or nil
+// when this checkout has no link onboard can use.
+//
+// That local record is the only way to find an existing project: a CircleCI-native
+// slug is "circleci/<orgID>/<projectID>" — opaque IDs, not the repository name —
+// and no API maps a name to a project within an org. Resolving before creating
+// keeps a re-run from attempting a create that could only conflict.
+//
+// A link only counts when its project belongs to orgID. A repository linked
+// elsewhere — a classic VCS project being migrated to a CircleCI-native org, say —
+// is ignored, so onboard sets up the organization the user actually chose. An
+// unresolvable link is ignored the same way; the create path handles everything a
+// link cannot supply.
+func resolveLinkedProject(ctx context.Context, client *apiclient.Client, workDir, orgID string) *apiclient.ProjectInfo {
+	if workDir == "" {
+		return nil
+	}
+	info, err := projectref.Read(workDir)
+	if err != nil {
+		// An absent file just means "not linked". Anything else is a file the user
+		// can fix, and every other command reports it rather than proceeding as if
+		// the checkout were unlinked.
+		if !errors.Is(err, projectref.ErrNotFound) {
+			iostream.ErrPrintf(ctx, "%s Ignoring %s: %s\n",
+				iostream.SymbolWarn(ctx), projectref.FilePath, err)
+		}
+		return nil
+	}
+	// Compare the recorded org before spending a request: a link to another org is
+	// rejected for free. Both IDs must be present — treating two empty strings as
+	// a match would reuse a foreign project while appearing to have checked.
+	if orgID == "" || (info.Organization.ID != "" && info.Organization.ID != orgID) {
+		return nil
+	}
+	proj, err := client.GetProjectInfo(ctx, info.EffectiveSlug())
+	if err != nil || proj.OrganizationID != orgID {
+		return nil
+	}
+	return proj
+}
+
+// writeProjectRef records the new project in .circleci/info.yml so a re-run of
+// onboard — and every other command in this repository — can resolve it without
+// asking the user for an opaque project ID.
+//
+// An existing file is never overwritten. It may be committed, and it may record a
+// project in another organization that this run has no mandate to replace —
+// `circleci project link` itself demands --force for exactly that reason.
+//
+// Failure is not fatal: the project exists and setup continues using the ID
+// already in hand. Only the next run loses the shortcut.
+func writeProjectRef(ctx context.Context, workDir string, proj *apiclient.ProjectInfo) {
+	if workDir == "" {
+		return
+	}
+	if _, err := os.Stat(projectref.Path(workDir)); err == nil {
+		iostream.ErrPrintf(ctx, "%s %s already records a different project; leaving it as it is.\n",
+			iostream.SymbolWarn(ctx), projectref.FilePath)
+		iostream.ErrPrintf(ctx, "  To point it at %s: circleci project link --force --project %s\n",
+			proj.Name, proj.Slug)
+		return
+	}
+	err := projectref.Write(workDir, &projectref.Info{
+		Organization: projectref.Organization{ID: proj.OrganizationID, Name: proj.OrganizationName},
+		Project:      projectref.Project{ID: proj.ID, Slug: proj.Slug, Name: proj.Name},
+	})
+	if err != nil {
+		iostream.ErrPrintf(ctx, "%s Could not write %s: %s\n",
+			iostream.SymbolWarn(ctx), projectref.FilePath, err)
+		return
+	}
+	iostream.Printf(ctx, "%s Linked this repository to the project in %s\n",
+		iostream.SymbolOK(ctx), projectref.FilePath)
+}
+
+// printLinkGuidance covers a project that exists in the organization but is not
+// the one this checkout resolves to. No API maps a project name to its ID, so the
+// ID has to come from the user — the same conclusion `circleci project link`
+// reaches when it cannot resolve a slug on its own.
+//
+// The command is spelled out with the organization already filled in. --project is
+// load-bearing: without it, link re-derives the slug from the git remote and a
+// repository linked elsewhere lands straight back where it started. --force is
+// added when .circleci/info.yml is present, since plain link refuses while it is.
+func printLinkGuidance(ctx context.Context, workDir, orgSlug string) {
+	args := "--project " + orgSlug + "/<projectID>"
+	if _, err := os.Stat(projectref.Path(workDir)); err == nil {
+		args = "--force " + args
+	}
+	iostream.Printf(ctx, "\nCopy that project's ID from its settings in CircleCI, then run:\n")
+	iostream.Printf(ctx, "  circleci project link %s\n", args)
+	iostream.Printf(ctx, "  circleci onboard\n")
+}
+
+func followClassicProject(ctx context.Context, client *apiclient.Client, appURL, vcs, orgName, repoName string) {
 	if err := client.FollowProject(ctx, vcs, orgName, repoName); err != nil {
 		iostream.ErrPrintf(ctx, "%s Could not connect project: %s\n", iostream.SymbolWarn(ctx), err)
 		printManualGuidance(ctx)
-		return nil
+		return
 	}
 
 	slug := fmt.Sprintf("%s/%s/%s", vcs, orgName, repoName)
@@ -294,7 +455,6 @@ func followClassicProject(ctx context.Context, client *apiclient.Client, appURL,
 		iostream.Printf(ctx, "  Pipelines: %s\n", pipelinesURL)
 	}
 	iostream.Printf(ctx, "\nCommit and push .circleci/config.yml to start your first pipeline.\n")
-	return nil
 }
 
 func printManualGuidance(ctx context.Context) {

--- a/internal/testing/fakes/circleci.go
+++ b/internal/testing/fakes/circleci.go
@@ -106,16 +106,17 @@ type CircleCI struct {
 	deletedRCs      map[string]bool  // resource class → deleted
 
 	// Project / env-var state.
-	followedProjects  []any            // list of project objects for GET /api/v1.1/projects
-	followedSlugs     map[string]bool  // vcs+org+repo → true (for follow idempotency)
-	envVars           map[string][]any // project slug → env vars
-	deletedEnvVars    map[string]bool  // "slug/name" → deleted
-	projectInfos      map[string]any   // project slug → project info response
-	projectsByID      map[string]any   // project UUID → V3 project response (GET /api/v3/projects/{id})
-	projectsBySlug    map[string]any   // project slug → V3 project entity (GET /api/v3/projects?filter[slug]=)
-	projectSettings   map[string]any   // project UUID → advanced settings attributes
-	createProjectResp any              // preset response for POST /organization/{vcs}/{org}/project
-	createOrgResp     any              // preset response for POST /organization
+	followedProjects    []any            // list of project objects for GET /api/v1.1/projects
+	followedSlugs       map[string]bool  // vcs+org+repo → true (for follow idempotency)
+	envVars             map[string][]any // project slug → env vars
+	deletedEnvVars      map[string]bool  // "slug/name" → deleted
+	projectInfos        map[string]any   // project slug → project info response
+	projectsByID        map[string]any   // project UUID → V3 project response (GET /api/v3/projects/{id})
+	projectsBySlug      map[string]any   // project slug → V3 project entity (GET /api/v3/projects?filter[slug]=)
+	projectSettings     map[string]any   // project UUID → advanced settings attributes
+	createProjectResp   any              // preset response for POST /organization/{vcs}/{org}/project
+	createProjectStatus int              // HTTP status for that POST (0 → 201 Created)
+	createOrgResp       any              // preset response for POST /organization
 
 	// Context state.
 	contexts                   map[string]any   // context id → context object
@@ -1838,6 +1839,16 @@ func (f *CircleCI) SetCreateProjectResponse(resp any) {
 	f.createProjectResp = resp
 }
 
+// SetCreateProjectConflict makes POST /api/v2/organization/{vcs}/{org}/project
+// answer 409, as the real API does when the organization already has a project
+// with that name.
+func (f *CircleCI) SetCreateProjectConflict() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.createProjectStatus = http.StatusConflict
+	f.createProjectResp = map[string]any{"message": "A project with this name already exists"}
+}
+
 // AddEnvVar registers an env var for a project.
 // slug should be in "vcs/org/repo" form.
 func (f *CircleCI) AddEnvVar(slug, name, value string, createdAt *time.Time) {
@@ -1901,12 +1912,34 @@ func (f *CircleCI) handleCreateOrg(w http.ResponseWriter, r *http.Request) {
 func (f *CircleCI) handleCreateProject(w http.ResponseWriter, r *http.Request) {
 	f.mu.RLock()
 	resp := f.createProjectResp
+	status := f.createProjectStatus
 	f.mu.RUnlock()
 
+	if status != 0 {
+		render.Status(r, status)
+		render.JSON(w, r, resp)
+		return
+	}
 	if resp == nil {
 		render.Status(r, http.StatusUnprocessableEntity)
 		render.JSON(w, r, map[string]any{"message": "project creation not configured"})
 		return
+	}
+	// Echo the requested name, as the real API does. Returning a canned name
+	// regardless of the request would let a caller send the wrong one and still
+	// look correct in the output a test asserts on.
+	if body, ok := resp.(map[string]any); ok {
+		var req struct {
+			Name string `json:"name"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err == nil && req.Name != "" {
+			echoed := make(map[string]any, len(body))
+			for k, v := range body {
+				echoed[k] = v
+			}
+			echoed["name"] = req.Name
+			resp = echoed
+		}
 	}
 	render.Status(r, http.StatusCreated)
 	render.JSON(w, r, resp)


### PR DESCRIPTION
## What this fixes

Running `circleci onboard` a second time fails, because onboard cannot find the project it created the first time.

**Before** — second run:

```
✓ Already signed in as testuser
✓ Using organization circleci/myorg
⚠ Could not create project: POST /api/v2/organization/circleci/8KsBMffqg…/project: 409 Conflict

Run 'circleci project create' to connect this repo to CircleCI.
```

**After** — second run:

```
✓ Already signed in as testuser
✓ Using organization circleci/myorg
✓ Using existing project: my-repo
  Organization: myorg
  Pipelines: https://app.circleci.com/pipelines/circleci/8KsBMffqg…/Y5nuJ5Zzav…
```

## Why it could not just look the project up

There is no way to ask CircleCI "which project is called `my-repo`?" A project can only be fetched by ID or by slug, and a CircleCI-native slug is `circleci/<orgID>/<projectID>` — opaque IDs, not the repository name. The 409 body carries only a message, and there is no endpoint that lists an organization's projects.

So onboard writes the ID down. After creating a project it records it in `.circleci/info.yml` — the same file `circleci project link` writes, and that other commands already read — and resolves from that file before attempting a create.

**First run now ends with:**

```
✓ Project created: my-repo
✓ Linked this repository to the project in .circleci/info.yml
  Organization: myorg
  Pipelines: https://app.circleci.com/pipelines/circleci/8KsBMffqg…/Y5nuJ5Zzav…

Commit .circleci/ (config.yml and info.yml). After your project is connected in CircleCI, pushing will start your first pipeline.
```

A side effect worth having: the repository ends up linked without a second command.

## Care taken

- **An existing `info.yml` is never overwritten.** It is meant to be committed and may deliberately point elsewhere; `project link` requires `--force` for the same reason. Onboard prints the command that would replace it.
- **A link only counts if its project is in the selected organization**, or onboard would set up a pipeline under an org the user did not choose.
- **The name prompt only appears when creating.** It used to run first, so a re-run asked for a name and then discarded it.
- **Run from a subdirectory, the file lands at the repository root**, where every command looks for it. `--signup` outside a repository writes nothing, so no stray `~/.circleci/info.yml`.
- **A malformed `info.yml` is reported**, not silently treated as absent — matching what other commands do with it.

## Fake-server fidelity

Two fixes without which the tests below pass against the wrong behaviour: the fake returned a canned project name whatever name was requested, and served a name-based slug that no real CircleCI-native project has.

## Test plan

- [ ] `task test` passes
- [ ] Two consecutive runs: the first creates and records, the second reports "Using existing project" and creates nothing
- [ ] An existing link is left byte-for-byte alone, with the replacing command printed, and is not reused when it points at another organization
- [ ] Name collision with no local record points at `circleci project link --project`, with no HTTP status or API path in stderr
- [ ] `--signup` from a subdirectory records at the repository root; outside a repository it records nothing

Third of the four PRs from #1647. #1655 and #1656 are merged; pipeline and trigger setup is #1658.
