### PR TITLE
Fix --failure-report aborting on not-run jobs

### DIFF
--- a/acceptance/run_failed_context_test.go
+++ b/acceptance/run_failed_context_test.go
@@ -41,6 +41,7 @@ const (
 	fcJob1ID = "d0000000-0000-4000-8000-0000000000f1" // single execution, one failed step
 	fcJob2ID = "d0000000-0000-4000-8000-0000000000f2" // parallel job, one of two executions failed
 	fcJob3ID = "d0000000-0000-4000-8000-0000000000f3" // succeeded, no failures — should not appear
+	fcJob4ID = "d0000000-0000-4000-8000-0000000000f4" // not-run job — GetJobV3 returns 404
 )
 
 // --- run get --failure-report ---
@@ -224,6 +225,58 @@ func TestRunGet_FailureReport_RejectsJSON(t *testing.T) {
 
 	assert.Check(t, cmp.Equal(result.ExitCode, 2))
 	assert.Check(t, cmp.Contains(result.Stderr, "run.failure_report_no_json"))
+}
+
+// TestRunGet_FailedContext_JobNotFound verifies that jobs whose GetJobV3 call
+// returns 404 (not-run / skipped jobs) are silently skipped rather than
+// aborting the report with an error. This reproduces a real-world failure where
+// workflows contain jobs with no status (e.g. "deploy.release-reporting") that
+// the API cannot serve because they never executed.
+func TestRunGet_FailedContext_JobNotFound(t *testing.T) {
+	fake := fakes.NewCircleCI(t)
+	fake.AddRunV3(fcRunID, runTestProjectID, fakeRunV3(fcRunID, runTestProjectID, "ended", "failed", "main", "abc1234def5678"))
+	fake.AddRunWorkflowsV3(fcRunID, fakeWorkflowV3(fcWfID, "build", fcRunID, runTestProjectID, "ended", "failed"))
+	// fcJob4ID is intentionally NOT registered with AddJobV3 — the fake returns
+	// 404 for it, simulating a not-run job in the workflow job list.
+	fake.AddWorkflowJobsV3(fcWfID,
+		fakeJobV3(fcJob1ID, "run-tests", fcWfID, runTestProjectID),
+		fakeJobV3(fcJob4ID, "deploy.release-reporting", fcWfID, runTestProjectID),
+	)
+
+	now := time.Date(2020, 1, 1, 12, 0, 0, 0, time.UTC).Format(v3TimeFormat)
+	fake.AddJobV3(fcJob1ID, map[string]any{"data": map[string]any{
+		"id": fcJob1ID,
+		"attributes": map[string]any{
+			"name": "run-tests", "type": "build", "phase": "ended", "outcome": "failed",
+			"started_at": now, "ended_at": now,
+			"parallel_executions": []map[string]any{{
+				"steps": []map[string]any{
+					{"name": "Spin up environment", "type": "spinup_environment", "num": 0, "phase": "ended", "outcome": "succeeded", "started_at": now, "ended_at": now},
+					{"name": "run tests", "type": "run", "num": 101, "phase": "ended", "outcome": "failed", "exit_code": 1, "started_at": now, "ended_at": now},
+				},
+			}},
+		},
+		"references": map[string]any{
+			"workflow": map[string]any{"id": fcWfID},
+			"project":  map[string]any{"id": runTestProjectID},
+		},
+	}})
+	fake.AddJobStdoutCondensed(fcJob1ID, 0, 101, []byte("FAILURE: 2 tests failed\n"))
+
+	env := testenv.New(t)
+	env.Token = testToken
+	env.CircleCIURL = fake.URL()
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"run", "get", fcRunID, "--failure-report"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Check(t, cmp.Equal(result.ExitCode, 0))
+	assert.Check(t, golden.String(result.Stdout, t.Name()+".txt"))
+	assert.Check(t, cmp.Equal(result.Stderr, ""))
 }
 
 // TestRunGet_FailedContext_WorkflowsNotFound exits 0 with no output when the

--- a/acceptance/testdata/TestRunGet_FailedContext_JobNotFound.txt
+++ b/acceptance/testdata/TestRunGet_FailedContext_JobNotFound.txt
@@ -1,0 +1,8 @@
+## workflow: build
+
+### job: run-tests
+
+#### step 101: run tests [exit: 1]
+
+FAILURE: 2 tests failed
+

--- a/internal/cmd/run/failed_context.go
+++ b/internal/cmd/run/failed_context.go
@@ -64,7 +64,7 @@ func runFailureReport(ctx context.Context, client *apiclient.Client, r *apiclien
 			jobDetail, err := client.GetJobV3(ctx, j.ID)
 			if err != nil {
 				if httpcl.HasStatusCode(err, http.StatusNotFound) {
-					continue // job hasn't run yet (not-run / skipped jobs return 404)
+					continue
 				}
 				return apiErr(err, j.ID.String())
 			}

--- a/internal/cmd/run/failed_context.go
+++ b/internal/cmd/run/failed_context.go
@@ -63,6 +63,9 @@ func runFailureReport(ctx context.Context, client *apiclient.Client, r *apiclien
 		for _, j := range jobs {
 			jobDetail, err := client.GetJobV3(ctx, j.ID)
 			if err != nil {
+				if httpcl.HasStatusCode(err, http.StatusNotFound) {
+					continue // job hasn't run yet (not-run / skipped jobs return 404)
+				}
 				return apiErr(err, j.ID.String())
 			}
 


### PR DESCRIPTION
## Summary

- `circleci run get <run-id> --failure-report` was returning an error (`No run found for "<job-uuid>"`) when the run's workflow included jobs that never executed (skipped, conditional, or blocked by earlier failures).
- These not-run jobs appear in the workflow job list but their detail endpoint returns 404, which `runFailureReport` was propagating as a fatal error instead of skipping.
- Fixed by applying the same 404-skip pattern already used for the workflows endpoint: when `GetJobV3` returns 404, continue to the next job.

## Root cause

`internal/cmd/run/failed_context.go` iterated over all jobs in a workflow and called `GetJobV3` for each one. The API returns 404 for jobs that were listed but never ran (e.g. `deploy.release-reporting`, `group-end` type jobs). The code had no 404 guard here, unlike the analogous code for workflow listing which already handled 404 gracefully.

## Test plan

- [ ] `TestRunGet_FailedContext_JobNotFound` — new acceptance test that registers a job in the workflow list without a corresponding `AddJobV3` entry (fake returns 404), verifying exit 0 and that the other failed job's output still appears correctly.
- [ ] All existing `TestRunGet_Failed*` tests continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)