### PR TITLE
Lead pack parse errors with a clickable file location

### DIFF
--- a/acceptance/config_test.go
+++ b/acceptance/config_test.go
@@ -561,6 +561,41 @@ func TestConfigPack(t *testing.T) {
 	assert.Check(t, golden.String(result.Stderr, t.Name()+".stderr.txt"))
 }
 
+// TestConfigPack_ParseErrorIsClickable is the end-to-end check for
+// https://github.com/CircleCI-Public/circleci-cli/issues/519: a YAML problem in
+// one file of a packed tree has to name that file and line, leading the message,
+// so the terminal turns it into a link.
+//
+// Asserted with Contains rather than a golden file because the message carries an
+// absolute path: a golden would embed this machine's temp directory, and would
+// need a second copy for Windows' separators.
+func TestConfigPack_ParseErrorIsClickable(t *testing.T) {
+	env := testenv.New(t)
+	env.Token = testToken
+
+	dir := t.TempDir()
+	assert.NilError(t, os.MkdirAll(filepath.Join(dir, ".circleci", "executors"), 0o755))
+	writeFile(t, filepath.Join(dir, ".circleci", "@config.yml"), "version: \"2.1\"\n")
+	writeFile(t, filepath.Join(dir, ".circleci", "executors", "executorA.yml"),
+		"docker:\n  - image: not-relevant\n    auth:\n"+
+			"      username: $DOCKERHUB_USER\n      password: $DOCKERHUB_ACCESSTOKEN\n    auth:\n")
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"config", "pack", ".circleci"},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	assert.Check(t, cmp.Equal(result.ExitCode, 2))
+	// The packed document is not emitted when packing fails.
+	assert.Check(t, cmp.Equal(result.Stdout, ""))
+	// The path is resolved by the CLI, so compare on the tail: the leading
+	// directory is the test's temp dir, which varies per run and per platform.
+	assert.Check(t, cmp.Contains(result.Stderr,
+		filepath.Join("executors", "executorA.yml")+`:6: mapping key "auth" already defined at line 3`))
+}
+
 func TestConfigPack_NotFound(t *testing.T) {
 	env := testenv.New(t)
 	env.Token = testToken

--- a/internal/cmd/config/pack.go
+++ b/internal/cmd/config/pack.go
@@ -24,6 +24,7 @@ package cmdconfig
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
@@ -68,7 +69,11 @@ func newPackCmd() *cobra.Command {
 			packed, err := pack.Pack(args[0])
 			if err != nil {
 				return clierrors.New("config.pack_failed", "Config pack failed",
-					fmt.Sprintf("Could not pack %q: %s", args[0], err)).
+					// A pack failure can name more than one bad file; indent the
+					// continuation lines so each located problem stays readable
+					// under the single-line "error: " prefix.
+					fmt.Sprintf("Could not pack %q: %s", args[0],
+						strings.ReplaceAll(err.Error(), "\n", "\n  "))).
 					WithExitCode(clierrors.ExitBadArguments)
 			}
 			_, _ = fmt.Fprint(iostream.Out(ctx), packed)

--- a/internal/cmd/orb/pack.go
+++ b/internal/cmd/orb/pack.go
@@ -24,6 +24,7 @@ package orb
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
@@ -77,7 +78,11 @@ func newPackCmd() *cobra.Command {
 			packed, err := pack.Pack(args[0])
 			if err != nil {
 				return clierrors.New("orb.pack_failed", "Orb pack failed",
-					fmt.Sprintf("Could not pack %q: %s", args[0], err)).
+					// A pack failure can name more than one bad file; indent the
+					// continuation lines so each located problem stays readable
+					// under the single-line "error: " prefix.
+					fmt.Sprintf("Could not pack %q: %s", args[0],
+						strings.ReplaceAll(err.Error(), "\n", "\n  "))).
 					WithExitCode(clierrors.ExitBadArguments)
 			}
 			_, _ = fmt.Fprint(iostream.Out(ctx), packed)

--- a/internal/pack/pack.go
+++ b/internal/pack/pack.go
@@ -36,6 +36,7 @@
 package pack
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -156,7 +157,7 @@ func packFile(path string) (map[string]any, error) {
 	}
 	var v any
 	if err := yaml.Unmarshal(b, &v); err != nil {
-		return nil, fmt.Errorf("parsing %q: %w", path, err)
+		return nil, parseError(path, err)
 	}
 	if v == nil {
 		return make(map[string]any), nil
@@ -198,6 +199,50 @@ func toStringMap(v any) map[string]any {
 		return out
 	}
 	return nil
+}
+
+// yamlLineRe matches the "line N: " prefix that gopkg.in/yaml.v3 puts on the
+// front of its messages. It appears on both top-level parse errors
+// ("yaml: line 4: could not find expected ':'") and on each entry of a
+// *yaml.TypeError ("line 6: mapping key \"auth\" already defined at line 3"),
+// so one expression handles both after the "yaml: " prefix is trimmed.
+var yamlLineRe = regexp.MustCompile(`^line (\d+): `)
+
+// parseError rewrites a gopkg.in/yaml.v3 parse or decode failure so the source
+// location leads the message, in the `file:line:` form that editors and
+// terminals turn into a clickable link:
+//
+//	/path/to/src/executors/executorA.yml:6: mapping key "auth" already defined at line 3
+//
+// rather than yaml.v3's own shape, which buries the filename in prose and puts
+// the line on a continuation line:
+//
+//	parsing "/path/to/src/executors/executorA.yml": yaml: unmarshal errors:
+//	  line 6: mapping key "auth" already defined at line 3
+//
+// A *yaml.TypeError carries one entry per problem found; each gets its own
+// located line so a file with several errors reports all of them. Messages with
+// no line number degrade to "file: message" — still a location, just a coarser
+// one. Columns are not available: yaml.v3 reports lines only.
+func parseError(path string, err error) error {
+	var typeErr *yaml.TypeError
+	if errors.As(err, &typeErr) && len(typeErr.Errors) > 0 {
+		located := make([]string, 0, len(typeErr.Errors))
+		for _, e := range typeErr.Errors {
+			located = append(located, locate(path, e))
+		}
+		return errors.New(strings.Join(located, "\n"))
+	}
+	return errors.New(locate(path, strings.TrimPrefix(err.Error(), "yaml: ")))
+}
+
+// locate prefixes msg with path, moving any leading "line N: " into the prefix
+// so the result reads "path:N: msg".
+func locate(path, msg string) string {
+	if m := yamlLineRe.FindStringSubmatch(msg); m != nil {
+		return fmt.Sprintf("%s:%s: %s", path, m[1], msg[len(m[0]):])
+	}
+	return fmt.Sprintf("%s: %s", path, msg)
 }
 
 var (

--- a/internal/pack/pack_test.go
+++ b/internal/pack/pack_test.go
@@ -23,8 +23,10 @@
 package pack_test
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -55,6 +57,71 @@ func TestPack_IndentationMatchesLegacyCLI(t *testing.T) {
 version: 2.1
 `
 	assert.Equal(t, packed, want)
+}
+
+// TestPack_ParseErrorIsClickable is the regression test for
+// https://github.com/CircleCI-Public/circleci-cli/issues/519: a YAML problem in
+// one file of a packed tree has to say which file, at which line, in a form the
+// terminal turns into a link. yaml.v3's own shape buries the filename in prose
+// and pushes the line onto a continuation line.
+func TestPack_ParseErrorIsClickable(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		// line and message are composed with the file path at assert time, using
+		// the platform separator — a hardcoded "executors/executorA.yml" passes
+		// on Unix and fails on Windows.
+		line    int
+		message string
+	}{
+		{
+			// The MWE from the issue: a key repeated after a bad merge.
+			name: "duplicate mapping key",
+			content: "docker:\n  - image: not-relevant\n    auth:\n" +
+				"      username: $DOCKERHUB_USER\n      password: $DOCKERHUB_ACCESSTOKEN\n    auth:\n",
+			line:    6,
+			message: `mapping key "auth" already defined at line 3`,
+		},
+		{
+			name:    "syntax error carries its line",
+			content: "docker:\n  - image: x\nsteps:\n\t- run: echo hi\n",
+			line:    4,
+			message: "found character that cannot start any token",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeFile(t, filepath.Join(dir, "@orb.yml"), "version: 2.1\n")
+			target := filepath.Join(dir, "executors", "executorA.yml")
+			writeFile(t, target, tt.content)
+
+			_, err := pack.Pack(dir)
+			assert.ErrorContains(t, err, fmt.Sprintf("%s:%d: %s", target, tt.line, tt.message))
+
+			// The location has to lead the message — a filename mentioned
+			// halfway through prose is not clickable.
+			assert.Equal(t, strings.HasPrefix(err.Error(), target+":"), true,
+				"error should start with the file path, got: %s", err)
+		})
+	}
+}
+
+// TestPack_ParseErrorWithoutLine covers the messages yaml.v3 emits with no line
+// number at all. Those still get a location, just a file-level one, rather than
+// losing the filename entirely.
+func TestPack_ParseErrorWithoutLine(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "@orb.yml"), "version: 2.1\n")
+	target := filepath.Join(dir, "commands", "bad.yml")
+	writeFile(t, target, "a: b: c\n")
+
+	_, err := pack.Pack(dir)
+	assert.ErrorContains(t, err, target+": mapping values are not allowed in this context")
+	// No bare "yaml: " prefix left over once the location leads.
+	assert.Equal(t, strings.Contains(err.Error(), "yaml: "), false,
+		"the yaml.v3 prefix should be replaced by the location, got: %s", err)
 }
 
 func writeFile(t *testing.T, path, content string) {


### PR DESCRIPTION
A YAML problem in one file of a packed tree reported the filename in prose and pushed the line number onto a continuation line, so neither iTerm2 nor VS Code could turn it into a link:

    parsing "/path/to/src/executors/executorA.yml": yaml: unmarshal errors:
      line 6: mapping key "auth" already defined at line 3

Move the location to the front in file:line: form:

    /path/to/src/executors/executorA.yml:6: mapping key "auth" already defined at line 3

A *yaml.TypeError carries one entry per problem, so each gets its own located line and a file with several errors reports all of them; the command layer indents the continuations. Messages that yaml.v3 emits with no line number at all degrade to "file: message" rather than losing the filename.

Columns are not emitted: yaml.v3 reports lines only.

Fixes #519

<!--
  Thank you for contributing to CircleCI CLI!

  For PRs adding new features, please raise an issue first.

  Squash your commits before requesting review and before merging.
-->
