### PR TITLE
Read yes/no/on/off as booleans when packing, as the compiler does

### DIFF
--- a/acceptance/orb_test.go
+++ b/acceptance/orb_test.go
@@ -693,6 +693,38 @@ func TestOrbPack_Directory_OrbYml(t *testing.T) {
 	assert.Check(t, golden.String(result.Stderr, t.Name()+".stderr.txt"))
 }
 
+// TestOrbPack_YAML11Booleans is the end-to-end check for
+// https://github.com/CircleCI-Public/circleci-cli/issues/691: a boolean orb
+// parameter defaulting to `on` packed to the string "on", so `orb validate` on
+// the packed output rejected the parameter against its own declared type.
+func TestOrbPack_YAML11Booleans(t *testing.T) {
+	_, env := setupOrbFake(t)
+
+	dir := t.TempDir()
+	assert.NilError(t, os.MkdirAll(filepath.Join(dir, "src", "commands"), 0o755))
+	writeOrbFile(t, filepath.Join(dir, "src", "@orb.yml"), "version: 2.1\n")
+	writeOrbFile(t, filepath.Join(dir, "src", "commands", "vpn.yml"),
+		"parameters:\n"+
+			"  killswitch:\n    type: boolean\n    default: on\n"+
+			"  verbose:\n    type: boolean\n    default: yes\n"+
+			"  quiet:\n    type: boolean\n    default: off\n"+
+			// Quoted: the author asked for the string, and packing must not
+			// decide otherwise.
+			"  label:\n    type: string\n    default: \"on\"\n"+
+			"steps:\n  - run: echo hi\n")
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"orb", "pack", "src"},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	assert.Check(t, cmp.Equal(result.ExitCode, 0), "stderr: %s", result.Stderr)
+	assert.Check(t, golden.String(result.Stdout, t.Name()+".txt"))
+	assert.Check(t, golden.String(result.Stderr, t.Name()+".stderr.txt"))
+}
+
 // --- edge case: missing args ---
 
 func TestOrbList_Namespace_NotFound(t *testing.T) {
@@ -957,4 +989,11 @@ func TestOrbInit_Git(t *testing.T) {
 	}
 	assert.Check(t, published, "expected a POST to /api/v3/orb/versions")
 	assert.Check(t, followed, "expected a follow request")
+}
+
+// writeOrbFile writes a file for the pack tests, creating parent directories.
+func writeOrbFile(t *testing.T, path, content string) {
+	t.Helper()
+	assert.NilError(t, os.MkdirAll(filepath.Dir(path), 0o750))
+	assert.NilError(t, os.WriteFile(path, []byte(content), 0o600))
 }

--- a/acceptance/testdata/TestOrbPack_YAML11Booleans.txt
+++ b/acceptance/testdata/TestOrbPack_YAML11Booleans.txt
@@ -1,0 +1,18 @@
+commands:
+    vpn:
+        parameters:
+            killswitch:
+                default: true
+                type: boolean
+            label:
+                default: "on"
+                type: string
+            quiet:
+                default: false
+                type: boolean
+            verbose:
+                default: true
+                type: boolean
+        steps:
+            - run: echo hi
+version: 2.1

--- a/internal/pack/pack.go
+++ b/internal/pack/pack.go
@@ -32,6 +32,8 @@
 //   - Dotfiles and non-YAML files are skipped.
 //   - Packing a single file round-trips it through the YAML parser (normalising
 //     formatting) and returns the result.
+//   - Unquoted yes/no/on/off are booleans, as the CircleCI config compiler reads
+//     them, not strings as YAML 1.2 would.
 //   - Output is indented with four spaces, matching the 0.1.x CLI byte for byte.
 package pack
 
@@ -150,13 +152,33 @@ func packDir(dirPath, absRoot string) (map[string]any, error) {
 }
 
 // packFile reads and parses a single YAML file, returning its root map.
+//
+// Parsing goes through a yaml.Node rather than straight into `any` so that
+// plain YAML 1.1 booleans can be retagged before the value is materialised —
+// see resolveYAML11Bools for why that matters.
 func packFile(path string) (map[string]any, error) {
 	b, err := os.ReadFile(path) //#nosec:G304 // path is a resolved filesystem path under the user-supplied pack root directory
 	if err != nil {
 		return nil, fmt.Errorf("reading %q: %w", path, err)
 	}
+
+	var node yaml.Node
+	if err := yaml.Unmarshal(b, &node); err != nil {
+		return nil, parseError(path, err)
+	}
+	// A file that is empty, or holds only comments, produces a zero node.
+	if node.Kind == 0 {
+		return make(map[string]any), nil
+	}
+
+	resolveYAML11Bools(&node, false)
+
 	var v any
-	if err := yaml.Unmarshal(b, &v); err != nil {
+	// Decoding is what surfaces duplicate mapping keys: yaml.Unmarshal into a
+	// yaml.Node accepts them, and only the decode into a Go value reports them.
+	// Both stages report through parseError, so a problem found at either one
+	// still leads with its file and line.
+	if err := node.Decode(&v); err != nil {
 		return nil, parseError(path, err)
 	}
 	if v == nil {
@@ -167,6 +189,67 @@ func packFile(path string) (map[string]any, error) {
 		return nil, fmt.Errorf("%q must have a YAML map at the root, got %T", path, v)
 	}
 	return m, nil
+}
+
+// yaml11Bools maps the plain scalars that YAML 1.1 resolves as booleans, but
+// YAML 1.2 — and therefore gopkg.in/yaml.v3 — resolves as strings.
+//
+// The single-character forms y/Y/n/N are deliberately absent. YAML 1.1 lists
+// them, but SnakeYAML (which backs the CircleCI config compiler) does not
+// resolve them as booleans, and "n" is a plausible string value in a real
+// config. Matching the compiler matters more here than matching the spec.
+var yaml11Bools = map[string]string{
+	"yes": "true", "Yes": "true", "YES": "true",
+	"on": "true", "On": "true", "ON": "true",
+	"no": "false", "No": "false", "NO": "false",
+	"off": "false", "Off": "false", "OFF": "false",
+}
+
+// resolveYAML11Bools retags unquoted yes/no/on/off scalars as booleans.
+//
+// The CircleCI config compiler reads YAML 1.1, where those six words are
+// booleans. gopkg.in/yaml.v3 reads YAML 1.2, where they are strings — so
+// packing decoded `default: on` to the string "on" and, because that string
+// would be ambiguous on the way out, re-emitted it quoted. A boolean parameter
+// then failed validation against its own declared type:
+//
+//	Parameter error: default value of parameter 'killswitch' is 'on' (type string): expected type boolean
+//
+// Retagging makes the packed output say what the compiler would have read from
+// the source, which is the whole job of pack. `on` becomes `true` rather than
+// an unquoted `on`: both are booleans in YAML 1.1 and 1.2, and `true` cannot be
+// misread by either.
+//
+// Two things are left alone:
+//
+//   - Quoted scalars. A source that says "on" or 'on' asked for the string, and
+//     yaml.v3 records that in Style, so the intent survives.
+//   - Mapping keys. isKey tracks them through the walk. A key retagged to a
+//     boolean would no longer decode into map[string]any, and CircleCI config
+//     has no boolean keys.
+func resolveYAML11Bools(n *yaml.Node, isKey bool) {
+	if n == nil {
+		return
+	}
+	if n.Kind == yaml.ScalarNode {
+		if !isKey && n.Tag == "!!str" && n.Style == 0 {
+			if b, ok := yaml11Bools[n.Value]; ok {
+				n.Tag = "!!bool"
+				n.Value = b
+			}
+		}
+		return
+	}
+	// Mappings alternate key, value, key, value through Content.
+	if n.Kind == yaml.MappingNode {
+		for i, child := range n.Content {
+			resolveYAML11Bools(child, i%2 == 0)
+		}
+		return
+	}
+	for _, child := range n.Content {
+		resolveYAML11Bools(child, false)
+	}
 }
 
 // mergeMaps shallow-merges any number of maps into a new map[string]any.

--- a/internal/pack/pack_test.go
+++ b/internal/pack/pack_test.go
@@ -124,6 +124,101 @@ func TestPack_ParseErrorWithoutLine(t *testing.T) {
 		"the yaml.v3 prefix should be replaced by the location, got: %s", err)
 }
 
+// TestPack_YAML11Booleans is the regression test for
+// https://github.com/CircleCI-Public/circleci-cli/issues/691: a boolean orb
+// parameter defaulting to `on` packed to the string "on", so `orb validate` on
+// the packed output rejected the parameter against its own declared type.
+func TestPack_YAML11Booleans(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "@orb.yml"), "version: 2.1\n")
+	writeFile(t, filepath.Join(dir, "commands", "vpn.yml"),
+		"parameters:\n"+
+			"  killswitch:\n    type: boolean\n    default: on\n"+
+			"  verbose:\n    type: boolean\n    default: yes\n"+
+			"  quiet:\n    type: boolean\n    default: off\n"+
+			"  dryrun:\n    type: boolean\n    default: no\n"+
+			"steps:\n  - run: echo hi\n")
+
+	packed, err := pack.Pack(dir)
+	assert.NilError(t, err)
+
+	const want = `commands:
+    vpn:
+        parameters:
+            dryrun:
+                default: false
+                type: boolean
+            killswitch:
+                default: true
+                type: boolean
+            quiet:
+                default: false
+                type: boolean
+            verbose:
+                default: true
+                type: boolean
+        steps:
+            - run: echo hi
+version: 2.1
+`
+	assert.Equal(t, packed, want)
+}
+
+// TestPack_YAML11Booleans_QuotedStaysString checks the other half of the
+// contract: a source that quotes the value asked for a string, and packing must
+// not decide otherwise.
+func TestPack_YAML11Booleans_QuotedStaysString(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "@orb.yml"), "version: 2.1\n")
+	writeFile(t, filepath.Join(dir, "commands", "c.yml"),
+		"parameters:\n"+
+			"  double:\n    type: string\n    default: \"on\"\n"+
+			"  single:\n    type: string\n    default: 'no'\n"+
+			// y/n are strings to the config compiler, so they stay strings here.
+			"  short:\n    type: string\n    default: n\n"+
+			"steps:\n  - run: echo hi\n")
+
+	packed, err := pack.Pack(dir)
+	assert.NilError(t, err)
+
+	assert.Check(t, strings.Contains(packed, `default: "on"`), "got:\n%s", packed)
+	assert.Check(t, strings.Contains(packed, `default: "no"`), "got:\n%s", packed)
+	// `n` stays a string. yaml.v3 quotes it on the way out because YAML 1.1
+	// would read a bare n as a boolean — which is the point: the quoting is
+	// what stops it being reinterpreted, and it is what the CLI already emitted
+	// before this change, so no committed packed file churns.
+	assert.Check(t, strings.Contains(packed, `default: "n"`), "got:\n%s", packed)
+}
+
+// TestPack_YAML11Booleans_KeysAreNotRetagged guards the mapping-key exclusion.
+// An `on:` key retagged to a boolean would stop the document decoding into
+// map[string]any at all.
+func TestPack_YAML11Booleans_KeysAreNotRetagged(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "@config.yml"), "version: 2.1\n")
+	writeFile(t, filepath.Join(dir, "jobs", "build.yml"), "environment:\n  on: value\n  off: other\n")
+
+	packed, err := pack.Pack(dir)
+	assert.NilError(t, err)
+
+	assert.Check(t, strings.Contains(packed, `"on": value`), "got:\n%s", packed)
+	assert.Check(t, strings.Contains(packed, `"off": other`), "got:\n%s", packed)
+}
+
+// TestPack_DuplicateKeysStillDetected guards a side effect of parsing through a
+// yaml.Node: yaml.Unmarshal into a Node accepts duplicate mapping keys, and only
+// the subsequent decode into a Go value reports them. Losing that would turn a
+// merge conflict into silently dropped config.
+func TestPack_DuplicateKeysStillDetected(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "@orb.yml"), "version: 2.1\n")
+	writeFile(t, filepath.Join(dir, "executors", "e.yml"),
+		"docker:\n  - image: x\n    auth:\n      username: $U\n    auth:\n")
+
+	_, err := pack.Pack(dir)
+	assert.ErrorContains(t, err, `mapping key "auth" already defined at line 3`)
+}
+
 func writeFile(t *testing.T, path, content string) {
 	t.Helper()
 	assert.NilError(t, os.MkdirAll(filepath.Dir(path), 0o750))


### PR DESCRIPTION
The CircleCI config compiler reads YAML 1.1, where yes/no/on/off are booleans. gopkg.in/yaml.v3 reads YAML 1.2, where they are strings. Pack decoded `default: on` to the string "on" and re-emitted it quoted, so a boolean orb parameter failed validation against its own declared type:

    Parameter error: default value of parameter 'killswitch' is 'on'
    (type string): expected type boolean

Parse each file into a yaml.Node and retag unquoted yes/no/on/off scalars as booleans before decoding, so packed output says what the compiler would have read from the source. `on` becomes `true`: a boolean under both YAML versions, unambiguous to either.

Left alone:

  - Quoted scalars. "on" asked for the string, and yaml.v3 records that in Style.
  - Mapping keys. A boolean key would not decode into map[string]any, and CircleCI config has no boolean keys.
  - y/Y/n/N. YAML 1.1 lists them, but SnakeYAML — which backs the config compiler — does not resolve them as booleans, and "n" is a plausible string value. Matching the compiler matters more than matching the spec.

Parsing via a Node means duplicate mapping keys are no longer reported by the Unmarshal call, only by the subsequent Decode into a Go value; both are checked, and a test guards it, because losing that would turn a merge conflict into silently dropped config.

Fixes #691

<!--
  Thank you for contributing to CircleCI CLI!

  For PRs adding new features, please raise an issue first.

  Squash your commits before requesting review and before merging.
-->
