### PR TITLE
Enable dynamic config for the project orb init sets up

### DIFF
--- a/acceptance/orb_test.go
+++ b/acceptance/orb_test.go
@@ -55,6 +55,10 @@ const testOrbUUID = "a1b2c3d4-0000-4000-8000-000000000001"
 const testOrbName = "myorg/my-orb"
 const testOrbNsName = "myorg"
 const testOrbShortName = "my-orb"
+
+// Valid hex UUIDs: ProjectRef.ID is a uuid.UUID and has to parse.
+const testOrbProjectID = "00000000-0000-4000-8000-0000000000b1"
+const testOrbOrgID = "00000000-0000-4000-8000-0000000000b2"
 const testOrbVersion = "1.0.0"
 const testOrbSource = "version: 2.1\ndescription: My test orb\n"
 
@@ -1001,6 +1005,10 @@ func TestOrbInit_SkipGit(t *testing.T) {
 func TestOrbInit_Git(t *testing.T) {
 	fake, env := setupOrbFake(t)
 	registerOrbTemplate(t, fake, env)
+	// Resolvable by slug so orb init can find the project it just followed, and
+	// known by UUID so the settings update lands, not 404s.
+	fake.AddProjectBySlug("gh/myorg/my-orb", testOrbProjectID, testOrbShortName, testOrbOrgID)
+	fake.SetProjectSettings(testOrbProjectID, map[string]any{"advanced": map[string]any{}})
 	// Provide a git identity so the initial commit succeeds deterministically.
 	env.Extra["GIT_AUTHOR_NAME"] = "Test"
 	env.Extra["GIT_AUTHOR_EMAIL"] = "test@example.com"
@@ -1047,6 +1055,57 @@ func TestOrbInit_Git(t *testing.T) {
 	}
 	assert.Check(t, published, "expected a POST to /api/v3/orb/versions")
 	assert.Check(t, followed, "expected a follow request")
+
+	// Dynamic config was enabled, so the orb dev kit's setup workflow will
+	// actually run on the first pipeline (issue 834).
+	var dynamicConfig any
+	for _, req := range fake.AllRequests() {
+		if req.Method == http.MethodPost &&
+			req.URL.Path == "/api/v3/projects/"+testOrbProjectID+"/update-settings" {
+			if req.Body == nil {
+				continue
+			}
+			var body map[string]any
+			assert.NilError(t, json.Unmarshal([]byte(*req.Body), &body))
+			if v, ok := body["enable_dynamic_config"]; ok {
+				dynamicConfig = v
+			}
+		}
+	}
+	assert.Check(t, cmp.Equal(dynamicConfig, true),
+		"expected enable_dynamic_config: true in an update-settings request")
+}
+
+// TestOrbInit_Git_DynamicConfigFailureDoesNotAbort pins the failure mode. By the
+// time dynamic config is enabled, the namespace, orb, publishing context, git
+// repository and dev release all exist. If the project cannot be resolved — it is
+// not registered by slug here — orb init must warn and still finish, rather than
+// abort and leave the author with a half-built project and no way to resume.
+func TestOrbInit_Git_DynamicConfigFailureDoesNotAbort(t *testing.T) {
+	fake, env := setupOrbFake(t)
+	registerOrbTemplate(t, fake, env)
+	env.Extra["GIT_AUTHOR_NAME"] = "Test"
+	env.Extra["GIT_AUTHOR_EMAIL"] = "test@example.com"
+	env.Extra["GIT_COMMITTER_NAME"] = "Test"
+	env.Extra["GIT_COMMITTER_EMAIL"] = "test@example.com"
+
+	workDir := t.TempDir()
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary: binaryPath,
+		Args: []string{
+			"orb", "init", orbInitDir,
+			"--org", "gh/myorg",
+			"--remote", "https://github.com/myorg/my-orb.git",
+			"--branch", "main",
+		},
+		Env:     env.Environ(),
+		WorkDir: workDir,
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Check(t, cmp.Contains(result.Stdout, "Could not enable dynamic configuration"))
+	// The run still reached its end: the orb is set up and on the alpha branch.
+	assert.Check(t, cmp.Contains(result.Stdout, "alpha"))
 }
 
 // writeOrbFile writes a file for the pack tests, creating parent directories.

--- a/acceptance/testdata/TestOrbInit_Git.txt
+++ b/acceptance/testdata/TestOrbInit_Git.txt
@@ -8,6 +8,7 @@ An initial commit has been created. Push it with:
   git branch -M main
   git push origin main
 ✓ Project followed on CircleCI
+✓ Dynamic configuration enabled
 ✓ Your orb project is set up. You are now on the alpha branch.
 Once the first version is published it will appear at: https://circleci.com/developer/orbs/orb/myorg/my-orb
 Orb authoring guide: https://circleci.com/docs/orbs/author/orb-author/

--- a/internal/cmd/orb/init.go
+++ b/internal/cmd/orb/init.go
@@ -69,8 +69,8 @@ func newInitCmd() *cobra.Command {
 			Scaffold a new orb project from CircleCI-Public/Orb-Template into <path>.
 
 			It then walks you through setup: reserving the namespace and orb, assigning
-			categories, creating an 'orb-publishing' context, initializing git, and
-			publishing a dev:alpha version.
+			categories, creating an 'orb-publishing' context, initializing git, enabling
+			dynamic config, and publishing a dev:alpha version.
 
 			Note: once published, orbs cannot be deleted.
 		`),
@@ -437,6 +437,7 @@ func applyOrbInitGit(ctx context.Context, client *apiclient.Client, path string,
 		iostream.Printf(ctx, "%s Could not follow the project automatically: %s\n", iostream.SymbolWarn(ctx), err)
 	} else {
 		iostream.Printf(ctx, "%s Project followed on CircleCI\n", iostream.SymbolOK(ctx))
+		enableDynamicConfig(ctx, client, g.vcsType, g.owner, projectName)
 	}
 
 	if err := orbinit.CheckoutAlpha(w); err != nil {
@@ -484,6 +485,44 @@ func setupPublishingContext(ctx context.Context, client *apiclient.Client, orgSl
 	if _, err := client.SetContextEnvVar(ctx, ctxt.ID.String(), "CIRCLE_TOKEN", token); err != nil {
 		iostream.Printf(ctx, "%s Could not set CIRCLE_TOKEN on the publishing context: %s\n", iostream.SymbolWarn(ctx), err)
 	}
+}
+
+// enableDynamicConfig turns on dynamic configuration for the orb's project.
+//
+// The orb development kit's config is a setup workflow, and a setup workflow does
+// nothing unless the project has dynamic config enabled. Without this the very
+// first pipeline of a brand-new orb fails with:
+//
+//	Use of setup workflows must be enabled in project settings
+//	(Project settings > Advanced -> Dynamic config using setup workflows)
+//
+// which every orb author then has to go and fix by hand in the web UI before
+// their orb can publish anything.
+//
+// Failures only warn. By the time this runs the namespace, orb, publishing
+// context, git repository and dev release all exist; aborting would leave the
+// author with a half-finished setup and no way to resume, to save them one click.
+// The same reasoning as the publishing context and project follow above.
+func enableDynamicConfig(ctx context.Context, client *apiclient.Client, vcsType, owner, projectName string) {
+	slug := vcsType + "/" + owner + "/" + projectName
+
+	proj, err := client.GetProjectBySlug(ctx, slug)
+	if err != nil {
+		iostream.Printf(ctx, "%s Could not enable dynamic configuration for %s: %s\n",
+			iostream.SymbolWarn(ctx), slug, err)
+		return
+	}
+
+	enabled := true
+	if _, err := client.UpdateProjectSettings(ctx, proj.ID, apiclient.ProjectSettingsUpdate{
+		DynamicConfig: &enabled,
+	}); err != nil {
+		iostream.Printf(ctx, "%s Could not enable dynamic configuration for %s: %s\n",
+			iostream.SymbolWarn(ctx), slug, err)
+		return
+	}
+
+	iostream.Printf(ctx, "%s Dynamic configuration enabled\n", iostream.SymbolOK(ctx))
 }
 
 func finalizeOrbInit(ctx context.Context, private bool, namespace, orbName, projectName string) error {

--- a/internal/cmd/root/testdata/help/circleci/orb/init.txt
+++ b/internal/cmd/root/testdata/help/circleci/orb/init.txt
@@ -36,8 +36,8 @@ Global flags: `-c, --config`, `--debug`, `--no-color`, `-q, --quiet` — see `ci
 Scaffold a new orb project from CircleCI-Public/Orb-Template into <path>.
 
 It then walks you through setup: reserving the namespace and orb, assigning
-categories, creating an 'orb-publishing' context, initializing git, and
-publishing a dev:alpha version.
+categories, creating an 'orb-publishing' context, initializing git, enabling
+dynamic config, and publishing a dev:alpha version.
 
 Note: once published, orbs cannot be deleted.
 

--- a/internal/cmd/root/testdata/help/circleci/reference.txt
+++ b/internal/cmd/root/testdata/help/circleci/reference.txt
@@ -1972,8 +1972,8 @@ Initialize a new orb project
 Scaffold a new orb project from CircleCI-Public/Orb-Template into <path>.
 
 It then walks you through setup: reserving the namespace and orb, assigning
-categories, creating an 'orb-publishing' context, initializing git, and
-publishing a dev:alpha version.
+categories, creating an 'orb-publishing' context, initializing git, enabling
+dynamic config, and publishing a dev:alpha version.
 
 Note: once published, orbs cannot be deleted.
 


### PR DESCRIPTION
The orb development kit's config is a setup workflow, and a setup workflow does
nothing unless the project has dynamic config enabled. So the very first pipeline
of a brand-new orb failed with

    Use of setup workflows must be enabled in project settings
    (Project settings > Advanced -> Dynamic config using setup workflows)

and every orb author had to go and fix that by hand in the web UI before their
orb could publish anything.

Enable it from the CLI instead, right after the project is followed: resolve the
project by slug, then set enable_dynamic_config on it.

Failures only warn. By the time this runs the namespace, orb, publishing context,
git repository and dev release all exist, so aborting would leave the author with
a half-finished project and no way to resume — to save them one click. That
matches how the publishing context and the project follow already behave, and an
acceptance test pins it: with the project unresolvable, init warns and still
finishes on the alpha branch.

Fixes #834
