### PR TITLE
Bullet each line of a multiline config validation error (v0)

### DIFF
--- a/config/v1_api_client.go
+++ b/config/v1_api_client.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/CircleCI-Public/circleci-cli/api/graphql"
 	"github.com/pkg/errors"
@@ -31,7 +32,11 @@ func (errs GQLErrorsCollection) Error() string {
 	message := "config compilation contains errors:"
 
 	for i := range errs {
-		message += fmt.Sprintf("\n\t- %s", errs[i].Message)
+		// A single error's message may itself span multiple newline-separated
+		// lines, so bullet every line rather than only the first.
+		for _, line := range strings.Split(errs[i].Message, "\n") {
+			message += fmt.Sprintf("\n\t- %s", line)
+		}
 	}
 
 	return message

--- a/config/v1_api_client_test.go
+++ b/config/v1_api_client_test.go
@@ -132,3 +132,22 @@ func TestAPIV1Flow(t *testing.T) {
 		assert.Equal(t, 0, gqlHitCounter)
 	})
 }
+
+func TestGQLErrorsCollection_Error(t *testing.T) {
+	t.Run("bullets every error", func(t *testing.T) {
+		errs := GQLErrorsCollection{
+			{Message: "error on line 1"},
+			{Message: "error on line 42"},
+		}
+		assert.Equal(t, "config compilation contains errors:\n\t- error on line 1\n\t- error on line 42", errs.Error())
+	})
+
+	t.Run("bullets every line of a single multiline error", func(t *testing.T) {
+		// A single error's Message may itself span multiple newline-separated
+		// lines; every line should get its own bullet rather than only the first.
+		errs := GQLErrorsCollection{
+			{Message: "error on line 1\nerror on line 42"},
+		}
+		assert.Equal(t, "config compilation contains errors:\n\t- error on line 1\n\t- error on line 42", errs.Error())
+	})
+}

--- a/config/v2_api_client.go
+++ b/config/v2_api_client.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"net/url"
+	"strings"
 
 	"github.com/CircleCI-Public/circleci-cli/api/rest"
 	"github.com/pkg/errors"
@@ -17,7 +18,11 @@ type v2APIClient struct {
 func configErrorsAsError(configErrors []ConfigError) error {
 	message := "config compilation contains errors:"
 	for _, err := range configErrors {
-		message += fmt.Sprintf("\n\t- %s", err.Message)
+		// A single error's message may itself span multiple newline-separated
+		// lines, so bullet every line rather than only the first.
+		for _, line := range strings.Split(err.Message, "\n") {
+			message += fmt.Sprintf("\n\t- %s", line)
+		}
 	}
 	return errors.New(message)
 }

--- a/config/v2_api_client_test.go
+++ b/config/v2_api_client_test.go
@@ -15,3 +15,15 @@ func TestConfigErrorsAsError(t *testing.T) {
 	- error on line 1
 	- error on line 42`)
 }
+
+func TestConfigErrorsAsError_MultilineMessage(t *testing.T) {
+	// A single ConfigError's Message may itself span multiple
+	// newline-separated lines; every line should get its own bullet rather
+	// than only the first.
+	err := configErrorsAsError([]ConfigError{
+		{Message: "error on line 1\nerror on line 42"},
+	})
+	assert.Error(t, err, `config compilation contains errors:
+	- error on line 1
+	- error on line 42`)
+}


### PR DESCRIPTION
# Checklist

=========

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked for similar issues and haven't found anything relevant.
- [x] This is not a security issue (which should be reported here: https://circleci.com/security/)
- [ ] I have read [Contribution Guidelines](https://github.com/CircleCI-Public/circleci-cli/blob/main/CONTRIBUTING.md).

### Internal Checklist
- [ ] I am requesting a review from my own team as well as the owning team
- [ ] I have a plan in place for the monitoring of the changes that I am making (this can include new monitors, logs to be aware of, etc...)

## Changes

=======

- Split each config compilation error's `Message` on `\n` before bulleting it in `configErrorsAsError` (`config/v2_api_client.go`), so every line gets its own `- ` prefix instead of only the first.
- Applied the same fix to `GQLErrorsCollection.Error()` (`config/v1_api_client.go`), used by the legacy GraphQL compile path.
- Added unit tests covering a single multiline error message for both the v2 REST and v1 GraphQL error-formatting paths.

## Rationale

=========

This is the `v0` (old CLI) counterpart to [CircleCI-Public/circleci-cli#1691](https://github.com/CircleCI-Public/circleci-cli/pull/1691), which fixed the current CLI (`main`) for the same underlying change: [orb-service#2001](https://github.com/circleci/orb-service/pull/2001) makes the config-compilation API return one combined error message (with embedded newlines) instead of several separate error strings when `next=true`.

The old CLI doesn't print errors via a shared bulleting helper the way `main` does — instead each API client wraps `response.Errors` into a single `error` value (`config compilation contains errors:\n\t- ...`) at the point the error is returned. That join only bulleted the first line of an error's message, so a combined multiline error would render with a hanging, unbulleted continuation.

## Considerations

==============

- Scoped to the two `Error`/error-formatting functions that actually do the line-joining (`config/v2_api_client.go`, `config/v1_api_client.go`). The `!response.Valid` branches in `config/commands.go` are effectively dead code for both API clients today, since both clients already return an `error` whenever `Errors` is non-empty, short-circuiting before that check is reached — so they were left untouched to keep this change minimal.
- Did not touch the pre-existing doubled `"config compilation contains errors:"` prefix in `v2APIClient.CompileConfig` (line wraps `configErrorsAsError`'s already-prefixed message in another `"config compilation contains errors: %s"`) — unrelated to this fix.

## Screenshots

============

N/A - CLI text output change, no visual/UI screenshots. See test assertions for exact before/after formatting.

Before:
<img width="721" height="108" alt="Screenshot 2026-08-05 at 4 53 02 PM" src="https://github.com/user-attachments/assets/0c18cf09-016d-4073-b9e8-61fd4f9daaa3" />
