### PR TITLE
Fix workflow rerun's request and response fields, and report the new ID

### DIFF
--- a/acceptance/testdata/TestWorkflowRerun.txt
+++ b/acceptance/testdata/TestWorkflowRerun.txt
@@ -1,1 +1,1 @@
-Rerunning workflow cccccccc-0000-0000-0000-000000000010 from scratch
+Rerunning cccccccc-0000-0000-0000-000000000010 from scratch as workflow 11111111-1111-4111-8111-111111111111

--- a/acceptance/testdata/TestWorkflowRerun_Color.txt
+++ b/acceptance/testdata/TestWorkflowRerun_Color.txt
@@ -1,1 +1,1 @@
-Rerunning workflow cccccccc-0000-0000-0000-000000000010 from scratch
+Rerunning cccccccc-0000-0000-0000-000000000010 from scratch as workflow 11111111-1111-4111-8111-111111111111

--- a/acceptance/testdata/TestWorkflowRerun_FromFailed.txt
+++ b/acceptance/testdata/TestWorkflowRerun_FromFailed.txt
@@ -1,1 +1,1 @@
-Rerunning failed jobs in workflow cccccccc-0000-0000-0000-000000000010
+Rerunning failed jobs from cccccccc-0000-0000-0000-000000000010 as workflow 11111111-1111-4111-8111-111111111111

--- a/acceptance/testdata/TestWorkflowRerun_FromFailed_Color.txt
+++ b/acceptance/testdata/TestWorkflowRerun_FromFailed_Color.txt
@@ -1,1 +1,1 @@
-Rerunning failed jobs in workflow cccccccc-0000-0000-0000-000000000010
+Rerunning failed jobs from cccccccc-0000-0000-0000-000000000010 as workflow 11111111-1111-4111-8111-111111111111

--- a/acceptance/workflow_test.go
+++ b/acceptance/workflow_test.go
@@ -58,7 +58,7 @@ func setupWorkflowFake(t *testing.T) (*fakes.CircleCI, *testenv.TestEnv) {
 		fakeJobV3("d0000000-0000-4000-8000-000000000201", "run-tests", testWorkflowDetailID, wfProjectID),
 		fakeJobV3("d0000000-0000-4000-8000-000000000202", "deploy", testWorkflowDetailID, wfProjectID),
 	)
-	fake.SetRerunResponse(testWorkflowDetailID, http.StatusAccepted)
+	fake.SetRerunResponse(testWorkflowDetailID, http.StatusCreated) // the real endpoint answers 201
 	fake.SetCancelResponse(testWorkflowDetailID, http.StatusAccepted)
 
 	env := testenv.New(t)
@@ -521,6 +521,12 @@ func TestWorkflowRerun(t *testing.T) {
 	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
 	assert.Check(t, golden.String(result.Stdout, t.Name()+".txt"))
 
+	// The rerun created a new workflow, and its id — not the spent one that was
+	// passed in — is what the user needs next.
+	assert.Check(t, cmp.Contains(result.Stdout, fakes.DefaultRerunWorkflowID))
+	// Without --from-failed the endpoint must see is_from_failed false.
+	assert.Check(t, !fake.RerunWasFromFailed(testWorkflowDetailID))
+
 	t.Run("check request", func(t *testing.T) {
 		assert.Check(t, cmp.DeepEqual(fake.LastRequest(), &httprecorder.Request{
 			Method: http.MethodPost,
@@ -529,9 +535,37 @@ func TestWorkflowRerun(t *testing.T) {
 				"Authorization": {"Bearer test-token"},
 				"User-Agent":    {httpcl.UserAgent(runtime.GOOS, runtime.GOARCH, "dev", "")},
 			},
-			Body: new(`{"from_failed":false}`),
+			Body: new(`{"is_from_failed":false}`),
 		}, ignoreCommonHeaders))
 	})
+}
+
+// TestWorkflowRerun_JSON pins the machine-readable shape. Reporting the new
+// workflow id is the point of --json here: it is the handle for whatever comes
+// next, and previously the CLI decoded it from the response and threw it away.
+func TestWorkflowRerun_JSON(t *testing.T) {
+	_, env := setupWorkflowFake(t)
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"workflow", "rerun", testWorkflowDetailID, "--from-failed", "--json"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+
+	var out struct {
+		WorkflowID string `json:"workflow_id"`
+		RerunFrom  string `json:"rerun_from"`
+		FromFailed bool   `json:"from_failed"`
+	}
+	assert.NilError(t, json.Unmarshal([]byte(result.Stdout), &out))
+	assert.Check(t, cmp.Equal(out.WorkflowID, fakes.DefaultRerunWorkflowID))
+	assert.Check(t, cmp.Equal(out.RerunFrom, testWorkflowDetailID))
+	assert.Check(t, cmp.Equal(out.FromFailed, true))
+	// The two must differ, or the id is useless for following the new run.
+	assert.Check(t, out.WorkflowID != out.RerunFrom)
 }
 
 func TestWorkflowRerun_Color(t *testing.T) {
@@ -570,9 +604,15 @@ func TestWorkflowRerun_FromFailed(t *testing.T) {
 				"Authorization": {"Bearer test-token"},
 				"User-Agent":    {httpcl.UserAgent(runtime.GOOS, runtime.GOARCH, "dev", "")},
 			},
-			Body: new(`{"from_failed":true}`),
+			Body: new(`{"is_from_failed":true}`),
 		}, ignoreCommonHeaders))
 	})
+
+	// The assertion with teeth: what the endpoint decoded, not merely what the
+	// client and the fake agreed to exchange. Sending the v2 field name to this v3
+	// endpoint left it false, and everything else still looked fine.
+	assert.Check(t, fake.RerunWasFromFailed(testWorkflowDetailID),
+		"the endpoint must have seen is_from_failed true")
 }
 
 func TestWorkflowRerun_FromFailed_Color(t *testing.T) {

--- a/internal/apiclient/workflow.go
+++ b/internal/apiclient/workflow.go
@@ -118,14 +118,27 @@ func (c *Client) GetRunWorkflowsV3(ctx context.Context, runID uuid.UUID) ([]Work
 
 // RerunWorkflow triggers a rerun of the given workflow. When fromFailed is
 // true only the failed jobs are rerun; otherwise all jobs restart from scratch.
-func (c *Client) RerunWorkflow(ctx context.Context, id string, fromFailed bool) error {
-	body := map[string]any{"from_failed": fromFailed}
+//
+// It returns the id of the *new* workflow the rerun created, which is what the
+// caller needs to follow the run they just started — the id passed in belongs to
+// the old workflow and is of no further use.
+//
+// The request field is "is_from_failed". Not "from_failed": that is the name the
+// v2 endpoint and the service's own internal client use, and the v3 handler
+// tolerates unknown fields rather than rejecting them — so sending the v2 name
+// here silently reran everything from scratch, with a 201 and a new workflow to
+// make it look like it had worked.
+func (c *Client) RerunWorkflow(ctx context.Context, id string, fromFailed bool) (string, error) {
+	body := map[string]any{"is_from_failed": fromFailed}
 	var resp v3Entity[struct {
-		WorkflowID string `json:"workflow_id"`
+		ID string `json:"id"`
 	}]
-	return c.postV3(ctx, "/workflows/%s/rerun", body, &resp,
+	if err := c.postV3(ctx, "/workflows/%s/rerun", body, &resp,
 		routeParams(id),
-	)
+	); err != nil {
+		return "", err
+	}
+	return resp.Data.ID, nil
 }
 
 // CancelWorkflow requests cancellation of a running workflow. Cancellation

--- a/internal/cmd/root/testdata/help/circleci/reference.txt
+++ b/internal/cmd/root/testdata/help/circleci/reference.txt
@@ -932,17 +932,16 @@ shown in the output of `circleci run get`.
 
 Rerun a workflow
 
-Rerun a CircleCI workflow.
+All jobs rerun from scratch unless --from-failed is given, which reruns
+only the jobs that failed. Either way a new workflow is created, and its
+ID is reported so you can follow the run.
 
-By default all jobs in the workflow are rerun from scratch. Use
---from-failed to rerun only the jobs that failed, leaving successful
-jobs untouched.
-
-Workflow IDs are shown in the output of 'circleci run get'.
+JSON fields: workflow_id, rerun_from, from_failed
 
 | Flag            | Description            |
 | --------------- | ---------------------- |
 | `--from-failed` | Rerun only failed jobs |
+| `--json`        | Output as JSON         |
 
 
 **Arguments:**
@@ -958,6 +957,8 @@ shown in the output of `circleci run get`.
   `circleci workflow rerun 5034460f-c7c4-4c43-9457-de07e2029e7b --from-failed`
 - Find a workflow ID from the latest run: 
   `circleci run get --json --jq '.workflows[].id'`
+- Rerun and capture the new workflow's ID: 
+  `circleci workflow rerun <workflow-id> --from-failed --json --jq .workflow_id`
 
 ## Management Commands
 

--- a/internal/cmd/root/testdata/help/circleci/workflow/rerun.txt
+++ b/internal/cmd/root/testdata/help/circleci/workflow/rerun.txt
@@ -14,6 +14,7 @@ shown in the output of `circleci run get`.
 | Flag            | Description            |
 | --------------- | ---------------------- |
 | `--from-failed` | Rerun only failed jobs |
+| `--json`        | Output as JSON         |
 
 Global flags: `-c, --config`, `--debug`, `--no-color`, `-q, --quiet` — see `circleci --help`.
 
@@ -25,14 +26,14 @@ Global flags: `-c, --config`, `--debug`, `--no-color`, `-q, --quiet` — see `ci
   `circleci workflow rerun 5034460f-c7c4-4c43-9457-de07e2029e7b --from-failed`
 - Find a workflow ID from the latest run: 
   `circleci run get --json --jq '.workflows[].id'`
+- Rerun and capture the new workflow's ID: 
+  `circleci workflow rerun <workflow-id> --from-failed --json --jq .workflow_id`
 
 ## Details
 
-Rerun a CircleCI workflow.
+All jobs rerun from scratch unless --from-failed is given, which reruns
+only the jobs that failed. Either way a new workflow is created, and its
+ID is reported so you can follow the run.
 
-By default all jobs in the workflow are rerun from scratch. Use
---from-failed to rerun only the jobs that failed, leaving successful
-jobs untouched.
-
-Workflow IDs are shown in the output of 'circleci run get'.
+JSON fields: workflow_id, rerun_from, from_failed
 

--- a/internal/cmd/root/testdata/usage/circleci/workflow/rerun.txt
+++ b/internal/cmd/root/testdata/usage/circleci/workflow/rerun.txt
@@ -3,4 +3,5 @@ Usage:  circleci workflow rerun <workflow-id> [flags]
 Flags:
       --from-failed   Rerun only failed jobs
   -h, --help          help for rerun
+      --json          Output as JSON
   

--- a/internal/cmd/workflow/rerun.go
+++ b/internal/cmd/workflow/rerun.go
@@ -34,7 +34,10 @@ import (
 )
 
 func newRerunCmd() *cobra.Command {
-	var fromFailed bool
+	var (
+		fromFailed bool
+		jsonOut    bool
+	)
 
 	cmd := &cobra.Command{
 		Use:   "rerun <workflow-id>",
@@ -46,13 +49,11 @@ func newRerunCmd() *cobra.Command {
 			`, "`"),
 		},
 		Long: heredoc.Doc(`
-			Rerun a CircleCI workflow.
+			All jobs rerun from scratch unless --from-failed is given, which reruns
+			only the jobs that failed. Either way a new workflow is created, and its
+			ID is reported so you can follow the run.
 
-			By default all jobs in the workflow are rerun from scratch. Use
-			--from-failed to rerun only the jobs that failed, leaving successful
-			jobs untouched.
-
-			Workflow IDs are shown in the output of 'circleci run get'.
+			JSON fields: workflow_id, rerun_from, from_failed
 		`),
 		Example: heredoc.Doc(`
 			# Rerun all jobs in a workflow from scratch
@@ -63,6 +64,9 @@ func newRerunCmd() *cobra.Command {
 
 			# Find a workflow ID from the latest run
 			$ circleci run get --json --jq '.workflows[].id'
+
+			# Rerun and capture the new workflow's ID
+			$ circleci workflow rerun <workflow-id> --from-failed --json --jq .workflow_id
 		`),
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -74,23 +78,44 @@ func newRerunCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return runRerun(ctx, client, args[0], fromFailed)
+			return runRerun(ctx, client, args[0], fromFailed, jsonOut)
 		},
 	}
 
 	cmd.Flags().BoolVar(&fromFailed, "from-failed", false, "Rerun only failed jobs")
+	cmdutil.AddJSONFlag(cmd, &jsonOut)
 	return cmd
 }
 
-func runRerun(ctx context.Context, client *apiclient.Client, id string, fromFailed bool) error {
-	if err := client.RerunWorkflow(ctx, id, fromFailed); err != nil {
+// rerunJSONOutput is the --json shape. rerun_from is echoed back because the new
+// workflow ID alone does not say what it came from.
+type rerunJSONOutput struct {
+	WorkflowID string `json:"workflow_id"`
+	RerunFrom  string `json:"rerun_from"`
+	FromFailed bool   `json:"from_failed"`
+}
+
+func runRerun(ctx context.Context, client *apiclient.Client, id string, fromFailed, jsonOut bool) error {
+	newID, err := client.RerunWorkflow(ctx, id, fromFailed)
+	if err != nil {
 		return apiErr(err, id)
 	}
 
+	if jsonOut {
+		return iostream.PrintJSON(ctx, rerunJSONOutput{
+			WorkflowID: newID,
+			RerunFrom:  id,
+			FromFailed: fromFailed,
+		})
+	}
+
+	// Lead with the new workflow's ID rather than the one that was passed in: the
+	// old one is spent, and the new one is what `workflow get` or `run watch`
+	// needs next.
 	if fromFailed {
-		iostream.Printf(ctx, "Rerunning failed jobs in workflow %s\n", id)
+		iostream.Printf(ctx, "Rerunning failed jobs from %s as workflow %s\n", id, newID)
 	} else {
-		iostream.Printf(ctx, "Rerunning workflow %s from scratch\n", id)
+		iostream.Printf(ctx, "Rerunning %s from scratch as workflow %s\n", id, newID)
 	}
 	return nil
 }

--- a/internal/testing/fakes/circleci.go
+++ b/internal/testing/fakes/circleci.go
@@ -73,12 +73,14 @@ type CircleCI struct {
 	listTriggerResponses              map[string][]any  // "projectID/pipelineDefinitionID" → list of triggers
 
 	// GitHub App state.
-	githubAppInstalled      map[string]bool  // orgID → app installed (200) vs not (404)
-	githubAppRepos          map[string][]any // orgID → repositories the app can access
-	githubAppInstallResp    any              // response body for POST /github-app/install
-	rerunResponses          map[string]int   // workflow id → HTTP status to return
-	cancelResponses         map[string]int   // workflow id → HTTP status to return
-	pipelineCancelResponses map[string]int   // pipeline id → HTTP status to return
+	githubAppInstalled      map[string]bool   // orgID → app installed (200) vs not (404)
+	githubAppRepos          map[string][]any  // orgID → repositories the app can access
+	githubAppInstallResp    any               // response body for POST /github-app/install
+	rerunResponses          map[string]int    // workflow id → HTTP status to return
+	rerunNewIDs             map[string]string // workflow id → id of the workflow its rerun creates
+	rerunFromFailed         map[string]bool   // workflow id → is_from_failed as the request actually set it
+	cancelResponses         map[string]int    // workflow id → HTTP status to return
+	pipelineCancelResponses map[string]int    // pipeline id → HTTP status to return
 
 	// Job (v3) state.
 	jobsV3             map[string]any    // job UUID → V3 response body
@@ -223,6 +225,8 @@ func NewCircleCI(t *testing.T) *CircleCI {
 		githubAppInstalled:                map[string]bool{},
 		githubAppRepos:                    map[string][]any{},
 		rerunResponses:                    map[string]int{},
+		rerunNewIDs:                       map[string]string{},
+		rerunFromFailed:                   map[string]bool{},
 		cancelResponses:                   map[string]int{},
 		pipelineCancelResponses:           map[string]int{},
 		jobsV3:                            map[string]any{},
@@ -454,6 +458,35 @@ func (f *CircleCI) SetOrbAddCategoryStatus(status int) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.orbAddCategoryStatus = status
+}
+
+// DefaultRerunWorkflowID is the id of the workflow a rerun creates, unless a test
+// overrides it with SetRerunNewWorkflowID.
+//
+// It is deliberately not the id being rerun. A rerun creates a *new* workflow, and
+// echoing the old id back would let a caller that mistakenly reports the id it was
+// given pass its tests.
+const DefaultRerunWorkflowID = "11111111-1111-4111-8111-111111111111"
+
+// RerunWasFromFailed reports whether the rerun request for workflowID actually set
+// is_from_failed, as decoded from the wire.
+//
+// Assert on this rather than on the raw request body: a body comparison passes as
+// long as client and fake agree, which is how sending the v2 field name to a v3
+// endpoint went unnoticed. This reports what the *endpoint* would have acted on, so
+// a wrong field name reads as false.
+func (f *CircleCI) RerunWasFromFailed(workflowID string) bool {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return f.rerunFromFailed[workflowID]
+}
+
+// SetRerunNewWorkflowID sets the id that rerunning workflowID reports, for a test
+// that needs to distinguish several reruns.
+func (f *CircleCI) SetRerunNewWorkflowID(workflowID, newID string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.rerunNewIDs[workflowID] = newID
 }
 
 // SetRerunResponse sets the HTTP status code returned for POST /api/v2/workflow/<id>/rerun.
@@ -1245,6 +1278,15 @@ func runStatus(run any) string {
 	return outcome
 }
 
+// handleRerunWorkflow mirrors POST /api/v3/workflows/:id/rerun as the real service
+// implements it, which matters more than usual here: this fake used to reply with a
+// "workflow_id" field the API does not have, and to ignore the request body
+// entirely. Because the client made the matching mistakes, assertions round-tripped
+// through agreeing errors and passed.
+//
+// So: decode *only* is_from_failed, tolerating unknown fields exactly as the real
+// handler does. A caller sending the wrong field name gets false recorded here and
+// fails a test, rather than being quietly accepted.
 func (f *CircleCI) handleRerunWorkflow(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 	f.mu.RLock()
@@ -1256,8 +1298,25 @@ func (f *CircleCI) handleRerunWorkflow(w http.ResponseWriter, r *http.Request) {
 		render.JSON(w, r, map[string]any{"message": "not found"})
 		return
 	}
+
+	// An absent body is a valid full rerun, so a decode failure is not an error.
+	var req struct {
+		IsFromFailed bool `json:"is_from_failed"`
+	}
+	_ = json.NewDecoder(r.Body).Decode(&req)
+
+	f.mu.Lock()
+	newID, override := f.rerunNewIDs[id]
+	f.rerunFromFailed[id] = req.IsFromFailed
+	f.mu.Unlock()
+	if !override {
+		newID = DefaultRerunWorkflowID
+	}
+
+	// The real endpoint identifies the new workflow at data.id, and sets Location.
+	w.Header().Set("Location", "/api/v3/workflows/"+newID)
 	render.Status(r, status)
-	render.JSON(w, r, map[string]any{"data": map[string]any{"workflow_id": id}})
+	render.JSON(w, r, map[string]any{"data": map[string]any{"id": newID}})
 }
 
 func (f *CircleCI) handleCancelWorkflow(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Three bugs in one endpoint, all of them silent.

The request field for POST /api/v3/workflows/:id/rerun is is_from_failed. We sent
from_failed — the name the v2 endpoint and the service's own internal client use —
and the v3 handler tolerates unknown fields rather than rejecting them. So every
`circleci workflow rerun --from-failed` reran the whole workflow from scratch,
returned 201, started a new workflow and printed "Rerunning failed jobs", with
nothing anywhere to suggest the flag had been dropped on the floor.

The response identifies the new workflow at data.id. We decoded data.workflow_id,
which does not exist, so the value was always empty.

And that empty value was discarded anyway: RerunWorkflow returned only an error,
and the command echoed back the ID it had been given, which is spent. Return the
new ID and report it, in both output modes:

    Rerunning cccccccc-… from scratch as workflow 11111111-…
    $ circleci workflow rerun <id> --from-failed --json --jq .workflow_id

--json also carries rerun_from and from_failed, since the new ID alone does not
say what it came from.

Why the tests did not catch any of this: the fake was written to match the client
rather than the API, so both agreed on the same wrong contract and every assertion
round-tripped through it vacuously. The acceptance tests went further and asserted
the buggy request body verbatim, pinning it in place. The fake now mirrors the real
endpoint — 201, data.id, a Location header — and decodes *only* is_from_failed, so
a wrong field name records false. Tests assert on that decoded value via
RerunWasFromFailed, not on a body comparison that only proves client and fake agree.

Verified by reintroducing each wrong field name in turn and confirming the suite
fails: the request one on the body and is-from-failed assertions, the response one
with "as workflow" followed by nothing.

Diagnosis and the authoritative contract came from the parallel fix in
circleci/mcp, which hit the same two field bugs; there the empty response ID was
user-visible as a zero UUID.

Long is trimmed to stay inside the 40-line help budget: it repeated "workflow IDs
are shown in the output of circleci run get", which the Arguments section and an
example both already say, and restated the Short verbatim.

