### PR TITLE
Warn when a list item's config is detached from its name

### DIFF
--- a/acceptance/config_test.go
+++ b/acceptance/config_test.go
@@ -655,6 +655,79 @@ func TestConfigPack_UnknownAnchor(t *testing.T) {
 	assert.Check(t, cmp.Contains(result.Stderr, "c.yml"))
 }
 
+// TestConfigPack_WarnsOnDetachedListKey is the end-to-end check for
+// https://github.com/CircleCI-Public/circleci-cli/issues/512: `requires`
+// indented level with the job name is, in YAML, a sibling of it, so the job gets
+// no value and CircleCI rejects the packed result at compile time.
+//
+// The pack still succeeds and still emits what the YAML says — the warning is
+// advisory. Two things matter here that the unit tests cannot show: the warning
+// goes to stderr, so stdout stays pipeable into validate, and the exit code
+// stays 0.
+func TestConfigPack_WarnsOnDetachedListKey(t *testing.T) {
+	env := testenv.New(t)
+	env.Token = testToken
+
+	dir := t.TempDir()
+	assert.NilError(t, os.MkdirAll(filepath.Join(dir, ".circleci", "workflows"), 0o755))
+	writeFile(t, filepath.Join(dir, ".circleci", "@config.yml"), "version: \"2.1\"\n")
+	writeFile(t, filepath.Join(dir, ".circleci", "workflows", "build_and_test.yml"),
+		"jobs:\n"+
+			"  - specs\n"+
+			"  - specs_feature_failures_only:\n"+
+			"    requires:\n"+
+			"      - specs\n")
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"config", "pack", ".circleci"},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	// Advisory: the document is well-formed YAML, so packing succeeds.
+	assert.Check(t, cmp.Equal(result.ExitCode, 0))
+	assert.Check(t, golden.String(result.Stdout, t.Name()+".txt"))
+
+	// Asserted with Contains rather than a golden because the warning carries an
+	// absolute path: a golden would embed this machine's temp directory, and would
+	// need a second copy for Windows' separators.
+	assert.Check(t, cmp.Contains(result.Stderr,
+		`"specs_feature_failures_only" has no value but shares a list item with "requires"`))
+	assert.Check(t, cmp.Contains(result.Stderr, `indent "requires" one level further`))
+	// The location leads, and points at the line the job name is on.
+	assert.Check(t, cmp.Contains(result.Stderr, filepath.Join("workflows", "build_and_test.yml")+":3: "))
+}
+
+// TestConfigPack_NoSpuriousWarning is the other half: a correctly indented
+// workflow job must pack silently. A warning on valid config is worse than a
+// missing one, so this pins stderr as empty.
+func TestConfigPack_NoSpuriousWarning(t *testing.T) {
+	env := testenv.New(t)
+	env.Token = testToken
+
+	dir := t.TempDir()
+	assert.NilError(t, os.MkdirAll(filepath.Join(dir, ".circleci", "workflows"), 0o755))
+	writeFile(t, filepath.Join(dir, ".circleci", "@config.yml"), "version: \"2.1\"\n")
+	writeFile(t, filepath.Join(dir, ".circleci", "workflows", "build_and_test.yml"),
+		"jobs:\n"+
+			"  - specs\n"+
+			"  - specs_feature_failures_only:\n"+
+			"      requires:\n"+
+			"        - specs\n")
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"config", "pack", ".circleci"},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	assert.Check(t, cmp.Equal(result.ExitCode, 0))
+	assert.Check(t, golden.String(result.Stdout, t.Name()+".txt"))
+	assert.Check(t, cmp.Equal(result.Stderr, ""))
+}
+
 func TestConfigPack_NotFound(t *testing.T) {
 	env := testenv.New(t)
 	env.Token = testToken

--- a/acceptance/testdata/TestConfigPack_NoSpuriousWarning.txt
+++ b/acceptance/testdata/TestConfigPack_NoSpuriousWarning.txt
@@ -1,0 +1,8 @@
+version: "2.1"
+workflows:
+    build_and_test:
+        jobs:
+            - specs
+            - specs_feature_failures_only:
+                requires:
+                    - specs

--- a/acceptance/testdata/TestConfigPack_WarnsOnDetachedListKey.txt
+++ b/acceptance/testdata/TestConfigPack_WarnsOnDetachedListKey.txt
@@ -1,0 +1,8 @@
+version: "2.1"
+workflows:
+    build_and_test:
+        jobs:
+            - specs
+            - requires:
+                - specs
+              specs_feature_failures_only: null

--- a/internal/cmd/config/pack.go
+++ b/internal/cmd/config/pack.go
@@ -24,7 +24,6 @@ package cmdconfig
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
@@ -66,15 +65,16 @@ func newPackCmd() *cobra.Command {
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
-			packed, err := pack.Pack(args[0])
+			packed, warnings, err := pack.Pack(args[0])
 			if err != nil {
 				return clierrors.New("config.pack_failed", "Config pack failed",
-					// A pack failure can name more than one bad file; indent the
-					// continuation lines so each located problem stays readable
-					// under the single-line "error: " prefix.
-					fmt.Sprintf("Could not pack %q: %s", args[0],
-						strings.ReplaceAll(err.Error(), "\n", "\n  "))).
+					fmt.Sprintf("Could not pack %q: %s", args[0], err)).
 					WithExitCode(clierrors.ExitBadArguments)
+			}
+			// Warnings go to stderr so the packed document on stdout stays
+			// pipeable into validate.
+			for _, w := range warnings {
+				_, _ = fmt.Fprintf(iostream.Err(ctx), "warning: %s\n", w)
 			}
 			_, _ = fmt.Fprint(iostream.Out(ctx), packed)
 			return nil

--- a/internal/cmd/orb/init.go
+++ b/internal/cmd/orb/init.go
@@ -408,7 +408,9 @@ func applyOrbInitGit(ctx context.Context, client *apiclient.Client, path string,
 	}
 
 	// Pack the orb source and publish a dev:alpha version.
-	packed, err := pack.Pack(filepath.Join(path, "src"))
+	// Warnings are dropped here: orb init is a guided flow with its own output,
+	// and `circleci orb pack` is where an author sees them.
+	packed, _, err := pack.Pack(filepath.Join(path, "src"))
 	if err != nil {
 		return clierrors.New("orb.init_pack_failed", "Could not pack orb source",
 			err.Error()).

--- a/internal/cmd/orb/pack.go
+++ b/internal/cmd/orb/pack.go
@@ -24,7 +24,6 @@ package orb
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
@@ -75,15 +74,16 @@ func newPackCmd() *cobra.Command {
 			if err := cmdutil.RequireArgs(args, "path"); err != nil {
 				return err
 			}
-			packed, err := pack.Pack(args[0])
+			packed, warnings, err := pack.Pack(args[0])
 			if err != nil {
 				return clierrors.New("orb.pack_failed", "Orb pack failed",
-					// A pack failure can name more than one bad file; indent the
-					// continuation lines so each located problem stays readable
-					// under the single-line "error: " prefix.
-					fmt.Sprintf("Could not pack %q: %s", args[0],
-						strings.ReplaceAll(err.Error(), "\n", "\n  "))).
+					fmt.Sprintf("Could not pack %q: %s", args[0], err)).
 					WithExitCode(clierrors.ExitBadArguments)
+			}
+			// Warnings go to stderr so the packed document on stdout stays
+			// pipeable into validate.
+			for _, w := range warnings {
+				_, _ = fmt.Fprintf(iostream.Err(ctx), "warning: %s\n", w)
 			}
 			_, _ = fmt.Fprint(iostream.Out(ctx), packed)
 			return nil

--- a/internal/pack/pack.go
+++ b/internal/pack/pack.go
@@ -66,33 +66,59 @@ import (
 // the same bytes and neither churns the other's output.
 const indent = 4
 
+// Warning is a problem found while packing that does not stop the pack. Packing
+// is a mechanical merge, so anything it notices about the *meaning* of the input
+// is advisory: the merge still produces output.
+type Warning struct {
+	// Path is the file the problem is in.
+	Path string
+	// Line is the 1-indexed line within Path.
+	Line int
+	// Message describes the problem and what to do about it.
+	Message string
+}
+
+// String renders the warning with its location leading, in the file:line: form
+// editors and terminals turn into a clickable link.
+func (w Warning) String() string {
+	return fmt.Sprintf("%s:%d: %s", w.Path, w.Line, w.Message)
+}
+
 // Pack reads all YAML files under rootPath and merges them into a single YAML
 // document. If rootPath is a single file it is parsed and re-serialised.
-func Pack(rootPath string) (string, error) {
+//
+// The returned warnings describe anything noticed about the input that is
+// suspicious but not fatal. They are ordered by the lexical file walk, so they
+// are stable across runs, and callers that have nowhere to show them may discard
+// them.
+func Pack(rootPath string) (string, []Warning, error) {
 	absRoot, err := filepath.Abs(rootPath)
 	if err != nil {
-		return "", fmt.Errorf("resolving path: %w", err)
+		return "", nil, fmt.Errorf("resolving path: %w", err)
 	}
 
 	info, err := os.Stat(absRoot)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return "", fmt.Errorf("accessing %q: no such file or directory", rootPath)
+			return "", nil, fmt.Errorf("accessing %q: no such file or directory", rootPath)
 		}
-		return "", fmt.Errorf("accessing %q: %w", rootPath, err)
+		return "", nil, fmt.Errorf("accessing %q: %w", rootPath, err)
 	}
 
-	var result map[string]any
+	var (
+		result   map[string]any
+		warnings []Warning
+	)
 	if info.IsDir() {
 		// Anchors are collected up front so a file may alias an anchor defined
 		// in any other file of the tree, not just its own.
-		result, err = packDir(absRoot, 0, collectAnchors(absRoot))
+		result, err = packDir(absRoot, 0, collectAnchors(absRoot), &warnings)
 	} else {
 		// A single file has nothing else to draw anchors from.
-		result, err = packFile(absRoot, nil)
+		result, err = packFile(absRoot, nil, &warnings)
 	}
 	if err != nil {
-		return "", err
+		return "", nil, err
 	}
 
 	var buf strings.Builder
@@ -100,9 +126,9 @@ func Pack(rootPath string) (string, error) {
 	enc.SetIndent(indent)
 	err = enc.Encode(result)
 	if err != nil {
-		return "", fmt.Errorf("marshaling result: %w", err)
+		return "", nil, fmt.Errorf("marshaling result: %w", err)
 	}
-	return buf.String(), nil
+	return buf.String(), warnings, nil
 }
 
 // packDir recursively merges all YAML files under dirPath.
@@ -119,7 +145,8 @@ func Pack(rootPath string) (string, error) {
 //     happened to sit where one belonged.
 //
 // anchors holds the anchors defined anywhere in the tree; see collectAnchors.
-func packDir(dirPath string, depth int, anchors map[string]*yaml.Node) (map[string]any, error) {
+// warnings accumulates advisory findings; see Warning.
+func packDir(dirPath string, depth int, anchors map[string]*yaml.Node, warnings *[]Warning) (map[string]any, error) {
 	entries, err := os.ReadDir(dirPath)
 	if err != nil {
 		return nil, fmt.Errorf("reading directory %q: %w", dirPath, err)
@@ -151,7 +178,7 @@ func packDir(dirPath string, depth int, anchors map[string]*yaml.Node) (map[stri
 		}
 
 		if entry.IsDir() {
-			childMap, err := packDir(fullPath, depth+1, anchors)
+			childMap, err := packDir(fullPath, depth+1, anchors, warnings)
 			if err != nil {
 				return nil, err
 			}
@@ -168,7 +195,7 @@ func packDir(dirPath string, depth int, anchors map[string]*yaml.Node) (map[stri
 			continue
 		}
 
-		content, err := packFile(fullPath, anchors)
+		content, err := packFile(fullPath, anchors, warnings)
 		if err != nil {
 			return nil, err
 		}
@@ -212,19 +239,26 @@ func packDir(dirPath string, depth int, anchors map[string]*yaml.Node) (map[stri
 // one of them fails to parse on its own — anchors are a property of a single YAML
 // document — so on that specific failure the parse is retried with those
 // definitions prepended. Pass nil to parse the file in isolation.
-func packFile(path string, anchors map[string]*yaml.Node) (map[string]any, error) {
+//
+// warnings accumulates advisory findings about this file; see Warning.
+func packFile(path string, anchors map[string]*yaml.Node, warnings *[]Warning) (map[string]any, error) {
 	b, err := os.ReadFile(path) //#nosec:G304 // path is a resolved filesystem path under the user-supplied pack root directory
 	if err != nil {
 		return nil, fmt.Errorf("reading %q: %w", path, err)
 	}
 
-	v, err := decodeYAML(b)
+	res, err := decodeYAML(b)
 	if err != nil {
-		v, err = retryWithAnchors(b, anchors, err)
+		res, err = retryWithAnchors(b, anchors, err)
 		if err != nil {
 			return nil, parseError(path, err)
 		}
 	}
+	if res.node != nil {
+		findDetachedListKeys(path, res.node, res.lineOffset, warnings)
+	}
+
+	v := res.value
 	if v == nil {
 		return make(map[string]any), nil
 	}
@@ -245,22 +279,36 @@ func packFile(path string, anchors map[string]*yaml.Node) (map[string]any, error
 // The separate Decode step is also what surfaces duplicate mapping keys:
 // yaml.Unmarshal into a yaml.Node accepts them, and only the decode into a Go
 // value reports them.
-func decodeYAML(b []byte) (any, error) {
+func decodeYAML(b []byte) (parsed, error) {
 	var node yaml.Node
 	if err := yaml.Unmarshal(b, &node); err != nil {
-		return nil, err
+		return parsed{}, err
 	}
 	if node.Kind == 0 {
-		return nil, nil
+		return parsed{}, nil
 	}
 
 	resolveYAML11Bools(&node, false)
 
 	var v any
 	if err := node.Decode(&v); err != nil {
-		return nil, err
+		return parsed{}, err
 	}
-	return v, nil
+	return parsed{value: v, node: &node}, nil
+}
+
+// parsed is a decoded document together with the node tree it came from, so a
+// caller can still ask where in the source something was after the value has
+// been materialised.
+type parsed struct {
+	value any
+	node  *yaml.Node
+
+	// lineOffset is how many lines were prepended ahead of the file's own first
+	// line before parsing. Non-zero only on the cross-file anchor retry, which
+	// parses a synthesised document; source positions must have it subtracted
+	// before they are reported to the user.
+	lineOffset int
 }
 
 // yaml11Bools maps the plain scalars that YAML 1.1 resolves as booleans, but
@@ -440,32 +488,33 @@ func containsAlias(n *yaml.Node) bool {
 //
 // The retry parses through decodeYAML rather than yaml.Unmarshal so that a file
 // which needed a sibling's anchor is treated identically to every other file.
-func retryWithAnchors(src []byte, anchors map[string]*yaml.Node, firstErr error) (any, error) {
+func retryWithAnchors(src []byte, anchors map[string]*yaml.Node, firstErr error) (parsed, error) {
 	if len(anchors) == 0 || !isUnknownAnchorErr(firstErr) {
-		return nil, firstErr
+		return parsed{}, firstErr
 	}
 
 	prefix, err := anchorDefinitions(anchors)
 	if err != nil {
-		return nil, firstErr
+		return parsed{}, firstErr
 	}
 
 	// decodeYAML, not a bare Unmarshal: a file that needed a sibling's anchor
 	// must still get YAML 1.1 boolean retagging and duplicate-key detection.
-	v, err := decodeYAML(append(prefix, src...))
+	res, err := decodeYAML(append(prefix, src...))
 	if err != nil {
 		var typeErr *yaml.TypeError
 		if errors.As(err, &typeErr) {
-			return nil, shiftLines(typeErr, bytes.Count(prefix, []byte("\n")))
+			return parsed{}, shiftLines(typeErr, bytes.Count(prefix, []byte("\n")))
 		}
-		return nil, firstErr
+		return parsed{}, firstErr
 	}
 	// The definitions block did its job during parsing; the aliases in the file
 	// are resolved values now, so drop it before the content is merged.
-	if m, ok := v.(map[string]any); ok {
+	if m, ok := res.value.(map[string]any); ok {
 		delete(m, anchorsKey)
 	}
-	return v, nil
+	res.lineOffset = bytes.Count(prefix, []byte("\n"))
+	return res, nil
 }
 
 // lineRefRe matches every line reference in a yaml.v3 decode message. A single
@@ -551,6 +600,112 @@ func flowCopy(n *yaml.Node) *yaml.Node {
 // yaml.v3 gives it no distinct type, so the message is all there is to match on.
 func isUnknownAnchorErr(err error) bool {
 	return err != nil && strings.Contains(err.Error(), "unknown anchor")
+}
+
+// attachedKeys are keys that only mean anything as part of the thing above them:
+// a workflow job's requires/context/filters, a step's name/command. Finding one
+// as a *sibling* of a valueless key inside a list item is the signature of the
+// mis-indentation this warning is about.
+//
+// Membership is deliberately narrow. The check only fires when one of these sits
+// beside a valueless key in a sequence item, and a wrong warning is worse than a
+// missing one.
+var attachedKeys = map[string]bool{
+	"requires":     true,
+	"context":      true,
+	"filters":      true,
+	"matrix":       true,
+	"name":         true,
+	"type":         true,
+	"pre-steps":    true,
+	"post-steps":   true,
+	"serial-group": true,
+	"parameters":   true,
+	"command":      true,
+}
+
+// findDetachedListKeys warns about a list item shaped like this:
+//
+//	jobs:
+//	  - specs
+//	  - other:
+//	    requires:
+//	      - specs
+//
+// `requires` is indented level with `other`, so YAML reads it as a *sibling* key
+// of `other` in the same list item, and `other` itself has no value. Packing is a
+// faithful merge, so it round-trips that as `other: null` alongside `requires`,
+// which CircleCI then rejects at compile time:
+//
+//   - other: null
+//     requires:
+//   - specs
+//
+// The YAML is not malformed and pack is not wrong, so this is a warning rather
+// than an error. But pack can see what was almost certainly meant, and saying so
+// at pack time beats a compile error later with no file or line attached.
+//
+// The check is on shape alone, not on position in the document. A decomposed
+// config puts `jobs:` at the top level of workflows/build_and_test.yml, so there
+// is no workflows.*.jobs path to match on — and the same mis-indentation in a
+// steps list deserves the same warning anyway.
+func findDetachedListKeys(path string, n *yaml.Node, lineOffset int, warnings *[]Warning) {
+	if n == nil {
+		return
+	}
+
+	if n.Kind == yaml.SequenceNode {
+		for _, item := range n.Content {
+			if item.Kind == yaml.MappingNode {
+				if w, ok := detachedKeyWarning(path, item, lineOffset); ok {
+					*warnings = append(*warnings, w)
+				}
+			}
+		}
+	}
+
+	for _, child := range n.Content {
+		findDetachedListKeys(path, child, lineOffset, warnings)
+	}
+}
+
+// detachedKeyWarning inspects one list item, reporting the valueless key and the
+// attached key that looks like it was meant to belong to it.
+//
+// Both halves are required, and they must be different keys. A valueless key on
+// its own is fine — `- specs:` is just a job with no configuration. An empty
+// attached key on its own is fine too: `- image: alpine` with a bare `command:`
+// under it is odd but says what it means.
+func detachedKeyWarning(path string, item *yaml.Node, lineOffset int) (Warning, bool) {
+	var (
+		orphan   *yaml.Node // valueless key, i.e. the intended job or step name
+		attached string     // the key that looks like it belongs to orphan
+	)
+
+	for i := 0; i+1 < len(item.Content); i += 2 {
+		key, value := item.Content[i], item.Content[i+1]
+		isAttached := attachedKeys[key.Value]
+		isEmpty := value.Tag == "!!null"
+
+		switch {
+		case isEmpty && !isAttached && orphan == nil:
+			orphan = key
+		case !isEmpty && isAttached && attached == "":
+			attached = key.Value
+		}
+	}
+
+	if orphan == nil || attached == "" {
+		return Warning{}, false
+	}
+
+	return Warning{
+		Path: path,
+		Line: orphan.Line - lineOffset,
+		Message: fmt.Sprintf(
+			"%q has no value but shares a list item with %q; indent %q one level further to attach it to %q",
+			orphan.Value, attached, attached, orphan.Value),
+	}, true
 }
 
 // mergeMaps shallow-merges any number of maps into a new map[string]any.

--- a/internal/pack/pack_test.go
+++ b/internal/pack/pack_test.go
@@ -45,7 +45,7 @@ func TestPack_IndentationMatchesLegacyCLI(t *testing.T) {
 	writeFile(t, filepath.Join(dir, "jobs", "build.yml"),
 		"docker:\n  - image: cimg/base:2024.01\nsteps:\n  - checkout\n")
 
-	packed, err := pack.Pack(dir)
+	packed, _, err := pack.Pack(dir)
 	assert.NilError(t, err)
 
 	const want = `jobs:
@@ -97,7 +97,7 @@ func TestPack_ParseErrorIsClickable(t *testing.T) {
 			target := filepath.Join(dir, "executors", "executorA.yml")
 			writeFile(t, target, tt.content)
 
-			_, err := pack.Pack(dir)
+			_, _, err := pack.Pack(dir)
 			assert.ErrorContains(t, err, fmt.Sprintf("%s:%d: %s", target, tt.line, tt.message))
 
 			// The location has to lead the message — a filename mentioned
@@ -117,7 +117,7 @@ func TestPack_ParseErrorWithoutLine(t *testing.T) {
 	target := filepath.Join(dir, "commands", "bad.yml")
 	writeFile(t, target, "a: b: c\n")
 
-	_, err := pack.Pack(dir)
+	_, _, err := pack.Pack(dir)
 	assert.ErrorContains(t, err, target+": mapping values are not allowed in this context")
 	// No bare "yaml: " prefix left over once the location leads.
 	assert.Equal(t, strings.Contains(err.Error(), "yaml: "), false,
@@ -139,7 +139,7 @@ func TestPack_YAML11Booleans(t *testing.T) {
 			"  dryrun:\n    type: boolean\n    default: no\n"+
 			"steps:\n  - run: echo hi\n")
 
-	packed, err := pack.Pack(dir)
+	packed, _, err := pack.Pack(dir)
 	assert.NilError(t, err)
 
 	const want = `commands:
@@ -178,7 +178,7 @@ func TestPack_YAML11Booleans_QuotedStaysString(t *testing.T) {
 			"  short:\n    type: string\n    default: n\n"+
 			"steps:\n  - run: echo hi\n")
 
-	packed, err := pack.Pack(dir)
+	packed, _, err := pack.Pack(dir)
 	assert.NilError(t, err)
 
 	assert.Check(t, strings.Contains(packed, `default: "on"`), "got:\n%s", packed)
@@ -198,7 +198,7 @@ func TestPack_YAML11Booleans_KeysAreNotRetagged(t *testing.T) {
 	writeFile(t, filepath.Join(dir, "@config.yml"), "version: 2.1\n")
 	writeFile(t, filepath.Join(dir, "jobs", "build.yml"), "environment:\n  on: value\n  off: other\n")
 
-	packed, err := pack.Pack(dir)
+	packed, _, err := pack.Pack(dir)
 	assert.NilError(t, err)
 
 	assert.Check(t, strings.Contains(packed, `"on": value`), "got:\n%s", packed)
@@ -215,7 +215,7 @@ func TestPack_DuplicateKeysStillDetected(t *testing.T) {
 	writeFile(t, filepath.Join(dir, "executors", "e.yml"),
 		"docker:\n  - image: x\n    auth:\n      username: $U\n    auth:\n")
 
-	_, err := pack.Pack(dir)
+	_, _, err := pack.Pack(dir)
 	assert.ErrorContains(t, err, `mapping key "auth" already defined at line 3`)
 }
 
@@ -232,7 +232,7 @@ func TestPack_NestedDirectoriesFlattenIntoSection(t *testing.T) {
 	writeFile(t, filepath.Join(dir, "commands", "gcp", "auth.yml"), "steps:\n  - run: echo auth\n")
 	writeFile(t, filepath.Join(dir, "jobs", "build", "unit.yml"), "steps:\n  - run: echo unit\n")
 
-	packed, err := pack.Pack(dir)
+	packed, _, err := pack.Pack(dir)
 	assert.NilError(t, err)
 
 	const want = `commands:
@@ -261,7 +261,7 @@ func TestPack_DeeplyNestedDirectoriesFlatten(t *testing.T) {
 	writeFile(t, filepath.Join(dir, "@orb.yml"), "version: 2.1\n")
 	writeFile(t, filepath.Join(dir, "commands", "a", "b", "c", "deep.yml"), "steps:\n  - run: echo deep\n")
 
-	packed, err := pack.Pack(dir)
+	packed, _, err := pack.Pack(dir)
 	assert.NilError(t, err)
 
 	const want = `commands:
@@ -316,7 +316,7 @@ func TestPack_NestedNameCollision(t *testing.T) {
 				writeFile(t, filepath.Join(dir, path), content)
 			}
 
-			_, err := pack.Pack(dir)
+			_, _, err := pack.Pack(dir)
 			assert.ErrorContains(t, err, `both define "login"`)
 			assert.ErrorContains(t, err, "cannot share a name")
 		})
@@ -332,7 +332,7 @@ func TestPack_TopLevelDirectoriesStillBecomeSections(t *testing.T) {
 	writeFile(t, filepath.Join(dir, "commands", "c.yml"), "steps:\n  - run: echo c\n")
 	writeFile(t, filepath.Join(dir, "executors", "e.yml"), "docker:\n  - image: alpine\n")
 
-	packed, err := pack.Pack(dir)
+	packed, _, err := pack.Pack(dir)
 	assert.NilError(t, err)
 
 	assert.Check(t, strings.Contains(packed, "commands:\n    c:"), "got:\n%s", packed)
@@ -348,7 +348,7 @@ func TestPack_CrossFileAnchors(t *testing.T) {
 	writeFile(t, filepath.Join(dir, "anchors", "@anchors.yml"), "my-anchor: &my-anchor my-value\n")
 	writeFile(t, filepath.Join(dir, "commands", "my-command.yml"), "description: *my-anchor\n")
 
-	packed, err := pack.Pack(dir)
+	packed, _, err := pack.Pack(dir)
 	assert.NilError(t, err)
 
 	const want = `anchors:
@@ -372,7 +372,7 @@ func TestPack_CrossFileAnchors_Collections(t *testing.T) {
 	writeFile(t, filepath.Join(dir, "jobs", "build.yml"),
 		"executor: *base\nbranches: *tags\nsteps:\n  - checkout\n")
 
-	packed, err := pack.Pack(dir)
+	packed, _, err := pack.Pack(dir)
 	assert.NilError(t, err)
 
 	const want = `anchors:
@@ -405,7 +405,7 @@ func TestPack_SameFileAnchorsStillWork(t *testing.T) {
 	writeFile(t, filepath.Join(dir, "commands", "c.yml"),
 		"parameters:\n  a: &shared\n    type: string\n    default: x\n  b: *shared\nsteps:\n  - run: echo hi\n")
 
-	packed, err := pack.Pack(dir)
+	packed, _, err := pack.Pack(dir)
 	assert.NilError(t, err)
 
 	assert.Check(t, strings.Count(packed, "default: x") == 2, "got:\n%s", packed)
@@ -420,7 +420,7 @@ func TestPack_UnknownAnchorStillReported(t *testing.T) {
 	target := filepath.Join(dir, "commands", "c.yml")
 	writeFile(t, target, "description: *my-anchr\n")
 
-	_, err := pack.Pack(dir)
+	_, _, err := pack.Pack(dir)
 	// The location leads, in the file:line: form parseError produces (issue 519),
 	// with no line to report for an unresolved alias. Built from filepath.Join so
 	// the separator is right on every platform.
@@ -443,7 +443,7 @@ func TestPack_CrossFileAnchors_RetagsYAML11Booleans(t *testing.T) {
 	writeFile(t, filepath.Join(dir, "commands", "vpn.yml"),
 		"parameters:\n  killswitch:\n    type: boolean\n    default: *flag\nsteps:\n  - run: echo hi\n")
 
-	packed, err := pack.Pack(dir)
+	packed, _, err := pack.Pack(dir)
 	assert.NilError(t, err)
 
 	// true, not "on" — in the anchor definition and at the alias site alike.
@@ -462,7 +462,7 @@ func TestPack_AnchorRetryReportsTheRealError(t *testing.T) {
 	writeFile(t, filepath.Join(dir, "commands", "c.yml"),
 		"description: *shared\ndupe: 1\ndupe: 2\n")
 
-	_, err := pack.Pack(dir)
+	_, _, err := pack.Pack(dir)
 	// The duplicate key is the surviving problem once the alias resolves, and its
 	// line numbers describe c.yml, not the synthesised document.
 	assert.ErrorContains(t, err, `mapping key "dupe" already defined at line 2`)
@@ -477,8 +477,142 @@ func TestPack_SingleFileAnchorsAreSelfContained(t *testing.T) {
 	target := filepath.Join(dir, "one.yml")
 	writeFile(t, target, "description: *shared\n")
 
-	_, err := pack.Pack(target)
+	_, _, err := pack.Pack(target)
 	assert.ErrorContains(t, err, "unknown anchor 'shared' referenced")
+}
+
+// TestPack_WarnsOnDetachedListKey is the regression test for
+// https://github.com/CircleCI-Public/circleci-cli/issues/512, using the layout
+// from the report: `requires` indented level with the job name, so YAML reads it
+// as a sibling and the job gets no value.
+func TestPack_WarnsOnDetachedListKey(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "@config.yml"), "version: 2.1\n")
+	writeFile(t, filepath.Join(dir, "workflows", "build_and_test.yml"),
+		"jobs:\n"+
+			"  - specs\n"+
+			"  - specs_feature_failures_only:\n"+
+			"    requires:\n"+
+			"      - specs\n")
+
+	packed, warnings, err := pack.Pack(dir)
+	assert.NilError(t, err)
+
+	// The pack still succeeds — the YAML is well-formed, just not what was meant.
+	assert.Check(t, strings.Contains(packed, "specs_feature_failures_only: null"), "got:\n%s", packed)
+
+	assert.Assert(t, len(warnings) == 1, "got %d warnings: %v", len(warnings), warnings)
+	w := warnings[0]
+	assert.Equal(t, w.Path, filepath.Join(dir, "workflows", "build_and_test.yml"))
+	// Line 3 is where the job name sits, which is what needs looking at.
+	assert.Equal(t, w.Line, 3)
+	assert.Check(t, strings.Contains(w.Message, `"specs_feature_failures_only" has no value`), w.Message)
+	assert.Check(t, strings.Contains(w.Message, `indent "requires" one level further`), w.Message)
+	// The rendered form leads with a clickable location.
+	assert.Check(t, strings.HasPrefix(w.String(), w.Path+":3: "), w.String())
+}
+
+// TestPack_WarnsOnDetachedStepKey covers the same mis-indentation in a steps
+// list, since the check is on shape rather than position: a decomposed config
+// puts `jobs:` at the top level of its own file, so there is no
+// workflows.*.jobs path to key off.
+func TestPack_WarnsOnDetachedStepKey(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "@orb.yml"), "version: 2.1\n")
+	writeFile(t, filepath.Join(dir, "commands", "c.yml"),
+		"steps:\n"+
+			"  - run:\n"+
+			"    name: say hello\n"+
+			"    command: echo hi\n")
+
+	_, warnings, err := pack.Pack(dir)
+	assert.NilError(t, err)
+
+	assert.Assert(t, len(warnings) == 1, "got %d warnings: %v", len(warnings), warnings)
+	assert.Check(t, strings.Contains(warnings[0].Message, `"run" has no value`), warnings[0].Message)
+}
+
+// TestPack_WarnsOnDetachedListKey_AfterAnchorRetry guards the seam between this
+// warning and cross-file anchors (issue 341).
+//
+// A file that aliases a sibling's anchor cannot parse alone, so it is parsed a
+// second time with the anchor definitions prepended. Those prepended lines shift
+// every source position in that parse, so a position taken from it has to have
+// the offset subtracted before the user sees it — otherwise the warning points at
+// the line after the one that needs fixing, which is worse than no line at all.
+func TestPack_WarnsOnDetachedListKey_AfterAnchorRetry(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "@config.yml"), "version: 2.1\n")
+	writeFile(t, filepath.Join(dir, "anchors", "@anchors.yml"), "ref: &ref specs\n")
+	target := filepath.Join(dir, "workflows", "build.yml")
+	writeFile(t, target,
+		"jobs:\n"+
+			"  - *ref\n"+
+			"  - other:\n"+
+			"    requires:\n"+
+			"      - specs\n")
+
+	_, warnings, err := pack.Pack(dir)
+	assert.NilError(t, err)
+
+	assert.Assert(t, len(warnings) == 1, "got %d warnings: %v", len(warnings), warnings)
+	assert.Equal(t, warnings[0].Path, target)
+	// Line 3 in the file the user wrote — "  - other:" — not line 4, which is
+	// where it sat in the synthesised document the retry parsed.
+	assert.Equal(t, warnings[0].Line, 3)
+}
+
+// TestPack_NoFalseWarnings is the important half. A wrong warning on valid config
+// is worse than a missing one, so every shape here must stay quiet.
+func TestPack_NoFalseWarnings(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+	}{
+		{
+			name:    "correctly indented job config",
+			content: "jobs:\n  - specs\n  - other:\n      requires:\n        - specs\n",
+		},
+		{
+			// `- specs:` is a job with no configuration, which is fine.
+			name:    "valueless job name alone",
+			content: "jobs:\n  - specs:\n  - other\n",
+		},
+		{
+			name:    "plain string items",
+			content: "jobs:\n  - specs\n  - js_tests\n  - static_analysis\n",
+		},
+		{
+			name:    "approval job",
+			content: "jobs:\n  - hold:\n      type: approval\n",
+		},
+		{
+			// A docker entry legitimately carries image and command together.
+			name:    "docker entry with siblings",
+			content: "docker:\n  - image: golang\n  - image: cockroach\n    command: start --insecure\n",
+		},
+		{
+			// An empty attached key with no orphan beside it says what it means.
+			name:    "empty command beside a set image",
+			content: "docker:\n  - image: alpine\n    command:\n",
+		},
+		{
+			name:    "empty non-attached key",
+			content: "docker:\n  - image: alpine\n    environment:\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeFile(t, filepath.Join(dir, "@config.yml"), "version: 2.1\n")
+			writeFile(t, filepath.Join(dir, "jobs", "build.yml"), tt.content)
+
+			_, warnings, err := pack.Pack(dir)
+			assert.NilError(t, err)
+			assert.Check(t, len(warnings) == 0, "expected no warnings, got: %v", warnings)
+		})
+	}
 }
 
 func writeFile(t *testing.T, path, content string) {


### PR DESCRIPTION
A workflow job written like this

    jobs:
      - specs
      - specs_feature_failures_only:
        requires:
          - specs

reads, in YAML, as one list item with two sibling keys: a valueless
specs_feature_failures_only and a requires. Pack is a faithful merge, so it
round-tripped that as `specs_feature_failures_only: null` alongside `requires`,
and CircleCI rejected it at compile time with nothing pointing back at the file.

The YAML is well-formed and pack is not wrong, so this is a warning rather than
an error — the pack still succeeds. But pack can see what was meant, and saying
so with a file and line beats a compile error later without one.

Detection is on shape, not position. A decomposed config puts `jobs:` at the top
level of workflows/build_and_test.yml, so there is no workflows.*.jobs path to
match against; and the same mis-indentation in a steps list deserves the same
warning. A list item is flagged when it has a valueless key that is not itself a
job/step config key, *plus* a non-empty key that is one. Both halves and the
distinctness matter for avoiding false positives: `- specs:` alone is a job with
no config, and a docker entry with a bare `command:` beside a set `image:` says
what it means. Tests cover both directions.

Pack now returns warnings alongside the document; the two pack commands print
them to stderr so stdout stays pipeable into validate, and orb init discards them.

Fixes https://github.com/CircleCI-Public/circleci-cli/issues/512