### PR TITLE
Set terminal window title in interactive TUI flows

### DIFF
--- a/internal/ui/login_flow.go
+++ b/internal/ui/login_flow.go
@@ -481,6 +481,19 @@ func (m LoginFlowModel) cmdGetUsername(token string) tea.Cmd {
 // --- views ---
 
 func (m LoginFlowModel) View() tea.View {
+	return withWindowTitle(m.buildView(), m.windowTitle())
+}
+
+// windowTitle names the auth flow in the terminal tab. Signup and login share
+// this model, so the wording follows opts.Signup.
+func (m LoginFlowModel) windowTitle() string {
+	if m.opts.Signup {
+		return flowTitle("sign up")
+	}
+	return flowTitle("log in")
+}
+
+func (m LoginFlowModel) buildView() tea.View {
 	var b strings.Builder
 	switch m.stage {
 	case stageHostSelect:

--- a/internal/ui/markdown.go
+++ b/internal/ui/markdown.go
@@ -89,5 +89,7 @@ func (m MarkdownViewportModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m MarkdownViewportModel) View() tea.View {
-	return m.pager.View("")
+	// A generic pager for arbitrary long output, so there is no single action to
+	// name — the bare prefix still marks the tab as ours.
+	return withWindowTitle(m.pager.View(""), flowTitle(""))
 }

--- a/internal/ui/orb_init_flow.go
+++ b/internal/ui/orb_init_flow.go
@@ -636,6 +636,10 @@ func (m *OrbInitFlowModel) enterConfirm(stage orbInitStage, prompt string) tea.C
 // --- views ---
 
 func (m OrbInitFlowModel) View() tea.View {
+	return withWindowTitle(m.buildView(), flowTitle("orb init"))
+}
+
+func (m OrbInitFlowModel) buildView() tea.View {
 	switch m.stage {
 	case oiVisibility, oiMode, oiCategories:
 		return m.sel.View()

--- a/internal/ui/run_get_flow.go
+++ b/internal/ui/run_get_flow.go
@@ -1667,6 +1667,10 @@ func (m RunGetFlowModel) updateHelp(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m RunGetFlowModel) View() tea.View {
+	return withWindowTitle(m.buildView(), flowTitle("run get"))
+}
+
+func (m RunGetFlowModel) buildView() tea.View {
 	switch m.stage {
 	case runGetStageRunSelect:
 		return m.runSelect.View()

--- a/internal/ui/theme_picker.go
+++ b/internal/ui/theme_picker.go
@@ -277,6 +277,10 @@ func (m ThemePickerModel) loadingView() string {
 }
 
 func (m ThemePickerModel) View() tea.View {
+	return withWindowTitle(m.buildView(), flowTitle("theme"))
+}
+
+func (m ThemePickerModel) buildView() tea.View {
 	if !m.ready {
 		return tea.NewView("")
 	}

--- a/internal/ui/window_title.go
+++ b/internal/ui/window_title.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package ui
+
+import tea "charm.land/bubbletea/v2"
+
+// titlePrefix leads every window title so the terminal tab is recognisable as
+// the CLI at a glance. The ◉ (fisheye) glyph echoes CircleCI's ringed logo
+// mark, the way the `claude` CLI leads its title with ✳.
+const titlePrefix = "◉ circleci"
+
+// flowTitle builds a terminal window/tab title for an interactive flow. Our
+// full-screen flows set this so the hosting terminal's tab reflects what the
+// CLI is doing — the way the `claude` CLI does. Bubble Tea emits it as OSC 2
+// (via tea.View.WindowTitle) and clears it again when the program exits.
+//
+// An empty action yields the bare prefix, for generic flows (e.g. the pager)
+// that have no single action to name.
+func flowTitle(action string) string {
+	if action == "" {
+		return titlePrefix
+	}
+	return titlePrefix + " · " + action
+}
+
+// withWindowTitle stamps title onto v and returns it. Callers set it on every
+// frame so the title stays put for the flow's lifetime; Bubble Tea only writes
+// the escape when the value changes, and resets the terminal title on exit.
+func withWindowTitle(v tea.View, title string) tea.View {
+	v.WindowTitle = title
+	return v
+}


### PR DESCRIPTION
The full-screen flows in internal/ui now set the terminal tab title to reflect what the CLI is doing — the way the `claude` CLI does — led by the ◉ (fisheye) glyph echoing CircleCI's ringed logo:

  login/signup → "◉ circleci · log in" / "· sign up"
  orb init     → "◉ circleci · orb init"
  run get      → "◉ circleci · run get"
  theme picker → "◉ circleci · theme"
  markdown pager → "◉ circleci"

Bubble Tea v2's tea.View.WindowTitle emits the title as OSC 2 and clears it on program exit, so no manual restore is needed. A shared helper builds the string and each flow's View() stamps it onto every frame.

<!--
  Thank you for contributing to CircleCI CLI!

  For PRs adding new features, please raise an issue first.

  Squash your commits before requesting review and before merging.
-->
