### PR TITLE
Delete resource classes by UUID

### DIFF
--- a/acceptance/runner_test.go
+++ b/acceptance/runner_test.go
@@ -78,8 +78,8 @@ func setupRunnerFake(t *testing.T) (*fakes.CircleCI, *testenv.TestEnv) {
 	t.Helper()
 	fake := fakes.NewCircleCI(t)
 
-	fake.AddResourceClass(fakeRC("rc-id-1", "my-org/linux-runner", "Linux amd64 runner"))
-	fake.AddResourceClass(fakeRC("rc-id-2", "my-org/arm-runner", "ARM runner"))
+	fake.AddResourceClass(fakeRC("11111111-1111-4111-8111-111111111111", "my-org/linux-runner", "Linux amd64 runner"))
+	fake.AddResourceClass(fakeRC("22222222-2222-4222-8222-222222222222", "my-org/arm-runner", "ARM runner"))
 
 	fake.AddRunnerToken("my-org/linux-runner", fakeToken("tok-id-1", "my-org/linux-runner", "prod-server-1"))
 	fake.AddRunnerToken("my-org/linux-runner", fakeToken("tok-id-2", "my-org/linux-runner", "prod-server-2"))
@@ -142,7 +142,7 @@ func TestRunnerResourceClassList_Namespace(t *testing.T) {
 
 func TestRunnerResourceClassList_NamespaceIgnoresInstances(t *testing.T) {
 	fake, env := setupRunnerFake(t)
-	fake.AddResourceClass(fakeRC("rc-id-3", "my-org/idle-runner", "No runners attached"))
+	fake.AddResourceClass(fakeRC("33333333-3333-4333-8333-333333333333", "my-org/idle-runner", "No runners attached"))
 	// Two instances on one class must not double it up in the listing.
 	fake.AddRunnerInstance(fakeInstance("my-org/linux-runner", "host-2.example.com", "runner-3", "1.0.0"))
 
@@ -556,10 +556,16 @@ func TestRunnerResourceClassDelete_Force(t *testing.T) {
 	assert.Check(t, golden.String(result.Stdout, t.Name()+".txt"))
 	assert.Check(t, golden.String(result.Stderr, t.Name()+".stderr.txt"))
 
-	t.Run("check request", func(t *testing.T) {
-		assert.Check(t, cmp.DeepEqual(fake.LastRequest(), &httprecorder.Request{
+	t.Run("check requests", func(t *testing.T) {
+		reqs := fake.AllRequests()
+		assert.Assert(t, cmp.Len(reqs, 2))
+		assert.Check(t, cmp.Equal(reqs[0].Method, http.MethodGet))
+		assert.Check(t, cmp.Equal(reqs[0].URL.Path, "/api/v3/runner/resource"))
+		assert.Check(t, cmp.Equal(reqs[0].URL.Query().Get("namespace"), "my-org"))
+
+		assert.Check(t, cmp.DeepEqual(reqs[1], httprecorder.Request{
 			Method: http.MethodDelete,
-			URL:    url.URL{Path: "/api/v3/runner/resource/my-org/linux-runner"},
+			URL:    url.URL{Path: "/api/v3/runner/resource/11111111-1111-4111-8111-111111111111/force"},
 			Header: http.Header{
 				"Authorization": {"Bearer test-token"},
 				"User-Agent":    {httpcl.UserAgent(runtime.GOOS, runtime.GOARCH, "dev", "")},
@@ -567,6 +573,27 @@ func TestRunnerResourceClassDelete_Force(t *testing.T) {
 			Body: new(""),
 		}, ignoreCommonHeaders))
 	})
+}
+
+func TestRunnerResourceClassDelete_Force_RemovesTokens(t *testing.T) {
+	_, env := setupRunnerFake(t)
+
+	del := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"runner", "resource-class", "delete", "my-org/linux-runner", "--force"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+	assert.Assert(t, cmp.Equal(del.ExitCode, 0))
+
+	list := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"runner", "token", "list", "--resource-class", "my-org/linux-runner", "--json"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+	assert.Check(t, cmp.Equal(list.ExitCode, 0), "stderr: %s", list.Stderr)
+	assert.Check(t, cmp.Equal(strings.TrimSpace(list.Stdout), "[]"))
 }
 
 func TestRunnerResourceClassDelete_NotFound(t *testing.T) {
@@ -592,7 +619,7 @@ func TestRunnerResourceClassDelete_NotFound(t *testing.T) {
 // Without --resource-class every resource class in the namespace is enumerated.
 func TestRunnerTokenList_EnumeratesEveryResourceClass(t *testing.T) {
 	fake, env := setupRunnerFake(t)
-	fake.AddResourceClass(fakeRC("rc-id-3", "my-org/idle-runner", "No runners attached"))
+	fake.AddResourceClass(fakeRC("33333333-3333-4333-8333-333333333333", "my-org/idle-runner", "No runners attached"))
 	fake.AddRunnerToken("my-org/idle-runner", fakeToken("tok-id-9", "my-org/idle-runner", "idle-token"))
 
 	dir := t.TempDir()

--- a/acceptance/testdata/TestRunnerResourceClassDelete_NotFound.stderr.txt
+++ b/acceptance/testdata/TestRunnerResourceClassDelete_NotFound.stderr.txt
@@ -1,6 +1,4 @@
-error: No runner resource found for "my-org/nonexistent".
-API: {"message":"not found"}
-
+error: No runner resource class named "my-org/nonexistent".
 
 Suggestions:
   • List available resource classes with: circleci runner resource-class list

--- a/acceptance/testdata/TestRunnerResourceClassList_JSON.json
+++ b/acceptance/testdata/TestRunnerResourceClassList_JSON.json
@@ -1,1 +1,1 @@
-[{"id":"rc-id-1","resource_class":"my-org/linux-runner","description":"Linux amd64 runner"},{"id":"rc-id-2","resource_class":"my-org/arm-runner","description":"ARM runner"}]
+[{"id":"11111111-1111-4111-8111-111111111111","resource_class":"my-org/linux-runner","description":"Linux amd64 runner"},{"id":"22222222-2222-4222-8222-222222222222","resource_class":"my-org/arm-runner","description":"ARM runner"}]

--- a/acceptance/testdata/TestRunnerResourceClassList_JSON_Color.json
+++ b/acceptance/testdata/TestRunnerResourceClassList_JSON_Color.json
@@ -1,11 +1,11 @@
 [1;37m[[m
   [1;37m{[m
-    [1;34m"id"[m[1;37m:[m [32m"rc-id-1"[m[1;37m,[m
+    [1;34m"id"[m[1;37m:[m [32m"11111111-1111-4111-8111-111111111111"[m[1;37m,[m
     [1;34m"resource_class"[m[1;37m:[m [32m"my-org/linux-runner"[m[1;37m,[m
     [1;34m"description"[m[1;37m:[m [32m"Linux amd64 runner"[m
   [1;37m}[m[1;37m,[m
   [1;37m{[m
-    [1;34m"id"[m[1;37m:[m [32m"rc-id-2"[m[1;37m,[m
+    [1;34m"id"[m[1;37m:[m [32m"22222222-2222-4222-8222-222222222222"[m[1;37m,[m
     [1;34m"resource_class"[m[1;37m:[m [32m"my-org/arm-runner"[m[1;37m,[m
     [1;34m"description"[m[1;37m:[m [32m"ARM runner"[m
   [1;37m}[m

--- a/internal/apiclient/runner.go
+++ b/internal/apiclient/runner.go
@@ -24,6 +24,9 @@ package apiclient
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"strings"
 
 	"github.com/google/uuid"
 )
@@ -109,10 +112,35 @@ func (c *Client) CreateResourceClass(ctx context.Context, resourceClass, descrip
 	return &rc, nil
 }
 
-// DeleteResourceClass deletes a runner resource class by its namespace/name slug.
-func (c *Client) DeleteResourceClass(ctx context.Context, resourceClass string) error {
-	return c.deleteV3(ctx, "/runner/resource/%s",
-		routeParams(resourceClass),
+// ErrResourceClassNotFound is returned by ResourceClassByName when no resource
+// class matches the slug.
+var ErrResourceClassNotFound = errors.New("resource class not found")
+
+// ResourceClassByName returns the resource class with the given namespace/name
+// slug. It lists the slug's namespace to find it.
+func (c *Client) ResourceClassByName(ctx context.Context, resourceClass string) (*ResourceClass, error) {
+	namespace, _, ok := strings.Cut(resourceClass, "/")
+	if !ok || namespace == "" {
+		return nil, fmt.Errorf("%w: %q is not in namespace/name form", ErrResourceClassNotFound, resourceClass)
+	}
+
+	classes, err := c.ListResourceClassesByNamespace(ctx, namespace)
+	if err != nil {
+		return nil, err
+	}
+	for _, rc := range classes {
+		if rc.ResourceClass == resourceClass {
+			return &rc, nil
+		}
+	}
+	return nil, fmt.Errorf("%w: %q", ErrResourceClassNotFound, resourceClass)
+}
+
+// DeleteResourceClass deletes a runner resource class by its id, along with any
+// tokens issued for it.
+func (c *Client) DeleteResourceClass(ctx context.Context, id uuid.UUID) error {
+	return c.deleteV3(ctx, "/runner/resource/%s/force",
+		routeParams(id.String()),
 	)
 }
 

--- a/internal/cmd/runner/resource_class.go
+++ b/internal/cmd/runner/resource_class.go
@@ -24,6 +24,7 @@ package runner
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -365,6 +366,13 @@ func newResourceClassDeleteCmd() *cobra.Command {
 }
 
 func runResourceClassDelete(ctx context.Context, client *apiclient.Client, resourceClass string, force bool) error {
+	if namespace, _, ok := strings.Cut(resourceClass, "/"); !ok || namespace == "" {
+		return clierrors.New("runner.malformed_resource_class", "Malformed resource class",
+			fmt.Sprintf("%q is not in namespace/name form.", resourceClass)).
+			WithSuggestions("Give the resource class as <namespace>/<name>, for example my-org/my-runner").
+			WithExitCode(clierrors.ExitBadArguments)
+	}
+
 	if err := cmdutil.ConfirmOrForce(ctx, iostream.Get(ctx), force,
 		fmt.Sprintf("Delete resource class %q? All tokens and runner connections will be removed.", resourceClass),
 		clierrors.New("runner.delete_aborted", "Deletion aborted",
@@ -377,7 +385,26 @@ func runResourceClassDelete(ctx context.Context, client *apiclient.Client, resou
 		return err
 	}
 
-	if err := client.DeleteResourceClass(ctx, resourceClass); err != nil {
+	rc, err := client.ResourceClassByName(ctx, resourceClass)
+	if err != nil {
+		if errors.Is(err, apiclient.ErrResourceClassNotFound) {
+			return clierrors.New("runner.not_found", "Not found",
+				fmt.Sprintf("No runner resource class named %q.", resourceClass)).
+				WithSuggestions("List available resource classes with: circleci runner resource-class list").
+				WithExitCode(clierrors.ExitNotFound)
+		}
+		if httpcl.HasStatusCode(err, http.StatusNotFound) {
+			return runnerNotEnabledErr()
+		}
+		return apiErr(err, resourceClass)
+	}
+
+	id, err := uuid.Parse(rc.ID)
+	if err != nil {
+		return apiErr(err, resourceClass)
+	}
+
+	if err := client.DeleteResourceClass(ctx, id); err != nil {
 		return apiErr(err, resourceClass)
 	}
 

--- a/internal/testing/fakes/circleci.go
+++ b/internal/testing/fakes/circleci.go
@@ -402,7 +402,8 @@ func NewCircleCI(t *testing.T) *CircleCI {
 	r.Get("/api/v3/runner", f.handleRunnerList)
 	r.Get("/api/v3/runner/resource", f.handleListResourceClasses)
 	r.Post("/api/v3/runner/resource", f.handleCreateResourceClass)
-	r.Delete("/api/v3/runner/resource/{namespace}/{name}", f.handleDeleteResourceClass)
+	r.Delete("/api/v3/runner/resource/{id}", f.handleDeleteResourceClass)
+	r.Delete("/api/v3/runner/resource/{id}/force", f.handleForceDeleteResourceClass)
 	r.Get("/api/v3/runner/token", f.handleListRunnerTokens)
 	r.Post("/api/v3/runner/token", f.handleCreateRunnerToken)
 	r.Delete("/api/v3/runner/token/{id}", f.handleDeleteRunnerToken)
@@ -1444,31 +1445,50 @@ func (f *CircleCI) handleCreateResourceClass(w http.ResponseWriter, r *http.Requ
 	render.JSON(w, r, rc)
 }
 
+// handleDeleteResourceClass serves DELETE /api/v3/runner/resource/{id}, which
+// refuses with 409 while the resource class still has tokens.
 func (f *CircleCI) handleDeleteResourceClass(w http.ResponseWriter, r *http.Request) {
-	slug := chi.URLParam(r, "namespace") + "/" + chi.URLParam(r, "name")
+	f.deleteResourceClass(w, r, false)
+}
+
+// handleForceDeleteResourceClass serves DELETE /api/v3/runner/resource/{id}/force,
+// which deletes the resource class and its tokens.
+func (f *CircleCI) handleForceDeleteResourceClass(w http.ResponseWriter, r *http.Request) {
+	f.deleteResourceClass(w, r, true)
+}
+
+func (f *CircleCI) deleteResourceClass(w http.ResponseWriter, r *http.Request, force bool) {
+	id := chi.URLParam(r, "id")
 	f.mu.Lock()
-	found := false
+	found, hasTokens := false, false
 	for _, rc := range f.resourceClasses {
 		m, ok := rc.(map[string]any)
 		if !ok {
 			continue
 		}
-		if m["resource_class"] == slug {
+		if m["id"] == id {
 			found = true
+			slug, _ := m["resource_class"].(string)
+			hasTokens = len(f.runnerTokens[slug]) > 0
+			if force || !hasTokens {
+				f.deletedRCs[slug] = true
+				delete(f.runnerTokens, slug)
+			}
 			break
 		}
 	}
-	if found {
-		f.deletedRCs[slug] = true
-	}
 	f.mu.Unlock()
 
-	if !found {
+	switch {
+	case !found:
 		render.Status(r, http.StatusNotFound)
 		render.JSON(w, r, map[string]any{"message": "not found"})
-		return
+	case !force && hasTokens:
+		render.Status(r, http.StatusConflict)
+		render.JSON(w, r, map[string]any{"message": "resource class still has tokens"})
+	default:
+		render.JSON(w, r, map[string]any{"message": "Deleted."})
 	}
-	render.JSON(w, r, map[string]any{"message": "Deleted."})
 }
 
 func (f *CircleCI) handleListRunnerTokens(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
The API addresses resource classes by UUID, but delete sent the `namespace/name` slug, so every attempt failed with `400 {"message":"id is not a valid uuid"}`. The command was unusable against the real API.

Resolve the slug through the namespace listing first, as the legacy CLI did, then delete by UUID. A slug that matches nothing now exits 5 from the lookup rather than surfacing a raw API 404 body.

Delete uses the `/force` endpoint so tokens go with the class, which is what the command already documents and its prompt already warns about. Without it the API returns 409 whenever a token exists.

The fake server routed the slug form, matching the CLI rather than the API, so no test could catch this. It now addresses resource classes by UUID and drops their tokens on delete.

Stacked on #1701, which fixes the namespace listing this lookup depends on. Review that one first.