### PR TITLE
Set up the first pipeline definition and trigger

### DIFF
--- a/acceptance/onboard_test.go
+++ b/acceptance/onboard_test.go
@@ -40,10 +40,14 @@ import (
 	"github.com/CircleCI-Public/circleci-cli/internal/testing/fakes"
 )
 
-// Fixture IDs shared by the onboard tests.
+// Fixture IDs shared by the onboard tests. The slug segments are deliberately
+// opaque short IDs rather than names, mirroring a real CircleCI-native project,
+// whose slug the API will not accept in name form.
 const (
-	onboardOrgID     = "org-uuid-1234"
-	onboardProjectID = "proj-uuid-5678"
+	onboardOrgID          = "org-uuid-1234"
+	onboardProjectID      = "proj-uuid-5678"
+	onboardPipelineDefID  = "pdef-uuid-1"
+	onboardRepoExternalID = "123456789"
 )
 
 func TestOnboard_PathInvalid(t *testing.T) {
@@ -289,14 +293,7 @@ func TestOnboard_ScanFlag_ExplicitSameAsDefault(t *testing.T) {
 }
 
 func TestOnboard_PostSignup_ProjectCreated(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("test runner uses sh -c")
-	}
-	dir := t.TempDir()
-	copyFixture(t, "testdata/test-run/dotnet", dir)
-	initGitRepoWithRemote(t, dir, "https://github.com/myorg/my-repo.git")
-
-	_, env := onboardStandaloneEnv(t, "testuser")
+	dir, _, env := onboardDotnetRepo(t)
 	addFakeDotnet(t, env, false)
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
@@ -306,9 +303,518 @@ func TestOnboard_PostSignup_ProjectCreated(t *testing.T) {
 	})
 
 	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
-	assert.Check(t, strings.Contains(result.Stdout, "Project created: my-repo"))
-	assert.Check(t, strings.Contains(result.Stdout, "Organization: myorg"))
-	assert.Check(t, cmp.Contains(result.Stdout, "Commit .circleci/"))
+	assert.Check(t, cmp.Contains(result.Stdout, "Project created: my-repo"))
+	assert.Check(t, cmp.Contains(result.Stdout, "Organization: myorg"))
+	assert.Check(t, cmp.Contains(result.Stdout, "Commit .circleci/config.yml"))
+}
+
+// TestOnboard_PostSignup_FreshSignup_ContinuesToProjectSetup is a regression test
+// for a fresh signup dead-ending at "Run 'circleci project create'" instead of
+// continuing into project, pipeline, and trigger setup.
+//
+// Signup writes the token to disk part-way through the run, but the config cached
+// in the context was loaded during bootstrap — before that write — so without a
+// reload LoadClient sees no token and the whole setup chain degrades to manual
+// guidance on the one run where it matters most.
+//
+// This test must NOT set env.Token: CIRCLE_TOKEN is read ahead of the cached
+// config, which masks the bug — and is why the other PostSignup tests, which all
+// pass a token through the environment, never caught it.
+func TestOnboard_PostSignup_FreshSignup_ContinuesToProjectSetup(t *testing.T) {
+	dir := t.TempDir()
+	initGitRepoWithRemote(t, dir, "https://github.com/myorg/my-repo.git")
+
+	fake := fakes.NewCircleCI(t)
+	fake.SetMe(map[string]any{
+		"id": "e4a72497-7c55-400d-a72d-dadc4b92255d",
+		"attributes": map[string]any{
+			"name":  "New User",
+			"login": "newuser",
+		},
+	})
+	fake.SetOAuthTokenResponse(map[string]any{
+		"access_token": "test-signup-token",
+		"token_type":   "Bearer",
+		"expires_in":   int64(7776000),
+	})
+	fake.SetCollaborations([]any{
+		map[string]any{"id": onboardOrgID, "name": "myorg", "slug": "circleci/myorg", "vcs_type": "circleci"},
+	})
+	fake.SetCreateProjectResponse(map[string]any{
+		"id":                onboardProjectID,
+		"slug":              "circleci/myorg/my-repo",
+		"name":              "my-repo",
+		"organization_name": "myorg",
+		"organization_slug": "circleci/myorg",
+		"organization_id":   onboardOrgID,
+	})
+	addFirstPipelineResponses(fake)
+
+	env := testenv.New(t)
+	env.CircleCIURL = fake.URL()
+	// Deliberately no env.Token — see the note above.
+	env.Extra["CIRCLE_LOGIN_TIMEOUT"] = "20s"
+	// Suppress the project-name prompt so the run completes without further input.
+	env.Extra["CIRCLE_NO_INTERACTIVE"] = "true"
+
+	console := binary.RunCLIInteractive(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"onboard", "--signup", "--no-browser", "--repo-id", onboardRepoExternalID},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	assert.Assert(t, t.Run("waits for browser callback", func(t *testing.T) {
+		_, err := console.ExpectString("Waiting for browser authentication")
+		assert.NilError(t, err)
+	}))
+
+	assert.Assert(t, t.Run("browser callback", func(t *testing.T) {
+		callbackViaPAR(t, fake)
+	}))
+
+	assert.Assert(t, t.Run("continues into project and pipeline setup", func(t *testing.T) {
+		_, err := console.ExpectString("Logged in as newuser")
+		assert.NilError(t, err)
+		_, err = console.ExpectString("Project created: my-repo")
+		assert.NilError(t, err)
+		_, err = console.ExpectString("Pipeline definition created: my-repo")
+		assert.NilError(t, err)
+		_, err = console.ExpectString("Trigger created: all-pushes")
+		assert.NilError(t, err)
+		_, err = console.ExpectString("Your project is ready!")
+		assert.NilError(t, err)
+	}))
+}
+
+// TestOnboard_PostSignup_KeepsExistingProjectRef pins that onboard never rewrites
+// an existing .circleci/info.yml.
+//
+// The file is meant to be committed, and it may record a project in another
+// organization that this run has no mandate to replace — `circleci project link`
+// requires --force for exactly that reason.
+func TestOnboard_PostSignup_KeepsExistingProjectRef(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test runner uses sh -c")
+	}
+	dir := t.TempDir()
+	copyFixture(t, "testdata/test-run/dotnet", dir)
+	initGitRepoWithRemote(t, dir, "https://github.com/myorg/my-repo.git")
+
+	// A link to a project in a different organization, so it is ignored and onboard
+	// proceeds to create — the path that reaches the write.
+	existing := "organization:\n  id: other-org-uuid\n" +
+		"project:\n  id: other-proj-uuid\n  slug: gh/myorg/my-repo\n  name: my-repo\n"
+	refPath := filepath.Join(dir, ".circleci", "info.yml")
+	mkErr := os.MkdirAll(filepath.Dir(refPath), 0o755)
+	assert.NilError(t, mkErr)
+	writeErr := os.WriteFile(refPath, []byte(existing), 0o644)
+	assert.NilError(t, writeErr)
+
+	_, env := onboardStandaloneEnv(t, "testuser")
+	addFakeDotnet(t, env, false)
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"onboard", "--scan"},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	body, readErr := os.ReadFile(refPath)
+	assert.NilError(t, readErr)
+	assert.Check(t, cmp.Equal(string(body), existing), "info.yml must be left byte-for-byte alone")
+	assert.Check(t, cmp.Contains(result.Stderr, "already records a different project"))
+	assert.Check(t, cmp.Contains(result.Stderr, "circleci project link --force --project"))
+}
+
+// TestOnboard_PostSignup_AddsPushTriggerAlongsideOthers pins that only an
+// all-pushes trigger satisfies onboard. A definition carrying just a schedule
+// trigger would otherwise be reported as ready, and the push onboard tells the
+// user to make would build nothing.
+func TestOnboard_PostSignup_AddsPushTriggerAlongsideOthers(t *testing.T) {
+	dir, fake, env := onboardDotnetRepo(t)
+	fake.AddPipelineDefinition(onboardProjectID, map[string]any{
+		"id":   onboardPipelineDefID,
+		"name": "my-repo",
+		"config_source": map[string]any{
+			"provider": "github_app",
+			"repo":     map[string]any{"external_id": onboardRepoExternalID},
+		},
+	})
+	// Only a schedule trigger exists — no push would build anything.
+	fake.AddTrigger(onboardProjectID, onboardPipelineDefID, map[string]any{
+		"id":           "trig-schedule",
+		"event_preset": "schedule",
+	})
+	fake.SetCreateTriggerResponse(onboardProjectID, onboardPipelineDefID, map[string]any{
+		"id":           "trig-uuid-1",
+		"event_preset": "all-pushes",
+	})
+	addFakeDotnet(t, env, false)
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"onboard", "--scan", "--repo-id", onboardRepoExternalID},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Check(t, cmp.Contains(result.Stdout, "Trigger created: all-pushes"))
+	assert.Check(t, !strings.Contains(result.Stdout, "Trigger already exists"),
+		"a schedule-only definition is not ready for a push")
+	assert.Check(t, cmp.Contains(result.Stdout, "Your project is ready!"))
+}
+
+// TestOnboard_SignupFlag_RecordsProjectRefAtRepoRoot pins where --signup records
+// the project link when run from a subdirectory.
+//
+// info.yml belongs beside config.yml at the top of the checkout. Writing it into
+// whatever directory the command was invoked from would leave it unreachable to
+// every command that looks for it at the root — and, run somewhere that is not a
+// repository at all, would litter a home directory.
+func TestOnboard_SignupFlag_RecordsProjectRefAtRepoRoot(t *testing.T) {
+	root := t.TempDir()
+	initGitRepoWithRemote(t, root, "https://github.com/myorg/my-repo.git")
+	sub := filepath.Join(root, "services", "api")
+	mkErr := os.MkdirAll(sub, 0o755)
+	assert.NilError(t, mkErr)
+
+	_, env := onboardStandaloneEnv(t, "testuser")
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"onboard", "--signup"},
+		Env:     env.Environ(),
+		WorkDir: sub,
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	_, rootErr := os.Stat(filepath.Join(root, ".circleci", "info.yml"))
+	assert.NilError(t, rootErr, "the link belongs at the repository root")
+	_, subErr := os.Stat(filepath.Join(sub, ".circleci", "info.yml"))
+	assert.Check(t, os.IsNotExist(subErr), "must not record the link in the invocation directory")
+}
+
+// TestOnboard_SignupFlag_WritesNoProjectRefOutsideRepo is the other half: with no
+// repository there is nothing to link, so nothing is written.
+func TestOnboard_SignupFlag_WritesNoProjectRefOutsideRepo(t *testing.T) {
+	dir := t.TempDir() // deliberately not a git checkout
+
+	_, env := onboardStandaloneEnv(t, "testuser")
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"onboard", "--signup"},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	_, statErr := os.Stat(filepath.Join(dir, ".circleci"))
+	assert.Check(t, os.IsNotExist(statErr), "must not create .circleci outside a repository")
+}
+
+// TestOnboard_PathArgument_UsesGivenDirectory pins that a path argument selects
+// the repository onboard describes.
+//
+// The process runs from a *different* checkout with a different remote, so any
+// detection that reads the working directory instead of the argument would name
+// the project after the wrong repository and wire the pipeline to the wrong repo —
+// silently, since every step still reports success.
+func TestOnboard_PathArgument_UsesGivenDirectory(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test runner uses sh -c")
+	}
+	dir := t.TempDir()
+	copyFixture(t, "testdata/test-run/dotnet", dir)
+	initGitRepoWithRemote(t, dir, "https://github.com/myorg/my-repo.git")
+
+	// A second, unrelated checkout to run from.
+	otherDir := t.TempDir()
+	initGitRepoWithRemote(t, otherDir, "https://github.com/myorg/wrong-repo.git")
+
+	fake, env := onboardStandaloneEnv(t, "testuser")
+	addFirstPipelineResponses(fake)
+	addFakeDotnet(t, env, false)
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"onboard", "--scan", "--repo-id", onboardRepoExternalID, dir},
+		Env:     env.Environ(),
+		WorkDir: otherDir,
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Check(t, cmp.Contains(result.Stdout, "Project created: my-repo"))
+	assert.Check(t, cmp.Contains(result.Stdout, "Your project is ready!"))
+	assert.Check(t, !strings.Contains(result.Stdout, "wrong-repo"),
+		"the working directory's repository must not leak into the run")
+	// The link belongs to the directory that was onboarded, not the cwd.
+	_, err := os.Stat(filepath.Join(dir, ".circleci", "info.yml"))
+	assert.NilError(t, err)
+	_, err = os.Stat(filepath.Join(otherDir, ".circleci", "info.yml"))
+	assert.Check(t, os.IsNotExist(err), "must not write into the working directory")
+}
+
+func TestOnboard_PostSignup_FirstPipelineCreated(t *testing.T) {
+	dir, fake, env := onboardDotnetRepo(t)
+	fake.SetCreatePipelineDefinitionResponse(onboardProjectID, map[string]any{
+		"id":         onboardPipelineDefID,
+		"name":       "my-repo",
+		"created_at": "2026-07-23T00:00:00Z",
+	})
+	fake.SetCreateTriggerResponse(onboardProjectID, onboardPipelineDefID, map[string]any{
+		"id":           "trig-uuid-1",
+		"created_at":   "2026-07-23T00:00:00Z",
+		"event_preset": "all-pushes",
+	})
+	addFakeDotnet(t, env, false)
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"onboard", "--scan", "--repo-id", onboardRepoExternalID},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Check(t, cmp.Contains(result.Stdout, "Project created: my-repo"))
+	assert.Check(t, cmp.Contains(result.Stdout, "Pipeline definition created: my-repo"))
+	assert.Check(t, cmp.Contains(result.Stdout, "Trigger created: all-pushes"))
+	assert.Check(t, cmp.Contains(result.Stdout, "Your project is ready!"))
+	assert.Check(t, cmp.Contains(result.Stdout, "git push"))
+}
+
+func TestOnboard_PostSignup_FirstPipeline_GitHubAppResolvesRepo(t *testing.T) {
+	dir, fake, env := onboardDotnetRepo(t)
+	// GitHub App is installed for the org and can access the repo, so the repo's
+	// external ID is resolved automatically — no --repo-id needed.
+	fake.SetGitHubAppInstalled(onboardOrgID, true)
+	fake.AddGitHubAppRepository(onboardOrgID, map[string]any{
+		"id":             987654321,
+		"repo_full_name": "myorg/my-repo",
+		"repo_name":      "my-repo",
+		"owner":          "myorg",
+		"default_branch": "main",
+		"private":        false,
+	})
+	addFirstPipelineResponses(fake)
+	addFakeDotnet(t, env, false)
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"onboard", "--scan"},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Check(t, cmp.Contains(result.Stdout, "Found repository myorg/my-repo"))
+	assert.Check(t, cmp.Contains(result.Stdout, "Pipeline definition created: my-repo"))
+	assert.Check(t, cmp.Contains(result.Stdout, "Trigger created: all-pushes"))
+	assert.Check(t, cmp.Contains(result.Stdout, "Your project is ready!"))
+}
+
+// TestOnboard_PostSignup_Rerun_Idempotent runs onboard twice over the same
+// repository. The first run creates the project and records it in
+// .circleci/info.yml; the second resolves it from that file instead of
+// attempting a create that could only conflict.
+//
+// That local record is what makes a re-run recoverable at all: a CircleCI-native
+// project slug is circleci/<orgID>/<projectID> — opaque IDs, not the repository
+// name — and no API maps a project name to its ID within an org.
+func TestOnboard_PostSignup_Rerun_Idempotent(t *testing.T) {
+	dir, fake, env := onboardDotnetRepo(t)
+	fake.SetGitHubAppInstalled(onboardOrgID, true)
+	fake.AddGitHubAppRepository(onboardOrgID, map[string]any{
+		"id":             987654321,
+		"repo_full_name": "myorg/my-repo",
+		"repo_name":      "my-repo",
+		"owner":          "myorg",
+	})
+	addFirstPipelineResponses(fake)
+	// The second run looks the project up by the slug projectref derives from the
+	// recorded UUIDs. The real API accepts that form and canonicalises it to the
+	// short-ID slug.
+	fake.AddProjectInfo("circleci/org-uuid-1234/proj-uuid-5678", map[string]any{
+		"id":                onboardProjectID,
+		"slug":              "circleci/Org1234ShortId/Proj5678ShortId",
+		"name":              "my-repo",
+		"organization_name": "myorg",
+		"organization_slug": "circleci/Org1234ShortId",
+		"organization_id":   onboardOrgID,
+	})
+	addFakeDotnet(t, env, false)
+
+	first := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"onboard", "--scan"},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+	assert.Equal(t, first.ExitCode, 0, "stderr: %s", first.Stderr)
+	assert.Check(t, cmp.Contains(first.Stdout, "Project created: my-repo"))
+	assert.Check(t, cmp.Contains(first.Stdout, "Linked this repository to the project"))
+	_, err := os.Stat(filepath.Join(dir, ".circleci", "info.yml"))
+	assert.NilError(t, err, "first run should record the project locally")
+	// The recorded ID is unrecoverable from the project name, so the next steps
+	// have to stage info.yml, not just config.yml.
+	assert.Check(t, cmp.Contains(first.Stdout, "git add .circleci/"))
+	assert.Check(t, !strings.Contains(first.Stdout, "git add .circleci/config.yml"),
+		"staging only config.yml would leave the project ID uncommitted")
+
+	// The project now has its pipeline definition and trigger.
+	fake.AddPipelineDefinition(onboardProjectID, map[string]any{
+		"id":   onboardPipelineDefID,
+		"name": "my-repo",
+		"config_source": map[string]any{
+			"provider": "github_app",
+			"repo":     map[string]any{"external_id": "987654321"},
+		},
+	})
+	fake.AddTrigger(onboardProjectID, onboardPipelineDefID, map[string]any{
+		"id":           "trig-uuid-1",
+		"event_preset": "all-pushes",
+	})
+
+	second := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"onboard", "--scan"},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+	assert.Equal(t, second.ExitCode, 0, "stderr: %s", second.Stderr)
+	assert.Check(t, cmp.Contains(second.Stdout, "Using existing project: my-repo"))
+	assert.Check(t, cmp.Contains(second.Stdout, "Pipeline definition already exists: my-repo"))
+	assert.Check(t, cmp.Contains(second.Stdout, "Trigger already exists"))
+	assert.Check(t, !strings.Contains(second.Stdout, "Project created"), "re-run should not create a second project")
+	assert.Check(t, !strings.Contains(second.Stderr, "already exists"), "re-run should not surface a conflict")
+}
+
+// TestOnboard_PostSignup_LinkedProjectInAnotherOrg covers a repository already
+// linked to a project in a different organization — a classic VCS project being
+// onboarded into a CircleCI-native org, which is what a migration looks like.
+//
+// The link must not be reused: it would set up pipelines in an organization the
+// user did not choose. It is ignored, onboard proceeds to create, and the name
+// collision that follows points at `project link --force`, since plain
+// `project link` refuses while .circleci/info.yml exists.
+func TestOnboard_PostSignup_LinkedProjectInAnotherOrg(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test runner uses sh -c")
+	}
+	dir := t.TempDir()
+	copyFixture(t, "testdata/test-run/dotnet", dir)
+	initGitRepoWithRemote(t, dir, "https://github.com/myorg/my-repo.git")
+
+	// A resolvable link, but to a project owned by a different org. Both IDs are
+	// recorded against a classic slug, exactly as `circleci project link` writes
+	// it — the slug must be used as-is rather than rebuilt into the circleci/ form.
+	assert.NilError(t, os.MkdirAll(filepath.Join(dir, ".circleci"), 0o755))
+	assert.NilError(t, os.WriteFile(filepath.Join(dir, ".circleci", "info.yml"), []byte(
+		"organization:\n  id: other-org-uuid\n  name: myorg\n"+
+			"project:\n  id: other-proj-uuid\n  slug: gh/myorg/my-repo\n  name: my-repo\n",
+	), 0o644))
+
+	fake, env := onboardStandaloneEnv(t, "testuser")
+	fake.AddProjectInfo("gh/myorg/my-repo", map[string]any{
+		"id":                "other-proj-uuid",
+		"slug":              "gh/myorg/my-repo",
+		"name":              "my-repo",
+		"organization_name": "myorg",
+		"organization_slug": "gh/myorg",
+		"organization_id":   "other-org-uuid",
+	})
+	fake.SetCreateProjectConflict()
+	addFakeDotnet(t, env, false)
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"onboard", "--scan"},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Check(t, !strings.Contains(result.Stdout, "Using existing project"),
+		"a project in another organization must not be reused")
+	assert.Check(t, cmp.Contains(result.Stderr, `project named "my-repo" already exists`))
+	// The guidance has to terminate: --force because info.yml exists, and --project
+	// because otherwise link re-derives the same foreign slug from the git remote.
+	assert.Check(t, strings.Contains(result.Stdout,
+		"circleci project link --force --project circleci/myorg/<projectID>"))
+	assert.Check(t, !strings.Contains(result.Stderr, "409"), "stderr should not leak an HTTP status")
+}
+
+// TestOnboard_PostSignup_ProjectNameConflict covers a name collision that onboard
+// cannot resolve: the org already has a project with this name, but the checkout
+// has no .circleci/info.yml recording its ID. Since a project cannot be looked up
+// by name, onboard points at `circleci project link` rather than reporting a raw
+// HTTP conflict.
+func TestOnboard_PostSignup_ProjectNameConflict(t *testing.T) {
+	dir, fake, env := onboardDotnetRepo(t)
+	fake.SetCreateProjectConflict()
+	addFakeDotnet(t, env, false)
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"onboard", "--scan"},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Check(t, cmp.Contains(result.Stderr, `project named "my-repo" already exists`))
+	assert.Check(t, cmp.Contains(result.Stdout, "circleci project link --project circleci/myorg/<projectID>"))
+	assert.Check(t, !strings.Contains(result.Stdout, "--force"), "no info.yml to overwrite")
+	// No raw HTTP internals for a conflict the user can resolve with one command.
+	assert.Check(t, !strings.Contains(result.Stderr, "409"), "stderr should not leak an HTTP status")
+	assert.Check(t, !strings.Contains(result.Stderr, "/api/v2/"), "stderr should not leak an API path")
+}
+
+func TestOnboard_PostSignup_FirstPipeline_RepoNotAccessible(t *testing.T) {
+	dir, fake, env := onboardDotnetRepo(t)
+	// App is installed, but the repo the user is in was not granted to it.
+	fake.SetGitHubAppInstalled(onboardOrgID, true)
+	fake.AddGitHubAppRepository(onboardOrgID, map[string]any{
+		"id":             111,
+		"repo_full_name": "myorg/some-other-repo",
+		"repo_name":      "some-other-repo",
+		"owner":          "myorg",
+	})
+	addFakeDotnet(t, env, false)
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"onboard", "--scan"},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Check(t, cmp.Contains(result.Stderr, "can't access myorg/my-repo"))
+	assert.Check(t, cmp.Contains(result.Stdout, "Commit .circleci/config.yml"))
+	assert.Check(t, !strings.Contains(result.Stdout, "Pipeline definition created"), "no pipeline def without a repo ID")
+}
+
+func TestOnboard_PostSignup_FirstPipeline_TriggerFails(t *testing.T) {
+	dir, fake, env := onboardDotnetRepo(t)
+	fake.SetCreatePipelineDefinitionResponse(onboardProjectID, map[string]any{
+		"id":   onboardPipelineDefID,
+		"name": "my-repo",
+	})
+	// No trigger response registered → the trigger create returns 404 and the
+	// flow degrades to manual guidance.
+	addFakeDotnet(t, env, false)
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"onboard", "--scan", "--repo-id", onboardRepoExternalID},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Check(t, cmp.Contains(result.Stdout, "Pipeline definition created: my-repo"))
+	assert.Check(t, cmp.Contains(result.Stderr, "Could not create trigger"))
+	assert.Check(t, cmp.Contains(result.Stdout, "Commit .circleci/config.yml"))
 }
 
 func TestOnboard_PostSignup_ClassicOrg_FollowsProject(t *testing.T) {
@@ -329,9 +835,9 @@ func TestOnboard_PostSignup_ClassicOrg_FollowsProject(t *testing.T) {
 	})
 
 	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
-	assert.Check(t, strings.Contains(result.Stdout, "Project connected: my-repo"))
-	assert.Check(t, strings.Contains(result.Stdout, "Organization: myorg"))
-	assert.Check(t, strings.Contains(result.Stdout, "Commit and push .circleci/config.yml"))
+	assert.Check(t, cmp.Contains(result.Stdout, "Project connected: my-repo"))
+	assert.Check(t, cmp.Contains(result.Stdout, "Organization: myorg"))
+	assert.Check(t, cmp.Contains(result.Stdout, "Commit and push .circleci/config.yml"))
 }
 
 func TestOnboard_PostSignup_NoOrgs(t *testing.T) {
@@ -353,18 +859,11 @@ func TestOnboard_PostSignup_NoOrgs(t *testing.T) {
 	})
 
 	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
-	assert.Check(t, strings.Contains(result.Stdout, "circleci project create"))
+	assert.Check(t, cmp.Contains(result.Stdout, "circleci project create"))
 }
 
 func TestOnboard_PostSignup_CreateFails(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("test runner uses sh -c")
-	}
-	dir := t.TempDir()
-	copyFixture(t, "testdata/test-run/dotnet", dir)
-	initGitRepoWithRemote(t, dir, "https://github.com/myorg/my-repo.git")
-
-	fake, env := onboardStandaloneEnv(t, "testuser")
+	dir, fake, env := onboardDotnetRepo(t)
 	fake.SetCreateProjectResponse(nil)
 	addFakeDotnet(t, env, false)
 	result := binary.RunCLI(t, binary.RunOpts{
@@ -375,79 +874,8 @@ func TestOnboard_PostSignup_CreateFails(t *testing.T) {
 	})
 
 	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
-	assert.Check(t, strings.Contains(result.Stderr, "Could not create project"))
-	assert.Check(t, strings.Contains(result.Stdout, "circleci project create"))
-}
-
-// TestOnboard_PostSignup_FreshSignup_ContinuesToProjectSetup is a regression test
-// for a fresh signup dead-ending before project creation.
-//
-// Signup writes the token to disk part-way through the run, but the config cached
-// in the context was loaded during bootstrap — before that write — so without a
-// reload LoadClient sees no token and project creation degrades to manual
-// guidance, on the one run where the user just signed up.
-//
-// This test must NOT set env.Token: CIRCLE_TOKEN is read ahead of the cached
-// config, which masks the bug, and is why the other post-signup tests never
-// caught it.
-func TestOnboard_PostSignup_FreshSignup_ContinuesToProjectSetup(t *testing.T) {
-	dir := t.TempDir()
-	initGitRepoWithRemote(t, dir, "https://github.com/myorg/my-repo.git")
-
-	fake := fakes.NewCircleCI(t)
-	fake.SetMe(map[string]any{
-		"id": "e4a72497-7c55-400d-a72d-dadc4b92255d",
-		"attributes": map[string]any{
-			"name":  "New User",
-			"login": "newuser",
-		},
-	})
-	fake.SetOAuthTokenResponse(map[string]any{
-		"access_token": "test-signup-token",
-		"token_type":   "Bearer",
-		"expires_in":   int64(7776000),
-	})
-	fake.SetCollaborations([]any{
-		map[string]any{"id": "org-uuid-1234", "name": "myorg", "slug": "circleci/myorg", "vcs_type": "circleci"},
-	})
-	fake.SetCreateProjectResponse(map[string]any{
-		"id":                "proj-uuid-5678",
-		"slug":              "circleci/Org1234ShortId/Proj5678ShortId",
-		"name":              "my-repo",
-		"organization_name": "myorg",
-		"organization_slug": "circleci/Org1234ShortId",
-		"organization_id":   "org-uuid-1234",
-	})
-
-	env := testenv.New(t)
-	env.CircleCIURL = fake.URL()
-	// Deliberately no env.Token — see the note above.
-	env.Extra["CIRCLE_LOGIN_TIMEOUT"] = "20s"
-	// Suppress the project-name prompt so the run completes without further input.
-	env.Extra["CIRCLE_NO_INTERACTIVE"] = "true"
-
-	console := binary.RunCLIInteractive(t, binary.RunOpts{
-		Binary:  binaryPath,
-		Args:    []string{"onboard", "--signup", "--no-browser"},
-		Env:     env.Environ(),
-		WorkDir: dir,
-	})
-
-	assert.Assert(t, t.Run("waits for browser callback", func(t *testing.T) {
-		_, err := console.ExpectString("Waiting for browser authentication")
-		assert.NilError(t, err)
-	}))
-
-	assert.Assert(t, t.Run("browser callback", func(t *testing.T) {
-		callbackViaPAR(t, fake)
-	}))
-
-	assert.Assert(t, t.Run("continues into project creation", func(t *testing.T) {
-		_, err := console.ExpectString("Logged in as newuser")
-		assert.NilError(t, err)
-		_, err = console.ExpectString("Project created: my-repo")
-		assert.NilError(t, err)
-	}))
+	assert.Check(t, cmp.Contains(result.Stderr, "Could not create project"))
+	assert.Check(t, cmp.Contains(result.Stdout, "circleci project create"))
 }
 
 // onboardDotnetRepo builds the fixture shared by the post-signup tests: a dotnet
@@ -456,145 +884,6 @@ func TestOnboard_PostSignup_FreshSignup_ContinuesToProjectSetup(t *testing.T) {
 //
 // Callers still wire their own fake dotnet binary, since whether the tests pass or
 // fail is the variable under test in some of them.
-// TestOnboard_PostSignup_Rerun_ReusesProject runs onboard twice over the same
-// repository. The first run creates the project and records it in
-// .circleci/info.yml; the second resolves it from that file instead of attempting
-// a create that could only conflict.
-//
-// That local record is what makes a re-run recoverable at all: a CircleCI-native
-// project slug is circleci/<orgID>/<projectID> — opaque IDs, not the repository
-// name — and no API maps a project name to its ID within an organization.
-func TestOnboard_PostSignup_Rerun_ReusesProject(t *testing.T) {
-	dir, fake, env := onboardDotnetRepo(t)
-	// The second run looks the project up by the slug projectref derives from the
-	// recorded UUIDs. The real API accepts that form and canonicalises it.
-	fake.AddProjectInfo("circleci/"+onboardOrgID+"/"+onboardProjectID, map[string]any{
-		"id":                onboardProjectID,
-		"slug":              "circleci/Org1234ShortId/Proj5678ShortId",
-		"name":              "my-repo",
-		"organization_name": "myorg",
-		"organization_slug": "circleci/Org1234ShortId",
-		"organization_id":   onboardOrgID,
-	})
-	addFakeDotnet(t, env, false)
-
-	first := binary.RunCLI(t, binary.RunOpts{
-		Binary: binaryPath, Args: []string{"onboard", "--scan"},
-		Env: env.Environ(), WorkDir: dir,
-	})
-	assert.Equal(t, first.ExitCode, 0, "stderr: %s", first.Stderr)
-	assert.Check(t, cmp.Contains(first.Stdout, "Project created: my-repo"))
-	assert.Check(t, cmp.Contains(first.Stdout, "Linked this repository to the project"))
-	_, statErr := os.Stat(filepath.Join(dir, ".circleci", "info.yml"))
-	assert.NilError(t, statErr, "first run should record the project locally")
-
-	second := binary.RunCLI(t, binary.RunOpts{
-		Binary: binaryPath, Args: []string{"onboard", "--scan"},
-		Env: env.Environ(), WorkDir: dir,
-	})
-	assert.Equal(t, second.ExitCode, 0, "stderr: %s", second.Stderr)
-	assert.Check(t, cmp.Contains(second.Stdout, "Using existing project: my-repo"))
-	assert.Check(t, !strings.Contains(second.Stdout, "Project created"),
-		"re-run should not create a second project")
-}
-
-// TestOnboard_PostSignup_KeepsExistingProjectRef pins that onboard never rewrites
-// an existing .circleci/info.yml. The file is meant to be committed, and it may
-// record a project in another organization that this run has no mandate to
-// replace — `circleci project link` requires --force for exactly that reason.
-func TestOnboard_PostSignup_KeepsExistingProjectRef(t *testing.T) {
-	dir, _, env := onboardDotnetRepo(t)
-
-	// A link to a project in a different organization, so it is ignored and onboard
-	// proceeds to create — the path that reaches the write.
-	existing := "organization:\n  id: other-org-uuid\n" +
-		"project:\n  id: other-proj-uuid\n  slug: gh/myorg/my-repo\n  name: my-repo\n"
-	refPath := filepath.Join(dir, ".circleci", "info.yml")
-	mkErr := os.MkdirAll(filepath.Dir(refPath), 0o755)
-	assert.NilError(t, mkErr)
-	writeErr := os.WriteFile(refPath, []byte(existing), 0o644)
-	assert.NilError(t, writeErr)
-	addFakeDotnet(t, env, false)
-
-	result := binary.RunCLI(t, binary.RunOpts{
-		Binary: binaryPath, Args: []string{"onboard", "--scan"},
-		Env: env.Environ(), WorkDir: dir,
-	})
-
-	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
-	body, readErr := os.ReadFile(refPath)
-	assert.NilError(t, readErr)
-	assert.Check(t, cmp.Equal(string(body), existing), "info.yml must be left byte-for-byte alone")
-	assert.Check(t, cmp.Contains(result.Stderr, "already records a different project"))
-	assert.Check(t, cmp.Contains(result.Stderr, "circleci project link --force --project"))
-	assert.Check(t, !strings.Contains(result.Stdout, "Using existing project"),
-		"a project in another organization must not be reused")
-}
-
-// TestOnboard_PostSignup_ProjectNameConflict covers a name collision onboard cannot
-// resolve: the organization already has a project with this name, but the checkout
-// has no info.yml recording its ID. Since a project cannot be looked up by name,
-// onboard points at `circleci project link` rather than reporting a raw conflict.
-func TestOnboard_PostSignup_ProjectNameConflict(t *testing.T) {
-	dir, fake, env := onboardDotnetRepo(t)
-	fake.SetCreateProjectConflict()
-	addFakeDotnet(t, env, false)
-
-	result := binary.RunCLI(t, binary.RunOpts{
-		Binary: binaryPath, Args: []string{"onboard", "--scan"},
-		Env: env.Environ(), WorkDir: dir,
-	})
-
-	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
-	assert.Check(t, cmp.Contains(result.Stderr, `project named "my-repo" already exists`))
-	assert.Check(t, cmp.Contains(result.Stdout, "circleci project link --project circleci/myorg/<projectID>"))
-	assert.Check(t, !strings.Contains(result.Stdout, "--force"), "no info.yml to overwrite")
-	// No raw HTTP internals for a conflict one command can resolve.
-	assert.Check(t, !strings.Contains(result.Stderr, "409"), "stderr should not leak an HTTP status")
-	assert.Check(t, !strings.Contains(result.Stderr, "/api/v2/"), "stderr should not leak an API path")
-}
-
-// TestOnboard_SignupFlag_RecordsProjectRefAtRepoRoot pins where --signup records the
-// link when run from a subdirectory. info.yml belongs beside config.yml at the top
-// of the checkout; writing it into the invocation directory would leave it
-// unreachable to every command that looks for it at the root.
-func TestOnboard_SignupFlag_RecordsProjectRefAtRepoRoot(t *testing.T) {
-	root := t.TempDir()
-	initGitRepoWithRemote(t, root, "https://github.com/myorg/my-repo.git")
-	sub := filepath.Join(root, "services", "api")
-	mkErr := os.MkdirAll(sub, 0o755)
-	assert.NilError(t, mkErr)
-
-	_, env := onboardStandaloneEnv(t, "testuser")
-	result := binary.RunCLI(t, binary.RunOpts{
-		Binary: binaryPath, Args: []string{"onboard", "--signup"},
-		Env: env.Environ(), WorkDir: sub,
-	})
-
-	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
-	_, rootErr := os.Stat(filepath.Join(root, ".circleci", "info.yml"))
-	assert.NilError(t, rootErr, "the link belongs at the repository root")
-	_, subErr := os.Stat(filepath.Join(sub, ".circleci", "info.yml"))
-	assert.Check(t, os.IsNotExist(subErr), "must not record the link in the invocation directory")
-}
-
-// TestOnboard_SignupFlag_WritesNoProjectRefOutsideRepo is the other half: with no
-// repository there is nothing to link, so nothing is written — a home directory
-// must not acquire a .circleci/info.yml.
-func TestOnboard_SignupFlag_WritesNoProjectRefOutsideRepo(t *testing.T) {
-	dir := t.TempDir() // deliberately not a git checkout
-
-	_, env := onboardStandaloneEnv(t, "testuser")
-	result := binary.RunCLI(t, binary.RunOpts{
-		Binary: binaryPath, Args: []string{"onboard", "--signup"},
-		Env: env.Environ(), WorkDir: dir,
-	})
-
-	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
-	_, statErr := os.Stat(filepath.Join(dir, ".circleci"))
-	assert.Check(t, os.IsNotExist(statErr), "must not create .circleci outside a repository")
-}
-
 func onboardDotnetRepo(t *testing.T) (string, *fakes.CircleCI, *testenv.TestEnv) {
 	t.Helper()
 	if runtime.GOOS == "windows" {
@@ -605,6 +894,19 @@ func onboardDotnetRepo(t *testing.T) (string, *fakes.CircleCI, *testenv.TestEnv)
 	initGitRepoWithRemote(t, dir, "https://github.com/myorg/my-repo.git")
 	fake, env := onboardStandaloneEnv(t, "testuser")
 	return dir, fake, env
+}
+
+// addFirstPipelineResponses registers the create responses for the pipeline
+// definition and all-pushes trigger that onboard wires up on the happy path.
+func addFirstPipelineResponses(fake *fakes.CircleCI) {
+	fake.SetCreatePipelineDefinitionResponse(onboardProjectID, map[string]any{
+		"id":   onboardPipelineDefID,
+		"name": "my-repo",
+	})
+	fake.SetCreateTriggerResponse(onboardProjectID, onboardPipelineDefID, map[string]any{
+		"id":           "trig-uuid-1",
+		"event_preset": "all-pushes",
+	})
 }
 
 func onboardStandaloneEnv(t *testing.T, login string) (*fakes.CircleCI, *testenv.TestEnv) {
@@ -619,11 +921,12 @@ func onboardStandaloneEnv(t *testing.T, login string) (*fakes.CircleCI, *testenv
 		},
 	})
 	fake.SetCollaborations([]any{
-		map[string]any{"id": "org-uuid-1234", "name": "myorg", "slug": "circleci/myorg", "vcs_type": "circleci"},
+		map[string]any{"id": onboardOrgID, "name": "myorg", "slug": "circleci/myorg", "vcs_type": "circleci"},
 	})
 	// A CircleCI-native project slug embeds opaque org and project short IDs, not
-	// the repository name — mirroring the real API, which rejects a name-based slug
-	// outright. The UUIDs are separate values used for project lookups.
+	// the repository name — mirroring the real API, where a name-based slug is
+	// rejected outright. The UUIDs are separate values used by the pipeline
+	// definition and GitHub App calls.
 	fake.SetCreateProjectResponse(map[string]any{
 		"id":                onboardProjectID,
 		"slug":              "circleci/Org1234ShortId/Proj5678ShortId",
@@ -651,15 +954,15 @@ func onboardAuthenticatedEnv(t *testing.T, login string) (*fakes.CircleCI, *test
 		},
 	})
 	fake.SetCollaborations([]any{
-		map[string]any{"id": "org-uuid-1234", "name": "myorg", "slug": "gh/myorg", "vcs_type": "github"},
+		map[string]any{"id": onboardOrgID, "name": "myorg", "slug": "gh/myorg", "vcs_type": "github"},
 	})
 	fake.SetCreateProjectResponse(map[string]any{
-		"id":                "proj-uuid-5678",
+		"id":                onboardProjectID,
 		"slug":              "gh/myorg/my-repo",
 		"name":              "my-repo",
 		"organization_name": "myorg",
 		"organization_slug": "gh/myorg",
-		"organization_id":   "org-uuid-1234",
+		"organization_id":   onboardOrgID,
 		"vcs_info": map[string]any{
 			"provider":       "GitHub",
 			"default_branch": "main",

--- a/acceptance/onboard_test.go
+++ b/acceptance/onboard_test.go
@@ -23,6 +23,7 @@
 package acceptance_test
 
 import (
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -829,6 +830,43 @@ func TestOnboard_PostSignup_FirstPipeline_MissingPrerequisiteSucceeds(t *testing
 	assert.Check(t, cmp.Contains(result.Stdout, "Project created: my-repo"))
 	assert.Check(t, cmp.Contains(result.Stderr, "can't access myorg/my-repo"))
 	assert.Check(t, cmp.Contains(result.Stdout, "circleci pipeline create"))
+}
+
+// TestOnboard_PostSignup_GitHubAppInstall_ReturnURL pins where the browser is sent
+// once the install finishes. The project's own page would report success in the
+// browser while the rest of setup sits waiting in the terminal.
+func TestOnboard_PostSignup_GitHubAppInstall_ReturnURL(t *testing.T) {
+	dir, fake, env := onboardDotnetRepo(t)
+	// The app is left uninstalled, so onboard initiates an install and has to hand
+	// over a return URL. Every other test here starts from an installed app, which
+	// never reaches this request.
+	addFakeDotnet(t, env, false)
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"onboard", "--scan"},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+
+	var returnURLs []string
+	for _, req := range fake.AllRequests() {
+		if req.Method != http.MethodPost || req.URL.Path != "/api/v2/github-app/install" {
+			continue
+		}
+		var body struct {
+			ReturnURL string `json:"return_url"`
+		}
+		assert.NilError(t, req.Decode(&body))
+		returnURLs = append(returnURLs, body.ReturnURL)
+	}
+
+	assert.Assert(t, cmp.Len(returnURLs, 1))
+	assert.Check(t, strings.HasSuffix(returnURLs[0], "/cli/github-app-installed"),
+		"return_url should land on the page that points back at the terminal, got %q", returnURLs[0])
+	assert.Check(t, !strings.Contains(returnURLs[0], "/pipelines/"),
+		"the project's pipelines page reads as a finish line in the browser, got %q", returnURLs[0])
 }
 
 func TestOnboard_PostSignup_ClassicOrg_FollowsProject(t *testing.T) {

--- a/acceptance/onboard_test.go
+++ b/acceptance/onboard_test.go
@@ -795,14 +795,19 @@ func TestOnboard_PostSignup_FirstPipeline_RepoNotAccessible(t *testing.T) {
 	assert.Check(t, !strings.Contains(result.Stdout, "Pipeline definition created"), "no pipeline def without a repo ID")
 }
 
+// TestOnboard_PostSignup_FirstPipeline_TriggerFails pins that a rejected request
+// exits non-zero.
+//
+// This is the case that must not report success: the definition exists and the
+// trigger does not, so nothing will build on push. A bootstrap script reading exit
+// 0 here would carry on believing CI was set up.
 func TestOnboard_PostSignup_FirstPipeline_TriggerFails(t *testing.T) {
 	dir, fake, env := onboardDotnetRepo(t)
 	fake.SetCreatePipelineDefinitionResponse(onboardProjectID, map[string]any{
 		"id":   onboardPipelineDefID,
 		"name": "my-repo",
 	})
-	// No trigger response registered → the trigger create returns 404 and the
-	// flow degrades to manual guidance.
+	// No trigger response registered → the trigger create fails.
 	addFakeDotnet(t, env, false)
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
@@ -811,10 +816,36 @@ func TestOnboard_PostSignup_FirstPipeline_TriggerFails(t *testing.T) {
 		WorkDir: dir,
 	})
 
-	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Equal(t, result.ExitCode, 4, "expected ExitAPIError, stderr: %s", result.Stderr)
 	assert.Check(t, cmp.Contains(result.Stdout, "Pipeline definition created: my-repo"))
-	assert.Check(t, cmp.Contains(result.Stderr, "Could not create trigger"))
-	assert.Check(t, cmp.Contains(result.Stdout, "Commit .circleci/config.yml"))
+	assert.Check(t, cmp.Contains(result.Stderr, "its trigger could not be"))
+	// The guidance moves into the error's suggestions rather than being dropped.
+	assert.Check(t, cmp.Contains(result.Stderr, "circleci project trigger create"))
+	assert.Check(t, !strings.Contains(result.Stdout, "Your project is ready!"),
+		"a project with no trigger is not ready")
+}
+
+// TestOnboard_PostSignup_FirstPipeline_MissingPrerequisiteSucceeds is the other
+// half of the exit-code rule: when a prerequisite is absent nothing was attempted,
+// so onboard prints the next step and succeeds. Reporting a failure for work it
+// never began would make a first run look broken.
+func TestOnboard_PostSignup_FirstPipeline_MissingPrerequisiteSucceeds(t *testing.T) {
+	dir, fake, env := onboardDotnetRepo(t)
+	// The GitHub App is installed but has not been granted this repository, so the
+	// external ID cannot be resolved and no pipeline request is ever made.
+	fake.SetGitHubAppInstalled(onboardOrgID, true)
+	addFakeDotnet(t, env, false)
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"onboard", "--scan"},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Check(t, cmp.Contains(result.Stdout, "Project created: my-repo"))
+	assert.Check(t, cmp.Contains(result.Stderr, "can't access myorg/my-repo"))
+	assert.Check(t, cmp.Contains(result.Stdout, "circleci pipeline create"))
 }
 
 func TestOnboard_PostSignup_ClassicOrg_FollowsProject(t *testing.T) {

--- a/acceptance/onboard_test.go
+++ b/acceptance/onboard_test.go
@@ -388,11 +388,7 @@ func TestOnboard_PostSignup_FreshSignup_ContinuesToProjectSetup(t *testing.T) {
 }
 
 // TestOnboard_PostSignup_KeepsExistingProjectRef pins that onboard never rewrites
-// an existing .circleci/info.yml.
-//
-// The file is meant to be committed, and it may record a project in another
-// organization that this run has no mandate to replace — `circleci project link`
-// requires --force for exactly that reason.
+// an existing .circleci/info.yml, which may be committed and may point elsewhere.
 func TestOnboard_PostSignup_KeepsExistingProjectRef(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("test runner uses sh -c")
@@ -430,9 +426,7 @@ func TestOnboard_PostSignup_KeepsExistingProjectRef(t *testing.T) {
 }
 
 // TestOnboard_PostSignup_AddsPushTriggerAlongsideOthers pins that only an
-// all-pushes trigger satisfies onboard. A definition carrying just a schedule
-// trigger would otherwise be reported as ready, and the push onboard tells the
-// user to make would build nothing.
+// all-pushes trigger satisfies onboard, not a schedule-only definition.
 func TestOnboard_PostSignup_AddsPushTriggerAlongsideOthers(t *testing.T) {
 	dir, fake, env := onboardDotnetRepo(t)
 	fake.AddPipelineDefinition(onboardProjectID, map[string]any{
@@ -515,13 +509,8 @@ func TestOnboard_SignupFlag_WritesNoProjectRefOutsideRepo(t *testing.T) {
 	assert.Check(t, os.IsNotExist(statErr), "must not create .circleci outside a repository")
 }
 
-// TestOnboard_PathArgument_UsesGivenDirectory pins that a path argument selects
-// the repository onboard describes.
-//
-// The process runs from a *different* checkout with a different remote, so any
-// detection that reads the working directory instead of the argument would name
-// the project after the wrong repository and wire the pipeline to the wrong repo —
-// silently, since every step still reports success.
+// TestOnboard_PathArgument_UsesGivenDirectory pins that a path argument selects the
+// repository onboard describes, not the one the process is running from.
 func TestOnboard_PathArgument_UsesGivenDirectory(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("test runner uses sh -c")
@@ -796,11 +785,7 @@ func TestOnboard_PostSignup_FirstPipeline_RepoNotAccessible(t *testing.T) {
 }
 
 // TestOnboard_PostSignup_FirstPipeline_TriggerFails pins that a rejected request
-// exits non-zero.
-//
-// This is the case that must not report success: the definition exists and the
-// trigger does not, so nothing will build on push. A bootstrap script reading exit
-// 0 here would carry on believing CI was set up.
+// exits non-zero: a definition with no trigger will never build.
 func TestOnboard_PostSignup_FirstPipeline_TriggerFails(t *testing.T) {
 	dir, fake, env := onboardDotnetRepo(t)
 	fake.SetCreatePipelineDefinitionResponse(onboardProjectID, map[string]any{
@@ -825,10 +810,8 @@ func TestOnboard_PostSignup_FirstPipeline_TriggerFails(t *testing.T) {
 		"a project with no trigger is not ready")
 }
 
-// TestOnboard_PostSignup_FirstPipeline_MissingPrerequisiteSucceeds is the other
-// half of the exit-code rule: when a prerequisite is absent nothing was attempted,
-// so onboard prints the next step and succeeds. Reporting a failure for work it
-// never began would make a first run look broken.
+// TestOnboard_PostSignup_FirstPipeline_MissingPrerequisiteSucceeds is the other half
+// of the exit-code rule: nothing was attempted, so onboard succeeds with guidance.
 func TestOnboard_PostSignup_FirstPipeline_MissingPrerequisiteSucceeds(t *testing.T) {
 	dir, fake, env := onboardDotnetRepo(t)
 	// The GitHub App is installed but has not been granted this repository, so the

--- a/internal/cmd/onboard/onboard.go
+++ b/internal/cmd/onboard/onboard.go
@@ -38,6 +38,7 @@ func NewOnboardCmd() *cobra.Command {
 		noBrowser bool
 		scan      bool
 		signup    bool
+		repoID    string
 	)
 
 	cmd := &cobra.Command{
@@ -46,15 +47,12 @@ func NewOnboardCmd() *cobra.Command {
 		Short:   "Guided onboarding: scan, test, generate config, sign up",
 		Annotations: map[string]string{
 			"help:arguments": heredoc.Docf(`
-				%[1]s<path>%[1]s is optional and is the directory to scan. Defaults to
-				the current directory.
+				%[1]s<path>%[1]s is the directory to scan. Defaults to the current directory.
 			`, "`"),
 		},
 		Long: heredoc.Doc(`
-			Guided onboarding: scan a local repository, run its detected tests,
-			generate a starter .circleci/config.yml, and sign up for CircleCI.
-
-			Interactively without --scan or --signup, a prompt offers both.
+			Interactively without --scan or --signup, a prompt offers both. For
+			CircleCI-native orgs it also creates the project and an all-pushes trigger.
 		`),
 		Example: heredoc.Doc(`
 			# Interactive mode: choose scan or signup
@@ -62,6 +60,9 @@ func NewOnboardCmd() *cobra.Command {
 
 			# Scan the current directory (skip the choice prompt)
 			$ circleci onboard --scan
+
+			# Scan and wire up the first pipeline without prompts
+			$ circleci onboard --scan --repo-id 123456789
 
 			# Sign up for CircleCI (no repo needed)
 			$ circleci onboard --signup
@@ -94,6 +95,7 @@ func NewOnboardCmd() *cobra.Command {
 				ConfigPath:    configPath,
 				Scan:          scan,
 				Signup:        signup,
+				RepoID:        repoID,
 			})
 		},
 	}
@@ -101,5 +103,6 @@ func NewOnboardCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&noBrowser, "no-browser", false, "Print the signup URL instead of opening a browser")
 	cmd.Flags().BoolVar(&scan, "scan", false, "Skip prompt: scan the repo and generate config")
 	cmd.Flags().BoolVar(&signup, "signup", false, "Skip prompt: sign up for CircleCI")
+	cmd.Flags().StringVar(&repoID, "repo-id", "", "Numeric repository ID, if the GitHub App cannot resolve it")
 	return cmd
 }

--- a/internal/cmd/root/testdata/help/circleci/onboard.txt
+++ b/internal/cmd/root/testdata/help/circleci/onboard.txt
@@ -6,16 +6,16 @@ Guided onboarding: scan, test, generate config, sign up
 
 ## Arguments
 
-`<path>` is optional and is the directory to scan. Defaults to
-the current directory.
+`<path>` is the directory to scan. Defaults to the current directory.
 
 ## Flags
 
-| Flag           | Description                                       |
-| -------------- | ------------------------------------------------- |
-| `--no-browser` | Print the signup URL instead of opening a browser |
-| `--scan`       | Skip prompt: scan the repo and generate config    |
-| `--signup`     | Skip prompt: sign up for CircleCI                 |
+| Flag               | Description                                                |
+| ------------------ | ---------------------------------------------------------- |
+| `--no-browser`     | Print the signup URL instead of opening a browser          |
+| `--repo-id string` | Numeric repository ID, if the GitHub App cannot resolve it |
+| `--scan`           | Skip prompt: scan the repo and generate config             |
+| `--signup`         | Skip prompt: sign up for CircleCI                          |
 
 Global flags: `-c, --config`, `--debug`, `--no-color`, `-q, --quiet` — see `circleci --help`.
 
@@ -25,6 +25,8 @@ Global flags: `-c, --config`, `--debug`, `--no-color`, `-q, --quiet` — see `ci
   `circleci onboard`
 - Scan the current directory (skip the choice prompt): 
   `circleci onboard --scan`
+- Scan and wire up the first pipeline without prompts: 
+  `circleci onboard --scan --repo-id 123456789`
 - Sign up for CircleCI (no repo needed): 
   `circleci onboard --signup`
 - Onboard a specific project path: 
@@ -34,8 +36,6 @@ Global flags: `-c, --config`, `--debug`, `--no-color`, `-q, --quiet` — see `ci
 
 ## Details
 
-Guided onboarding: scan a local repository, run its detected tests,
-generate a starter .circleci/config.yml, and sign up for CircleCI.
-
-Interactively without --scan or --signup, a prompt offers both.
+Interactively without --scan or --signup, a prompt offers both. For
+CircleCI-native orgs it also creates the project and an all-pushes trigger.
 

--- a/internal/cmd/root/testdata/help/circleci/reference.txt
+++ b/internal/cmd/root/testdata/help/circleci/reference.txt
@@ -4206,22 +4206,20 @@ the run's "org/repo" repository (when known) and project_id its UUID.
 
 Guided onboarding: scan, test, generate config, sign up
 
-Guided onboarding: scan a local repository, run its detected tests,
-generate a starter .circleci/config.yml, and sign up for CircleCI.
+Interactively without --scan or --signup, a prompt offers both. For
+CircleCI-native orgs it also creates the project and an all-pushes trigger.
 
-Interactively without --scan or --signup, a prompt offers both.
-
-| Flag           | Description                                       |
-| -------------- | ------------------------------------------------- |
-| `--no-browser` | Print the signup URL instead of opening a browser |
-| `--scan`       | Skip prompt: scan the repo and generate config    |
-| `--signup`     | Skip prompt: sign up for CircleCI                 |
+| Flag               | Description                                                |
+| ------------------ | ---------------------------------------------------------- |
+| `--no-browser`     | Print the signup URL instead of opening a browser          |
+| `--repo-id string` | Numeric repository ID, if the GitHub App cannot resolve it |
+| `--scan`           | Skip prompt: scan the repo and generate config             |
+| `--signup`         | Skip prompt: sign up for CircleCI                          |
 
 
 **Arguments:**
 
-`<path>` is optional and is the directory to scan. Defaults to
-the current directory.
+`<path>` is the directory to scan. Defaults to the current directory.
 
 **Examples:**
 
@@ -4229,6 +4227,8 @@ the current directory.
   `circleci onboard`
 - Scan the current directory (skip the choice prompt): 
   `circleci onboard --scan`
+- Scan and wire up the first pipeline without prompts: 
+  `circleci onboard --scan --repo-id 123456789`
 - Sign up for CircleCI (no repo needed): 
   `circleci onboard --signup`
 - Onboard a specific project path: 

--- a/internal/cmd/root/testdata/usage/circleci/onboard.txt
+++ b/internal/cmd/root/testdata/usage/circleci/onboard.txt
@@ -1,8 +1,9 @@
 Usage:  circleci onboard [path] [flags]
 
 Flags:
-  -h, --help         help for onboard
-      --no-browser   Print the signup URL instead of opening a browser
-      --scan         Skip prompt: scan the repo and generate config
-      --signup       Skip prompt: sign up for CircleCI
+  -h, --help             help for onboard
+      --no-browser       Print the signup URL instead of opening a browser
+      --repo-id string   Numeric repository ID, if the GitHub App cannot resolve it
+      --scan             Skip prompt: scan the repo and generate config
+      --signup           Skip prompt: sign up for CircleCI
   

--- a/internal/cmdutil/appurls.go
+++ b/internal/cmdutil/appurls.go
@@ -54,6 +54,13 @@ func RunSlugURL(appURL string, slug string) (string, error) {
 	), nil
 }
 
+// GitHubAppInstalledURL returns the page to send the browser to once a CircleCI
+// GitHub App install completes. It confirms the install and points the user back
+// at their terminal, where the rest of onboarding happens.
+func GitHubAppInstalledURL(appURL string) string {
+	return fmt.Sprintf("%s/cli/github-app-installed", appURL)
+}
+
 // RunURL returns the CircleCI pipelines page URL for the given project slug.
 func RunURL(appURL string, id uuid.UUID) string {
 	return fmt.Sprintf("%s/pipeline/%s", appURL, id)

--- a/internal/cmdutil/appurls_test.go
+++ b/internal/cmdutil/appurls_test.go
@@ -64,6 +64,11 @@ func TestRunURL(t *testing.T) {
 	assert.Check(t, cmp.Equal(u, "https://app.circleci.com/pipeline/8cb37115-80a4-4af6-b377-eddd0f7c7167"))
 }
 
+func TestGitHubAppInstalledURL(t *testing.T) {
+	u := GitHubAppInstalledURL(testAppURL)
+	assert.Check(t, cmp.Equal(u, "https://app.circleci.com/cli/github-app-installed"))
+}
+
 func TestWorkflowURL(t *testing.T) {
 	u := WorkflowURL(testAppURL, uuid.MustParse("41212e5f-8b9c-465f-bd77-c6f02ba91f7b"))
 	assert.Check(t, cmp.Equal(u, "https://app.circleci.com/workflow/41212e5f-8b9c-465f-bd77-c6f02ba91f7b"))

--- a/internal/githubapp/githubapp.go
+++ b/internal/githubapp/githubapp.go
@@ -121,10 +121,22 @@ func pollInstalled(ctx context.Context, client *apiclient.Client, orgID string) 
 	}
 }
 
+// ErrTooManyRepositories reports that the search reached its page cap before
+// examining every repository, so the target may well be accessible.
+//
+// Callers must not report this as "the app cannot access that repository": the
+// advice that follows from it — grant access and re-run — can never help, because
+// re-running searches the same bounded prefix again.
+var ErrTooManyRepositories = errors.New("too many repositories to search for a match")
+
 // ResolveRepoID returns the external (numeric) ID of the repository named
 // repoFullName ("owner/repo") among the repositories the GitHub App can access
-// for the organization. It returns "" (with no error) when the repository is
-// not found — e.g. it exists but was not granted to the app.
+// for the organization.
+//
+// It returns "" with no error only when the whole list was examined and held no
+// match — the repository exists but was not granted to the app. Reaching the page
+// cap first returns ErrTooManyRepositories instead, because that is not the same
+// answer. The endpoint offers no name filter, so the list has to be walked.
 func ResolveRepoID(ctx context.Context, client *apiclient.Client, orgID, repoFullName string) (string, error) {
 	if repoFullName == "" {
 		return "", nil
@@ -143,8 +155,8 @@ func ResolveRepoID(ctx context.Context, client *apiclient.Client, orgID, repoFul
 		}
 		seen += len(repos)
 		if len(repos) == 0 || (total > 0 && seen >= total) {
-			break
+			return "", nil // whole list examined, genuinely no match
 		}
 	}
-	return "", nil
+	return "", ErrTooManyRepositories
 }

--- a/internal/githubapp/githubapp.go
+++ b/internal/githubapp/githubapp.go
@@ -22,8 +22,7 @@
 
 // Package githubapp drives the CircleCI GitHub App onboarding steps: checking
 // whether the app is installed for an organization, walking the user through a
-// browser-based install, and resolving a repository's external ID. It talks to
-// the public v2 GitHub App endpoints exposed by public-api-service.
+// browser-based install, and resolving a repository's external ID.
 package githubapp
 
 import (
@@ -39,25 +38,19 @@ import (
 )
 
 const (
-	// pollInterval is how often the install poll checks the installation status.
-	pollInterval = 3 * time.Second
-	// pollTimeout bounds how long we wait for a browser-based install.
-	pollTimeout = 3 * time.Minute
-	// repoPageLimit is the page size used when listing repositories.
+	pollInterval  = 3 * time.Second
+	pollTimeout   = 3 * time.Minute
 	repoPageLimit = 100
-	// maxRepoPages bounds the repository pagination to avoid an unbounded loop.
+	// maxRepoPages keeps the walk in ResolveRepoID bounded.
 	maxRepoPages = 50
 )
 
 // EnsureInstalled reports whether the CircleCI GitHub App is installed for the
-// organization, walking the user through a browser-based install when it is
-// not. orgID is the organization UUID; returnURL is where GitHub redirects
-// after install (an app.circleci.com URL).
+// organization, walking the user through a browser-based install when it is not.
+// returnURL is where GitHub redirects after install.
 //
-// It returns true once the app is installed. In non-interactive sessions (or
-// with noBrowser), it prints the install URL and returns false without waiting.
-// A returned error is a genuine API failure; callers typically degrade to
-// manual guidance on either a false result or an error.
+// Non-interactive sessions (or noBrowser) print the install URL and return false
+// without waiting. Callers degrade to manual guidance on false or on an error.
 func EnsureInstalled(ctx context.Context, client *apiclient.Client, orgID, returnURL string, noBrowser bool) (bool, error) {
 	if _, err := client.GetGitHubAppInstallation(ctx, orgID); err == nil {
 		return true, nil
@@ -121,22 +114,18 @@ func pollInstalled(ctx context.Context, client *apiclient.Client, orgID string) 
 	}
 }
 
-// ErrTooManyRepositories reports that the search reached its page cap before
-// examining every repository, so the target may well be accessible.
-//
-// Callers must not report this as "the app cannot access that repository": the
-// advice that follows from it — grant access and re-run — can never help, because
-// re-running searches the same bounded prefix again.
+// ErrTooManyRepositories reports that the search hit its page cap before examining
+// every repository, so the target may well be accessible. Callers must not report it
+// as "the app cannot access that repository" — the advice that follows from that,
+// grant access and re-run, searches the same bounded prefix again.
 var ErrTooManyRepositories = errors.New("too many repositories to search for a match")
 
-// ResolveRepoID returns the external (numeric) ID of the repository named
-// repoFullName ("owner/repo") among the repositories the GitHub App can access
-// for the organization.
+// ResolveRepoID returns the external (numeric) ID of repoFullName ("owner/repo")
+// among the repositories the GitHub App can access for the organization. The
+// endpoint offers no name filter, so the list has to be walked.
 //
 // It returns "" with no error only when the whole list was examined and held no
-// match — the repository exists but was not granted to the app. Reaching the page
-// cap first returns ErrTooManyRepositories instead, because that is not the same
-// answer. The endpoint offers no name filter, so the list has to be walked.
+// match; hitting the page cap first returns ErrTooManyRepositories.
 func ResolveRepoID(ctx context.Context, client *apiclient.Client, orgID, repoFullName string) (string, error) {
 	if repoFullName == "" {
 		return "", nil

--- a/internal/githubapp/githubapp_test.go
+++ b/internal/githubapp/githubapp_test.go
@@ -25,12 +25,14 @@ package githubapp_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
 	"testing"
 
 	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
 
 	"github.com/CircleCI-Public/circleci-cli/internal/apiclient"
 	"github.com/CircleCI-Public/circleci-cli/internal/githubapp"
@@ -81,6 +83,36 @@ func pagedReposServer(t *testing.T, fullNames []string) *apiclient.Client {
 	t.Cleanup(srv.Close)
 
 	return apiclient.New(apiclient.Config{BaseURL: srv.URL, Token: "test-token"})
+}
+
+// TestResolveRepoID_PageCap pins that exhausting the page cap is reported as its
+// own condition rather than as "no match".
+//
+// Conflating them makes onboard tell the user the GitHub App cannot access a
+// repository it may well have access to, and the advice that follows — grant
+// access, then re-run — can never help, because the next run searches the same
+// bounded prefix.
+func TestResolveRepoID_PageCap(t *testing.T) {
+	// A server that always has more pages: total_count never gets satisfied, so
+	// the loop can only end by hitting its cap.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"items": []map[string]any{
+				{"id": 1, "repo_full_name": "myorg/filler-a"},
+				{"id": 2, "repo_full_name": "myorg/filler-b"},
+			},
+			"total_count": 1_000_000,
+		})
+	}))
+	t.Cleanup(srv.Close)
+	client := apiclient.New(apiclient.Config{BaseURL: srv.URL, Token: "test-token"})
+
+	id, err := githubapp.ResolveRepoID(testCtx(), client, "org-1", "myorg/needle")
+
+	assert.Check(t, cmp.Equal(id, ""))
+	assert.Check(t, errors.Is(err, githubapp.ErrTooManyRepositories),
+		"hitting the page cap must be distinguishable from an absent repository, got: %v", err)
 }
 
 func TestResolveRepoID(t *testing.T) {

--- a/internal/onboarder/onboarder.go
+++ b/internal/onboarder/onboarder.go
@@ -321,12 +321,9 @@ func selectOrg(ctx context.Context, orgs []apiclient.Collaboration) *apiclient.C
 }
 
 // stopWithGuidance prints how to connect the repository by hand and ends the run
-// successfully.
-//
-// Everything up to the point where the project exists is recoverable this way: the
-// user is told exactly what to run, so stopping here is not the command failing.
-// Once a request has been made and rejected, setupFirstPipeline returns a real
-// error instead.
+// successfully. Everything up to the point where the project exists is recoverable
+// this way; once a request has been made and rejected, setupFirstPipeline returns a
+// real error instead.
 func stopWithGuidance(ctx context.Context) error {
 	printManualGuidance(ctx)
 	return nil
@@ -493,24 +490,14 @@ func writeProjectRef(ctx context.Context, workDir string, proj *apiclient.Projec
 // the github_app provider, and the repo's external ID for both config and
 // checkout sources).
 //
-// A missing prerequisite and a failed request are different outcomes, and the
-// exit code distinguishes them.
-//
-// When a prerequisite is absent — no GitHub App, the repository not granted to it,
-// a repository that is not on GitHub — nothing was attempted. The user has a clear
-// next step, so onboard prints it and succeeds; reporting a failure for work it
-// never began would make a first run look broken.
-//
-// When a request was made and the API rejected it, that is a failure. It also
-// leaves the project half-configured — a definition with no trigger will never
-// build — which is exactly the state a script must not read as success.
-// `circleci pipeline create` and `circleci project trigger create` return a
-// structured error for these same endpoints; onboard was discarding it.
+// A missing prerequisite — no GitHub App, the repository not granted to it, a repo
+// that is not on GitHub — means nothing was attempted, so onboard prints the next
+// step and succeeds. A request the API rejected is a real error: it leaves the
+// project half-configured, and a definition with no trigger will never build.
 func setupFirstPipeline(ctx context.Context, client *apiclient.Client, returnURL string, proj *apiclient.ProjectInfo, remote gitRemote, opts Options) error {
 	repoID := resolveRepoID(ctx, client, returnURL, proj, remote, opts)
 	if repoID == "" {
-		// Without the repo's external ID we can't create the pipeline
-		// definition. The project still exists; guide the user to finish setup.
+		// No external ID, so there is nothing to attach a definition to.
 		trackOnboard(ctx, "onboard_project_setup", map[string]any{"outcome": "skipped_no_repo_id"})
 		printManualPipelineGuidance(ctx)
 		return nil

--- a/internal/onboarder/onboarder.go
+++ b/internal/onboarder/onboarder.go
@@ -283,13 +283,10 @@ func postSignupGuidance(ctx context.Context, dir string, opts Options) error {
 		iostream.Printf(ctx, "  Pipelines: %s\n", pipelinesURL)
 	}
 
-	// Where GitHub returns the browser after a GitHub App install. The project's
-	// own page is the most useful landing spot; the app URL is the fallback when a
-	// slug could not be turned into one.
-	returnURL := pipelinesURL
-	if returnURL == "" {
-		returnURL = appURL
-	}
+	// Where GitHub returns the browser after a GitHub App install. Landing on the
+	// project's own page reads as a finish line, in the browser, while the rest of
+	// setup is still waiting back in the terminal.
+	returnURL := cmdutil.GitHubAppInstalledURL(appURL)
 	return setupFirstPipeline(ctx, client, returnURL, proj, remote, opts)
 }
 

--- a/internal/onboarder/onboarder.go
+++ b/internal/onboarder/onboarder.go
@@ -206,56 +206,27 @@ func repoDir(dir string) string {
 // that `circleci onboard <path>` describes the directory it was given rather than
 // the one the process happens to be sitting in.
 //
-// Errors are handled gracefully: any failure falls through to manual guidance
-// rather than failing the onboard command.
+// Failures up to the point where the project exists fall through to manual
+// guidance and succeed; a rejected pipeline request is a real error. See
+// setupFirstPipeline.
 func postSignupGuidance(ctx context.Context, dir string, opts Options) error {
 	ctx = refreshConfig(ctx, opts)
 
 	client, err := cmdutil.LoadClient(ctx)
 	if err != nil {
-		printManualGuidance(ctx)
-		return nil
+		return stopWithGuidance(ctx)
 	}
-
-	appURL, _ := cmdutil.AppURL(ctx)
 
 	orgs, err := org.Require(ctx, client)
 	if err != nil {
-		printManualGuidance(ctx)
-		return nil
+		return stopWithGuidance(ctx)
+	}
+	selectedOrg := selectOrg(ctx, orgs)
+	if selectedOrg == nil {
+		return stopWithGuidance(ctx)
 	}
 
-	var selectedOrg apiclient.Collaboration
-	switch {
-	case len(orgs) == 1:
-		selectedOrg = orgs[0]
-		iostream.Printf(ctx, "%s Using organization %s\n", iostream.SymbolOK(ctx), selectedOrg.Slug)
-	case iostream.IsInteractive(ctx):
-		iostream.ErrPrintf(ctx, "\nLet's create your CircleCI project.\n\n")
-		labels := make([]string, len(orgs))
-		for i, c := range orgs {
-			labels[i] = c.Slug
-			if c.Name != "" && c.Name != c.Slug {
-				labels[i] = fmt.Sprintf("%s (%s)", c.Slug, c.Name)
-			}
-		}
-		idx, err := iostream.PromptSelect(ctx,
-			"Which organization should this project belong to?", labels)
-		if err != nil || idx < 0 {
-			printManualGuidance(ctx)
-			return nil
-		}
-		selectedOrg = orgs[idx]
-	default:
-		printManualGuidance(ctx)
-		return nil
-	}
-
-	vcs, orgName, err := org.ParseSlug(selectedOrg.Slug)
-	if err != nil {
-		printManualGuidance(ctx)
-		return nil
-	}
+	appURL, _ := cmdutil.AppURL(ctx)
 
 	// One read of the checkout's remote serves both the suggested project name and
 	// the owner/repo the GitHub App lookup needs.
@@ -270,11 +241,17 @@ func postSignupGuidance(ctx context.Context, dir string, opts Options) error {
 		proj = resolveLinkedProject(ctx, client, dir, selectedOrg.ID)
 	}
 
+	// A classic organization is never linked — resolveLinkedProject is only
+	// consulted for CircleCI-native orgs — so it always lands here and shares the
+	// name prompt and slug parse with the create path.
 	if proj == nil {
 		name := promptProjectName(ctx, remote.Repo)
 		if name == "" {
-			printManualGuidance(ctx)
-			return nil
+			return stopWithGuidance(ctx)
+		}
+		vcs, orgName, err := org.ParseSlug(selectedOrg.Slug)
+		if err != nil {
+			return stopWithGuidance(ctx)
 		}
 
 		if selectedOrg.VCSType != "circleci" {
@@ -291,8 +268,7 @@ func postSignupGuidance(ctx context.Context, dir string, opts Options) error {
 				return nil
 			}
 			iostream.ErrPrintf(ctx, "%s Could not create project: %s\n", iostream.SymbolWarn(ctx), err)
-			printManualGuidance(ctx)
-			return nil
+			return stopWithGuidance(ctx)
 		}
 		proj = created
 		iostream.Printf(ctx, "%s Project created: %s\n", iostream.SymbolOK(ctx), proj.Name)
@@ -307,7 +283,53 @@ func postSignupGuidance(ctx context.Context, dir string, opts Options) error {
 		iostream.Printf(ctx, "  Pipelines: %s\n", pipelinesURL)
 	}
 
-	return setupFirstPipeline(ctx, client, pipelinesURL, appURL, proj, remote, opts)
+	// Where GitHub returns the browser after a GitHub App install. The project's
+	// own page is the most useful landing spot; the app URL is the fallback when a
+	// slug could not be turned into one.
+	returnURL := pipelinesURL
+	if returnURL == "" {
+		returnURL = appURL
+	}
+	return setupFirstPipeline(ctx, client, returnURL, proj, remote, opts)
+}
+
+// selectOrg picks the organization to create the project in, returning nil when
+// the user cannot be asked or declines.
+func selectOrg(ctx context.Context, orgs []apiclient.Collaboration) *apiclient.Collaboration {
+	if len(orgs) == 1 {
+		iostream.Printf(ctx, "%s Using organization %s\n", iostream.SymbolOK(ctx), orgs[0].Slug)
+		return &orgs[0]
+	}
+	if !iostream.IsInteractive(ctx) {
+		return nil
+	}
+
+	iostream.ErrPrintf(ctx, "\nLet's create your CircleCI project.\n\n")
+	labels := make([]string, len(orgs))
+	for i, c := range orgs {
+		labels[i] = c.Slug
+		if c.Name != "" && c.Name != c.Slug {
+			labels[i] = fmt.Sprintf("%s (%s)", c.Slug, c.Name)
+		}
+	}
+	idx, err := iostream.PromptSelect(ctx,
+		"Which organization should this project belong to?", labels)
+	if err != nil || idx < 0 {
+		return nil
+	}
+	return &orgs[idx]
+}
+
+// stopWithGuidance prints how to connect the repository by hand and ends the run
+// successfully.
+//
+// Everything up to the point where the project exists is recoverable this way: the
+// user is told exactly what to run, so stopping here is not the command failing.
+// Once a request has been made and rejected, setupFirstPipeline returns a real
+// error instead.
+func stopWithGuidance(ctx context.Context) error {
+	printManualGuidance(ctx)
+	return nil
 }
 
 // promptProjectName asks for the project name, offering defaultName. It returns
@@ -484,8 +506,8 @@ func writeProjectRef(ctx context.Context, workDir string, proj *apiclient.Projec
 // build — which is exactly the state a script must not read as success.
 // `circleci pipeline create` and `circleci project trigger create` return a
 // structured error for these same endpoints; onboard was discarding it.
-func setupFirstPipeline(ctx context.Context, client *apiclient.Client, pipelinesURL, appURL string, proj *apiclient.ProjectInfo, remote gitRemote, opts Options) error {
-	repoID := resolveRepoID(ctx, client, pipelinesURL, appURL, proj, remote, opts)
+func setupFirstPipeline(ctx context.Context, client *apiclient.Client, returnURL string, proj *apiclient.ProjectInfo, remote gitRemote, opts Options) error {
+	repoID := resolveRepoID(ctx, client, returnURL, proj, remote, opts)
 	if repoID == "" {
 		// Without the repo's external ID we can't create the pipeline
 		// definition. The project still exists; guide the user to finish setup.
@@ -592,7 +614,7 @@ func ensureTrigger(ctx context.Context, client *apiclient.Client, projectID, def
 // App is installed for the org and matches the git remote against the app's
 // accessible repositories. Any failure returns "" so the caller degrades to
 // manual guidance rather than prompting for an opaque numeric ID.
-func resolveRepoID(ctx context.Context, client *apiclient.Client, pipelinesURL, appURL string, proj *apiclient.ProjectInfo, remote gitRemote, opts Options) string {
+func resolveRepoID(ctx context.Context, client *apiclient.Client, returnURL string, proj *apiclient.ProjectInfo, remote gitRemote, opts Options) string {
 	if opts.RepoID != "" {
 		return opts.RepoID
 	}
@@ -613,11 +635,6 @@ func resolveRepoID(ctx context.Context, client *apiclient.Client, pipelinesURL, 
 			iostream.SymbolWarn(ctx), fullName)
 		iostream.ErrPrintf(ctx, "  Re-run with --repo-id <id> to set up the pipeline.\n")
 		return ""
-	}
-
-	returnURL := pipelinesURL
-	if returnURL == "" {
-		returnURL = appURL
 	}
 
 	installed, err := githubapp.EnsureInstalled(ctx, client, proj.OrganizationID, returnURL, opts.NoBrowser)

--- a/internal/onboarder/onboarder.go
+++ b/internal/onboarder/onboarder.go
@@ -307,8 +307,7 @@ func postSignupGuidance(ctx context.Context, dir string, opts Options) error {
 		iostream.Printf(ctx, "  Pipelines: %s\n", pipelinesURL)
 	}
 
-	setupFirstPipeline(ctx, client, pipelinesURL, appURL, proj, remote, opts)
-	return nil
+	return setupFirstPipeline(ctx, client, pipelinesURL, appURL, proj, remote, opts)
 }
 
 // promptProjectName asks for the project name, offering defaultName. It returns
@@ -472,35 +471,57 @@ func writeProjectRef(ctx context.Context, workDir string, proj *apiclient.Projec
 // the github_app provider, and the repo's external ID for both config and
 // checkout sources).
 //
-// Every step degrades gracefully: the project already exists, so any failure
-// prints manual guidance rather than failing the command.
-func setupFirstPipeline(ctx context.Context, client *apiclient.Client, pipelinesURL, appURL string, proj *apiclient.ProjectInfo, remote gitRemote, opts Options) {
+// A missing prerequisite and a failed request are different outcomes, and the
+// exit code distinguishes them.
+//
+// When a prerequisite is absent — no GitHub App, the repository not granted to it,
+// a repository that is not on GitHub — nothing was attempted. The user has a clear
+// next step, so onboard prints it and succeeds; reporting a failure for work it
+// never began would make a first run look broken.
+//
+// When a request was made and the API rejected it, that is a failure. It also
+// leaves the project half-configured — a definition with no trigger will never
+// build — which is exactly the state a script must not read as success.
+// `circleci pipeline create` and `circleci project trigger create` return a
+// structured error for these same endpoints; onboard was discarding it.
+func setupFirstPipeline(ctx context.Context, client *apiclient.Client, pipelinesURL, appURL string, proj *apiclient.ProjectInfo, remote gitRemote, opts Options) error {
 	repoID := resolveRepoID(ctx, client, pipelinesURL, appURL, proj, remote, opts)
 	if repoID == "" {
 		// Without the repo's external ID we can't create the pipeline
 		// definition. The project still exists; guide the user to finish setup.
 		trackOnboard(ctx, "onboard_project_setup", map[string]any{"outcome": "skipped_no_repo_id"})
 		printManualPipelineGuidance(ctx)
-		return
+		return nil
 	}
 
 	def, err := ensurePipelineDefinition(ctx, client, proj.ID, proj.Name, repoID)
 	if err != nil {
-		iostream.ErrPrintf(ctx, "%s Could not create pipeline definition: %s\n", iostream.SymbolWarn(ctx), err)
 		trackOnboard(ctx, "onboard_project_setup", map[string]any{"outcome": "pipeline_definition_failed"})
-		printManualPipelineGuidance(ctx)
-		return
+		return clierrors.New("onboard.pipeline_definition_failed",
+			"Could not set up the pipeline definition",
+			fmt.Sprintf("The project was created, but its pipeline definition could not be set up: %s.", err)).
+			WithSuggestions(
+				"Run 'circleci pipeline create' to finish setting up the pipeline",
+				"Then commit and push .circleci/ to start your first pipeline",
+			).
+			WithExitCode(clierrors.ExitAPIError)
 	}
 
 	if err := ensureTrigger(ctx, client, proj.ID, def.ID, repoID); err != nil {
-		iostream.ErrPrintf(ctx, "%s Could not create trigger: %s\n", iostream.SymbolWarn(ctx), err)
 		trackOnboard(ctx, "onboard_project_setup", map[string]any{"outcome": "trigger_failed"})
-		printManualPipelineGuidance(ctx)
-		return
+		return clierrors.New("onboard.trigger_failed",
+			"Could not set up the trigger",
+			fmt.Sprintf("The pipeline definition was created, but its trigger could not be: %s.", err)).
+			WithSuggestions(
+				"Run 'circleci project trigger create' to finish setting up the trigger",
+				"Until a trigger exists, pushing will not start a pipeline",
+			).
+			WithExitCode(clierrors.ExitAPIError)
 	}
 
 	trackOnboard(ctx, "onboard_project_setup", map[string]any{"outcome": "created"})
 	printPipelineReadyGuidance(ctx)
+	return nil
 }
 
 // ensurePipelineDefinition returns the pipeline definition already configured

--- a/internal/onboarder/onboarder.go
+++ b/internal/onboarder/onboarder.go
@@ -40,6 +40,7 @@ import (
 	"github.com/CircleCI-Public/circleci-cli/internal/config"
 	"github.com/CircleCI-Public/circleci-cli/internal/configgen"
 	clierrors "github.com/CircleCI-Public/circleci-cli/internal/errors"
+	"github.com/CircleCI-Public/circleci-cli/internal/githubapp"
 	"github.com/CircleCI-Public/circleci-cli/internal/gitremote"
 	"github.com/CircleCI-Public/circleci-cli/internal/httpcl"
 	"github.com/CircleCI-Public/circleci-cli/internal/iostream"
@@ -57,6 +58,10 @@ const (
 	modeSignup             // sign up only — no repo required
 )
 
+// allPushesPreset is the trigger event preset that starts a pipeline on every
+// push, which is what onboard sets up.
+const allPushesPreset = "all-pushes"
+
 // Options configures the onboarding flow.
 type Options struct {
 	ConfigPath    string
@@ -64,6 +69,12 @@ type Options struct {
 	SecureStorage bool
 	Scan          bool
 	Signup        bool
+	// RepoID is the VCS repository external ID (the numeric GitHub repo ID) used
+	// to wire up the first pipeline definition and trigger. When empty it is
+	// resolved through the CircleCI GitHub App; if that cannot resolve it, pipeline
+	// setup is skipped with manual guidance. It is never prompted for — an opaque
+	// numeric ID is not something a user can be expected to know.
+	RepoID string
 }
 
 // Run scans a repository, verifies its tests, generates a starter config when
@@ -170,28 +181,6 @@ func Run(ctx context.Context, dir string, opts Options) error {
 	return postSignupGuidance(ctx, dir, opts)
 }
 
-// refreshConfig re-reads the config from disk when the cached copy carries no
-// token.
-//
-// A fresh signup persists the token to the keyring (or the config file), but the
-// *config.Config in ctx was loaded during root's bootstrap — before that write —
-// so it still looks unauthenticated. Without this reload, LoadClient fails with
-// auth.token_missing on the very run that just signed the user up, and project
-// creation degrades to manual guidance.
-//
-// A reload failure is not fatal: returning the unchanged ctx degrades exactly as
-// it would have anyway.
-func refreshConfig(ctx context.Context, opts Options) context.Context {
-	if cmdutil.GetConfig(ctx).EffectiveToken() != "" {
-		return ctx
-	}
-	cfg, err := config.Load(ctx, opts.ConfigPath, opts.SecureStorage)
-	if err != nil {
-		return ctx
-	}
-	return cmdutil.WithConfig(ctx, cfg)
-}
-
 // repoDir returns the root of the repository containing dir, and "" when dir is
 // not inside one. A "" result disables everything that reads or writes repository
 // state, which is the right behaviour when there is no repository to describe.
@@ -208,10 +197,17 @@ func repoDir(dir string) string {
 }
 
 // postSignupGuidance offers inline project creation and prints a follow-up
-// message after the user has authenticated.
+// message after the user has authenticated. For modern (CircleCI-native) orgs
+// it continues past project creation to set up the first pipeline definition
+// and trigger, so a subsequent push starts a build.
 //
-// Errors are handled gracefully: project creation failure falls through to
-// manual guidance rather than failing the onboard command.
+// dir is the checkout being onboarded, or "" when there is none. Every read of
+// repository state — the git remote and .circleci/info.yml — is scoped to it, so
+// that `circleci onboard <path>` describes the directory it was given rather than
+// the one the process happens to be sitting in.
+//
+// Errors are handled gracefully: any failure falls through to manual guidance
+// rather than failing the onboard command.
 func postSignupGuidance(ctx context.Context, dir string, opts Options) error {
 	ctx = refreshConfig(ctx, opts)
 
@@ -261,6 +257,10 @@ func postSignupGuidance(ctx context.Context, dir string, opts Options) error {
 		return nil
 	}
 
+	// One read of the checkout's remote serves both the suggested project name and
+	// the owner/repo the GitHub App lookup needs.
+	remote := detectRemote(dir)
+
 	// Resolve a project this repository is already linked to before asking for a
 	// name. On a re-run the answer would be discarded, and offering one is
 	// actively misleading: the recorded slug of a standalone project carries
@@ -271,7 +271,7 @@ func postSignupGuidance(ctx context.Context, dir string, opts Options) error {
 	}
 
 	if proj == nil {
-		name := promptProjectName(ctx, repoNameIn(dir))
+		name := promptProjectName(ctx, remote.Repo)
 		if name == "" {
 			printManualGuidance(ctx)
 			return nil
@@ -301,15 +301,13 @@ func postSignupGuidance(ctx context.Context, dir string, opts Options) error {
 		iostream.Printf(ctx, "%s Using existing project: %s\n", iostream.SymbolOK(ctx), proj.Name)
 	}
 
+	pipelinesURL, _ := cmdutil.RunSlugURL(appURL, proj.Slug)
 	iostream.Printf(ctx, "  Organization: %s\n", proj.OrganizationName)
-	if pipelinesURL, err := cmdutil.RunSlugURL(appURL, proj.Slug); err == nil {
+	if pipelinesURL != "" {
 		iostream.Printf(ctx, "  Pipelines: %s\n", pipelinesURL)
 	}
-	// Stage the whole directory: info.yml records the project's ID, and that ID is
-	// not recoverable from its name — no API maps one to the other. Committing it is
-	// what lets a fresh clone, a teammate, or a later run find this project instead
-	// of colliding with it.
-	iostream.Printf(ctx, "\nCommit .circleci/ (config.yml and info.yml). After your project is connected in CircleCI, pushing will start your first pipeline.\n")
+
+	setupFirstPipeline(ctx, client, pipelinesURL, appURL, proj, remote, opts)
 	return nil
 }
 
@@ -330,21 +328,66 @@ func promptProjectName(ctx context.Context, defaultName string) string {
 	return name
 }
 
-// repoNameIn returns the repository name of the checkout at dir, or "" when there
-// is no readable remote there.
-func repoNameIn(dir string) string {
-	if dir == "" {
+// gitRemote is what onboard needs to know about a checkout's origin remote.
+type gitRemote struct {
+	// VCS is the provider segment of the slug ("gh", "bb", "gl"), or "" when the
+	// remote could not be read.
+	VCS string
+	// Owner and Repo name the repository, e.g. "acme" and "web".
+	Owner, Repo string
+}
+
+// FullName is the "owner/repo" form used as the GitHub App's repository key, or
+// "" when the remote could not be read.
+func (r gitRemote) FullName() string {
+	if r.Owner == "" || r.Repo == "" {
 		return ""
+	}
+	return r.Owner + "/" + r.Repo
+}
+
+// IsGitHub reports whether this is a GitHub repository — the only provider the
+// CircleCI GitHub App can resolve.
+func (r gitRemote) IsGitHub() bool { return r.VCS == "gh" }
+
+// detectRemote reads the origin remote of the checkout at dir. A failure yields
+// the zero value rather than an error: onboard degrades to prompting for a name
+// and to manual pipeline guidance.
+func detectRemote(dir string) gitRemote {
+	if dir == "" {
+		return gitRemote{}
 	}
 	info, err := gitremote.DetectFromRemoteIn(dir)
 	if err != nil {
-		return ""
+		return gitRemote{}
 	}
 	parts := strings.Split(info.Slug, "/")
 	if len(parts) != 3 {
-		return ""
+		return gitRemote{}
 	}
-	return parts[2]
+	return gitRemote{VCS: parts[0], Owner: parts[1], Repo: parts[2]}
+}
+
+// refreshConfig re-reads the config from disk when the cached copy carries no
+// token.
+//
+// A fresh signup persists the token to the keyring (or the config file), but the
+// *config.Config in ctx was loaded during root's bootstrap — before that write —
+// so it still looks unauthenticated. Without this reload, LoadClient fails with
+// auth.token_missing on the very run that just signed the user up, and the whole
+// project setup degrades to manual guidance.
+//
+// A reload failure is not fatal: returning the unchanged ctx degrades exactly as
+// it would have anyway.
+func refreshConfig(ctx context.Context, opts Options) context.Context {
+	if cmdutil.GetConfig(ctx).EffectiveToken() != "" {
+		return ctx
+	}
+	cfg, err := config.Load(ctx, opts.ConfigPath, opts.SecureStorage)
+	if err != nil {
+		return ctx
+	}
+	return cmdutil.WithConfig(ctx, cfg)
 }
 
 // resolveLinkedProject returns the project recorded in .circleci/info.yml, or nil
@@ -358,8 +401,8 @@ func repoNameIn(dir string) string {
 // A link only counts when its project belongs to orgID. A repository linked
 // elsewhere — a classic VCS project being migrated to a CircleCI-native org, say —
 // is ignored, so onboard sets up the organization the user actually chose. An
-// unresolvable link is ignored the same way; the create path handles everything a
-// link cannot supply.
+// unresolvable link is ignored the same way; the create path below handles
+// everything a link cannot supply.
 func resolveLinkedProject(ctx context.Context, client *apiclient.Client, workDir, orgID string) *apiclient.ProjectInfo {
 	if workDir == "" {
 		return nil
@@ -422,23 +465,191 @@ func writeProjectRef(ctx context.Context, workDir string, proj *apiclient.Projec
 		iostream.SymbolOK(ctx), projectref.FilePath)
 }
 
-// printLinkGuidance covers a project that exists in the organization but is not
-// the one this checkout resolves to. No API maps a project name to its ID, so the
-// ID has to come from the user — the same conclusion `circleci project link`
-// reaches when it cannot resolve a slug on its own.
+// setupFirstPipeline wires up a pipeline definition and an all-pushes trigger
+// for a freshly created project so the first push starts a build. It uses the
+// same v2 endpoints as `circleci pipeline create` and `circleci project trigger
+// create`, with sensible zero-prompt defaults (config at .circleci/config.yml,
+// the github_app provider, and the repo's external ID for both config and
+// checkout sources).
 //
-// The command is spelled out with the organization already filled in. --project is
-// load-bearing: without it, link re-derives the slug from the git remote and a
-// repository linked elsewhere lands straight back where it started. --force is
-// added when .circleci/info.yml is present, since plain link refuses while it is.
-func printLinkGuidance(ctx context.Context, workDir, orgSlug string) {
-	args := "--project " + orgSlug + "/<projectID>"
-	if _, err := os.Stat(projectref.Path(workDir)); err == nil {
-		args = "--force " + args
+// Every step degrades gracefully: the project already exists, so any failure
+// prints manual guidance rather than failing the command.
+func setupFirstPipeline(ctx context.Context, client *apiclient.Client, pipelinesURL, appURL string, proj *apiclient.ProjectInfo, remote gitRemote, opts Options) {
+	repoID := resolveRepoID(ctx, client, pipelinesURL, appURL, proj, remote, opts)
+	if repoID == "" {
+		// Without the repo's external ID we can't create the pipeline
+		// definition. The project still exists; guide the user to finish setup.
+		trackOnboard(ctx, "onboard_project_setup", map[string]any{"outcome": "skipped_no_repo_id"})
+		printManualPipelineGuidance(ctx)
+		return
 	}
-	iostream.Printf(ctx, "\nCopy that project's ID from its settings in CircleCI, then run:\n")
-	iostream.Printf(ctx, "  circleci project link %s\n", args)
-	iostream.Printf(ctx, "  circleci onboard\n")
+
+	def, err := ensurePipelineDefinition(ctx, client, proj.ID, proj.Name, repoID)
+	if err != nil {
+		iostream.ErrPrintf(ctx, "%s Could not create pipeline definition: %s\n", iostream.SymbolWarn(ctx), err)
+		trackOnboard(ctx, "onboard_project_setup", map[string]any{"outcome": "pipeline_definition_failed"})
+		printManualPipelineGuidance(ctx)
+		return
+	}
+
+	if err := ensureTrigger(ctx, client, proj.ID, def.ID, repoID); err != nil {
+		iostream.ErrPrintf(ctx, "%s Could not create trigger: %s\n", iostream.SymbolWarn(ctx), err)
+		trackOnboard(ctx, "onboard_project_setup", map[string]any{"outcome": "trigger_failed"})
+		printManualPipelineGuidance(ctx)
+		return
+	}
+
+	trackOnboard(ctx, "onboard_project_setup", map[string]any{"outcome": "created"})
+	printPipelineReadyGuidance(ctx)
+}
+
+// ensurePipelineDefinition returns the pipeline definition already configured
+// for the repo, or creates one. Reusing an existing definition keeps re-runs of
+// onboard from creating duplicates.
+func ensurePipelineDefinition(ctx context.Context, client *apiclient.Client, projectID, name, repoID string) (*apiclient.PipelineDefinition, error) {
+	defs, err := client.ListPipelineDefinitions(ctx, projectID)
+	if err != nil {
+		// Creating blindly after a failed lookup risks a duplicate definition, so
+		// report the lookup failure instead of guessing.
+		return nil, err
+	}
+	for i := range defs {
+		cs := defs[i].ConfigSource
+		if cs != nil && cs.Repo != nil && cs.Repo.ExternalID == repoID {
+			iostream.Printf(ctx, "%s Pipeline definition already exists: %s\n", iostream.SymbolOK(ctx), defs[i].Name)
+			return &defs[i], nil
+		}
+	}
+
+	def, err := client.CreatePipelineDefinition(ctx, projectID, apiclient.CreatePipelineDefinitionInput{
+		Name:             name,
+		ConfigProvider:   "github_app",
+		ConfigRepoID:     repoID,
+		ConfigFilePath:   ".circleci/config.yml",
+		CheckoutProvider: "github_app",
+		CheckoutRepoID:   repoID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	iostream.Printf(ctx, "%s Pipeline definition created: %s\n", iostream.SymbolOK(ctx), def.Name)
+	return def, nil
+}
+
+// ensureTrigger creates an all-pushes trigger for the pipeline definition unless
+// one already exists, so re-runs of onboard don't add duplicate triggers.
+//
+// Only an all-pushes trigger counts. A definition carrying just a schedule or
+// webhook trigger would otherwise be reported as ready, and the push onboard tells
+// the user to make would build nothing.
+func ensureTrigger(ctx context.Context, client *apiclient.Client, projectID, definitionID, repoID string) error {
+	trigs, err := client.ListTriggers(ctx, projectID, definitionID)
+	if err != nil {
+		return err
+	}
+	for _, t := range trigs {
+		if t.EventPreset == allPushesPreset {
+			iostream.Printf(ctx, "%s Trigger already exists: %s\n", iostream.SymbolOK(ctx), t.EventPreset)
+			return nil
+		}
+	}
+
+	trig, err := client.CreateTrigger(ctx, projectID, definitionID, "github_app", repoID, allPushesPreset, "", "")
+	if err != nil {
+		return err
+	}
+	preset := trig.EventPreset
+	if preset == "" {
+		preset = allPushesPreset
+	}
+	iostream.Printf(ctx, "%s Trigger created: %s\n", iostream.SymbolOK(ctx), preset)
+	return nil
+}
+
+// resolveRepoID determines the repo external ID for the pipeline definition and
+// trigger. An explicit --repo-id wins. Otherwise it ensures the CircleCI GitHub
+// App is installed for the org and matches the git remote against the app's
+// accessible repositories. Any failure returns "" so the caller degrades to
+// manual guidance rather than prompting for an opaque numeric ID.
+func resolveRepoID(ctx context.Context, client *apiclient.Client, pipelinesURL, appURL string, proj *apiclient.ProjectInfo, remote gitRemote, opts Options) string {
+	if opts.RepoID != "" {
+		return opts.RepoID
+	}
+	if proj.OrganizationID == "" {
+		return ""
+	}
+	fullName := remote.FullName()
+	if fullName == "" {
+		iostream.ErrPrintf(ctx, "%s Could not read this repository's git remote, so the pipeline was not set up.\n",
+			iostream.SymbolWarn(ctx))
+		return ""
+	}
+	// The GitHub App resolves GitHub repositories only. Sending a GitLab or
+	// Bitbucket remote through it produces an install prompt that cannot help and
+	// a "grant access to this repository" message that can never be satisfied.
+	if !remote.IsGitHub() {
+		iostream.ErrPrintf(ctx, "%s %s is not a GitHub repository, so its ID cannot be looked up automatically.\n",
+			iostream.SymbolWarn(ctx), fullName)
+		iostream.ErrPrintf(ctx, "  Re-run with --repo-id <id> to set up the pipeline.\n")
+		return ""
+	}
+
+	returnURL := pipelinesURL
+	if returnURL == "" {
+		returnURL = appURL
+	}
+
+	installed, err := githubapp.EnsureInstalled(ctx, client, proj.OrganizationID, returnURL, opts.NoBrowser)
+	if err != nil {
+		iostream.ErrPrintf(ctx, "%s Could not check GitHub App installation: %s\n", iostream.SymbolWarn(ctx), err)
+		return ""
+	}
+	if !installed {
+		return ""
+	}
+
+	id, err := githubapp.ResolveRepoID(ctx, client, proj.OrganizationID, fullName)
+	if errors.Is(err, githubapp.ErrTooManyRepositories) {
+		iostream.ErrPrintf(ctx, "%s This organization has too many repositories to find %s automatically.\n",
+			iostream.SymbolWarn(ctx), fullName)
+		iostream.ErrPrintf(ctx, "  Re-run with --repo-id <id> to set up the pipeline.\n")
+		return ""
+	}
+	if err != nil {
+		iostream.ErrPrintf(ctx, "%s Could not list GitHub App repositories: %s\n", iostream.SymbolWarn(ctx), err)
+		return ""
+	}
+	if id == "" {
+		iostream.ErrPrintf(ctx, "%s The GitHub App can't access %s yet. Grant it access to this repository, then re-run.\n",
+			iostream.SymbolWarn(ctx), fullName)
+		return ""
+	}
+
+	iostream.Printf(ctx, "%s Found repository %s\n", iostream.SymbolOK(ctx), fullName)
+	return id
+}
+
+// printPipelineReadyGuidance prints the happy-path next steps once the pipeline
+// definition and trigger have been created. The pipelines URL is not repeated
+// here; the caller has already printed it alongside the project details.
+func printPipelineReadyGuidance(ctx context.Context) {
+	// Stage the whole directory rather than just config.yml: info.yml records the
+	// project's ID, and that ID is not recoverable from its name — no API maps one
+	// to the other. Committing it is what lets a fresh clone, a teammate, or a
+	// later onboard run find this project instead of colliding with it.
+	iostream.Printf(ctx, "\nYour project is ready! Next steps:\n")
+	iostream.Printf(ctx, "  1. git add .circleci/\n")
+	iostream.Printf(ctx, "  2. git commit -m \"Add CircleCI config\"\n")
+	iostream.Printf(ctx, "  3. git push\n")
+	iostream.Printf(ctx, "\nPushing will trigger your first pipeline.\n")
+}
+
+// printManualPipelineGuidance is the fallback when the pipeline definition or
+// trigger could not be created. The project exists, so point the user at the
+// commands that finish the job.
+func printManualPipelineGuidance(ctx context.Context) {
+	iostream.Printf(ctx, "\nCommit .circleci/config.yml. After your project is connected in CircleCI, pushing will start your first pipeline.\n")
+	iostream.Printf(ctx, "To set up a trigger now, run 'circleci pipeline create' then 'circleci project trigger create'.\n")
 }
 
 func followClassicProject(ctx context.Context, client *apiclient.Client, appURL, vcs, orgName, repoName string) {
@@ -459,6 +670,25 @@ func followClassicProject(ctx context.Context, client *apiclient.Client, appURL,
 
 func printManualGuidance(ctx context.Context) {
 	iostream.Printf(ctx, "\nRun 'circleci project create' to connect this repo to CircleCI.\n")
+}
+
+// printLinkGuidance covers a project that exists in the organization but is not
+// the one this checkout resolves to. No API maps a project name to its ID, so the
+// ID has to come from the user — the same conclusion `circleci project link`
+// reaches when it cannot resolve a slug on its own.
+//
+// The command is spelled out with the organization already filled in. --project is
+// load-bearing: without it, link re-derives the slug from the git remote and a
+// repository linked elsewhere lands straight back where it started. --force is
+// added when .circleci/info.yml is present, since plain link refuses while it is.
+func printLinkGuidance(ctx context.Context, workDir, orgSlug string) {
+	args := "--project " + orgSlug + "/<projectID>"
+	if _, err := os.Stat(projectref.Path(workDir)); err == nil {
+		args = "--force " + args
+	}
+	iostream.Printf(ctx, "\nCopy that project's ID from its settings in CircleCI, then run:\n")
+	iostream.Printf(ctx, "  circleci project link %s\n", args)
+	iostream.Printf(ctx, "  circleci onboard\n")
 }
 
 func trackOnboard(ctx context.Context, event string, props map[string]any) {
@@ -534,6 +764,8 @@ func displayPreamble(ctx context.Context, dir string) error {
 			"Run your tests locally",
 			"Generate a starter .circleci/config.yml",
 			"Sign you up for CircleCI",
+			"Create your project and connect it to GitHub",
+			"Set up your first pipeline trigger",
 		},
 	)
 	p := tea.NewProgram(model,


### PR DESCRIPTION
## What this adds

onboard already created your project and wrote a config file. This PR makes it
set up the pipeline itself, so a fresh repo goes from nothing to building on the
next push without any follow-up commands.

Previously you had to run `circleci pipeline create` and `circleci project trigger
create` yourself. Nothing had told CircleCI *"when code lands in this repo, read
that config and run it"* — so you could finish onboard, push, and watch nothing
happen.

**Before** — end of a successful run:

```
✓ Project created: my-repo
✓ Linked this repository to the project in .circleci/info.yml
  Organization: myorg
  Pipelines: https://app.circleci.com/pipelines/circleci/8KsBMffqg…/Y5nuJ5Zzav…

Commit .circleci/ (config.yml and info.yml). After your project is connected in CircleCI, pushing will start your first pipeline.
```

Note the hedge: *"after your project is connected"*. Nothing had connected it.

**After:**

```
✓ Project created: my-repo
✓ Linked this repository to the project in .circleci/info.yml
  Organization: myorg
  Pipelines: https://app.circleci.com/pipelines/circleci/8KsBMffqg…/Y5nuJ5Zzav…
✓ Pipeline definition created: my-repo
✓ Trigger created: all-pushes

Your project is ready! Next steps:
  1. git add .circleci/
  2. git commit -m "Add CircleCI config"
  3. git push
```

Built on the same v2 endpoints as `circleci pipeline create` and `circleci project
trigger create`, with zero-prompt defaults. The definition needs GitHub's numeric
repo ID, which onboard resolves through the GitHub App; `--repo-id` supplies it
directly when that cannot work.

## Also added: a return page for the GitHub App install

When the app is not installed, onboard opens a browser and keeps polling, so setup
carries on in the terminal. That install used to land on the project's pipelines
page — a finish line in the wrong place, with nothing to say the terminal is still
waiting.

It now returns to `/cli/github-app-installed`, which points the user back. That
page is already deployed, so the redirect has somewhere to land.

## Exit codes for the new path

A missing prerequisite — no GitHub App, repo not granted to it, repo not on GitHub —
exits **0**. Nothing was attempted and the user has a clear next step, so failing
there would make a first run look broken.

A request the API rejected exits **4**. A definition with no trigger will never
build, and that is the state a script must not read as success:

```
$ circleci onboard --scan --repo-id 123456789     # trigger creation rejected
✓ Pipeline definition created: my-repo
error: The pipeline definition was created, but its trigger could not be: … 404 Not Found.

Suggestions:
  • Run 'circleci project trigger create' to finish setting up the trigger
$ echo $?
4
```

## Cases the new path handles

Worth a look, since each one is a way an automatic setup could otherwise claim
success it had not earned:

- **Only an `all-pushes` trigger counts as one.** A definition carrying just a
  schedule would otherwise be reported as ready, and the push would build nothing.
- **A failed existence check does not fall through to creating a definition**,
  which would risk a duplicate. It reports the failure instead.
- **A GitLab or Bitbucket remote does not go through the GitHub App.** It says so
  and asks for `--repo-id`, rather than prompting for an install that cannot help.

## One fix to existing code

`githubapp.ResolveRepoID` (merged earlier) could not tell *"no match"* from *"gave
up after 5,000 repos"* — both surfaced as the app being unable to access the repo,
so the advice that followed, grant access and re-run, could never work: the next
run searches the same bounded prefix. The page cap is now its own error. The
endpoint offers no name filter, so the list still has to be walked.

## Test plan

- [ ] `task test` passes
- [ ] `--scan --repo-id <id>` creates the definition and trigger, prints "Your project is ready!"
- [ ] GitHub App resolution finds the repository without `--repo-id`
- [ ] A schedule-only definition still gets an all-pushes trigger
- [ ] Rejected trigger exits 4 and does not claim the project is ready
- [ ] Missing prerequisite exits 0 with the next step
- [ ] Install redirects to `/cli/github-app-installed`, not the pipelines page

Last of the four PRs split out of #1647. The other three (#1655, #1656, #1657) are merged, so this one stands alone on top of main.
