### PR TITLE
Deflake the telemetry sender timestamp assertions

### DIFF
--- a/internal/telemetry/sender_test.go
+++ b/internal/telemetry/sender_test.go
@@ -106,6 +106,13 @@ func TestClient_Track_with_user_id(t *testing.T) {
 	})
 	assert.NilError(t, err)
 
+	// Anchor the expected timestamps before the event is tracked, rather than
+	// inside the poll callback below. A time.Now() evaluated per retry drifts
+	// further from the timestamps actually recorded with every attempt, so once the
+	// batch takes longer than the comparison tolerance to arrive the test can never
+	// pass — it failed only under load, which is what made it flaky.
+	sent := time.Now()
+
 	err = ac.Track("myevent", map[string]any{
 		"foo": "bar",
 		"baz": 42,
@@ -118,15 +125,14 @@ func TestClient_Track_with_user_id(t *testing.T) {
 
 	poll.WaitOn(t, func(t poll.LogT) poll.Result {
 		batches := fs.Batches()
-		now := time.Now()
 		return poll.Compare(cmp.DeepEqual(batches, []fakesegment.Batch{
 			{
-				SentAt: now,
+				SentAt: sent,
 				Messages: []analytics.Track{
 					{
 						Type:      "track",
 						MessageId: "ignored",
-						Timestamp: now,
+						Timestamp: sent,
 						UserId:    userID.String(),
 						Event:     "myevent",
 						Properties: analytics.Properties{
@@ -194,6 +200,13 @@ func TestClient_Track_without_userid(t *testing.T) {
 	})
 	assert.NilError(t, err)
 
+	// Anchor the expected timestamps before the event is tracked, rather than
+	// inside the poll callback below. A time.Now() evaluated per retry drifts
+	// further from the timestamps actually recorded with every attempt, so once the
+	// batch takes longer than the comparison tolerance to arrive the test can never
+	// pass — it failed only under load, which is what made it flaky.
+	sent := time.Now()
+
 	err = ac.Track("user-event", map[string]any{
 		"foo": "bar",
 		"baz": 84,
@@ -206,15 +219,14 @@ func TestClient_Track_without_userid(t *testing.T) {
 
 	poll.WaitOn(t, func(t poll.LogT) poll.Result {
 		batches := fs.Batches()
-		now := time.Now()
 		return poll.Compare(cmp.DeepEqual(batches, []fakesegment.Batch{
 			{
-				SentAt: now,
+				SentAt: sent,
 				Messages: []analytics.Track{
 					{
 						Type:      "track",
 						MessageId: "ignored",
-						Timestamp: now,
+						Timestamp: sent,
 						UserId:    telemetry.AnonymousID.String(),
 						Event:     "user-event",
 						Properties: analytics.Properties{

--- a/internal/testing/fakesegment/fakesegment.go
+++ b/internal/testing/fakesegment/fakesegment.go
@@ -106,5 +106,16 @@ func basicAuth(username, password string) string {
 
 var (
 	CompareTrack = cmpopts.IgnoreFields(analytics.Track{}, "MessageId")
-	CompareTime  = cmpopts.EquateApproxTime(time.Second)
+
+	// CompareTime treats timestamps as equal when they are close, because a test
+	// cannot know the instant the sender stamped an event or the instant this fake
+	// received the batch.
+	//
+	// The window is deliberately loose. What these assertions are for is "a
+	// plausible time was recorded" — that the field was populated at all, from the
+	// clock rather than left zero — not sub-second precision. A tight window buys
+	// no extra coverage and turns a slow CI box, or a `-race` run under load, into
+	// a failure: flushing the batch and delivering it over HTTP is what separates
+	// the two times, and that is not bounded by anything the test controls.
+	CompareTime = cmpopts.EquateApproxTime(time.Minute)
 )


### PR DESCRIPTION
TestClient_Track_with_user_id and TestClient_Track_without_userid failed
intermittently, and reliably under `-race` across the whole tree — enough to fail
CI on unrelated PRs twice this week.

Two independent causes, both needed fixing.

The expectation was built from a time.Now() evaluated *inside* the poll callback,
so it moved forward on every retry while the recorded timestamps stayed put. Once
the batch took longer to arrive than the comparison tolerance, the test could
never pass: it just retried until the poll timed out, reporting whatever drift had
accumulated by then — around ten seconds in the failures observed. Anchor the
expectation to a time captured just before the event is tracked instead, so it
stops moving.

That alone is not sufficient. With the anchor in place and the old one-second
tolerance restored, the suite still failed, now by a bounded 1.27s on SentAt
specifically: the fake stamps SentAt when it receives the batch, so flushing and
delivering over HTTP is what separates it from the anchor, and under load that
exceeds a second. Widen the tolerance to a minute, which is what these assertions
are actually for — that a plausible time was recorded rather than left zero, not
sub-second precision. Timestamp was already within tolerance once anchored.

Verified with two clean full-tree `-race` runs, where the previous code failed
nearly every time.
