### PR TITLE
Make `config validate` support not having auth

### DIFF
--- a/acceptance/config_test.go
+++ b/acceptance/config_test.go
@@ -474,6 +474,104 @@ func TestConfigValidate_NoOrgOutsideGitRemote(t *testing.T) {
 	assert.Check(t, cmp.Equal(fake.LastCompileOwnerID(), ""))
 }
 
+// TestConfigValidate_NoToken pins that validation is usable with no API token
+// at all: the compile endpoint serves anonymous callers, so linting a config
+// that uses only public orbs must not demand `circleci auth login` first.
+//
+// It also asserts the request carried no Authorization header. Sending a
+// valueless "Bearer" instead reads as malformed credentials rather than as an
+// anonymous request, which the real API rejects.
+func TestConfigValidate_NoToken(t *testing.T) {
+	fake := fakes.NewCircleCI(t)
+	fake.SetCompileResponse(true, testCompiledYAML)
+
+	env := testenv.New(t)
+	env.CircleCIURL = fake.URL()
+
+	dir := t.TempDir()
+	writeConfig(t, dir, testConfigYAML)
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"config", "validate", "--config", ".circleci/config.yml"},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	assert.Check(t, cmp.Equal(result.ExitCode, 0), "stderr: %s", result.Stderr)
+	assert.Check(t, cmp.Contains(result.Stdout, ".circleci/config.yml"))
+
+	var compiled bool
+	for _, req := range fake.AllRequests() {
+		if req.URL.Path != "/api/v2/compile-config-with-defaults" {
+			continue
+		}
+		compiled = true
+		assert.Check(t, cmp.Equal(req.Header.Get("Authorization"), ""),
+			"anonymous validate must send no Authorization header")
+	}
+	assert.Check(t, compiled, "expected a compile request")
+}
+
+// TestConfigValidate_NoTokenSkipsOrgInference pins that the anonymous path
+// makes no attempt to infer the org. Every route to an org ID needs a token, so
+// inside a git checkout with no token the project lookup would only ever 401 —
+// validate compiles with an empty owner_id instead of spending the round-trip.
+func TestConfigValidate_NoTokenSkipsOrgInference(t *testing.T) {
+	fake := fakes.NewCircleCI(t)
+	fake.SetCompileResponse(true, testCompiledYAML)
+	fake.AddProjectBySlug("gh/myorg/myrepo", "00000000-0000-0000-0000-0000000000b5", "myrepo", testOrgUUID)
+
+	env := testenv.New(t)
+	env.CircleCIURL = fake.URL()
+
+	dir := t.TempDir()
+	initGitRepoWithRemote(t, dir, "https://github.com/myorg/myrepo")
+	writeConfig(t, dir, testConfigYAML)
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"config", "validate", "--config", ".circleci/config.yml"},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	assert.Check(t, cmp.Equal(result.ExitCode, 0), "stderr: %s", result.Stderr)
+	assert.Check(t, cmp.Equal(fake.LastCompileOwnerID(), ""))
+	for _, req := range fake.AllRequests() {
+		assert.Check(t, cmp.Equal(req.URL.Path, "/api/v2/compile-config-with-defaults"),
+			"unexpected request on the anonymous path")
+	}
+}
+
+// TestConfigValidate_NoTokenWithOrg pins the one case where the anonymous path
+// still fails: --org cannot be honoured without a token, and quietly ignoring
+// it would report a config as valid while skipping the private orb resolution
+// the user explicitly asked for.
+func TestConfigValidate_NoTokenWithOrg(t *testing.T) {
+	fake := fakes.NewCircleCI(t)
+	fake.SetCompileResponse(true, testCompiledYAML)
+	fake.AddOrg(testOrgUUID, "gh/myorg", "myorg", "github")
+
+	env := testenv.New(t)
+	env.CircleCIURL = fake.URL()
+
+	dir := t.TempDir()
+	writeConfig(t, dir, testConfigYAML)
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"config", "validate", "--org", "gh/myorg"},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	assert.Check(t, cmp.Equal(result.ExitCode, 3))
+	assert.Check(t, cmp.Contains(result.Stderr, "Resolving --org requires a CircleCI API token."))
+	assert.Check(t, cmp.Contains(result.Stderr, "Or drop --org to validate against public orbs only"))
+	assert.Check(t, cmp.Len(fake.AllRequests(), 0), "must not call the API without a token")
+}
+
 // TestConfigValidate_RemovedOrgFlags pins the clean break from the legacy org
 // flag names: --org-id and --org-slug were collapsed into --org and must no
 // longer be accepted. Cobra reports unknown flags with a non-zero exit and an

--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -32,7 +32,8 @@ import (
 	"github.com/CircleCI-Public/circleci-cli/internal/httpcl"
 )
 
-// Client is an authenticated CircleCI API client.
+// Client is a CircleCI API client. It is authenticated when Config.Token was
+// set; see Authenticated.
 type Client struct {
 	main  *httpcl.Client // circleci.com/api/v1.1, /api/v2
 	raw   *httpcl.Client
@@ -60,11 +61,18 @@ func New(cfg Config) *Client {
 	}
 
 	baseCfg := httpcl.Config{
-		AuthToken:  "Bearer " + cfg.Token,
 		AuthHeader: "Authorization",
 		UserAgent:  httpcl.UserAgent(runtime.GOOS, runtime.GOARCH, cfg.Version, cfg.Agent),
 		Transport:  cfg.Transport,
 		OnWarn:     cfg.OnWarn,
+	}
+	// Leave AuthToken empty for an anonymous client so httpcl omits the header
+	// entirely. Sending a valueless "Authorization: Bearer" instead makes the API
+	// reject the request as malformed credentials rather than treating it as
+	// unauthenticated, which breaks the endpoints that do serve anonymous callers
+	// (see cmdutil.LoadClientOptionalAuth).
+	if cfg.Token != "" {
+		baseCfg.AuthToken = "Bearer " + cfg.Token
 	}
 
 	mainCfg := baseCfg
@@ -76,6 +84,9 @@ func New(cfg Config) *Client {
 		token: cfg.Token,
 	}
 }
+
+// Authenticated reports whether the client carries an API token.
+func (c *Client) Authenticated() bool { return c.token != "" }
 
 func queryParam(key, val string) func(*httpcl.Request) {
 	return httpcl.QueryParam(key, val)

--- a/internal/cmd/config/config.go
+++ b/internal/cmd/config/config.go
@@ -123,6 +123,33 @@ func resolveOrgID(ctx context.Context, client *apiclient.Client, org, cmdName st
 	return id.String(), nil
 }
 
+// validateOrgID is resolveOrgID for `config validate`, which accepts an
+// unauthenticated client (see cmdutil.LoadClientOptionalAuth).
+//
+// Every path to an org ID needs a token: inference looks the project up through
+// the API, and an org only owns orbs the caller is authorized to read. So when
+// there is no token we skip resolution entirely and compile with no owner —
+// public orbs still resolve — rather than spending a round-trip on a request
+// that can only 401. An explicit --org is a hard error instead: silently
+// ignoring it would report a config as valid while skipping the private orb
+// resolution the user asked for.
+func validateOrgID(ctx context.Context, client *apiclient.Client, org string) (string, error) {
+	if !client.Authenticated() {
+		if org != "" {
+			return "", clierrors.New("auth.token_missing", "Authentication required",
+				"Resolving --org requires a CircleCI API token.").
+				WithSuggestions(
+					"Run: circleci auth login",
+					"Or set the CIRCLE_TOKEN environment variable",
+					"Or drop --org to validate against public orbs only",
+				).
+				WithExitCode(clierrors.ExitAuthError)
+		}
+		return "", nil
+	}
+	return resolveOrgID(ctx, client, org, "circleci config validate")
+}
+
 // printValidationErrors writes each compilation error as a bulleted line to
 // stderr. An error's message may itself span multiple newline-separated
 // lines (the API sometimes returns one error with embedded detail lines

--- a/internal/cmd/config/validate.go
+++ b/internal/cmd/config/validate.go
@@ -24,6 +24,7 @@ package cmdconfig
 
 import (
 	"fmt"
+	"net/http"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
@@ -31,6 +32,7 @@ import (
 	"github.com/CircleCI-Public/circleci-cli/internal/cmdutil"
 	"github.com/CircleCI-Public/circleci-cli/internal/configcmd"
 	clierrors "github.com/CircleCI-Public/circleci-cli/internal/errors"
+	"github.com/CircleCI-Public/circleci-cli/internal/httpcl"
 	"github.com/CircleCI-Public/circleci-cli/internal/iostream"
 )
 
@@ -52,9 +54,9 @@ func newValidateCmd() *cobra.Command {
 			`, "`"),
 		},
 		Long: heredoc.Doc(`
-			Private and namespaced orbs resolve against your organization. With --org
-			omitted the org comes from a 'circleci project link' binding if present,
-			otherwise the git remote.
+			No API token is required; without one, only public orbs resolve.
+			Private and namespaced orbs need a token and resolve against your org, taken
+			from --org, a 'circleci project link' binding, or the git remote, in that order.
 
 			JSON fields (--json): valid (bool), compiled_yaml (string, when valid), errors (array of compilation messages, when invalid)
 		`),
@@ -83,23 +85,37 @@ func newValidateCmd() *cobra.Command {
 				path = args[0]
 			}
 
-			client, err := cmdutil.LoadClient(ctx)
-			if err != nil {
-				return err
-			}
+			// Validation is the one config command that works without a token:
+			// the compile endpoint serves anonymous callers, and linting a config
+			// that uses only public orbs is the first thing a new user — or a
+			// pre-commit hook, or a CI job without a token — wants to do. An
+			// authenticated call is unchanged.
+			client := cmdutil.LoadClientOptionalAuth(ctx)
 
 			yaml, err := readConfigInput(ctx, path)
 			if err != nil {
 				return err
 			}
 
-			orgID, err := resolveOrgID(ctx, client, org, "circleci config validate")
+			orgID, err := validateOrgID(ctx, client, org)
 			if err != nil {
 				return err
 			}
 
 			result, err := configcmd.Validate(ctx, client, yaml, orgID, previewNext)
 			if err != nil {
+				// A 401 on an anonymous call means this host will not compile
+				// without credentials, so the generic "token was rejected" wording
+				// APIErr uses for an authenticated 401 would be wrong here.
+				if !client.Authenticated() && httpcl.HasStatusCode(err, http.StatusUnauthorized) {
+					return clierrors.New("auth.token_missing", "Authentication required",
+						"This CircleCI host requires an API token to validate config.").
+						WithSuggestions(
+							"Run: circleci auth login",
+							"Or set the CIRCLE_TOKEN environment variable",
+						).
+						WithExitCode(clierrors.ExitAuthError)
+				}
 				return configAPIErr(err)
 			}
 

--- a/internal/cmd/root/testdata/help/circleci/config/validate.txt
+++ b/internal/cmd/root/testdata/help/circleci/config/validate.txt
@@ -33,9 +33,9 @@ Global flags: `--debug`, `--no-color`, `-q, --quiet` — see `circleci --help`.
 
 ## Details
 
-Private and namespaced orbs resolve against your organization. With --org
-omitted the org comes from a 'circleci project link' binding if present,
-otherwise the git remote.
+No API token is required; without one, only public orbs resolve.
+Private and namespaced orbs need a token and resolve against your org, taken
+from --org, a 'circleci project link' binding, or the git remote, in that order.
 
 JSON fields (--json): valid (bool), compiled_yaml (string, when valid), errors (array of compilation messages, when invalid)
 

--- a/internal/cmd/root/testdata/help/circleci/reference.txt
+++ b/internal/cmd/root/testdata/help/circleci/reference.txt
@@ -150,9 +150,9 @@ from stdin.
 
 Validate a pipeline config file
 
-Private and namespaced orbs resolve against your organization. With --org
-omitted the org comes from a 'circleci project link' binding if present,
-otherwise the git remote.
+No API token is required; without one, only public orbs resolve.
+Private and namespaced orbs need a token and resolve against your org, taken
+from --org, a 'circleci project link' binding, or the git remote, in that order.
 
 JSON fields (--json): valid (bool), compiled_yaml (string, when valid), errors (array of compilation messages, when invalid)
 

--- a/internal/cmdutil/client.go
+++ b/internal/cmdutil/client.go
@@ -150,7 +150,8 @@ func GetConfig(ctx context.Context) *config.Config {
 
 // LoadClient reads the CLI config, validates that a token is present, and
 // returns an authenticated API client. On failure it returns a structured
-// CLIError ready to be returned directly from a RunE handler.
+// CLIError ready to be returned directly from a RunE handler. This is the
+// default; see LoadClientOptionalAuth for the anonymous-capable variant.
 //
 // Honors a --config path set by the root PersistentPreRunE via WithConfigPath.
 func LoadClient(ctx context.Context) (*apiclient.Client, error) {
@@ -168,6 +169,23 @@ func LoadClient(ctx context.Context) (*apiclient.Client, error) {
 			WithRef("https://app.circleci.com/settings/user/oauth-clients").
 			WithExitCode(clierrors.ExitAuthError)
 	}
+	return newAPIClient(ctx, cfg, token), nil
+}
+
+// LoadClientOptionalAuth returns an API client without requiring a token, for
+// commands that work against endpoints CircleCI also serves anonymously. When a
+// token *is* configured it is still sent, so the authenticated behaviour is
+// unchanged; the returned client reports which it is via Authenticated().
+//
+// Prefer LoadClient everywhere else. Against an endpoint that requires a token,
+// an anonymous client turns the actionable "Authentication required" error into
+// a bare 401 from the API.
+func LoadClientOptionalAuth(ctx context.Context) *apiclient.Client {
+	cfg := GetConfig(ctx)
+	return newAPIClient(ctx, cfg, cfg.EffectiveToken())
+}
+
+func newAPIClient(ctx context.Context, cfg *config.Config, token string) *apiclient.Client {
 	return apiclient.New(apiclient.Config{
 		BaseURL: cfg.EffectiveHost(),
 		Token:   token,
@@ -176,7 +194,7 @@ func LoadClient(ctx context.Context) (*apiclient.Client, error) {
 		OnWarn: func(msg string) {
 			iostream.ErrPrintf(ctx, "warning: %s\n", msg)
 		},
-	}), nil
+	})
 }
 
 func AppURL(ctx context.Context) (string, error) {


### PR DESCRIPTION
<!--
  Thank you for contributing to CircleCI CLI!

  For PRs adding new features, please raise an issue first.

  Squash your commits before requesting review and before merging.
-->
