### PR TITLE
Bullet each line of a multiline config validation error

### DIFF
--- a/acceptance/config_test.go
+++ b/acceptance/config_test.go
@@ -146,6 +146,34 @@ func TestConfigValidate_Invalid(t *testing.T) {
 	assert.Check(t, golden.String(result.Stderr, t.Name()+".stderr.txt"))
 }
 
+// TestConfigValidate_MultilineError covers an API error message that spans
+// multiple newline-separated lines rather than being split into separate
+// error strings. Every line must get its own bullet so the output stays
+// aligned.
+func TestConfigValidate_MultilineError(t *testing.T) {
+	fake := fakes.NewCircleCI(t)
+	fake.SetCompileResponse(false, "",
+		"Error calling workflow: 'build-test-deploy-bug'\nError calling job: 'buggy-orb/exhibit-bug'\nReferred to a variable \"pipeline.parameters.bug\" that does not exist:\n<< pipeline.parameters.bug >>\n ^^^^^^^^^^^^^^^^^^^^^^^")
+
+	env := testenv.New(t)
+	env.Token = testToken
+	env.CircleCIURL = fake.URL()
+
+	dir := t.TempDir()
+	writeConfig(t, dir, "version: \"2.1\"\nfoo: bar\n")
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"config", "validate", "--config", ".circleci/config.yml"},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	assert.Check(t, cmp.Equal(result.ExitCode, 7))
+	assert.Check(t, golden.String(result.Stdout, t.Name()+".txt"))
+	assert.Check(t, golden.String(result.Stderr, t.Name()+".stderr.txt"))
+}
+
 func TestConfigValidate_FileNotFound(t *testing.T) {
 	fake := fakes.NewCircleCI(t)
 

--- a/acceptance/config_test.go
+++ b/acceptance/config_test.go
@@ -174,6 +174,38 @@ func TestConfigValidate_MultilineError(t *testing.T) {
 	assert.Check(t, golden.String(result.Stderr, t.Name()+".stderr.txt"))
 }
 
+// TestConfigValidate_MultipleErrors covers the same error content as
+// TestConfigValidate_MultilineError, but sent as separate error strings
+// rather than one string with embedded newlines. It asserts against the same
+// golden files to prove both API response shapes render identically.
+func TestConfigValidate_MultipleErrors(t *testing.T) {
+	fake := fakes.NewCircleCI(t)
+	fake.SetCompileResponse(false, "",
+		"Error calling workflow: 'build-test-deploy-bug'",
+		"Error calling job: 'buggy-orb/exhibit-bug'",
+		"Referred to a variable \"pipeline.parameters.bug\" that does not exist:",
+		"<< pipeline.parameters.bug >>",
+		" ^^^^^^^^^^^^^^^^^^^^^^^")
+
+	env := testenv.New(t)
+	env.Token = testToken
+	env.CircleCIURL = fake.URL()
+
+	dir := t.TempDir()
+	writeConfig(t, dir, "version: \"2.1\"\nfoo: bar\n")
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"config", "validate", "--config", ".circleci/config.yml"},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	assert.Check(t, cmp.Equal(result.ExitCode, 7))
+	assert.Check(t, golden.String(result.Stdout, "TestConfigValidate_MultilineError.txt"))
+	assert.Check(t, golden.String(result.Stderr, "TestConfigValidate_MultilineError.stderr.txt"))
+}
+
 func TestConfigValidate_FileNotFound(t *testing.T) {
 	fake := fakes.NewCircleCI(t)
 

--- a/acceptance/testdata/TestConfigValidate_MultilineError.stderr.txt
+++ b/acceptance/testdata/TestConfigValidate_MultilineError.stderr.txt
@@ -1,0 +1,6 @@
+  • Error calling workflow: 'build-test-deploy-bug'
+  • Error calling job: 'buggy-orb/exhibit-bug'
+  • Referred to a variable "pipeline.parameters.bug" that does not exist:
+  • << pipeline.parameters.bug >>
+  •  ^^^^^^^^^^^^^^^^^^^^^^^
+error: Config file ".circleci/config.yml" contains compilation errors.

--- a/internal/cmd/config/config.go
+++ b/internal/cmd/config/config.go
@@ -32,6 +32,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
@@ -120,6 +121,19 @@ func resolveOrgID(ctx context.Context, client *apiclient.Client, org, cmdName st
 		return "", err
 	}
 	return id.String(), nil
+}
+
+// printValidationErrors writes each compilation error as a bulleted line to
+// stderr. An error's message may itself span multiple newline-separated
+// lines (the API sometimes returns one error with embedded detail lines
+// rather than several separate errors), so each line gets its own bullet to
+// keep the output visually aligned.
+func printValidationErrors(ctx context.Context, errs []string) {
+	for _, e := range errs {
+		for _, line := range strings.Split(e, "\n") {
+			iostream.ErrPrintf(ctx, "  • %s\n", line)
+		}
+	}
 }
 
 func configAPIErr(err error) *clierrors.CLIError {

--- a/internal/cmd/config/process.go
+++ b/internal/cmd/config/process.go
@@ -104,9 +104,7 @@ func newProcessCmd() *cobra.Command {
 			}
 
 			if !result.Valid {
-				for _, e := range result.Errors {
-					iostream.ErrPrintf(ctx, "  • %s\n", e)
-				}
+				printValidationErrors(ctx, result.Errors)
 				return clierrors.New("config.invalid", "Config is invalid",
 					fmt.Sprintf("Config file %q contains compilation errors.", args[0])).
 					WithExitCode(clierrors.ExitValidationFail)

--- a/internal/cmd/config/validate.go
+++ b/internal/cmd/config/validate.go
@@ -116,9 +116,7 @@ func newValidateCmd() *cobra.Command {
 			}
 
 			if !result.Valid {
-				for _, e := range result.Errors {
-					iostream.ErrPrintf(ctx, "  • %s\n", e)
-				}
+				printValidationErrors(ctx, result.Errors)
 				return clierrors.New("config.invalid", "Config is invalid",
 					fmt.Sprintf("Config file %q contains compilation errors.", path)).
 					WithExitCode(clierrors.ExitValidationFail)


### PR DESCRIPTION
## Summary
- `circleci config validate`/`process` bullets each entry in `result.Errors`, but the API will now return one error whose message spans multiple newline-separated lines instead of several separate error strings
- Previously only the first line of such an error got a bullet, breaking the visual alignment other lines relied on
- Added `printValidationErrors` (shared by validate and process) which splits each error string on `\n` and bullets every resulting line
- Added `TestConfigValidate_MultilineError` acceptance test covering this case, since nothing previously asserted on the bullet formatting
- Added `TestConfigValidate_MultipleErrors`, which sends the same content as separate error strings and asserts against the same golden files — proving both API response shapes (one multiline string vs. several separate strings) render identically

## Test plan
- [x] `task test -- ./acceptance/... -run TestConfigValidate`
- [x] `go build ./...`