### PR TITLE
Wrap org ID in backticks in org list table output

### DIFF
--- a/acceptance/testdata/TestOrgList.txt
+++ b/acceptance/testdata/TestOrgList.txt
@@ -1,4 +1,4 @@
 # Organizations
-| Slug     | Name  | VCS    | Organization ID                      |
-| -------- | ----- | ------ | ------------------------------------ |
-| gh/myorg | myorg | github | a0000000-0000-4000-8000-0000000c0002 |
+| Slug     | Name  | VCS    | Organization ID                        |
+| -------- | ----- | ------ | -------------------------------------- |
+| gh/myorg | myorg | github | `a0000000-0000-4000-8000-0000000c0002` |

--- a/internal/cmd/org/list.go
+++ b/internal/cmd/org/list.go
@@ -116,7 +116,7 @@ func runOrgList(ctx context.Context, client *apiclient.Client, jsonOut bool) err
 				vcs = parts[0]
 			}
 		}
-		tbl.Row(o.Slug, o.Name, vcs, o.ID)
+		tbl.Row(o.Slug, o.Name, vcs, "`"+o.ID+"`")
 	}
 	iostream.PrintMarkdown(ctx, fmt.Sprintf("# Organizations\n%s", tbl.Render()))
 	return nil


### PR DESCRIPTION
## Summary
- Wrap the organization ID in backticks in the human-readable `org list` table output so it renders as inline code in Markdown viewers

## Test plan
- [ ] `task test -- -run TestOrgList ./acceptance/...` passes
- [ ] `go run ./cmd/circleci org list` shows org ID wrapped in backticks