### PR TITLE
Restore << include(file) >> directive support in orb pack

### DIFF
--- a/acceptance/orb_test.go
+++ b/acceptance/orb_test.go
@@ -724,6 +724,32 @@ func TestOrbPack_YAML11Booleans(t *testing.T) {
 	assert.Check(t, golden.String(result.Stderr, t.Name()+".stderr.txt"))
 }
 
+// TestOrbPack_Includes is the end-to-end check for the include directive that
+// was dropped in the v1 rewrite: a step whose value is exactly
+// '<< include(file) >>' must be replaced with that file's contents. See
+// https://github.com/CircleCI-Public/circleci-cli/pull/737.
+func TestOrbPack_Includes(t *testing.T) {
+	_, env := setupOrbFake(t)
+
+	dir := t.TempDir()
+	writeOrbFile(t, filepath.Join(dir, "src", "@orb.yml"), "version: 2.1\n")
+	writeOrbFile(t, filepath.Join(dir, "src", "commands", "greet.yml"),
+		"steps:\n  - run: << include(scripts/greet.sh) >>\n")
+	writeOrbFile(t, filepath.Join(dir, "src", "scripts", "greet.sh"),
+		"echo hello\necho world\n")
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"orb", "pack", "src"},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	assert.Check(t, cmp.Equal(result.ExitCode, 0), "stderr: %s", result.Stderr)
+	assert.Check(t, golden.String(result.Stdout, t.Name()+".txt"))
+	assert.Check(t, golden.String(result.Stderr, t.Name()+".stderr.txt"))
+}
+
 // TestOrbPack_NestedDirectories is the end-to-end check for
 // https://github.com/CircleCI-Public/circleci-cli/issues/755: an orb author
 // organising commands/ into subdirectories. Those files used to pack into

--- a/acceptance/testdata/TestOrbPack_Includes.txt
+++ b/acceptance/testdata/TestOrbPack_Includes.txt
@@ -1,0 +1,7 @@
+commands:
+    greet:
+        steps:
+            - run: |
+                echo hello
+                echo world
+version: 2.1

--- a/internal/cmd/orb/init.go
+++ b/internal/cmd/orb/init.go
@@ -410,7 +410,7 @@ func applyOrbInitGit(ctx context.Context, client *apiclient.Client, path string,
 	// Pack the orb source and publish a dev:alpha version.
 	// Warnings are dropped here: orb init is a guided flow with its own output,
 	// and `circleci orb pack` is where an author sees them.
-	packed, _, err := pack.Pack(filepath.Join(path, "src"))
+	packed, _, err := pack.Pack(filepath.Join(path, "src"), pack.WithIncludes())
 	if err != nil {
 		return clierrors.New("orb.init_pack_failed", "Could not pack orb source",
 			err.Error()).

--- a/internal/cmd/orb/pack.go
+++ b/internal/cmd/orb/pack.go
@@ -53,6 +53,9 @@ func newPackCmd() *cobra.Command {
 
 			If the path is a single file it is parsed and written to stdout.
 
+			A value that is exactly '<< include(path) >>' is replaced with the
+			contents of that file, resolved relative to the orb root.
+
 			The merged YAML is written to stdout.
 		`),
 		Example: heredoc.Doc(`
@@ -74,7 +77,7 @@ func newPackCmd() *cobra.Command {
 			if err := cmdutil.RequireArgs(args, "path"); err != nil {
 				return err
 			}
-			packed, warnings, err := pack.Pack(args[0])
+			packed, warnings, err := pack.Pack(args[0], pack.WithIncludes())
 			if err != nil {
 				return clierrors.New("orb.pack_failed", "Orb pack failed",
 					fmt.Sprintf("Could not pack %q: %s", args[0], err)).

--- a/internal/cmd/root/testdata/help/circleci/orb/pack.txt
+++ b/internal/cmd/root/testdata/help/circleci/orb/pack.txt
@@ -34,5 +34,8 @@ entry under the corresponding top-level key.
 
 If the path is a single file it is parsed and written to stdout.
 
+A value that is exactly '<< include(path) >>' is replaced with the
+contents of that file, resolved relative to the orb root.
+
 The merged YAML is written to stdout.
 

--- a/internal/cmd/root/testdata/help/circleci/reference.txt
+++ b/internal/cmd/root/testdata/help/circleci/reference.txt
@@ -2085,6 +2085,9 @@ entry under the corresponding top-level key.
 
 If the path is a single file it is parsed and written to stdout.
 
+A value that is exactly '<< include(path) >>' is replaced with the
+contents of that file, resolved relative to the orb root.
+
 The merged YAML is written to stdout.
 
 **Arguments:**

--- a/internal/pack/pack.go
+++ b/internal/pack/pack.go
@@ -84,6 +84,21 @@ func (w Warning) String() string {
 	return fmt.Sprintf("%s:%d: %s", w.Path, w.Line, w.Message)
 }
 
+// Option configures a Pack call.
+type Option func(*options)
+
+type options struct {
+	resolveIncludes bool
+}
+
+// WithIncludes enables resolution of `<< include(file) >>` directives: a scalar
+// whose entire value is such a directive is replaced with the contents of the
+// referenced file, resolved relative to the pack root. This is an orb-authoring
+// feature — config packing does not use it. See resolveIncludes.
+func WithIncludes() Option {
+	return func(o *options) { o.resolveIncludes = true }
+}
+
 // Pack reads all YAML files under rootPath and merges them into a single YAML
 // document. If rootPath is a single file it is parsed and re-serialised.
 //
@@ -91,7 +106,12 @@ func (w Warning) String() string {
 // suspicious but not fatal. They are ordered by the lexical file walk, so they
 // are stable across runs, and callers that have nowhere to show them may discard
 // them.
-func Pack(rootPath string) (string, []Warning, error) {
+func Pack(rootPath string, opts ...Option) (string, []Warning, error) {
+	var o options
+	for _, opt := range opts {
+		opt(&o)
+	}
+
 	absRoot, err := filepath.Abs(rootPath)
 	if err != nil {
 		return "", nil, fmt.Errorf("resolving path: %w", err)
@@ -119,6 +139,18 @@ func Pack(rootPath string) (string, []Warning, error) {
 	}
 	if err != nil {
 		return "", nil, err
+	}
+
+	if o.resolveIncludes {
+		// Includes resolve relative to the pack root directory, or the
+		// containing directory when a single file is packed.
+		baseDir := absRoot
+		if !info.IsDir() {
+			baseDir = filepath.Dir(absRoot)
+		}
+		if err := resolveIncludes(result, baseDir); err != nil {
+			return "", nil, err
+		}
 	}
 
 	var buf strings.Builder
@@ -184,7 +216,14 @@ func packDir(dirPath string, depth int, anchors map[string]*yaml.Node, warnings 
 			}
 			if depth == 0 {
 				existing, _ := subtree[name].(map[string]any)
-				subtree[name] = mergeMaps(existing, childMap)
+				merged := mergeMaps(existing, childMap)
+				// A root subdirectory with no YAML content is not a section: it
+				// holds sidecar files such as the scripts an orb pulls in with
+				// << include(...) >>. Emitting it as an empty "scripts: {}" key
+				// would invent a top-level section the author never wrote.
+				if len(merged) > 0 {
+					subtree[name] = merged
+				}
 			} else {
 				nested = append(nested, nestedResult{path: fullPath, content: childMap})
 			}
@@ -794,4 +833,103 @@ func isSpecialName(name string) bool { return specialRe.MatchString(name) }
 
 func nameWithoutExt(name string) string {
 	return strings.TrimSuffix(name, filepath.Ext(name))
+}
+
+// includeRe matches a `<< include(path) >>` directive. Whitespace inside the
+// guillemets is optional and the closing paren is tolerated as absent, matching
+// the directive the 0.1.x CLI accepted byte for byte.
+var includeRe = regexp.MustCompile(`<<[\s]*include\(([-\w/.]+)\)?[\s]*>>`)
+
+// resolveIncludes replaces `<< include(file) >>` directives in the jobs,
+// commands and executors sections of a packed orb with the contents of the
+// referenced files.
+//
+// Only those three sections are searched, matching the 0.1.x CLI: includes are
+// a way to pull a script or template into a step, so resolving them in, say, a
+// description or an example would inline a file where the author meant to show
+// the directive itself.
+func resolveIncludes(result map[string]any, baseDir string) error {
+	for _, key := range []string{"jobs", "commands", "executors"} {
+		section, ok := result[key]
+		if !ok {
+			continue
+		}
+		resolved, err := resolveIncludeValue(section, baseDir)
+		if err != nil {
+			return err
+		}
+		result[key] = resolved
+	}
+	return nil
+}
+
+// resolveIncludeValue walks a decoded YAML value, replacing every scalar string
+// that is a `<< include(file) >>` directive with the referenced file's contents.
+// Maps and sequences are recursed into; other scalars are returned unchanged.
+func resolveIncludeValue(v any, baseDir string) (any, error) {
+	switch t := v.(type) {
+	case string:
+		return maybeIncludeFile(t, baseDir)
+	case map[string]any:
+		for k, val := range t {
+			r, err := resolveIncludeValue(val, baseDir)
+			if err != nil {
+				return nil, err
+			}
+			t[k] = r
+		}
+		return t, nil
+	case map[any]any:
+		for k, val := range t {
+			r, err := resolveIncludeValue(val, baseDir)
+			if err != nil {
+				return nil, err
+			}
+			t[k] = r
+		}
+		return t, nil
+	case []any:
+		for i, val := range t {
+			r, err := resolveIncludeValue(val, baseDir)
+			if err != nil {
+				return nil, err
+			}
+			t[i] = r
+		}
+		return t, nil
+	default:
+		return v, nil
+	}
+}
+
+// maybeIncludeFile returns the contents of the file named by a lone
+// `<< include(file) >>` directive, or s unchanged when it holds no directive.
+//
+// The directive must be the entire value: a scalar is either an include or it
+// is not, so a directive with text around it, or more than one directive in the
+// same scalar, is an error rather than a partial substitution. `<<` sequences in
+// the included file are escaped to `\<<` so the inlined content is never itself
+// interpreted as parameter interpolation.
+func maybeIncludeFile(s, baseDir string) (string, error) {
+	// Find at most two matches: one is a valid include, more than one is the
+	// error case, and there is no reason to scan further.
+	matches := includeRe.FindAllStringSubmatch(s, 2)
+	if len(matches) > 1 {
+		return "", fmt.Errorf("multiple include statements in one value: %q", s)
+	}
+	if len(matches) == 0 {
+		return s, nil
+	}
+
+	full, rel := matches[0][0], matches[0][1]
+	if full != s {
+		return "", fmt.Errorf("an include statement must be the entire value: %q", s)
+	}
+
+	path := filepath.Join(baseDir, rel)
+	content, err := os.ReadFile(path) //#nosec:G304 // path is under the user-supplied pack root; includes are an author-controlled, local-only feature
+	if err != nil {
+		return "", fmt.Errorf("could not read included file %q: %w", path, err)
+	}
+	return strings.ReplaceAll(string(content), "<<", `\<<`), nil
 }

--- a/internal/pack/pack_test.go
+++ b/internal/pack/pack_test.go
@@ -615,6 +615,105 @@ func TestPack_NoFalseWarnings(t *testing.T) {
 	}
 }
 
+// TestPack_ResolvesIncludes is the regression test for the include directive
+// dropped in the v1 rewrite: a value that is exactly '<< include(file) >>' must
+// be replaced with that file's contents when WithIncludes is set. See
+// https://github.com/CircleCI-Public/circleci-cli/pull/737.
+func TestPack_ResolvesIncludes(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "@orb.yml"), "version: 2.1\n")
+	writeFile(t, filepath.Join(dir, "commands", "greet.yml"),
+		"steps:\n  - run: << include(scripts/greet.sh) >>\n")
+	writeFile(t, filepath.Join(dir, "scripts", "greet.sh"), "echo hello\n")
+
+	packed, _, err := pack.Pack(dir, pack.WithIncludes())
+	assert.NilError(t, err)
+	assert.Check(t, strings.Contains(packed, "echo hello"),
+		"included file contents should be inlined, got:\n%s", packed)
+	assert.Check(t, !strings.Contains(packed, "include("),
+		"the directive should be gone, got:\n%s", packed)
+}
+
+// TestPack_WithoutIncludesLeavesDirectiveUntouched pins that the directive is a
+// no-op unless WithIncludes is passed, so config packing never reads sidecar
+// files.
+func TestPack_WithoutIncludesLeavesDirectiveUntouched(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "@orb.yml"), "version: 2.1\n")
+	writeFile(t, filepath.Join(dir, "commands", "greet.yml"),
+		"steps:\n  - run: << include(scripts/greet.sh) >>\n")
+	writeFile(t, filepath.Join(dir, "scripts", "greet.sh"), "echo hello\n")
+
+	packed, _, err := pack.Pack(dir)
+	assert.NilError(t, err)
+	assert.Check(t, strings.Contains(packed, "include(scripts/greet.sh)"),
+		"directive should be left verbatim without WithIncludes, got:\n%s", packed)
+}
+
+// TestPack_IncludeEscapesInterpolation checks that '<<' in the included file is
+// escaped to '\<<' so inlined content is never itself read as a parameter.
+func TestPack_IncludeEscapesInterpolation(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "@orb.yml"), "version: 2.1\n")
+	writeFile(t, filepath.Join(dir, "commands", "greet.yml"),
+		"steps:\n  - run: << include(scripts/tmpl.sh) >>\n")
+	writeFile(t, filepath.Join(dir, "scripts", "tmpl.sh"), "echo << parameters.name >>\n")
+
+	packed, _, err := pack.Pack(dir, pack.WithIncludes())
+	assert.NilError(t, err)
+	assert.Check(t, strings.Contains(packed, `\<< parameters.name >>`),
+		"<< in included content should be escaped, got:\n%s", packed)
+}
+
+// TestPack_IncludeOnlyInJobsCommandsExecutors pins that directives outside those
+// three sections are left alone, matching the 0.1.x CLI.
+func TestPack_IncludeOnlyInJobsCommandsExecutors(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "@orb.yml"),
+		"version: 2.1\ndescription: << include(scripts/greet.sh) >>\n")
+	writeFile(t, filepath.Join(dir, "scripts", "greet.sh"), "echo hello\n")
+
+	packed, _, err := pack.Pack(dir, pack.WithIncludes())
+	assert.NilError(t, err)
+	assert.Check(t, strings.Contains(packed, "include(scripts/greet.sh)"),
+		"a directive in description should be left verbatim, got:\n%s", packed)
+}
+
+func TestPack_IncludeErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+		wantErr string
+	}{
+		{
+			name:    "directive not the entire value",
+			command: "steps:\n  - run: echo << include(scripts/greet.sh) >>\n",
+			wantErr: "entire value",
+		},
+		{
+			name:    "two directives in one value",
+			command: "steps:\n  - run: << include(scripts/greet.sh) >> << include(scripts/greet.sh) >>\n",
+			wantErr: "multiple include statements",
+		},
+		{
+			name:    "missing file",
+			command: "steps:\n  - run: << include(scripts/nope.sh) >>\n",
+			wantErr: "could not read included file",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeFile(t, filepath.Join(dir, "@orb.yml"), "version: 2.1\n")
+			writeFile(t, filepath.Join(dir, "commands", "greet.yml"), tt.command)
+			writeFile(t, filepath.Join(dir, "scripts", "greet.sh"), "echo hello\n")
+
+			_, _, err := pack.Pack(dir, pack.WithIncludes())
+			assert.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
 func writeFile(t *testing.T, path, content string) {
 	t.Helper()
 	assert.NilError(t, os.MkdirAll(filepath.Dir(path), 0o750))


### PR DESCRIPTION
The v1 rewrite dropped the orb-packing include directive: `orb pack` passed `<< include(path) >>` through literally instead of inlining the referenced file, a silent regression from the 0.1.x CLI.

Reintroduce it in `internal/pack` behind a `WithIncludes` option, wired up by `orb pack` and `orb init` (config packing does not use it). A value that is exactly the directive is replaced with the file's contents, resolved relative to the orb root, with `<<` escaped to `\<<` so inlined content is never itself read as parameter interpolation. Only jobs, commands and executors are searched, matching the old CLI. A directive that is not the whole value, or more than one in a value, is an error (matching 0.1.x — relaxing these is the separate #737 proposal).

Also stop emitting an empty `scripts: {}` top-level key: a root subdirectory with no YAML content is a sidecar for include files, not an orb section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)