### PR TITLE
Adopt an existing git repository in orb init

### DIFF
--- a/acceptance/orb_test.go
+++ b/acceptance/orb_test.go
@@ -35,6 +35,9 @@ import (
 	"testing"
 
 	"github.com/CircleCI-Public/circleci-cli/internal/httpcl"
+	"github.com/go-git/go-git/v6"
+	gitconfig "github.com/go-git/go-git/v6/config"
+
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/golden"
@@ -1167,6 +1170,111 @@ func TestOrbInit_Interactive_CategoryFailureDoesNotAbort(t *testing.T) {
 	expect(`Could not add myorg/my-orb to the "Testing" category`)
 	// ...and the run still reaches its normal end rather than aborting.
 	expect("is ready")
+}
+
+// TestOrbInit_AdoptsExistingClone is the regression test for
+// https://github.com/CircleCI-Public/circleci-cli/issues/803, following the steps
+// in the report: an admin creates an empty repository, the author clones it and
+// runs orb init inside. That used to dead-end on "already a git repository;
+// delete its .git directory and retry", with no way through — and cloning first
+// is the only route when repository creation is restricted to admins.
+//
+// No --remote is passed: the clone's origin is what the author intends to push
+// to, so orb init has to read it rather than demand it again.
+func TestOrbInit_AdoptsExistingClone(t *testing.T) {
+	fake, env := setupOrbFake(t)
+	registerOrbTemplate(t, fake, env)
+	env.Extra["GIT_AUTHOR_NAME"] = "Test"
+	env.Extra["GIT_AUTHOR_EMAIL"] = "test@example.com"
+	env.Extra["GIT_COMMITTER_NAME"] = "Test"
+	env.Extra["GIT_COMMITTER_EMAIL"] = "test@example.com"
+
+	workDir := t.TempDir()
+	orbDir := filepath.Join(workDir, orbInitDir)
+
+	// The repository is named differently from the orb directory, as in the
+	// issue (circleci-orb-myorbname cloned into my-orb). That difference is what
+	// proves the project details come from the clone's origin rather than from
+	// the directory name or a flag default.
+	const cloneURL = "https://github.com/myorg/circleci-orb-myorbname.git"
+	const cloneProject = "circleci-orb-myorbname"
+
+	// Resolvable so the followed project can have dynamic config enabled on it.
+	fake.AddProjectBySlug("gh/myorg/"+cloneProject, testOrbProjectID, cloneProject, testOrbOrgID)
+	fake.SetProjectSettings(testOrbProjectID, map[string]any{"advanced": map[string]any{}})
+
+	// Stand in for `git clone` of an empty repository: a repository with an
+	// origin and no commits.
+	assert.NilError(t, os.MkdirAll(orbDir, 0o750))
+	repo, err := git.PlainInit(orbDir, false)
+	assert.NilError(t, err)
+	_, err = repo.CreateRemote(&gitconfig.RemoteConfig{
+		Name: "origin",
+		URLs: []string{cloneURL},
+	})
+	assert.NilError(t, err)
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary: binaryPath,
+		// Deliberately no --remote: it comes from the clone.
+		Args:    []string{"orb", "init", orbInitDir, "--org", "gh/myorg", "--branch", "main"},
+		Env:     env.Environ(),
+		WorkDir: workDir,
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Check(t, cmp.Contains(result.Stdout, "Using origin from the existing repository"))
+	assert.Check(t, cmp.Contains(result.Stdout, cloneURL))
+
+	// The clone's origin survived rather than being replaced.
+	reopened, err := git.PlainOpen(orbDir)
+	assert.NilError(t, err)
+	origin, err := reopened.Remote("origin")
+	assert.NilError(t, err)
+	assert.Check(t, cmp.DeepEqual(origin.Config().URLs, []string{cloneURL}))
+
+	// And the template was committed into it, so the project is genuinely set up.
+	cfg, err := os.ReadFile(filepath.Join(orbDir, ".circleci", "config.yml"))
+	assert.NilError(t, err)
+	assert.Check(t, cmp.Contains(string(cfg), "myorg/my-orb"))
+
+	// The project followed, and the one dynamic config was enabled on, are both
+	// derived from the clone's origin — not from the orb directory name. This is
+	// the seam between adopting a clone (issue 803) and enabling dynamic config
+	// (issue 834), which only exists once both are in.
+	var followed, configured bool
+	for _, req := range fake.AllRequests() {
+		if req.Method == http.MethodPost &&
+			req.URL.Path == "/api/v1.1/project/gh/myorg/"+cloneProject+"/follow" {
+			followed = true
+		}
+		if req.Method == http.MethodPost &&
+			req.URL.Path == "/api/v3/projects/"+testOrbProjectID+"/update-settings" {
+			configured = true
+		}
+	}
+	assert.Check(t, followed, "expected the project from the clone's origin to be followed")
+	assert.Check(t, configured, "expected dynamic config to be enabled on that project")
+	assert.Check(t, cmp.Contains(result.Stdout, "Dynamic configuration enabled"))
+}
+
+// TestOrbInit_NoRemoteAndNoRepoStillErrors keeps the other side intact: with
+// nothing to adopt and no --remote, git setup cannot proceed and says so.
+func TestOrbInit_NoRemoteAndNoRepoStillErrors(t *testing.T) {
+	fake, env := setupOrbFake(t)
+	registerOrbTemplate(t, fake, env)
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"orb", "init", orbInitDir, "--org", "gh/myorg"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Check(t, cmp.Equal(result.ExitCode, 2))
+	assert.Check(t, cmp.Contains(result.Stderr, "Pass --remote <url>"))
+	// The suggestion names the way out that issue 803 added.
+	assert.Check(t, cmp.Contains(result.Stderr, "Running inside an existing clone uses its origin automatically"))
 }
 
 // writeOrbFile writes a file for the pack tests, creating parent directories.

--- a/internal/cmd/orb/init.go
+++ b/internal/cmd/orb/init.go
@@ -177,16 +177,22 @@ func runOrbInitInteractive(ctx context.Context, opts orbInitOpts) error {
 		return client, clientErr
 	}
 
+	// A repository already at the path answers the branch and remote questions,
+	// so read it before prompting rather than asking for what is on disk.
+	existing := detectExistingRepo(ctx, opts.path)
+
 	model := ui.NewOrbInitFlow(ctx, ui.OrbInitFlowOptions{
-		Path:         opts.path,
-		Private:      opts.private,
-		TemplateOnly: opts.templateOnly,
-		OrgSlug:      opts.org,
-		SkipGit:      opts.skipGit,
-		Branch:       opts.branch,
-		Remote:       opts.remote,
-		Color:        iostream.ColorEnabled(ctx),
-		Animate:      iostream.SpinnerEnabled(ctx),
+		Path:           opts.path,
+		Private:        opts.private,
+		TemplateOnly:   opts.templateOnly,
+		OrgSlug:        opts.org,
+		SkipGit:        opts.skipGit,
+		Branch:         opts.branch,
+		Remote:         opts.remote,
+		ExistingRemote: existing.RemoteURL,
+		ExistingBranch: existing.Branch,
+		Color:          iostream.ColorEnabled(ctx),
+		Animate:        iostream.SpinnerEnabled(ctx),
 		Download: func(ctx context.Context, private bool) error {
 			if err := orbinit.FetchTemplate(ctx, opts.path); err != nil {
 				return orbInitDownloadErr(err)
@@ -391,13 +397,24 @@ type orbInitGitContext struct {
 }
 
 func applyOrbInitGit(ctx context.Context, client *apiclient.Client, path string, d orbInitDecisions, interactive bool, g orbInitGitContext) error {
-	if d.remote == "" {
-		return clierrors.New("orb.init_remote_required", "Remote repository required",
-			"Pass --remote <url> to set up git non-interactively, or use --skip-git.").
-			WithExitCode(clierrors.ExitBadArguments)
+	// A repository already at the path supplies the remote, so --remote is only
+	// required when there is nothing to adopt. Cloning an empty repository and
+	// running orb init in it is a normal way to work — and the only way when
+	// repository creation is restricted to admins.
+	remote := d.remote
+	if remote == "" {
+		existing := detectExistingRepo(ctx, path)
+		if existing.RemoteURL == "" {
+			return clierrors.New("orb.init_remote_required", "Remote repository required",
+				"Pass --remote <url> to set up git non-interactively, or use --skip-git.").
+				WithSuggestions("Running inside an existing clone uses its origin automatically.").
+				WithExitCode(clierrors.ExitBadArguments)
+		}
+		remote = existing.RemoteURL
+		iostream.Printf(ctx, "Using origin from the existing repository: %s\n", remote)
 	}
 
-	projectName := orbinit.ProjectNameFromRemote(d.remote)
+	projectName := orbinit.ProjectNameFromRemote(remote)
 
 	// Rewrite the template placeholders now that we know the project details.
 	if err := orbinit.ApplyTemplate(path, projectName, g.owner, g.orbName, g.namespace); err != nil {
@@ -407,7 +424,7 @@ func applyOrbInitGit(ctx context.Context, client *apiclient.Client, path string,
 	}
 
 	iostream.Printf(ctx, "Setting up your orb...\n")
-	_, w, err := orbinit.InitRepo(path, d.remote, d.branch)
+	_, w, err := orbinit.InitRepo(path, remote, d.branch)
 	if err != nil {
 		return clierrors.New("orb.init_git_failed", "Could not initialize git repository",
 			err.Error()).
@@ -530,6 +547,24 @@ func enableDynamicConfig(ctx context.Context, client *apiclient.Client, vcsType,
 	}
 
 	iostream.Printf(ctx, "%s Dynamic configuration enabled\n", iostream.SymbolOK(ctx))
+}
+
+// detectExistingRepo reports what the git repository at path already has
+// configured, so orb init can adopt it rather than prompt for details that are
+// sitting in .git/config.
+//
+// Anything unreadable is reported as "nothing found" rather than as an error:
+// this only ever removes a question, so the fallback is simply to ask it.
+func detectExistingRepo(ctx context.Context, path string) orbinit.ExistingRepo {
+	if !orbinit.IsRepo(path) {
+		return orbinit.ExistingRepo{}
+	}
+	found, err := orbinit.InspectRepo(path)
+	if err != nil {
+		iostream.DebugContext(ctx, "could not inspect existing git repository", "path", path, "error", err)
+		return orbinit.ExistingRepo{}
+	}
+	return found
 }
 
 func finalizeOrbInit(ctx context.Context, private bool, namespace, orbName, projectName string) error {

--- a/internal/orbinit/orbinit.go
+++ b/internal/orbinit/orbinit.go
@@ -29,6 +29,7 @@ package orbinit
 import (
 	"archive/zip"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -231,27 +232,78 @@ func Substitute(contents, projectName, org, orbName, namespace string) string {
 	return metaLineRegex.ReplaceAllString(replacer.Replace(contents), "")
 }
 
-// InitRepo initializes a git repository at orbPath, adds an "origin" remote
-// pointing at remoteURL, tracks branch, stages all files, and creates an
-// initial commit. It returns the repository and its worktree.
-func InitRepo(orbPath, remoteURL, branch string) (*git.Repository, *git.Worktree, error) {
-	if _, err := os.Stat(filepath.Join(orbPath, ".git")); err == nil {
-		return nil, nil, fmt.Errorf("%s is already a git repository; delete its .git directory and retry", orbPath)
+// IsRepo reports whether orbPath already holds a git repository.
+func IsRepo(orbPath string) bool {
+	_, err := os.Stat(filepath.Join(orbPath, ".git"))
+	return err == nil
+}
+
+// ExistingRepo describes a git repository that is already present at the orb
+// path. Both fields are best-effort: a freshly cloned empty repository has an
+// origin but no commits, so no branch can be resolved from HEAD.
+type ExistingRepo struct {
+	// RemoteURL is origin's URL, empty if there is no origin remote.
+	RemoteURL string
+	// Branch is the checked-out branch, empty if HEAD cannot be resolved.
+	Branch string
+}
+
+// InspectRepo reads what is already configured in the repository at orbPath, so
+// orb init can adopt it instead of asking for details that are on disk.
+//
+// Cloning an empty repository and running `orb init .` inside it is the obvious
+// way to use this command when only admins may create repositories — and it is
+// the case that used to dead-end.
+func InspectRepo(orbPath string) (ExistingRepo, error) {
+	repo, err := git.PlainOpen(orbPath)
+	if err != nil {
+		return ExistingRepo{}, fmt.Errorf("opening git repository at %s: %w", orbPath, err)
 	}
 
-	repo, err := git.PlainInit(orbPath, false)
+	var found ExistingRepo
+	if remote, err := repo.Remote("origin"); err == nil {
+		if urls := remote.Config().URLs; len(urls) > 0 {
+			found.RemoteURL = urls[0]
+		}
+	}
+	// A repository with no commits has an unresolvable HEAD. That is normal for a
+	// fresh clone of an empty repository, so it is not an error here.
+	if head, err := repo.Head(); err == nil {
+		found.Branch = head.Name().Short()
+	}
+	return found, nil
+}
+
+// InitRepo prepares the git repository at orbPath for the orb's initial commit:
+// it stages every file and commits. It returns the repository and its worktree.
+//
+// An existing repository is adopted rather than refused. remoteURL and branch are
+// only applied to what is missing — a repository that already has an origin keeps
+// it, and one that already has commits keeps its current branch. Cloning an empty
+// repository and initialising the orb into it is a reasonable way to work, and is
+// the only way when repository creation is restricted to admins.
+func InitRepo(orbPath, remoteURL, branch string) (*git.Repository, *git.Worktree, error) {
+	repo, err := openOrInitRepo(orbPath)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	if _, err := repo.CreateRemote(&config.RemoteConfig{
-		Name: "origin",
-		URLs: []string{remoteURL},
-	}); err != nil {
-		return nil, nil, err
+	// Only add origin if the repository does not already have one. A clone's
+	// origin is authoritative: it is where the user actually intends to push.
+	if _, err := repo.Remote("origin"); err != nil {
+		if _, err := repo.CreateRemote(&config.RemoteConfig{
+			Name: "origin",
+			URLs: []string{remoteURL},
+		}); err != nil {
+			return nil, nil, err
+		}
 	}
 
-	if err := repo.CreateBranch(&config.Branch{Name: branch, Remote: "origin"}); err != nil {
+	// CreateBranch records tracking config, and errors if the branch is already
+	// configured — which it is when the repository came from a clone. Nothing to
+	// do in that case.
+	if err := repo.CreateBranch(&config.Branch{Name: branch, Remote: "origin"}); err != nil &&
+		!errors.Is(err, git.ErrBranchExists) {
 		return nil, nil, fmt.Errorf("creating branch %q: %w", branch, err)
 	}
 
@@ -266,6 +318,18 @@ func InitRepo(orbPath, remoteURL, branch string) (*git.Repository, *git.Worktree
 		return nil, nil, err
 	}
 	return repo, w, nil
+}
+
+// openOrInitRepo opens the repository at orbPath, creating one if there is none.
+func openOrInitRepo(orbPath string) (*git.Repository, error) {
+	if IsRepo(orbPath) {
+		repo, err := git.PlainOpen(orbPath)
+		if err != nil {
+			return nil, fmt.Errorf("opening git repository at %s: %w", orbPath, err)
+		}
+		return repo, nil
+	}
+	return git.PlainInit(orbPath, false)
 }
 
 // commitInitial creates the initial commit. It first lets go-git read the

--- a/internal/orbinit/orbinit_test.go
+++ b/internal/orbinit/orbinit_test.go
@@ -32,6 +32,9 @@ import (
 	"os"
 	"testing"
 
+	"github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/config"
+
 	"github.com/CircleCI-Public/circleci-cli/internal/iostream"
 
 	"gotest.tools/v3/assert"
@@ -266,9 +269,100 @@ func TestInitRepoAndCheckoutAlpha(t *testing.T) {
 	})
 }
 
-func TestInitRepo_ExistingRepoRejected(t *testing.T) {
+// TestInitRepo_AdoptsExistingRepo is the regression test for
+// https://github.com/CircleCI-Public/circleci-cli/issues/803. Cloning an empty
+// repository and running orb init inside it used to dead-end with "already a git
+// repository; delete its .git directory and retry" — which is the obvious way to
+// use the command when only admins may create repositories.
+//
+// The clone's own origin wins: it is where the author actually intends to push,
+// so the URL orb init was given must not overwrite it.
+func TestInitRepo_AdoptsExistingRepo(t *testing.T) {
+	dir := fs.NewDir(t, "orbinit", fs.WithFile("README.md", "hi"))
+
+	// Stand in for `git clone` of an empty repository: a repository with an
+	// origin and no commits.
+	existing, err := git.PlainInit(dir.Path(), false)
+	assert.NilError(t, err)
+	_, err = existing.CreateRemote(&config.RemoteConfig{
+		Name: "origin",
+		URLs: []string{"git@github.com:myorg/circleci-orb-myorbname.git"},
+	})
+	assert.NilError(t, err)
+
+	repo, _, err := InitRepo(dir.Path(), "https://github.com/wrong/url.git", "main")
+	assert.NilError(t, err)
+
+	t.Run("keeps the existing origin", func(t *testing.T) {
+		remote, err := repo.Remote("origin")
+		assert.NilError(t, err)
+		assert.Check(t, is.DeepEqual(remote.Config().URLs,
+			[]string{"git@github.com:myorg/circleci-orb-myorbname.git"}))
+	})
+
+	t.Run("commits the template into it", func(t *testing.T) {
+		head, err := repo.Head()
+		assert.NilError(t, err)
+		_, err = repo.CommitObject(head.Hash())
+		assert.NilError(t, err)
+	})
+}
+
+// TestInitRepo_BrokenRepoStillErrors keeps a real failure loud: a .git that is
+// not a usable repository must not be silently re-initialised over.
+func TestInitRepo_BrokenRepoStillErrors(t *testing.T) {
 	dir := fs.NewDir(t, "orbinit", fs.WithDir(".git"))
 
 	_, _, err := InitRepo(dir.Path(), "https://github.com/acme/my-orb.git", "main")
-	assert.ErrorContains(t, err, "already a git repository")
+	assert.ErrorContains(t, err, "opening git repository")
+}
+
+// TestInspectRepo reports what orb init can reuse instead of prompting for it.
+func TestInspectRepo(t *testing.T) {
+	t.Run("reads origin from a clone with no commits", func(t *testing.T) {
+		dir := fs.NewDir(t, "orbinit")
+		repo, err := git.PlainInit(dir.Path(), false)
+		assert.NilError(t, err)
+		_, err = repo.CreateRemote(&config.RemoteConfig{
+			Name: "origin",
+			URLs: []string{"git@github.com:myorg/my-orb.git"},
+		})
+		assert.NilError(t, err)
+
+		found, err := InspectRepo(dir.Path())
+		assert.NilError(t, err)
+		assert.Check(t, is.Equal(found.RemoteURL, "git@github.com:myorg/my-orb.git"))
+		// No commits yet, so HEAD resolves to nothing. Not an error.
+		assert.Check(t, is.Equal(found.Branch, ""))
+	})
+
+	t.Run("reads the branch once there is a commit", func(t *testing.T) {
+		dir := fs.NewDir(t, "orbinit", fs.WithFile("README.md", "hi"))
+		repo, _, err := InitRepo(dir.Path(), "https://github.com/acme/my-orb.git", "trunk")
+		assert.NilError(t, err)
+		head, err := repo.Head()
+		assert.NilError(t, err)
+
+		found, err := InspectRepo(dir.Path())
+		assert.NilError(t, err)
+		assert.Check(t, is.Equal(found.RemoteURL, "https://github.com/acme/my-orb.git"))
+		assert.Check(t, is.Equal(found.Branch, head.Name().Short()))
+	})
+
+	t.Run("errors when there is no repository", func(t *testing.T) {
+		dir := fs.NewDir(t, "orbinit")
+		_, err := InspectRepo(dir.Path())
+		assert.ErrorContains(t, err, "opening git repository")
+	})
+}
+
+// TestIsRepo distinguishes a directory that already holds a repository.
+func TestIsRepo(t *testing.T) {
+	plain := fs.NewDir(t, "orbinit")
+	assert.Check(t, !IsRepo(plain.Path()))
+
+	repo := fs.NewDir(t, "orbinit")
+	_, err := git.PlainInit(repo.Path(), false)
+	assert.NilError(t, err)
+	assert.Check(t, IsRepo(repo.Path()))
 }

--- a/internal/ui/orb_init_flow.go
+++ b/internal/ui/orb_init_flow.go
@@ -143,6 +143,14 @@ type OrbInitFlowOptions struct {
 	// prompts for it) but carried for symmetry.
 	Remote string
 
+	// ExistingRemote and ExistingBranch are what the git repository already at
+	// Path has configured, empty when there is no repository or the value is not
+	// set there yet. When a value is present its prompt is skipped: asking for a
+	// remote URL that is sitting in .git/config is asking the author to retype
+	// something the CLI can read, and lets them mistype it.
+	ExistingRemote string
+	ExistingBranch string
+
 	// Download fetches and extracts the orb template into Path, removing the
 	// template LICENSE when private is true. Shown behind a spinner.
 	Download func(ctx context.Context, private bool) error
@@ -374,8 +382,7 @@ func (m OrbInitFlowModel) commitText(val string) (tea.Model, tea.Cmd) {
 		return m, m.startCheckOrb()
 	case oiBranch:
 		m.result.Branch = val
-		def := "https://github.com/" + m.owner + "/" + m.result.OrbName
-		return m, m.enterText(oiRemote, "Enter the remote git repository URL", def, def)
+		return m, m.afterBranch()
 	case oiRemote:
 		m.result.Remote = val
 		m.stage = oiDone
@@ -436,11 +443,31 @@ func (m *OrbInitFlowModel) afterGitSetup() tea.Cmd {
 		m.stage = oiDone
 		return tea.Quit
 	}
+
+	// An adopted repository answers these questions itself. Take what it has and
+	// only prompt for the rest.
+	if m.opts.ExistingBranch != "" {
+		m.result.Branch = m.opts.ExistingBranch
+		return m.afterBranch()
+	}
+
 	branch := m.opts.Branch
 	if branch == "" {
 		branch = "main"
 	}
 	return m.enterText(oiBranch, "Enter your primary git branch", branch, branch)
+}
+
+// afterBranch moves on from the branch to the remote, skipping the remote prompt
+// when the repository already has an origin.
+func (m *OrbInitFlowModel) afterBranch() tea.Cmd {
+	if m.opts.ExistingRemote != "" {
+		m.result.Remote = m.opts.ExistingRemote
+		m.stage = oiDone
+		return tea.Quit
+	}
+	def := "https://github.com/" + m.owner + "/" + m.result.OrbName
+	return m.enterText(oiRemote, "Enter the remote git repository URL", def, def)
 }
 
 // --- async callbacks + their result handlers ---

--- a/internal/ui/orb_init_flow_test.go
+++ b/internal/ui/orb_init_flow_test.go
@@ -408,6 +408,71 @@ func TestOrbInitFlow_GitGathersBranchAndRemote(t *testing.T) {
 	assert.Check(t, cmp.Contains(v, "https://github.com/acme/my-orb"))
 }
 
+// TestOrbInitFlow_AdoptedRepoSkipsBranchAndRemote is the flow half of
+// https://github.com/CircleCI-Public/circleci-cli/issues/803: when the orb path
+// is already a clone, its branch and origin are on disk. Asking the author to
+// retype them invites a typo and was the first of the two complaints in the
+// issue.
+func TestOrbInitFlow_AdoptedRepoSkipsBranchAndRemote(t *testing.T) {
+	f := &oiFakes{}
+	tm := startOrbFlow(t, newOrbFlow(f, ui.OrbInitFlowOptions{
+		Path:           "my-orb",
+		OrgSlug:        "gh/acme",
+		ExistingBranch: "trunk",
+		ExistingRemote: "git@github.com:myorg/circleci-orb-myorbname.git",
+	}))
+	oiWaitFor(t, tm, "public or private orb")
+	tm.Send(oiKeyEnter)
+	oiWaitFor(t, tm, "automated setup")
+	tm.Send(oiKeyEnter)
+	oiWaitFor(t, tm, "Enter the namespace")
+	tm.Send(oiKeyEnter)
+	oiWaitFor(t, tm, "Orb name")
+	tm.Send(oiKeyEnter)
+	oiWaitFor(t, tm, "publishing context")
+	tm.Send(oiKeyN)
+	oiWaitFor(t, tm, "set up your git project")
+	tm.Send(oiKeyY) // yes — and neither branch nor remote is asked for
+
+	res := oiResult(t, tm)
+	assert.Check(t, cmp.Equal(res.GitSetup, true))
+	assert.Check(t, cmp.Equal(res.Branch, "trunk"))
+	assert.Check(t, cmp.Equal(res.Remote, "git@github.com:myorg/circleci-orb-myorbname.git"))
+}
+
+// TestOrbInitFlow_AdoptedRepoWithoutCommitsStillAsksBranch covers a fresh clone
+// of an empty repository: it has an origin but no HEAD, so the branch is still an
+// open question while the remote is not.
+func TestOrbInitFlow_AdoptedRepoWithoutCommitsStillAsksBranch(t *testing.T) {
+	f := &oiFakes{}
+	tm := startOrbFlow(t, newOrbFlow(f, ui.OrbInitFlowOptions{
+		Path:           "my-orb",
+		OrgSlug:        "gh/acme",
+		Branch:         "main",
+		ExistingRemote: "git@github.com:myorg/circleci-orb-myorbname.git",
+	}))
+	oiWaitFor(t, tm, "public or private orb")
+	tm.Send(oiKeyEnter)
+	oiWaitFor(t, tm, "automated setup")
+	tm.Send(oiKeyEnter)
+	oiWaitFor(t, tm, "Enter the namespace")
+	tm.Send(oiKeyEnter)
+	oiWaitFor(t, tm, "Orb name")
+	tm.Send(oiKeyEnter)
+	oiWaitFor(t, tm, "publishing context")
+	tm.Send(oiKeyN)
+	oiWaitFor(t, tm, "set up your git project")
+	tm.Send(oiKeyY)
+
+	// Branch is asked, remote is not.
+	oiWaitFor(t, tm, "primary git branch")
+	tm.Send(oiKeyEnter)
+
+	res := oiResult(t, tm)
+	assert.Check(t, cmp.Equal(res.Branch, "main"))
+	assert.Check(t, cmp.Equal(res.Remote, "git@github.com:myorg/circleci-orb-myorbname.git"))
+}
+
 // TestOrbInitFlow_GitEndToEnd accepts git setup and accepts both defaults,
 // confirming the gathered branch and remote reach the result.
 func TestOrbInitFlow_GitEndToEnd(t *testing.T) {


### PR DESCRIPTION
Cloning an empty repository and running orb init inside it dead-ended:

    Error: my-orb is already a git repository; delete its .git directory and retry

with no way through. Cloning first is the obvious way to use the command, and the
only way when repository creation is restricted to org admins.

Adopt the repository instead. InitRepo now opens what is there rather than
refusing it, and applies the remote and branch only to what is missing: a clone
keeps its own origin, since that is where the author actually intends to push, and
a repository with commits keeps its current branch.

The prompts follow. InspectRepo reads origin and HEAD up front, and the
interactive flow skips whichever questions the repository already answers — asking
someone to retype a URL out of .git/config only invites a typo. A fresh clone of
an empty repository has an origin but no HEAD, so the branch is still asked for
while the remote is not. Non-interactively, --remote becomes optional when there
is a clone to read it from, and the error when there is not now says so.

A .git that is not a usable repository is still an error rather than something to
re-initialise over, and that is tested.

Fixes #803
