### PR TITLE
Flatten nested pack directories into the section they belong to

### DIFF
--- a/acceptance/orb_test.go
+++ b/acceptance/orb_test.go
@@ -701,7 +701,6 @@ func TestOrbPack_YAML11Booleans(t *testing.T) {
 	_, env := setupOrbFake(t)
 
 	dir := t.TempDir()
-	assert.NilError(t, os.MkdirAll(filepath.Join(dir, "src", "commands"), 0o755))
 	writeOrbFile(t, filepath.Join(dir, "src", "@orb.yml"), "version: 2.1\n")
 	writeOrbFile(t, filepath.Join(dir, "src", "commands", "vpn.yml"),
 		"parameters:\n"+
@@ -723,6 +722,65 @@ func TestOrbPack_YAML11Booleans(t *testing.T) {
 	assert.Check(t, cmp.Equal(result.ExitCode, 0), "stderr: %s", result.Stderr)
 	assert.Check(t, golden.String(result.Stdout, t.Name()+".txt"))
 	assert.Check(t, golden.String(result.Stderr, t.Name()+".stderr.txt"))
+}
+
+// TestOrbPack_NestedDirectories is the end-to-end check for
+// https://github.com/CircleCI-Public/circleci-cli/issues/755: an orb author
+// organising commands/ into subdirectories. Those files used to pack into
+// commands.<dir>.<file>, producing a "command" that was really a map of
+// commands, so the orb was invalid.
+func TestOrbPack_NestedDirectories(t *testing.T) {
+	_, env := setupOrbFake(t)
+
+	dir := t.TempDir()
+	writeOrbFile(t, filepath.Join(dir, "src", "@orb.yml"), "version: 2.1\n")
+	writeOrbFile(t, filepath.Join(dir, "src", "commands", "top.yml"), "steps:\n  - run: echo top\n")
+	writeOrbFile(t, filepath.Join(dir, "src", "commands", "aws", "login.yml"), "steps:\n  - run: echo login\n")
+	writeOrbFile(t, filepath.Join(dir, "src", "commands", "gcp", "auth.yml"), "steps:\n  - run: echo auth\n")
+	writeOrbFile(t, filepath.Join(dir, "src", "jobs", "build", "unit.yml"), "steps:\n  - run: echo unit\n")
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"orb", "pack", "src"},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	assert.Check(t, cmp.Equal(result.ExitCode, 0), "stderr: %s", result.Stderr)
+	assert.Check(t, golden.String(result.Stdout, t.Name()+".txt"))
+	assert.Check(t, golden.String(result.Stderr, t.Name()+".stderr.txt"))
+}
+
+// TestOrbPack_NestedNameCollision covers the cost of flattening: two files in
+// different subdirectories of one section would silently claim the same key, and
+// one would win. Say so instead, naming both files.
+//
+// Asserted with Contains rather than a golden file because the message carries
+// absolute, %q-quoted paths: a golden would embed this machine's temp directory,
+// and %q escapes the separator on Windows.
+func TestOrbPack_NestedNameCollision(t *testing.T) {
+	_, env := setupOrbFake(t)
+
+	dir := t.TempDir()
+	writeOrbFile(t, filepath.Join(dir, "src", "@orb.yml"), "version: 2.1\n")
+	writeOrbFile(t, filepath.Join(dir, "src", "commands", "aws", "login.yml"), "steps:\n  - run: echo a\n")
+	writeOrbFile(t, filepath.Join(dir, "src", "commands", "gcp", "login.yml"), "steps:\n  - run: echo b\n")
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"orb", "pack", "src"},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	assert.Check(t, cmp.Equal(result.ExitCode, 2))
+	// No half-packed document on stdout when the pack fails.
+	assert.Check(t, cmp.Equal(result.Stdout, ""))
+	assert.Check(t, cmp.Contains(result.Stderr, `both define "login"`))
+	assert.Check(t, cmp.Contains(result.Stderr, "cannot share a name"))
+	// Both source files are named, so the author knows which two to reconcile.
+	assert.Check(t, cmp.Contains(result.Stderr, "aws"))
+	assert.Check(t, cmp.Contains(result.Stderr, "gcp"))
 }
 
 // --- edge case: missing args ---

--- a/acceptance/testdata/TestOrbPack_NestedDirectories.txt
+++ b/acceptance/testdata/TestOrbPack_NestedDirectories.txt
@@ -1,0 +1,15 @@
+commands:
+    auth:
+        steps:
+            - run: echo auth
+    login:
+        steps:
+            - run: echo login
+    top:
+        steps:
+            - run: echo top
+jobs:
+    unit:
+        steps:
+            - run: echo unit
+version: 2.1

--- a/internal/pack/pack.go
+++ b/internal/pack/pack.go
@@ -27,6 +27,9 @@
 //   - Files at the pack root are merged at the top level of the output.
 //   - Subdirectory names become top-level YAML keys; files inside become entries
 //     under that key, keyed by filename without extension.
+//   - Deeper subdirectories are organisational only: their files join the
+//     top-level section their ancestor opened, so commands/aws/login.yml becomes
+//     commands.login. Two files that would claim the same key are an error.
 //   - Files whose names begin with "@" are merged at the current directory level
 //     rather than nested under a key (used for base files like @orb.yml).
 //   - Dotfiles and non-YAML files are skipped.
@@ -75,7 +78,7 @@ func Pack(rootPath string) (string, error) {
 
 	var result map[string]any
 	if info.IsDir() {
-		result, err = packDir(absRoot, absRoot)
+		result, err = packDir(absRoot, 0)
 	} else {
 		result, err = packFile(absRoot)
 	}
@@ -94,16 +97,39 @@ func Pack(rootPath string) (string, error) {
 }
 
 // packDir recursively merges all YAML files under dirPath.
-// absRoot identifies which level is the "root" for top-level merge behaviour.
-func packDir(dirPath, absRoot string) (map[string]any, error) {
+//
+// depth is the nesting level below the pack root, and it decides what a
+// subdirectory means:
+//
+//   - At depth 0 (the pack root) a subdirectory opens a top-level section:
+//     src/commands/ becomes the "commands" key.
+//   - Below that, subdirectories are organisational only. Their files join the
+//     section their ancestor opened, keyed by filename, so
+//     src/commands/aws/login.yml becomes commands.login rather than
+//     commands.aws.login — which was not a command at all, just a map that
+//     happened to sit where one belonged.
+func packDir(dirPath string, depth int) (map[string]any, error) {
 	entries, err := os.ReadDir(dirPath)
 	if err != nil {
 		return nil, fmt.Errorf("reading directory %q: %w", dirPath, err)
 	}
 
 	subtree := make(map[string]any)
-	isRoot := dirPath == absRoot
 	dirBasename := nameWithoutExt(filepath.Base(dirPath))
+
+	// origins records which file or directory claimed each key at this level, so
+	// a collision between two sources can name both of them. Only populated
+	// below the root, where flattening makes collisions possible.
+	origins := make(map[string]string)
+
+	// Subdirectory results are held back and merged after the files at this
+	// level, so a collision is caught whichever order os.ReadDir returns them
+	// in: commands/login.yml and commands/aws/login.yml collide either way.
+	type nestedResult struct {
+		path    string
+		content map[string]any
+	}
+	var nested []nestedResult
 
 	for _, entry := range entries {
 		name := entry.Name()
@@ -114,12 +140,16 @@ func packDir(dirPath, absRoot string) (map[string]any, error) {
 		}
 
 		if entry.IsDir() {
-			childMap, err := packDir(fullPath, absRoot)
+			childMap, err := packDir(fullPath, depth+1)
 			if err != nil {
 				return nil, err
 			}
-			existing, _ := subtree[name].(map[string]any)
-			subtree[name] = mergeMaps(existing, childMap)
+			if depth == 0 {
+				existing, _ := subtree[name].(map[string]any)
+				subtree[name] = mergeMaps(existing, childMap)
+			} else {
+				nested = append(nested, nestedResult{path: fullPath, content: childMap})
+			}
 			continue
 		}
 
@@ -133,7 +163,7 @@ func packDir(dirPath, absRoot string) (map[string]any, error) {
 		}
 
 		switch {
-		case isRoot:
+		case depth == 0:
 			// Files directly under the pack root are merged at the top level.
 			subtree = mergeMaps(subtree, content)
 		case isSpecialName(name):
@@ -146,8 +176,22 @@ func packDir(dirPath, absRoot string) (map[string]any, error) {
 			key := nameWithoutExt(name)
 			existing, _ := subtree[key].(map[string]any)
 			subtree[key] = mergeMaps(existing, content)
+			origins[key] = fullPath
 		}
 	}
+
+	for _, n := range nested {
+		for key := range n.content {
+			if from, taken := origins[key]; taken {
+				return nil, fmt.Errorf(
+					"%q and %q both define %q; two files that pack into the same section cannot share a name",
+					from, filepath.Join(n.path, key+".yml"), key)
+			}
+			origins[key] = filepath.Join(n.path, key+".yml")
+		}
+		subtree = mergeMaps(subtree, n.content)
+	}
+
 	return subtree, nil
 }
 

--- a/internal/pack/pack_test.go
+++ b/internal/pack/pack_test.go
@@ -219,6 +219,126 @@ func TestPack_DuplicateKeysStillDetected(t *testing.T) {
 	assert.ErrorContains(t, err, `mapping key "auth" already defined at line 3`)
 }
 
+// TestPack_NestedDirectoriesFlattenIntoSection is the regression test for
+// https://github.com/CircleCI-Public/circleci-cli/issues/755: an orb author
+// wants to organise commands/ and jobs/ into subdirectories. Those files used to
+// pack into commands.<dir>.<file>, producing a "command" that was really a map
+// of commands, so the orb was invalid.
+func TestPack_NestedDirectoriesFlattenIntoSection(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "@orb.yml"), "version: 2.1\n")
+	writeFile(t, filepath.Join(dir, "commands", "top.yml"), "steps:\n  - run: echo top\n")
+	writeFile(t, filepath.Join(dir, "commands", "aws", "login.yml"), "steps:\n  - run: echo login\n")
+	writeFile(t, filepath.Join(dir, "commands", "gcp", "auth.yml"), "steps:\n  - run: echo auth\n")
+	writeFile(t, filepath.Join(dir, "jobs", "build", "unit.yml"), "steps:\n  - run: echo unit\n")
+
+	packed, err := pack.Pack(dir)
+	assert.NilError(t, err)
+
+	const want = `commands:
+    auth:
+        steps:
+            - run: echo auth
+    login:
+        steps:
+            - run: echo login
+    top:
+        steps:
+            - run: echo top
+jobs:
+    unit:
+        steps:
+            - run: echo unit
+version: 2.1
+`
+	assert.Equal(t, packed, want)
+}
+
+// TestPack_DeeplyNestedDirectoriesFlatten checks that flattening is not limited
+// to one level below a section.
+func TestPack_DeeplyNestedDirectoriesFlatten(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "@orb.yml"), "version: 2.1\n")
+	writeFile(t, filepath.Join(dir, "commands", "a", "b", "c", "deep.yml"), "steps:\n  - run: echo deep\n")
+
+	packed, err := pack.Pack(dir)
+	assert.NilError(t, err)
+
+	const want = `commands:
+    deep:
+        steps:
+            - run: echo deep
+version: 2.1
+`
+	assert.Equal(t, packed, want)
+}
+
+// TestPack_NestedNameCollision covers the cost of flattening: two files in
+// different subdirectories of one section would silently claim the same key, and
+// one would win. Say so instead, naming both files. Checked in both directory
+// orders, because os.ReadDir returns entries sorted and a plain merge would only
+// catch one of them.
+func TestPack_NestedNameCollision(t *testing.T) {
+	tests := []struct {
+		name  string
+		files map[string]string
+	}{
+		{
+			// "login.yml" sorts before the "zzz" directory.
+			name: "file before directory",
+			files: map[string]string{
+				filepath.Join("commands", "login.yml"):        "steps:\n  - run: echo a\n",
+				filepath.Join("commands", "zzz", "login.yml"): "steps:\n  - run: echo b\n",
+			},
+		},
+		{
+			// The "aaa" directory sorts before "login.yml".
+			name: "directory before file",
+			files: map[string]string{
+				filepath.Join("commands", "aaa", "login.yml"): "steps:\n  - run: echo b\n",
+				filepath.Join("commands", "login.yml"):        "steps:\n  - run: echo a\n",
+			},
+		},
+		{
+			name: "two sibling directories",
+			files: map[string]string{
+				filepath.Join("commands", "aws", "login.yml"): "steps:\n  - run: echo a\n",
+				filepath.Join("commands", "gcp", "login.yml"): "steps:\n  - run: echo b\n",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeFile(t, filepath.Join(dir, "@orb.yml"), "version: 2.1\n")
+			for path, content := range tt.files {
+				writeFile(t, filepath.Join(dir, path), content)
+			}
+
+			_, err := pack.Pack(dir)
+			assert.ErrorContains(t, err, `both define "login"`)
+			assert.ErrorContains(t, err, "cannot share a name")
+		})
+	}
+}
+
+// TestPack_TopLevelDirectoriesStillBecomeSections guards the boundary: only
+// directories *below* a section flatten. A directory at the pack root still
+// opens a section, which is the whole existing layout convention.
+func TestPack_TopLevelDirectoriesStillBecomeSections(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "@orb.yml"), "version: 2.1\n")
+	writeFile(t, filepath.Join(dir, "commands", "c.yml"), "steps:\n  - run: echo c\n")
+	writeFile(t, filepath.Join(dir, "executors", "e.yml"), "docker:\n  - image: alpine\n")
+
+	packed, err := pack.Pack(dir)
+	assert.NilError(t, err)
+
+	assert.Check(t, strings.Contains(packed, "commands:\n    c:"), "got:\n%s", packed)
+	assert.Check(t, strings.Contains(packed, "executors:\n    e:"), "got:\n%s", packed)
+}
+
 func writeFile(t *testing.T, path, content string) {
 	t.Helper()
 	assert.NilError(t, os.MkdirAll(filepath.Dir(path), 0o750))


### PR DESCRIPTION
Organising an orb's commands/, jobs/ or executors/ into subdirectories produced config that was not an orb: src/commands/aws/login.yml packed to commands.aws.login, so "aws" looked like a command whose body was a map of commands. (The 0.1.x CLI skipped those files entirely — a different failure, same outcome.)

Treat depth as the deciding factor. A directory at the pack root still opens a top-level section, which is the existing layout convention. Below that, directories are organisational only: their files join the section their ancestor opened, keyed by filename, at any depth. So commands/aws/login.yml becomes commands.login.

Flattening means two files in different subdirectories of one section can claim the same key. Rather than let one silently win, name both files and stop. Subdirectory results are held back and merged after the files at their level so the collision is caught whichever order os.ReadDir returns them in.

Fixes #755

<!--
  Thank you for contributing to CircleCI CLI!

  For PRs adding new features, please raise an issue first.

  Squash your commits before requesting review and before merging.
-->
