### PR TITLE
Support multiple and embedded << include(file) >> directives

### DIFF
--- a/acceptance/orb_test.go
+++ b/acceptance/orb_test.go
@@ -754,6 +754,31 @@ func TestOrbPack_Includes(t *testing.T) {
 	assert.Check(t, golden.String(result.Stderr, t.Name()+".stderr.txt"))
 }
 
+// TestOrbPack_IncludesMultipleAndEmbedded is the end-to-end check for
+// https://github.com/CircleCI-Public/circleci-cli/pull/737: a value may hold
+// several '<< include(...) >>' directives and surround them with other text.
+func TestOrbPack_IncludesMultipleAndEmbedded(t *testing.T) {
+	_, env := setupOrbFake(t)
+
+	dir := t.TempDir()
+	writeOrbFile(t, filepath.Join(dir, "src", "@orb.yml"), "version: 2.1\n")
+	writeOrbFile(t, filepath.Join(dir, "src", "commands", "greet.yml"),
+		"steps:\n  - run: echo \"<< include(scripts/a.txt) >> << include(scripts/b.txt) >>\"\n")
+	writeOrbFile(t, filepath.Join(dir, "src", "scripts", "a.txt"), "Hello,")
+	writeOrbFile(t, filepath.Join(dir, "src", "scripts", "b.txt"), "world!")
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"orb", "pack", "src"},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	assert.Check(t, cmp.Equal(result.ExitCode, 0), "stderr: %s", result.Stderr)
+	assert.Check(t, golden.String(result.Stdout, t.Name()+".txt"))
+	assert.Check(t, golden.String(result.Stderr, t.Name()+".stderr.txt"))
+}
+
 // TestOrbPack_NestedDirectories is the end-to-end check for
 // https://github.com/CircleCI-Public/circleci-cli/issues/755: an orb author
 // organising commands/ into subdirectories. Those files used to pack into

--- a/acceptance/testdata/TestOrbPack_IncludesMultipleAndEmbedded.txt
+++ b/acceptance/testdata/TestOrbPack_IncludesMultipleAndEmbedded.txt
@@ -1,0 +1,5 @@
+commands:
+    greet:
+        steps:
+            - run: echo "Hello, world!"
+version: 2.1

--- a/internal/cmd/orb/pack.go
+++ b/internal/cmd/orb/pack.go
@@ -53,8 +53,8 @@ func newPackCmd() *cobra.Command {
 
 			If the path is a single file it is parsed and written to stdout.
 
-			A value that is exactly '<< include(path) >>' is replaced with the
-			contents of that file, resolved relative to the orb root.
+			Any '<< include(path) >>' directive, alone or embedded in a larger
+			value, is replaced with that file's contents, relative to the orb root.
 
 			The merged YAML is written to stdout.
 		`),

--- a/internal/cmd/root/testdata/help/circleci/orb/pack.txt
+++ b/internal/cmd/root/testdata/help/circleci/orb/pack.txt
@@ -34,8 +34,8 @@ entry under the corresponding top-level key.
 
 If the path is a single file it is parsed and written to stdout.
 
-A value that is exactly '<< include(path) >>' is replaced with the
-contents of that file, resolved relative to the orb root.
+Any '<< include(path) >>' directive, alone or embedded in a larger
+value, is replaced with that file's contents, relative to the orb root.
 
 The merged YAML is written to stdout.
 

--- a/internal/cmd/root/testdata/help/circleci/reference.txt
+++ b/internal/cmd/root/testdata/help/circleci/reference.txt
@@ -2085,8 +2085,8 @@ entry under the corresponding top-level key.
 
 If the path is a single file it is parsed and written to stdout.
 
-A value that is exactly '<< include(path) >>' is replaced with the
-contents of that file, resolved relative to the orb root.
+Any '<< include(path) >>' directive, alone or embedded in a larger
+value, is replaced with that file's contents, relative to the orb root.
 
 The merged YAML is written to stdout.
 

--- a/internal/pack/pack.go
+++ b/internal/pack/pack.go
@@ -91,10 +91,10 @@ type options struct {
 	resolveIncludes bool
 }
 
-// WithIncludes enables resolution of `<< include(file) >>` directives: a scalar
-// whose entire value is such a directive is replaced with the contents of the
-// referenced file, resolved relative to the pack root. This is an orb-authoring
-// feature — config packing does not use it. See resolveIncludes.
+// WithIncludes enables resolution of `<< include(file) >>` directives: each such
+// directive in a scalar is replaced with the contents of the referenced file,
+// resolved relative to the pack root. This is an orb-authoring feature — config
+// packing does not use it. See resolveIncludes.
 func WithIncludes() Option {
 	return func(o *options) { o.resolveIncludes = true }
 }
@@ -902,34 +902,39 @@ func resolveIncludeValue(v any, baseDir string) (any, error) {
 	}
 }
 
-// maybeIncludeFile returns the contents of the file named by a lone
-// `<< include(file) >>` directive, or s unchanged when it holds no directive.
+// maybeIncludeFile replaces every `<< include(file) >>` directive in s with the
+// contents of the referenced file, and returns s unchanged when it holds none.
 //
-// The directive must be the entire value: a scalar is either an include or it
-// is not, so a directive with text around it, or more than one directive in the
-// same scalar, is an error rather than a partial substitution. `<<` sequences in
-// the included file are escaped to `\<<` so the inlined content is never itself
-// interpreted as parameter interpolation.
+// A value may hold more than one directive and may surround them with other
+// text: `echo "<< include(banner.txt) >>"` inlines banner.txt inside the echo.
+// Each file is read relative to baseDir, and `<<` sequences in the included
+// content are escaped to `\<<` so inlined content is never itself interpreted as
+// parameter interpolation.
 func maybeIncludeFile(s, baseDir string) (string, error) {
-	// Find at most two matches: one is a valid include, more than one is the
-	// error case, and there is no reason to scan further.
-	matches := includeRe.FindAllStringSubmatch(s, 2)
-	if len(matches) > 1 {
-		return "", fmt.Errorf("multiple include statements in one value: %q", s)
-	}
-	if len(matches) == 0 {
+	// Submatch indices let us rewrite in a single pass: loc[0:2] spans the whole
+	// directive and loc[2:4] the captured path. Replacing by index (rather than
+	// string) means overlapping or repeated directives cannot substitute each
+	// other's output.
+	locs := includeRe.FindAllStringSubmatchIndex(s, -1)
+	if len(locs) == 0 {
 		return s, nil
 	}
 
-	full, rel := matches[0][0], matches[0][1]
-	if full != s {
-		return "", fmt.Errorf("an include statement must be the entire value: %q", s)
-	}
+	var b strings.Builder
+	last := 0
+	for _, loc := range locs {
+		b.WriteString(s[last:loc[0]])
 
-	path := filepath.Join(baseDir, rel)
-	content, err := os.ReadFile(path) //#nosec:G304 // path is under the user-supplied pack root; includes are an author-controlled, local-only feature
-	if err != nil {
-		return "", fmt.Errorf("could not read included file %q: %w", path, err)
+		rel := s[loc[2]:loc[3]]
+		path := filepath.Join(baseDir, rel)
+		content, err := os.ReadFile(path) //#nosec:G304 // path is under the user-supplied pack root; includes are an author-controlled, local-only feature
+		if err != nil {
+			return "", fmt.Errorf("could not read included file %q: %w", path, err)
+		}
+		b.WriteString(strings.ReplaceAll(string(content), "<<", `\<<`))
+
+		last = loc[1]
 	}
-	return strings.ReplaceAll(string(content), "<<", `\<<`), nil
+	b.WriteString(s[last:])
+	return b.String(), nil
 }

--- a/internal/pack/pack_test.go
+++ b/internal/pack/pack_test.go
@@ -679,39 +679,46 @@ func TestPack_IncludeOnlyInJobsCommandsExecutors(t *testing.T) {
 		"a directive in description should be left verbatim, got:\n%s", packed)
 }
 
-func TestPack_IncludeErrors(t *testing.T) {
-	tests := []struct {
-		name    string
-		command string
-		wantErr string
-	}{
-		{
-			name:    "directive not the entire value",
-			command: "steps:\n  - run: echo << include(scripts/greet.sh) >>\n",
-			wantErr: "entire value",
-		},
-		{
-			name:    "two directives in one value",
-			command: "steps:\n  - run: << include(scripts/greet.sh) >> << include(scripts/greet.sh) >>\n",
-			wantErr: "multiple include statements",
-		},
-		{
-			name:    "missing file",
-			command: "steps:\n  - run: << include(scripts/nope.sh) >>\n",
-			wantErr: "could not read included file",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			dir := t.TempDir()
-			writeFile(t, filepath.Join(dir, "@orb.yml"), "version: 2.1\n")
-			writeFile(t, filepath.Join(dir, "commands", "greet.yml"), tt.command)
-			writeFile(t, filepath.Join(dir, "scripts", "greet.sh"), "echo hello\n")
+// TestPack_IncludeEmbeddedInLargerValue checks that a directive surrounded by
+// other text is inlined in place rather than rejected — the "embedded" half of
+// https://github.com/CircleCI-Public/circleci-cli/pull/737.
+func TestPack_IncludeEmbeddedInLargerValue(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "@orb.yml"), "version: 2.1\n")
+	writeFile(t, filepath.Join(dir, "commands", "greet.yml"),
+		"steps:\n  - run: echo \"<< include(scripts/banner.txt) >>\"\n")
+	writeFile(t, filepath.Join(dir, "scripts", "banner.txt"), "Hello, world!")
 
-			_, _, err := pack.Pack(dir, pack.WithIncludes())
-			assert.ErrorContains(t, err, tt.wantErr)
-		})
-	}
+	packed, _, err := pack.Pack(dir, pack.WithIncludes())
+	assert.NilError(t, err)
+	assert.Check(t, strings.Contains(packed, `echo "Hello, world!"`),
+		"directive should be inlined in place, got:\n%s", packed)
+}
+
+// TestPack_MultipleIncludesInOneValue checks that several directives in one
+// value are each inlined — the "multiple" half of #737.
+func TestPack_MultipleIncludesInOneValue(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "@orb.yml"), "version: 2.1\n")
+	writeFile(t, filepath.Join(dir, "commands", "greet.yml"),
+		"steps:\n  - run: << include(scripts/a.sh) >> << include(scripts/b.sh) >>\n")
+	writeFile(t, filepath.Join(dir, "scripts", "a.sh"), "echo Hello,")
+	writeFile(t, filepath.Join(dir, "scripts", "b.sh"), "world!")
+
+	packed, _, err := pack.Pack(dir, pack.WithIncludes())
+	assert.NilError(t, err)
+	assert.Check(t, strings.Contains(packed, "echo Hello, world!"),
+		"both directives should be inlined, got:\n%s", packed)
+}
+
+func TestPack_IncludeMissingFileErrors(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "@orb.yml"), "version: 2.1\n")
+	writeFile(t, filepath.Join(dir, "commands", "greet.yml"),
+		"steps:\n  - run: << include(scripts/nope.sh) >>\n")
+
+	_, _, err := pack.Pack(dir, pack.WithIncludes())
+	assert.ErrorContains(t, err, "could not read included file")
 }
 
 func writeFile(t *testing.T, path, content string) {


### PR DESCRIPTION
Stacked on #1683 (targets `fix/orb-pack-includes`, not `main`).

Implements the #737 proposal on top of the restored include directive: a value may hold more than one `<< include(...) >>` directive and may surround them with other text, e.g. `echo "<< include(banner.txt) >>"`. Each directive is inlined in place instead of a value being all-or-nothing.

`maybeIncludeFile` now rewrites every match in a single index-based pass rather than requiring a lone whole-value directive, so repeated or overlapping directives cannot substitute each other's output. The two former error cases (more than one directive; directive not the whole value) become supported input.

Closes #737.

🤖 Generated with [Claude Code](https://claude.com/claude-code)