### PR TITLE
Stop offering orb categories past the registry's limit

### DIFF
--- a/acceptance/orb_test.go
+++ b/acceptance/orb_test.go
@@ -1049,6 +1049,67 @@ func TestOrbInit_Git(t *testing.T) {
 	assert.Check(t, followed, "expected a follow request")
 }
 
+// TestOrbInit_Interactive_CategoryFailureDoesNotAbort is the regression test for
+// the costly half of https://github.com/CircleCI-Public/circleci-cli/issues/609.
+//
+// Assigning a category used to abort the run on failure. That happens after the
+// namespace and the orb already exist, and orb init has no resume — so the
+// author's only recourse was to start over and re-answer every prompt, which is
+// what the issue complains about. The registry refusing a category has to warn
+// and let the rest of the setup finish.
+//
+// Driven through a PTY because categories are gathered interactively: the
+// non-interactive path takes no category flags, so it never reaches this code.
+func TestOrbInit_Interactive_CategoryFailureDoesNotAbort(t *testing.T) {
+	fake, env := setupOrbFake(t)
+	registerOrbTemplate(t, fake, env)
+	fake.AddOrbCategory(testOrbCategoryID, "Testing")
+	// The registry refuses the category, as it does past an orb's limit.
+	fake.SetOrbAddCategoryStatus(http.StatusBadRequest)
+
+	console := binary.RunCLIInteractive(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"orb", "init", orbInitDir, "--org", "gh/myorg"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	expect := func(want string) {
+		t.Helper()
+		_, err := console.ExpectString(want)
+		assert.NilError(t, err, "waiting for %q", want)
+	}
+	send := func(keys string) {
+		t.Helper()
+		_, err := console.Send(keys)
+		assert.NilError(t, err)
+	}
+
+	expect("public or private orb")
+	send("\r") // Public
+	expect("automated setup")
+	send("\r") // Yes, walk me through it
+	expect("Enter the namespace")
+	send("\r") // default: myorg
+	expect("Orb name")
+	send("\r") // default: my-orb
+
+	// The prompt states the limit before the choice is made.
+	expect("up to 2")
+	send("\x1b[B") // down: "(done)" → "Testing"
+	send("\r")     // choose it; only one category exists, so the loop ends
+
+	expect("publishing context")
+	send("n")
+	expect("set up your git project")
+	send("n")
+
+	// The refusal is reported, naming the category...
+	expect(`Could not add myorg/my-orb to the "Testing" category`)
+	// ...and the run still reaches its normal end rather than aborting.
+	expect("is ready")
+}
+
 // writeOrbFile writes a file for the pack tests, creating parent directories.
 func writeOrbFile(t *testing.T, path, content string) {
 	t.Helper()

--- a/internal/cmd/orb/init.go
+++ b/internal/cmd/orb/init.go
@@ -354,9 +354,16 @@ func applyOrbInitSetup(ctx context.Context, client *apiclient.Client, path strin
 		iostream.Printf(ctx, "%s Created orb %q\n", iostream.SymbolOK(ctx), fullName)
 	}
 
+	// A category that will not attach is not worth abandoning the run over. The
+	// namespace, the orb and possibly the publishing context already exist by
+	// now, and orb init has no resume: aborting here means the author starts over
+	// and re-answers every prompt, which is the complaint in issue 609. Warn and
+	// carry on — categories are metadata, and `circleci orb add-to-category` can
+	// fix them up afterwards.
 	for _, cat := range d.categories {
 		if err := client.AddOrbToCategory(ctx, orbID, cat.ID); err != nil {
-			return orbAPIErr(err, cat.Name)
+			iostream.Printf(ctx, "%s Could not add %s to the %q category: %s\n",
+				iostream.SymbolWarn(ctx), fullName, cat.Name, err)
 		}
 	}
 

--- a/internal/testing/fakes/circleci.go
+++ b/internal/testing/fakes/circleci.go
@@ -153,18 +153,22 @@ type CircleCI struct {
 	parCounter         int          // monotonic ID generator for request_uri values
 
 	// Orb state (v3).
-	orbPackages         map[string]map[string]any // id → package object
-	orbPackagesByName   map[string]string         // "ns/name" → id
-	orbVersions         map[string]map[string]any // id → version object
-	orbVersionsByRef    map[string]string         // "ns/name@version" → id
-	orbVersionsByOrbID  map[string][]string       // orbID → ordered version IDs
-	orbCategories       map[string]map[string]any // id → category object
-	orbCategoriesByName map[string]string         // name → id
-	orbValidateResponse *orbFakeValidateResponse  // override for validate/process responses
-	orbCreatedPackages  []map[string]any          // packages created via POST
-	orbCreatedVersions  []map[string]any          // versions created via POST
-	orbUnlistedPackages map[string]bool           // id → unlisted
-	orbCategoryMembers  map[string][]string       // packageID → []categoryID
+	orbPackages        map[string]map[string]any // id → package object
+	orbPackagesByName  map[string]string         // "ns/name" → id
+	orbVersions        map[string]map[string]any // id → version object
+	orbVersionsByRef   map[string]string         // "ns/name@version" → id
+	orbVersionsByOrbID map[string][]string       // orbID → ordered version IDs
+	orbCategories      map[string]map[string]any // id → category object
+	// orbAddCategoryStatus, when non-zero, is the HTTP status returned for every
+	// POST /api/v3/orb/packages/{id}/add-category, so a test can exercise how a
+	// caller copes with the registry refusing a category.
+	orbAddCategoryStatus int
+	orbCategoriesByName  map[string]string        // name → id
+	orbValidateResponse  *orbFakeValidateResponse // override for validate/process responses
+	orbCreatedPackages   []map[string]any         // packages created via POST
+	orbCreatedVersions   []map[string]any         // versions created via POST
+	orbUnlistedPackages  map[string]bool          // id → unlisted
+	orbCategoryMembers   map[string][]string      // packageID → []categoryID
 
 	// Namespace state (served via /graphql-unstable).
 	namespaces        map[string]any    // namespace id → {id, name}
@@ -441,6 +445,15 @@ func (f *CircleCI) SetPipelineCancelResponse(pipelineID string, status int) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.pipelineCancelResponses[pipelineID] = status
+}
+
+// SetOrbAddCategoryStatus makes every POST
+// /api/v3/orb/packages/<id>/add-category fail with the given status, carrying the
+// message the real registry returns when an orb is already at its category limit.
+func (f *CircleCI) SetOrbAddCategoryStatus(status int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.orbAddCategoryStatus = status
 }
 
 // SetRerunResponse sets the HTTP status code returned for POST /api/v2/workflow/<id>/rerun.
@@ -3262,6 +3275,18 @@ func (f *CircleCI) handleOrbSetListed(w http.ResponseWriter, r *http.Request) {
 
 func (f *CircleCI) handleOrbAddCategory(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
+
+	f.mu.RLock()
+	forced := f.orbAddCategoryStatus
+	f.mu.RUnlock()
+	if forced != 0 {
+		render.Status(r, forced)
+		render.JSON(w, r, map[string]any{
+			"message": "Orbs may only belong to 2 category(s). This orb has already been " +
+				"placed under the following category(s): Build,Deployment.",
+		})
+		return
+	}
 	var body struct {
 		CategoryID string `json:"category_id"`
 	}

--- a/internal/ui/orb_init_flow.go
+++ b/internal/ui/orb_init_flow.go
@@ -24,6 +24,7 @@ package ui
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"strings"
 
@@ -65,9 +66,27 @@ const (
 const (
 	orbInitVisibilityPrompt = "Would you like to create a public or private orb?"
 	orbInitModePrompt       = "Would you like to perform an automated setup of this orb?"
-	orbInitCategoryPrompt   = "Add a category for this orb (choose (done) to finish)"
 	orbInitCategoryDone     = "(done)"
 )
+
+// maxOrbCategories is how many categories an orb may belong to.
+//
+// The registry enforces this and rejects the extras:
+//
+//	Orbs may only belong to 2 category(s). This orb has already been placed
+//	under the following category(s): Build,Deployment.
+//
+// It is a constant here because the API does not advertise it: GET
+// /orb/categories returns each category's id and name and nothing about how many
+// an orb may hold. If the server-side limit ever changes, picking too few is the
+// safe direction to be wrong in — and the assignment step warns rather than
+// aborting, so a mismatch costs a warning instead of a failed run.
+const maxOrbCategories = 2
+
+// orbInitCategoryPrompt names the limit, so the answer to "how many can I have?"
+// arrives before the choice rather than after the registry rejects it.
+var orbInitCategoryPrompt = fmt.Sprintf(
+	"Add a category for this orb (up to %d, choose (done) to finish)", maxOrbCategories)
 
 var (
 	orbInitVisibilityOptions = []string{"Public", "Private"}
@@ -306,7 +325,9 @@ func (m *OrbInitFlowModel) afterCategoryPick(idx int) tea.Cmd {
 	}
 	m.result.Categories = append(m.result.Categories, m.catRemaining[idx-1])
 	m.catRemaining = append(m.catRemaining[:idx-1], m.catRemaining[idx:]...)
-	if len(m.catRemaining) == 0 {
+	// Stop offering once the limit is reached, so the invalid state is
+	// unreachable rather than rejected by the registry three prompts later.
+	if len(m.catRemaining) == 0 || len(m.result.Categories) >= maxOrbCategories {
 		return m.enterConfirm(oiPublishingContext, "Automatically set up a publishing context with your API token?")
 	}
 	return m.enterCategorySelect()

--- a/internal/ui/orb_init_flow_test.go
+++ b/internal/ui/orb_init_flow_test.go
@@ -333,6 +333,51 @@ func TestOrbInitFlow_Categories(t *testing.T) {
 	assert.Check(t, cmp.Equal(res.Categories[0].Name, "Testing"))
 }
 
+// TestOrbInitFlow_CategoryLimit is the regression test for
+// https://github.com/CircleCI-Public/circleci-cli/issues/609: the picker used to
+// keep offering categories past the registry's limit of two, and the run then
+// failed at the end with "Orbs may only belong to 2 category(s)" — after every
+// other prompt had been answered.
+//
+// Three categories are offered and two are chosen; the flow must move on to the
+// publishing-context question by itself rather than offering the third.
+func TestOrbInitFlow_CategoryLimit(t *testing.T) {
+	f := &oiFakes{categories: []ui.OrbInitCategory{
+		{ID: "c1", Name: "Testing"},
+		{ID: "c2", Name: "Deployment"},
+		{ID: "c3", Name: "Monitoring"},
+	}}
+	tm := startOrbFlow(t, newOrbFlow(f, ui.OrbInitFlowOptions{Path: "my-orb", OrgSlug: "gh/acme"}))
+	oiWaitFor(t, tm, "public or private orb")
+	tm.Send(oiKeyEnter)
+	oiWaitFor(t, tm, "automated setup")
+	tm.Send(oiKeyEnter)
+	oiWaitFor(t, tm, "Enter the namespace")
+	tm.Send(oiKeyEnter)
+	oiWaitFor(t, tm, "Orb name")
+	tm.Send(oiKeyEnter)
+
+	// The prompt states the limit up front.
+	oiWaitFor(t, tm, "up to 2")
+
+	tm.Send(oiKeyDown)  // "(done)" → "Testing"
+	tm.Send(oiKeyEnter) // 1 of 2
+	oiWaitFor(t, tm, "Deployment")
+	tm.Send(oiKeyDown)  // "(done)" → "Deployment"
+	tm.Send(oiKeyEnter) // 2 of 2 → limit reached, picker must not reappear
+
+	// Straight to the publishing context: "Monitoring" is never offered.
+	oiWaitFor(t, tm, "publishing context")
+	tm.Send(oiKeyN)
+	oiWaitFor(t, tm, "set up your git project")
+	tm.Send(oiKeyN)
+
+	res := oiResult(t, tm)
+	assert.Assert(t, cmp.Len(res.Categories, 2))
+	assert.Check(t, cmp.Equal(res.Categories[0].Name, "Testing"))
+	assert.Check(t, cmp.Equal(res.Categories[1].Name, "Deployment"))
+}
+
 // TestOrbInitFlow_GitGathersBranchAndRemote confirms accepting git setup gathers
 // the branch and remote, defaulting them from the flag and the org/orb.
 func TestOrbInitFlow_GitGathersBranchAndRemote(t *testing.T) {


### PR DESCRIPTION
Picking a third category was allowed all the way to the end of orb init, where
the registry rejected it:

    Orbs may only belong to 2 category(s). This orb has already been placed
    under the following category(s): Build,Deployment.

Two changes, and the second matters more.

Cap the picker at two, and say so in the prompt, so the invalid state is
unreachable instead of rejected several prompts later. The limit is a constant
because the API does not advertise it — GET /orb/categories returns each
category's id and name and nothing about how many an orb may hold.

More importantly, stop aborting when a category will not attach. That happens
after the namespace and the orb already exist, and orb init has no resume, so the
author's only recourse was to start over and re-answer every prompt — the actual
complaint in the issue. Warn and carry on: categories are metadata, and
`circleci orb add-to-category` fixes them afterwards. This also means a
server-side limit that no longer matches the constant above costs a warning
rather than a failed run.

The acceptance test drives the flow through a PTY, since categories are gathered
interactively and the non-interactive path takes no category flags. It needed a
fake that can refuse a category, so SetOrbAddCategoryStatus joins the other
status-override knobs.

Fixes #609
