### PR TITLE
Start a fresh orb init repository on the configured branch

### DIFF
--- a/acceptance/orb_test.go
+++ b/acceptance/orb_test.go
@@ -1091,6 +1091,11 @@ func TestOrbInit_Git(t *testing.T) {
 	_, err := os.Stat(filepath.Join(orbDir, ".git"))
 	assert.NilError(t, err)
 
+	// The initial commit landed on the configured branch, never go-git's default
+	// "master" (PR 678) — so a master ref is never created.
+	_, err = os.Stat(filepath.Join(orbDir, ".git", "refs", "heads", "master"))
+	assert.Check(t, os.IsNotExist(err), "orb init must not create a master branch")
+
 	// Template placeholders were substituted in the generated config.
 	cfg, err := os.ReadFile(filepath.Join(orbDir, ".circleci", "config.yml"))
 	assert.NilError(t, err)

--- a/acceptance/testdata/TestOrbInit_Git.txt
+++ b/acceptance/testdata/TestOrbInit_Git.txt
@@ -4,8 +4,7 @@ Downloading orb project template into my-orb
 Setting up your orb...
 ✓ Published myorg/my-orb@dev:alpha
 
-An initial commit has been created. Push it with:
-  git branch -M main
+An initial commit has been created on main. Push it with:
   git push origin main
 ✓ Project followed on CircleCI
 ✓ Dynamic configuration enabled

--- a/internal/cmd/orb/init.go
+++ b/internal/cmd/orb/init.go
@@ -449,8 +449,7 @@ func applyOrbInitGit(ctx context.Context, client *apiclient.Client, path string,
 	}
 	iostream.Printf(ctx, "%s Published %s@dev:alpha\n", iostream.SymbolOK(ctx), g.fullName)
 
-	iostream.Printf(ctx, "\nAn initial commit has been created. Push it with:\n")
-	iostream.Printf(ctx, "  git branch -M %s\n", d.branch)
+	iostream.Printf(ctx, "\nAn initial commit has been created on %s. Push it with:\n", d.branch)
 	iostream.Printf(ctx, "  git push origin %s\n", d.branch)
 
 	if interactive {

--- a/internal/orbinit/orbinit.go
+++ b/internal/orbinit/orbinit.go
@@ -288,6 +288,19 @@ func InitRepo(orbPath, remoteURL, branch string) (*git.Repository, *git.Worktree
 		return nil, nil, err
 	}
 
+	// A repository with no commits yet — freshly initialised here, or a clone of
+	// an empty repository — has an unborn HEAD that go-git points at "master".
+	// Point it at the branch the orb is meant to track so the initial commit
+	// lands there; without this a brand-new orb starts on "master" however the
+	// author set --branch (default "main"). A repository that already has commits
+	// keeps whatever branch it is on.
+	if _, err := repo.Head(); err != nil {
+		ref := plumbing.NewSymbolicReference(plumbing.HEAD, plumbing.NewBranchReferenceName(branch))
+		if err := repo.Storer.SetReference(ref); err != nil {
+			return nil, nil, fmt.Errorf("setting initial branch to %q: %w", branch, err)
+		}
+	}
+
 	// Only add origin if the repository does not already have one. A clone's
 	// origin is authoritative: it is where the user actually intends to push.
 	if _, err := repo.Remote("origin"); err != nil {

--- a/internal/orbinit/orbinit_test.go
+++ b/internal/orbinit/orbinit_test.go
@@ -261,6 +261,15 @@ func TestInitRepoAndCheckoutAlpha(t *testing.T) {
 		assert.NilError(t, err)
 	})
 
+	// Regression test for https://github.com/CircleCI-Public/circleci-cli/pull/678:
+	// a fresh repository committed on go-git's default "master" regardless of the
+	// requested branch. Must run before the CheckoutAlpha subtest, which moves HEAD.
+	t.Run("initial commit is on the configured branch", func(t *testing.T) {
+		head, err := repo.Head()
+		assert.NilError(t, err)
+		assert.Check(t, is.Equal(head.Name().Short(), "main"))
+	})
+
 	t.Run("CheckoutAlpha switches to the alpha branch", func(t *testing.T) {
 		assert.NilError(t, CheckoutAlpha(w))
 		head, err := repo.Head()
@@ -306,6 +315,52 @@ func TestInitRepo_AdoptsExistingRepo(t *testing.T) {
 		_, err = repo.CommitObject(head.Hash())
 		assert.NilError(t, err)
 	})
+}
+
+// TestInitRepo_EmptyCloneUsesConfiguredBranch covers the second no-commits case
+// from https://github.com/CircleCI-Public/circleci-cli/pull/678: a clone of an
+// empty repository has an origin but an unborn HEAD, so the initial commit must
+// land on the branch orb init was told to track.
+func TestInitRepo_EmptyCloneUsesConfiguredBranch(t *testing.T) {
+	dir := fs.NewDir(t, "orbinit", fs.WithFile("README.md", "hi"))
+
+	// Stand in for `git clone` of an empty repository: an origin, no commits.
+	existing, err := git.PlainInit(dir.Path(), false)
+	assert.NilError(t, err)
+	_, err = existing.CreateRemote(&config.RemoteConfig{
+		Name: "origin",
+		URLs: []string{"git@github.com:myorg/my-orb.git"},
+	})
+	assert.NilError(t, err)
+
+	repo, _, err := InitRepo(dir.Path(), "https://github.com/wrong/url.git", "main")
+	assert.NilError(t, err)
+
+	head, err := repo.Head()
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(head.Name().Short(), "main"))
+}
+
+// TestInitRepo_AdoptedRepoKeepsItsBranch pins the other half of #1682: a
+// repository that already has commits keeps its current branch, so a requested
+// branch that disagrees must not move HEAD.
+func TestInitRepo_AdoptedRepoKeepsItsBranch(t *testing.T) {
+	dir := fs.NewDir(t, "orbinit", fs.WithFile("README.md", "hi"))
+
+	// The first init puts the repository on "trunk" with a commit.
+	_, _, err := InitRepo(dir.Path(), "git@github.com:myorg/my-orb.git", "trunk")
+	assert.NilError(t, err)
+
+	// A new file gives the adopting init something to commit.
+	assert.NilError(t, os.WriteFile(dir.Join("orb.yml"), []byte("version: 2.1\n"), 0o600))
+
+	// Re-run asking for "main": the existing branch must win.
+	repo, _, err := InitRepo(dir.Path(), "git@github.com:myorg/my-orb.git", "main")
+	assert.NilError(t, err)
+
+	head, err := repo.Head()
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(head.Name().Short(), "trunk"))
 }
 
 // TestInitRepo_BrokenRepoStillErrors keeps a real failure loud: a .git that is


### PR DESCRIPTION
`orb init` committed onto go-git's default `master` whenever it created the repository, ignoring `--branch` (default `main`): `PlainInit` leaves an unborn HEAD on `refs/heads/master`, and `CreateBranch` only records tracking config, so the initial commit landed on `master`. Authors then had to run `git branch -M main` by hand — which is exactly why the command printed that step.

When the repository has no commits yet — a fresh init, or a clone of an empty repository — point HEAD at the branch `orb init` was told to track before committing. A repository that already has commits keeps its current branch, preserving the adopt behaviour from #1682. The push instructions drop the now-redundant `git branch -M`.

Fixes #678. Supersedes the v0 change in #678.

🤖 Generated with [Claude Code](https://claude.com/claude-code)