### PR TITLE
Name the generated runner config after machine runner 3

### DIFF
--- a/acceptance/runner_test.go
+++ b/acceptance/runner_test.go
@@ -1034,7 +1034,7 @@ func TestRunnerConfig_ExistingToken(t *testing.T) {
 func TestRunnerConfig_OutputFile(t *testing.T) {
 	_, env := setupRunnerFake(t)
 	dir := t.TempDir()
-	outPath := dir + "/launch-agent-config.yaml"
+	outPath := dir + "/circleci-runner-config.yaml"
 
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,

--- a/internal/cmd/root/testdata/help/circleci/reference.txt
+++ b/internal/cmd/root/testdata/help/circleci/reference.txt
@@ -3342,7 +3342,7 @@ Resource class names use the format namespace/name (e.g. my-org/my-runner).
 Generate a runner agent configuration file
 
 Generate a runner agent configuration YAML for a resource class, suitable for
-use as the agent's launch-agent-config.yaml.
+use as the agent's circleci-runner-config.yaml.
 
 A new authentication token is created unless you pass an existing one with
 --token, which generates the YAML without an API call.
@@ -3364,9 +3364,9 @@ in the form `namespace/name` (for example, `my-org/my-runner`).
 - Create a new token and print config to stdout: 
   `circleci runner config my-org/my-runner`
 - Write config directly to a file: 
-  `circleci runner config my-org/my-runner --output launch-agent-config.yaml`
+  `circleci runner config my-org/my-runner --output circleci-runner-config.yaml`
 - Create a nicely-labeled token and write to a file: 
-  `circleci runner config my-org/my-runner --nickname "prod-server-1" --output /etc/circleci/launch-agent-config.yaml`
+  `circleci runner config my-org/my-runner --nickname "prod-server-1" --output /etc/circleci-runner/circleci-runner-config.yaml`
 - Generate config from an existing token value (no API token creation): 
   `circleci runner config my-org/my-runner --token "$EXISTING_TOKEN_VALUE"`
 

--- a/internal/cmd/root/testdata/help/circleci/runner/config.txt
+++ b/internal/cmd/root/testdata/help/circleci/runner/config.txt
@@ -24,16 +24,16 @@ Global flags: `-c, --config`, `--debug`, `--no-color`, `-q, --quiet` — see `ci
 - Create a new token and print config to stdout: 
   `circleci runner config my-org/my-runner`
 - Write config directly to a file: 
-  `circleci runner config my-org/my-runner --output launch-agent-config.yaml`
+  `circleci runner config my-org/my-runner --output circleci-runner-config.yaml`
 - Create a nicely-labeled token and write to a file: 
-  `circleci runner config my-org/my-runner --nickname "prod-server-1" --output /etc/circleci/launch-agent-config.yaml`
+  `circleci runner config my-org/my-runner --nickname "prod-server-1" --output /etc/circleci-runner/circleci-runner-config.yaml`
 - Generate config from an existing token value (no API token creation): 
   `circleci runner config my-org/my-runner --token "$EXISTING_TOKEN_VALUE"`
 
 ## Details
 
 Generate a runner agent configuration YAML for a resource class, suitable for
-use as the agent's launch-agent-config.yaml.
+use as the agent's circleci-runner-config.yaml.
 
 A new authentication token is created unless you pass an existing one with
 --token, which generates the YAML without an API call.

--- a/internal/cmd/runner/config.go
+++ b/internal/cmd/runner/config.go
@@ -53,7 +53,7 @@ func newConfigCmd() *cobra.Command {
 		},
 		Long: heredoc.Doc(`
 			Generate a runner agent configuration YAML for a resource class, suitable for
-			use as the agent's launch-agent-config.yaml.
+			use as the agent's circleci-runner-config.yaml.
 
 			A new authentication token is created unless you pass an existing one with
 			--token, which generates the YAML without an API call.
@@ -63,10 +63,10 @@ func newConfigCmd() *cobra.Command {
 			$ circleci runner config my-org/my-runner
 
 			# Write config directly to a file
-			$ circleci runner config my-org/my-runner --output launch-agent-config.yaml
+			$ circleci runner config my-org/my-runner --output circleci-runner-config.yaml
 
 			# Create a nicely-labeled token and write to a file
-			$ circleci runner config my-org/my-runner --nickname "prod-server-1" --output /etc/circleci/launch-agent-config.yaml
+			$ circleci runner config my-org/my-runner --nickname "prod-server-1" --output /etc/circleci-runner/circleci-runner-config.yaml
 
 			# Generate config from an existing token value (no API token creation)
 			$ circleci runner config my-org/my-runner --token "$EXISTING_TOKEN_VALUE"


### PR DESCRIPTION
`circleci-launch-agent` 1.1 is [deprecated](https://circleci.com/docs/guides/execution-runner/runner-overview/#circleci-launch-agent-1-1-deprecated) and machine runner 3 is its replacement, so `runner config` should not point people at a file the current agent does not read.

The generated YAML is unchanged. Machine runner 3 still takes the token at `api.auth_token`, only the file it lives in was renamed to `/etc/circleci-runner/circleci-runner-config.yaml` ([config reference](https://circleci.com/docs/guides/execution-runner/machine-runner-3-configuration-reference/#introduction)).