### PR TITLE
Resolve YAML anchors across files when packing

### DIFF
--- a/acceptance/config_test.go
+++ b/acceptance/config_test.go
@@ -596,6 +596,65 @@ func TestConfigPack_ParseErrorIsClickable(t *testing.T) {
 		filepath.Join("executors", "executorA.yml")+`:6: mapping key "auth" already defined at line 3`))
 }
 
+// TestConfigPack_CrossFileAnchors is the end-to-end check for
+// https://github.com/CircleCI-Public/circleci-cli/issues/341, using the layout
+// and expected output from the report: an anchor defined in anchors/@anchors.yml
+// aliased from commands/my-command.yml.
+func TestConfigPack_CrossFileAnchors(t *testing.T) {
+	env := testenv.New(t)
+	env.Token = testToken
+
+	dir := t.TempDir()
+	assert.NilError(t, os.MkdirAll(filepath.Join(dir, "src", "anchors"), 0o755))
+	assert.NilError(t, os.MkdirAll(filepath.Join(dir, "src", "commands"), 0o755))
+	writeFile(t, filepath.Join(dir, "src", "anchors", "@anchors.yml"), "my-anchor: &my-anchor my-value\n")
+	writeFile(t, filepath.Join(dir, "src", "commands", "my-command.yml"), "description: *my-anchor\n")
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"config", "pack", "src"},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	assert.Check(t, cmp.Equal(result.ExitCode, 0), "stderr: %s", result.Stderr)
+	assert.Check(t, golden.String(result.Stdout, t.Name()+".txt"))
+	assert.Check(t, golden.String(result.Stderr, t.Name()+".stderr.txt"))
+}
+
+// TestConfigPack_UnknownAnchor checks that resolving anchors across files does
+// not turn a mistyped alias into silence: with no definition anywhere in the
+// tree it is still an error, and still names the anchor.
+//
+// Asserted with Contains rather than a golden file because the message carries an
+// absolute path: a golden would embed this machine's temp directory, and would
+// need a second copy for Windows' separators.
+func TestConfigPack_UnknownAnchor(t *testing.T) {
+	env := testenv.New(t)
+	env.Token = testToken
+
+	dir := t.TempDir()
+	assert.NilError(t, os.MkdirAll(filepath.Join(dir, "src", "anchors"), 0o755))
+	assert.NilError(t, os.MkdirAll(filepath.Join(dir, "src", "commands"), 0o755))
+	writeFile(t, filepath.Join(dir, "src", "anchors", "@anchors.yml"), "my-anchor: &my-anchor my-value\n")
+	writeFile(t, filepath.Join(dir, "src", "commands", "c.yml"), "description: *my-anchr\n")
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"config", "pack", "src"},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	assert.Check(t, cmp.Equal(result.ExitCode, 2))
+	assert.Check(t, cmp.Equal(result.Stdout, ""))
+	assert.Check(t, cmp.Contains(result.Stderr, "unknown anchor 'my-anchr' referenced"))
+	// Just the filename, no directory: the path is %q-quoted in the message, and
+	// %q escapes the separator on Windows, so "commands\c.yml" would not be found
+	// in a message reading "commands\\c.yml". c.yml is unambiguous in this tree.
+	assert.Check(t, cmp.Contains(result.Stderr, "c.yml"))
+}
+
 func TestConfigPack_NotFound(t *testing.T) {
 	env := testenv.New(t)
 	env.Token = testToken

--- a/acceptance/testdata/TestConfigPack_CrossFileAnchors.txt
+++ b/acceptance/testdata/TestConfigPack_CrossFileAnchors.txt
@@ -1,0 +1,5 @@
+anchors:
+    my-anchor: my-value
+commands:
+    my-command:
+        description: my-value

--- a/internal/pack/pack.go
+++ b/internal/pack/pack.go
@@ -37,15 +37,21 @@
 //     formatting) and returns the result.
 //   - Unquoted yes/no/on/off are booleans, as the CircleCI config compiler reads
 //     them, not strings as YAML 1.2 would.
+//   - A YAML anchor defined in one file may be aliased from any other file in the
+//     tree; the alias is replaced by the anchored value in the output.
 //   - Output is indented with four spaces, matching the 0.1.x CLI byte for byte.
 package pack
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
+	"strconv"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -78,9 +84,12 @@ func Pack(rootPath string) (string, error) {
 
 	var result map[string]any
 	if info.IsDir() {
-		result, err = packDir(absRoot, 0)
+		// Anchors are collected up front so a file may alias an anchor defined
+		// in any other file of the tree, not just its own.
+		result, err = packDir(absRoot, 0, collectAnchors(absRoot))
 	} else {
-		result, err = packFile(absRoot)
+		// A single file has nothing else to draw anchors from.
+		result, err = packFile(absRoot, nil)
 	}
 	if err != nil {
 		return "", err
@@ -108,7 +117,9 @@ func Pack(rootPath string) (string, error) {
 //     src/commands/aws/login.yml becomes commands.login rather than
 //     commands.aws.login — which was not a command at all, just a map that
 //     happened to sit where one belonged.
-func packDir(dirPath string, depth int) (map[string]any, error) {
+//
+// anchors holds the anchors defined anywhere in the tree; see collectAnchors.
+func packDir(dirPath string, depth int, anchors map[string]*yaml.Node) (map[string]any, error) {
 	entries, err := os.ReadDir(dirPath)
 	if err != nil {
 		return nil, fmt.Errorf("reading directory %q: %w", dirPath, err)
@@ -140,7 +151,7 @@ func packDir(dirPath string, depth int) (map[string]any, error) {
 		}
 
 		if entry.IsDir() {
-			childMap, err := packDir(fullPath, depth+1)
+			childMap, err := packDir(fullPath, depth+1, anchors)
 			if err != nil {
 				return nil, err
 			}
@@ -157,7 +168,7 @@ func packDir(dirPath string, depth int) (map[string]any, error) {
 			continue
 		}
 
-		content, err := packFile(fullPath)
+		content, err := packFile(fullPath, anchors)
 		if err != nil {
 			return nil, err
 		}
@@ -197,33 +208,22 @@ func packDir(dirPath string, depth int) (map[string]any, error) {
 
 // packFile reads and parses a single YAML file, returning its root map.
 //
-// Parsing goes through a yaml.Node rather than straight into `any` so that
-// plain YAML 1.1 booleans can be retagged before the value is materialised —
-// see resolveYAML11Bools for why that matters.
-func packFile(path string) (map[string]any, error) {
+// anchors supplies the anchors defined elsewhere in the tree. A file that aliases
+// one of them fails to parse on its own — anchors are a property of a single YAML
+// document — so on that specific failure the parse is retried with those
+// definitions prepended. Pass nil to parse the file in isolation.
+func packFile(path string, anchors map[string]*yaml.Node) (map[string]any, error) {
 	b, err := os.ReadFile(path) //#nosec:G304 // path is a resolved filesystem path under the user-supplied pack root directory
 	if err != nil {
 		return nil, fmt.Errorf("reading %q: %w", path, err)
 	}
 
-	var node yaml.Node
-	if err := yaml.Unmarshal(b, &node); err != nil {
-		return nil, parseError(path, err)
-	}
-	// A file that is empty, or holds only comments, produces a zero node.
-	if node.Kind == 0 {
-		return make(map[string]any), nil
-	}
-
-	resolveYAML11Bools(&node, false)
-
-	var v any
-	// Decoding is what surfaces duplicate mapping keys: yaml.Unmarshal into a
-	// yaml.Node accepts them, and only the decode into a Go value reports them.
-	// Both stages report through parseError, so a problem found at either one
-	// still leads with its file and line.
-	if err := node.Decode(&v); err != nil {
-		return nil, parseError(path, err)
+	v, err := decodeYAML(b)
+	if err != nil {
+		v, err = retryWithAnchors(b, anchors, err)
+		if err != nil {
+			return nil, parseError(path, err)
+		}
 	}
 	if v == nil {
 		return make(map[string]any), nil
@@ -233,6 +233,34 @@ func packFile(path string) (map[string]any, error) {
 		return nil, fmt.Errorf("%q must have a YAML map at the root, got %T", path, v)
 	}
 	return m, nil
+}
+
+// decodeYAML parses one YAML document into a Go value.
+//
+// It goes through a yaml.Node rather than straight into `any` so that plain
+// YAML 1.1 booleans can be retagged before the value is materialised — see
+// resolveYAML11Bools for why that matters. A file that is empty, or holds only
+// comments, yields a nil value and no error.
+//
+// The separate Decode step is also what surfaces duplicate mapping keys:
+// yaml.Unmarshal into a yaml.Node accepts them, and only the decode into a Go
+// value reports them.
+func decodeYAML(b []byte) (any, error) {
+	var node yaml.Node
+	if err := yaml.Unmarshal(b, &node); err != nil {
+		return nil, err
+	}
+	if node.Kind == 0 {
+		return nil, nil
+	}
+
+	resolveYAML11Bools(&node, false)
+
+	var v any
+	if err := node.Decode(&v); err != nil {
+		return nil, err
+	}
+	return v, nil
 }
 
 // yaml11Bools maps the plain scalars that YAML 1.1 resolves as booleans, but
@@ -294,6 +322,235 @@ func resolveYAML11Bools(n *yaml.Node, isKey bool) {
 	for _, child := range n.Content {
 		resolveYAML11Bools(child, false)
 	}
+}
+
+// anchorsKey is the throwaway top-level key the anchor definitions are hung
+// from when a file is re-parsed. It is deleted before the file's content is
+// merged. The name is not valid anywhere in a CircleCI config or orb, so it
+// cannot shadow something real.
+const anchorsKey = "__circleci_pack_anchors__"
+
+// collectAnchors records every anchor defined by every YAML file under root.
+//
+// A decomposed orb naturally wants to define shared values once — conventionally
+// in an anchors/@anchors.yml — and alias them from the files that need them. YAML
+// will not do that on its own: an anchor is scoped to the document that defines
+// it, so each file parsed alone fails with "unknown anchor".
+//
+// Files that fail to parse are skipped rather than reported. A file with an
+// unresolved alias is exactly the case this exists to fix, and any genuine syntax
+// error in it surfaces from the main pack pass with its own message.
+//
+// filepath.WalkDir visits lexically, so when two files define the same anchor
+// name the later path wins, deterministically.
+func collectAnchors(root string) map[string]*yaml.Node {
+	anchors := make(map[string]*yaml.Node)
+
+	// Reads go through an os.Root so they cannot follow a symlink out of the
+	// pack directory between the walk seeing an entry and this opening it.
+	dirRoot, err := os.OpenRoot(root)
+	if err != nil {
+		return anchors
+	}
+	// Close errors are immaterial here: this whole function is best-effort, and
+	// every real problem with a file is reported by the main pack pass.
+	defer func() { _ = dirRoot.Close() }()
+
+	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return nil //nolint:nilerr // unreadable entries are reported by the main pass
+		}
+		if strings.HasPrefix(d.Name(), ".") && path != root {
+			if d.IsDir() {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if d.IsDir() || !isYAMLName(d.Name()) {
+			return nil
+		}
+
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return nil
+		}
+		b, readErr := dirRoot.ReadFile(rel)
+		if readErr != nil {
+			return nil
+		}
+		var node yaml.Node
+		if yaml.Unmarshal(b, &node) != nil {
+			return nil
+		}
+		collectNodeAnchors(&node, anchors)
+		return nil
+	})
+
+	return anchors
+}
+
+// collectNodeAnchors walks a parsed document recording anchor definitions.
+//
+// An anchor whose own subtree contains an alias is skipped: re-serialising it in
+// isolation would emit that alias with nothing to resolve it against, and one
+// such anchor would break the definitions block for every file. Chaining an
+// anchor to another anchor therefore only works within a single file.
+func collectNodeAnchors(n *yaml.Node, into map[string]*yaml.Node) {
+	if n == nil {
+		return
+	}
+	if n.Anchor != "" && !containsAlias(n) {
+		into[n.Anchor] = n
+	}
+	for _, child := range n.Content {
+		collectNodeAnchors(child, into)
+	}
+}
+
+func containsAlias(n *yaml.Node) bool {
+	if n.Kind == yaml.AliasNode {
+		return true
+	}
+	for _, child := range n.Content {
+		if containsAlias(child) {
+			return true
+		}
+	}
+	return false
+}
+
+// retryWithAnchors re-parses src with anchors defined ahead of it, for a file
+// whose only problem is an alias to an anchor defined in a sibling file.
+//
+// firstErr is the failure from parsing src alone. Anything other than an unknown
+// anchor is returned untouched — this is not a general-purpose second chance.
+//
+// Which error to report when the retry also fails needs care, because the retry
+// parses a synthesised document rather than the user's file:
+//
+//   - A *yaml.TypeError means the document parsed and only the decode into a Go
+//     value objected — so the anchors did resolve, and the remaining problem
+//     (a duplicate key, say) is real. Report it, with its line numbers shifted
+//     back onto the user's file. Reporting firstErr here would claim the anchor
+//     was unknown when it was not.
+//   - Anything else is a parse failure that src alone did not have, so it is an
+//     artifact of prepending the definitions — a file whose root is a sequence,
+//     or one that opens its own document with ---. Report firstErr, which is at
+//     least a true statement about the real file.
+//
+// The retry parses through decodeYAML rather than yaml.Unmarshal so that a file
+// which needed a sibling's anchor is treated identically to every other file.
+func retryWithAnchors(src []byte, anchors map[string]*yaml.Node, firstErr error) (any, error) {
+	if len(anchors) == 0 || !isUnknownAnchorErr(firstErr) {
+		return nil, firstErr
+	}
+
+	prefix, err := anchorDefinitions(anchors)
+	if err != nil {
+		return nil, firstErr
+	}
+
+	// decodeYAML, not a bare Unmarshal: a file that needed a sibling's anchor
+	// must still get YAML 1.1 boolean retagging and duplicate-key detection.
+	v, err := decodeYAML(append(prefix, src...))
+	if err != nil {
+		var typeErr *yaml.TypeError
+		if errors.As(err, &typeErr) {
+			return nil, shiftLines(typeErr, bytes.Count(prefix, []byte("\n")))
+		}
+		return nil, firstErr
+	}
+	// The definitions block did its job during parsing; the aliases in the file
+	// are resolved values now, so drop it before the content is merged.
+	if m, ok := v.(map[string]any); ok {
+		delete(m, anchorsKey)
+	}
+	return v, nil
+}
+
+// lineRefRe matches every line reference in a yaml.v3 decode message. A single
+// message can carry more than one, as duplicate-key reports do:
+// `line 3: mapping key "dupe" already defined at line 2`.
+var lineRefRe = regexp.MustCompile(`line (\d+)`)
+
+// shiftLines moves every line number in a decode error back by offset, undoing
+// the lines that anchorDefinitions prepended, so the reported positions point at
+// the file the user actually wrote.
+func shiftLines(typeErr *yaml.TypeError, offset int) error {
+	if offset == 0 {
+		return typeErr
+	}
+	shifted := make([]string, 0, len(typeErr.Errors))
+	for _, e := range typeErr.Errors {
+		shifted = append(shifted, lineRefRe.ReplaceAllStringFunc(e, func(match string) string {
+			n, convErr := strconv.Atoi(lineRefRe.FindStringSubmatch(match)[1])
+			if convErr != nil || n-offset < 1 {
+				return match
+			}
+			return fmt.Sprintf("line %d", n-offset)
+		}))
+	}
+	return &yaml.TypeError{Errors: shifted}
+}
+
+// anchorDefinitions renders the collected anchors as a single-line mapping entry
+// that can be prepended to a file, e.g.
+//
+//	__circleci_pack_anchors__: [&my-anchor my-value, &other {a: 1}]
+//
+// Flow style keeps it to one line and self-contained, so prepending it cannot
+// disturb the indentation of what follows.
+func anchorDefinitions(anchors map[string]*yaml.Node) ([]byte, error) {
+	names := make([]string, 0, len(anchors))
+	for name := range anchors {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	seq := &yaml.Node{Kind: yaml.SequenceNode, Style: yaml.FlowStyle}
+	for _, name := range names {
+		def := flowCopy(anchors[name])
+		seq.Content = append(seq.Content, def)
+	}
+
+	doc := &yaml.Node{Kind: yaml.MappingNode, Content: []*yaml.Node{
+		{Kind: yaml.ScalarNode, Tag: "!!str", Value: anchorsKey},
+		seq,
+	}}
+
+	out, err := yaml.Marshal(doc)
+	if err != nil {
+		return nil, err
+	}
+	if !strings.HasSuffix(string(out), "\n") {
+		out = append(out, '\n')
+	}
+	return out, nil
+}
+
+// flowCopy deep-copies a node with every collection forced to flow style, so it
+// serialises on one line. Copying matters because the source nodes are shared
+// across every file that needs them.
+func flowCopy(n *yaml.Node) *yaml.Node {
+	if n == nil {
+		return nil
+	}
+	cp := *n
+	cp.HeadComment, cp.LineComment, cp.FootComment = "", "", ""
+	if cp.Kind == yaml.MappingNode || cp.Kind == yaml.SequenceNode {
+		cp.Style = yaml.FlowStyle
+	}
+	cp.Content = nil
+	for _, child := range n.Content {
+		cp.Content = append(cp.Content, flowCopy(child))
+	}
+	return &cp
+}
+
+// isUnknownAnchorErr reports whether err is yaml.v3's undefined-alias failure.
+// yaml.v3 gives it no distinct type, so the message is all there is to match on.
+func isUnknownAnchorErr(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "unknown anchor")
 }
 
 // mergeMaps shallow-merges any number of maps into a new map[string]any.

--- a/internal/pack/pack_test.go
+++ b/internal/pack/pack_test.go
@@ -339,6 +339,148 @@ func TestPack_TopLevelDirectoriesStillBecomeSections(t *testing.T) {
 	assert.Check(t, strings.Contains(packed, "executors:\n    e:"), "got:\n%s", packed)
 }
 
+// TestPack_CrossFileAnchors is the regression test for
+// https://github.com/CircleCI-Public/circleci-cli/issues/341, using the layout
+// and expected output from the report: an anchor defined in anchors/@anchors.yml
+// aliased from commands/my-command.yml.
+func TestPack_CrossFileAnchors(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "anchors", "@anchors.yml"), "my-anchor: &my-anchor my-value\n")
+	writeFile(t, filepath.Join(dir, "commands", "my-command.yml"), "description: *my-anchor\n")
+
+	packed, err := pack.Pack(dir)
+	assert.NilError(t, err)
+
+	const want = `anchors:
+    my-anchor: my-value
+commands:
+    my-command:
+        description: my-value
+`
+	assert.Equal(t, packed, want)
+}
+
+// TestPack_CrossFileAnchors_Collections checks that an anchor on a map or a
+// sequence survives the round trip, not just a scalar. Those are the ones worth
+// sharing — a common docker executor, a filter block.
+func TestPack_CrossFileAnchors_Collections(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "@orb.yml"), "version: 2.1\n")
+	writeFile(t, filepath.Join(dir, "anchors", "@anchors.yml"),
+		"base: &base\n  docker:\n    - image: cimg/base:2024.01\n"+
+			"tags: &tags\n  - main\n  - release\n")
+	writeFile(t, filepath.Join(dir, "jobs", "build.yml"),
+		"executor: *base\nbranches: *tags\nsteps:\n  - checkout\n")
+
+	packed, err := pack.Pack(dir)
+	assert.NilError(t, err)
+
+	const want = `anchors:
+    base:
+        docker:
+            - image: cimg/base:2024.01
+    tags:
+        - main
+        - release
+jobs:
+    build:
+        branches:
+            - main
+            - release
+        executor:
+            docker:
+                - image: cimg/base:2024.01
+        steps:
+            - checkout
+version: 2.1
+`
+	assert.Equal(t, packed, want)
+}
+
+// TestPack_SameFileAnchorsStillWork guards the ordinary case: anchors used within
+// one file must not be disturbed by the cross-file machinery.
+func TestPack_SameFileAnchorsStillWork(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "@orb.yml"), "version: 2.1\n")
+	writeFile(t, filepath.Join(dir, "commands", "c.yml"),
+		"parameters:\n  a: &shared\n    type: string\n    default: x\n  b: *shared\nsteps:\n  - run: echo hi\n")
+
+	packed, err := pack.Pack(dir)
+	assert.NilError(t, err)
+
+	assert.Check(t, strings.Count(packed, "default: x") == 2, "got:\n%s", packed)
+}
+
+// TestPack_UnknownAnchorStillReported checks that an alias with no definition
+// anywhere in the tree is still an error, and still names the anchor. Resolving
+// across files must not turn a typo into silence.
+func TestPack_UnknownAnchorStillReported(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "anchors", "@anchors.yml"), "my-anchor: &my-anchor my-value\n")
+	target := filepath.Join(dir, "commands", "c.yml")
+	writeFile(t, target, "description: *my-anchr\n")
+
+	_, err := pack.Pack(dir)
+	// The location leads, in the file:line: form parseError produces (issue 519),
+	// with no line to report for an unresolved alias. Built from filepath.Join so
+	// the separator is right on every platform.
+	assert.ErrorContains(t, err, target+": unknown anchor 'my-anchr' referenced")
+}
+
+// TestPack_CrossFileAnchors_RetagsYAML11Booleans guards the seam between two
+// features that landed separately: cross-file anchors (issue 341) and reading
+// unquoted on/off as booleans (issue 691).
+//
+// A file that aliases a sibling's anchor cannot parse alone, so it is parsed a
+// second time with the definitions prepended. That retry has to go through the
+// same decode path as every other file — otherwise these files, and only these
+// files, would silently miss the YAML 1.1 boolean retagging and pack `default: on`
+// back to the string "on".
+func TestPack_CrossFileAnchors_RetagsYAML11Booleans(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "@orb.yml"), "version: 2.1\n")
+	writeFile(t, filepath.Join(dir, "anchors", "@anchors.yml"), "flag: &flag on\n")
+	writeFile(t, filepath.Join(dir, "commands", "vpn.yml"),
+		"parameters:\n  killswitch:\n    type: boolean\n    default: *flag\nsteps:\n  - run: echo hi\n")
+
+	packed, err := pack.Pack(dir)
+	assert.NilError(t, err)
+
+	// true, not "on" — in the anchor definition and at the alias site alike.
+	assert.Check(t, strings.Contains(packed, "flag: true"), "got:\n%s", packed)
+	assert.Check(t, strings.Contains(packed, "default: true"), "got:\n%s", packed)
+	assert.Check(t, !strings.Contains(packed, `"on"`), "nothing should still be the string \"on\", got:\n%s", packed)
+}
+
+// TestPack_AnchorRetryReportsTheRealError checks the fallback: when a file has an
+// unresolved alias *and* another problem, the reported error describes the real
+// file. The retry parses a synthesised document whose line numbers do not line up
+// with the user's file, so its error is never the one shown.
+func TestPack_AnchorRetryReportsTheRealError(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "anchors", "@anchors.yml"), "a: &shared value\n")
+	writeFile(t, filepath.Join(dir, "commands", "c.yml"),
+		"description: *shared\ndupe: 1\ndupe: 2\n")
+
+	_, err := pack.Pack(dir)
+	// The duplicate key is the surviving problem once the alias resolves, and its
+	// line numbers describe c.yml, not the synthesised document.
+	assert.ErrorContains(t, err, `mapping key "dupe" already defined at line 2`)
+}
+
+// TestPack_SingleFileAnchorsAreSelfContained checks that packing one file does
+// not reach out to a sibling for anchors — there is no tree to draw from, and the
+// error should say so plainly.
+func TestPack_SingleFileAnchorsAreSelfContained(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "@anchors.yml"), "a: &shared value\n")
+	target := filepath.Join(dir, "one.yml")
+	writeFile(t, target, "description: *shared\n")
+
+	_, err := pack.Pack(target)
+	assert.ErrorContains(t, err, "unknown anchor 'shared' referenced")
+}
+
 func writeFile(t *testing.T, path, content string) {
 	t.Helper()
 	assert.NilError(t, os.MkdirAll(filepath.Dir(path), 0o750))


### PR DESCRIPTION
A decomposed orb wants to define shared values once — conventionally in anchors/@anchors.yml — and alias them where needed. YAML will not do that on its own: an anchor is scoped to the document defining it, so each file parsed alone failed with "unknown anchor 'my-anchor' referenced".

Collect every anchor in the tree up front, then retry any file that fails on an unknown anchor with those definitions prepended as a single throwaway flow-style line. Aliases resolve to their values during the parse, so the packed output carries the value, which is the output the issue asks for.

Reporting the right error when the retry also fails needs care, since the retry parses a synthesised document rather than the user's file:

  - A *yaml.TypeError means the document parsed and only the decode objected, so the anchors did resolve and the remaining problem is real. Report it, with line numbers shifted back onto the user's file. Reporting the original error here would claim an anchor was unknown when it was not.
  - Any other failure is an artifact of prepending (a file rooted at a sequence, or one opening its own --- document), so report the original error, which is at least true of the real file.

An unknown anchor with no definition anywhere is still an error naming the anchor, so a typo does not become silence. Anchors whose own subtree contains an alias are skipped, since re-serialising one in isolation would emit an alias with nothing to resolve against; chaining still works within a file. Reads go through an os.Root so the walk cannot be raced into following a symlink out of the tree.

Fixes #341

<!--
  Thank you for contributing to CircleCI CLI!

  For PRs adding new features, please raise an issue first.

  Squash your commits before requesting review and before merging.
-->
