### PR TITLE
Handle unstarted jobs more gracefully

### DIFF
--- a/acceptance/run_test.go
+++ b/acceptance/run_test.go
@@ -507,6 +507,7 @@ const (
 	irunWfID   = "b0000000-0000-4000-8000-0000000000a1"
 	irunJob1ID = "d0000000-0000-4000-8000-0000000000a1"
 	irunJob2ID = "d0000000-0000-4000-8000-0000000000a2"
+	irunJob3ID = "d0000000-0000-4000-8000-0000000000a3"
 
 	// keyEsc is a lone Escape byte. In the interactive picker esc means "go
 	// back a step" (except on the first picker, where it quits).
@@ -547,10 +548,31 @@ func setupRunGetInteractiveFake(t *testing.T) *testenv.TestEnv {
 	wf := fakeWorkflowV3(irunWfID, "build", irunRun1ID, runTestProjectID, "ended", "succeeded")
 	fake.AddRunWorkflowsV3(irunRun1ID, wf)
 	fake.AddWorkflowV3(irunWfID, wf)
+	// A job that has not started, wired the way the API really reports one. The
+	// jobs *list* calls it "started" the moment the workflow dispatches it and
+	// simply omits started_at; the job's own detail endpoint says "queued" and
+	// carries no parallel executions. Reported verbatim the row would draw the
+	// running ● and then have no steps to drill into.
+	queuedListJob := fakeJobV3(irunJob3ID, "publish", irunWfID, runTestProjectID)
+	queuedListAttrs := queuedListJob["attributes"].(map[string]any)
+	queuedListAttrs["phase"] = "started"
+	delete(queuedListAttrs, "outcome")
+	delete(queuedListAttrs, "started_at")
+	delete(queuedListAttrs, "ended_at")
+
+	queuedDetailJob := fakeJobV3(irunJob3ID, "publish", irunWfID, runTestProjectID)
+	queuedDetailAttrs := queuedDetailJob["attributes"].(map[string]any)
+	queuedDetailAttrs["phase"] = "queued"
+	delete(queuedDetailAttrs, "outcome")
+	delete(queuedDetailAttrs, "started_at")
+	delete(queuedDetailAttrs, "ended_at")
+
 	fake.AddWorkflowJobsV3(irunWfID,
 		fakeJobV3(irunJob1ID, "run-tests", irunWfID, runTestProjectID),
 		fakeJobV3(irunJob2ID, "deploy", irunWfID, runTestProjectID),
+		queuedListJob,
 	)
+	fake.AddJobV3(irunJob3ID, map[string]any{"data": queuedDetailJob})
 
 	// The job the step picker drills into: two steps, the second failed.
 	now := time.Date(2020, 1, 1, 12, 0, 0, 0, time.UTC).Format(v3TimeFormat)
@@ -745,6 +767,47 @@ func TestRunGet_Interactive_FullOutputReport(t *testing.T) {
 	assert.NilError(t, err)
 
 	// The report is paged in-flow, so the program is still running; ctrl+c quits.
+	_, err = console.Send(keyCtrlC)
+	assert.NilError(t, err)
+}
+
+// TestRunGet_Interactive_QueuedJobReport drills into a job that has not started —
+// one the jobs list optimistically calls "started" with no started_at (see
+// setupRunGetInteractiveFake). The row must read "(queued)" rather than draw the
+// running dot, and since the job has no steps the flow pages its job report
+// in-flow: esc returns to the job picker instead of the program quitting to print
+// the report.
+func TestRunGet_Interactive_QueuedJobReport(t *testing.T) {
+	env := setupRunGetInteractiveFake(t)
+	console := startRunGetInteractive(t, env)
+
+	_, err := console.ExpectString("Select a run")
+	assert.NilError(t, err)
+	_, err = console.Send("\r")
+	assert.NilError(t, err)
+
+	_, err = console.ExpectString("build")
+	assert.NilError(t, err)
+	_, err = console.Send(keyDown + "\r") // skip "see all workflows"
+	assert.NilError(t, err)
+
+	// Pick "publish": past "all jobs in workflow", "run-tests" and "deploy".
+	_, err = console.ExpectString("publish (queued)")
+	assert.NilError(t, err)
+	_, err = console.Send(keyDown + keyDown + keyDown + "\r")
+	assert.NilError(t, err)
+
+	// The job report is paged in-flow; it carries the job's own UUID.
+	_, err = console.ExpectString(irunJob3ID)
+	assert.NilError(t, err)
+
+	// esc returns to the job picker, which rewrites its rows in full.
+	_, err = console.Send(keyEsc)
+	assert.NilError(t, err)
+	_, err = console.ExpectString("publish (queued)")
+	assert.NilError(t, err)
+
+	// The flow is still running, so ctrl+c quits.
 	_, err = console.Send(keyCtrlC)
 	assert.NilError(t, err)
 }

--- a/internal/apiclient/job.go
+++ b/internal/apiclient/job.go
@@ -207,6 +207,28 @@ func (w jobWire) toJobV3() *JobV3 {
 	return j
 }
 
+// V3 lifecycle phases, as reported in the phase field of a run, workflow, job or
+// step. The API is free to report others (it has its own vocabulary for the
+// pre-start states); see PhaseNotStarted.
+const (
+	PhaseCreated = "created"
+	PhaseQueued  = "queued"
+	PhaseStarted = "started"
+	PhaseEnded   = "ended"
+)
+
+// PhaseNotStarted reports whether a phase means the work has not begun: the
+// "created" and "queued" phases, and — deliberately — any phase this client does
+// not recognise. Only "started" and "ended" describe work that has produced
+// something to look at, so an unfamiliar phase is presumed to be another
+// pre-start state rather than a synonym for one of those two. An unrecognised
+// phase has no glyph of its own (PhaseOutcomeSymbol falls back to a neutral
+// bullet, easily read as "running"), so the caller needs to be able to tell it
+// apart from a job that is genuinely running.
+func PhaseNotStarted(phase string) bool {
+	return phase != PhaseStarted && phase != PhaseEnded
+}
+
 // PhaseOutcomeStatus derives a human-readable status string from V3
 // phase, outcome, and current_outcome fields, prefixed with a status emoji.
 // The emoji is a real Unicode glyph (e.g. "✅ succeeded"), not a ":shortcode:",
@@ -238,11 +260,11 @@ func PhaseOutcomeText(phase, outcome, currentOutcome string) string {
 // and PhaseOutcomeText. An empty emoji means the word stands alone.
 func phaseOutcomeParts(phase, outcome, currentOutcome string) (emoji, text string) {
 	switch phase {
-	case "created":
+	case PhaseCreated:
 		return "⏳", "created"
-	case "queued":
+	case PhaseQueued:
 		return "⌛", "queued"
-	case "started":
+	case PhaseStarted:
 		switch currentOutcome {
 		case "failed":
 			return "🔴", "failing"
@@ -253,7 +275,7 @@ func phaseOutcomeParts(phase, outcome, currentOutcome string) (emoji, text strin
 		default:
 			return "🔵", "running"
 		}
-	case "ended":
+	case PhaseEnded:
 		// The V3 runs API reports only current_outcome, never outcome,
 		// even once a run has ended (a rerun can change it later).
 		if outcome == "" {
@@ -271,9 +293,9 @@ func phaseOutcomeParts(phase, outcome, currentOutcome string) (emoji, text strin
 // width-2 emoji from PhaseOutcomeStatus would throw off column padding.
 func PhaseOutcomeSymbol(phase, outcome, currentOutcome string) string {
 	switch phase {
-	case "created", "queued":
+	case PhaseCreated, PhaseQueued:
 		return "○"
-	case "started":
+	case PhaseStarted:
 		switch currentOutcome {
 		case "failed":
 			return "✗"
@@ -284,7 +306,7 @@ func PhaseOutcomeSymbol(phase, outcome, currentOutcome string) string {
 		default:
 			return "●"
 		}
-	case "ended":
+	case PhaseEnded:
 		// As in PhaseOutcomeStatus, the V3 runs API reports only
 		// current_outcome once a run has ended.
 		if outcome == "" {

--- a/internal/apiclient/phase_outcome_test.go
+++ b/internal/apiclient/phase_outcome_test.go
@@ -66,6 +66,22 @@ func TestPhaseOutcome_StatusIsTextWithEmoji(t *testing.T) {
 	}
 }
 
+// TestPhaseNotStarted checks the "has this work begun?" predicate: only
+// "started" and "ended" describe work that has produced something to look at, so
+// every other phase — including one this client has no glyph or wording for —
+// counts as not started. That default matters: an unrecognised phase renders as a
+// neutral bullet, which reads like the running dot, so callers must be able to
+// tell it apart from a job that is genuinely running.
+func TestPhaseNotStarted(t *testing.T) {
+	notStarted := []string{"created", "queued", "pending", "blocked", "some_new_phase", ""}
+	for _, phase := range notStarted {
+		assert.Check(t, apiclient.PhaseNotStarted(phase), "phase %q should count as not started", phase)
+	}
+	for _, phase := range []string{"started", "ended"} {
+		assert.Check(t, !apiclient.PhaseNotStarted(phase), "phase %q should count as started", phase)
+	}
+}
+
 // TestStatusPhaseOutcome checks the pipeline.status → (phase, current_outcome)
 // reverse mapping the my-runs endpoint filters on: terminal statuses map to an
 // "ended" phase with the matching outcome, in-progress statuses to their

--- a/internal/apiclient/workflow.go
+++ b/internal/apiclient/workflow.go
@@ -202,7 +202,7 @@ func (w workflowJobWire) toDomain() WorkflowJobV3 {
 	return WorkflowJobV3{
 		ID:             w.ID,
 		Name:           a.Name,
-		Phase:          a.Phase,
+		Phase:          effectiveJobPhase(a.Phase, a.StartedAt),
 		Outcome:        a.Outcome,
 		CurrentOutcome: a.CurrentOutcome,
 		Type:           a.Type,
@@ -210,6 +210,32 @@ func (w workflowJobWire) toDomain() WorkflowJobV3 {
 		StartedAt:      a.StartedAt,
 		EndedAt:        a.EndedAt,
 	}
+}
+
+// effectiveJobPhase corrects the phase the jobs *list* endpoint reports, which is
+// optimistic: it flips a job to "started" as soon as its workflow dispatches the
+// job, while the job is still waiting for an executor. Observed on one workflow's
+// list response, all six jobs at once:
+//
+//	list   GET /jobs?filter[workflow_id]=…  → phase "started", started_at null
+//	detail GET /jobs/{id}                   → phase "queued",  started_at null,
+//	                                          parallel_executions []
+//
+// started_at is stamped only when the job really begins. Taking the list's phase
+// verbatim therefore shows a queued job as running — a blue ● in the interactive
+// picker, "🔵 running" in the summary tables, "phase":"started" in --json — and
+// then finds no steps to drill into. A "started" job with no start time is
+// reported as queued instead, which is what the job's own detail says.
+//
+// The list also lags by a second or two the other way: a job that has just begun
+// can still show a null started_at, so it reads as queued until the next poll.
+// That is the lesser error — the phase and started_at it returns contradict each
+// other, and the row is only ever mislabelled, never made unreachable.
+func effectiveJobPhase(phase string, startedAt *time.Time) string {
+	if phase == PhaseStarted && startedAt == nil {
+		return PhaseQueued
+	}
+	return phase
 }
 
 // GetWorkflowJobsV3 returns all jobs for a workflow via the V3 API.

--- a/internal/apiclient/workflow_test.go
+++ b/internal/apiclient/workflow_test.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package apiclient_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+
+	"github.com/CircleCI-Public/circleci-cli/internal/apiclient"
+	"github.com/CircleCI-Public/circleci-cli/internal/iostream"
+)
+
+// TestGetWorkflowJobsV3_QueuedJobPhase pins the correction applied to the jobs
+// list endpoint's optimistic phase. The body below is a real response, trimmed to
+// three jobs: every job in the workflow reads "started" the moment the workflow
+// dispatches it, and the ones still waiting for an executor simply omit
+// started_at — while GET /jobs/{id} for those same jobs returns phase "queued"
+// with no parallel_executions.
+//
+// Reported verbatim, a queued job is indistinguishable from a running one: the
+// interactive picker draws the blue running ●, the summary tables say
+// "🔵 running", --json says "phase":"started" — and drilling in finds no steps.
+// So a "started" job with no start time is reported as queued.
+func TestGetWorkflowJobsV3_QueuedJobPhase(t *testing.T) {
+	ctx := iostream.Testing(context.Background())
+	workflowID := uuid.MustParse("a2d4f75d-f6f9-46dc-8e7b-1ea85c40d0ed")
+
+	const body = `{"data":[
+		{"id":"4405c050-a8b8-474f-aa70-79efcf25bc4a",
+		 "attributes":{"number":47378,"name":"docs","type":"build","phase":"started"}},
+		{"id":"1a8727c9-ccf2-40f5-814c-7c1cd56c5677",
+		 "attributes":{"number":47379,"name":"test-macos","type":"build","phase":"started","started_at":"2026-08-07T12:09:59.650Z"}},
+		{"id":"bc7361ba-9aa1-44da-822d-beb9e9dca672",
+		 "attributes":{"number":47383,"name":"check","type":"build","phase":"ended","outcome":"succeeded","started_at":"2026-08-07T12:09:59.346Z","ended_at":"2026-08-07T12:12:01.000Z"}}
+	]}`
+
+	r := chi.NewMux()
+	r.Get("/api/v3/jobs", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	})
+	srv := httptest.NewServer(r)
+	t.Cleanup(srv.Close)
+
+	c := apiclient.New(apiclient.Config{BaseURL: srv.URL, Token: "t", Version: "1.2.3"})
+	jobs, err := c.GetWorkflowJobsV3(ctx, workflowID)
+	assert.NilError(t, err)
+	assert.Assert(t, is.Len(jobs, 3))
+
+	// "started" with no start time is really queued — the state that used to read
+	// as running and then had no steps to open.
+	assert.Check(t, is.Equal(jobs[0].Name, "docs"))
+	assert.Check(t, is.Equal(jobs[0].Phase, apiclient.PhaseQueued))
+	assert.Check(t, is.Nil(jobs[0].StartedAt))
+	assert.Check(t, is.Equal(jobs[0].Status(), "⌛ queued"))
+	assert.Check(t, is.Equal(apiclient.PhaseOutcomeSymbol(jobs[0].Phase, jobs[0].Outcome, jobs[0].CurrentOutcome), "○"))
+
+	// A job with a start time is left alone: it really is running.
+	assert.Check(t, is.Equal(jobs[1].Name, "test-macos"))
+	assert.Check(t, is.Equal(jobs[1].Phase, apiclient.PhaseStarted))
+	assert.Check(t, is.Equal(apiclient.PhaseOutcomeSymbol(jobs[1].Phase, jobs[1].Outcome, jobs[1].CurrentOutcome), "●"))
+
+	// So is a finished one — the correction only ever applies to "started".
+	assert.Check(t, is.Equal(jobs[2].Name, "check"))
+	assert.Check(t, is.Equal(jobs[2].Phase, apiclient.PhaseEnded))
+	assert.Check(t, is.Equal(jobs[2].Status(), "✅ succeeded"))
+}

--- a/internal/cmd/run/get.go
+++ b/internal/cmd/run/get.go
@@ -558,13 +558,29 @@ func jobItems(client *apiclient.Client) func(context.Context, uuid.UUID) ([]ui.R
 		items := make([]ui.RunGetItem, len(jobs))
 		for i, j := range jobs {
 			items[i] = ui.RunGetItem{
-				ID:    j.ID,
-				Icon:  apiclient.PhaseOutcomeSymbol(j.Phase, j.Outcome, j.CurrentOutcome),
-				Label: j.Name,
+				ID:      j.ID,
+				Icon:    apiclient.PhaseOutcomeSymbol(j.Phase, j.Outcome, j.CurrentOutcome),
+				Label:   j.Name,
+				Pending: pendingJobStatus(j),
 			}
 		}
 		return items, nil
 	}
+}
+
+// pendingJobStatus names the status of a job that has not started — "queued",
+// "created", or the phase verbatim for a pre-start state this client does not know
+// — and is empty once the job is running or finished. Such a job has no steps yet,
+// so the picker labels the row with the status rather than letting a hollow or
+// neutral dot pass for a running job (see ui.RunGetItem.Pending). The phase it
+// reads has already been corrected for the jobs list's optimistic "started" (see
+// apiclient.effectiveJobPhase), which is what made a queued job indistinguishable
+// from a running one here.
+func pendingJobStatus(j apiclient.WorkflowJobV3) string {
+	if !apiclient.PhaseNotStarted(j.Phase) {
+		return ""
+	}
+	return apiclient.PhaseOutcomeText(j.Phase, j.Outcome, j.CurrentOutcome)
 }
 
 // executionItems returns a fetch closure for the run-get picker: it lists a

--- a/internal/cmd/run/get_test.go
+++ b/internal/cmd/run/get_test.go
@@ -80,6 +80,40 @@ func TestStepRows_UnfinishedStep(t *testing.T) {
 	assert.Check(t, strings.Contains(rows[1].Label, "~    "), "~ should be padded to the duration column width: %q", rows[1].Label)
 }
 
+// TestPendingJobStatus covers the status word the job picker appends to a job that
+// has not started, so it does not read like a running one. The phase arrives
+// already corrected for the jobs list's optimistic "started" (see
+// apiclient.effectiveJobPhase and TestGetWorkflowJobsV3_QueuedJobPhase), so
+// "queued" here is the state that actually caused the confusion. An unrecognised
+// phase is passed through verbatim rather than dropped: it has no glyph of its own,
+// so the word is all the user gets. A running or finished job gets no word — its
+// glyph already says it.
+func TestPendingJobStatus(t *testing.T) {
+	tests := []struct {
+		phase, outcome, current string
+		want                    string
+	}{
+		{phase: "queued", want: "queued"},
+		{phase: "created", want: "created"},
+		{phase: "pending", want: "pending"},    // unrecognised pre-start phase, verbatim
+		{phase: "blocked", want: "blocked"},    // ditto
+		{phase: "started", want: ""},           // running: the ● glyph is enough
+		{phase: "started", current: "failed"},  // failing
+		{phase: "ended", outcome: "succeeded"}, // finished
+		{phase: "ended", current: "not_run"},   // finished without running
+		{phase: "", want: ""},                  // no phase reported: nothing to say
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.phase+"/"+tt.outcome+tt.current, func(t *testing.T) {
+			got := pendingJobStatus(apiclient.WorkflowJobV3{
+				Phase: tt.phase, Outcome: tt.outcome, CurrentOutcome: tt.current,
+			})
+			assert.Check(t, is.Equal(got, tt.want))
+		})
+	}
+}
+
 // TestRunItemLabel covers the picker label for well-formed runs and for runs
 // that resolved no commit — an errored/not-run pipeline whose config could not
 // be fetched — where the old "%s [%s]" format left a blank "[]" row.

--- a/internal/ui/run_get_flow.go
+++ b/internal/ui/run_get_flow.go
@@ -184,6 +184,15 @@ type RunGetItem struct {
 	// that produced no workflows (e.g. a config that failed to compile) explains
 	// itself rather than presenting an empty list.
 	Errors []RunGetError
+	// Pending, set only for job rows, names the status of a job that has not started
+	// yet — "queued", "created" — and is empty once the job is running or finished.
+	// Those states are the ones the glyph column conveys least well: they sit a
+	// hollow or neutral dot away from the running one, and the API's own jobs list
+	// reports a queued job as "started" until the CLI corrects it
+	// (apiclient.effectiveJobPhase). Such a job also has no steps to pick from — it
+	// opens straight into its job report — so the picker appends the status to the
+	// label, making it unmistakable beside a running job before it is picked.
+	Pending string
 }
 
 // RunGetError is a single run-level error (type + message) surfaced under the
@@ -1175,9 +1184,12 @@ func (m RunGetFlowModel) onExecutions(msg runGetExecutionsMsg) (tea.Model, tea.C
 
 	switch len(m.executions) {
 	case 0:
-		// No resolvable steps — skip straight to the job report rather than show
-		// an empty picker.
-		return m.quit(RunGetResult{Action: RunGetActionShowJob, JobID: m.jobID})
+		// No resolvable steps — a queued job has none yet — so skip the empty step
+		// picker and page the job report in-flow, esc returning to the job picker.
+		// Quitting the program to print the report instead would drop the user out of
+		// the flow with no way back, for a job that may simply not have started.
+		return m.openSummary(m.opts.RenderJobSummary, m.jobID, runGetStageJobSelect,
+			"Fetching job report", RunGetResult{Action: RunGetActionShowJob, JobID: m.jobID})
 	case 1:
 		// Single execution: no execution picker, go straight to its steps.
 		return m.enterStepSelect(m.executions[0]), nil
@@ -1835,13 +1847,41 @@ func (m RunGetFlowModel) runErrorNote() string {
 }
 
 func (m RunGetFlowModel) newJobSelect() components.SelectModel {
-	labels := append([]string{runGetAllJobsLabel}, itemLabels(m.jobs)...)
+	labels := append([]string{runGetAllJobsLabel}, m.jobLabels()...)
 	icons := append([]string{m.metaIcon()}, m.itemIcons(m.jobs)...)
 	return components.NewSelectModel("Select a job", labels).
 		WithIcons(icons).
+		WithItemStyleFunc(m.jobItemStyle).
 		WithCursor(m.jobCursor).
 		WithKeys(m.backKeys()...).
 		WithHeight(m.height)
+}
+
+// jobLabels are the job picker's rows: the job name, with the status of a job that
+// has not started appended — "deploy (queued)". The ○/● glyph difference alone is
+// easy to miss, and picking such a job leads to a job report rather than steps, so
+// the row says as much in words.
+func (m RunGetFlowModel) jobLabels() []string {
+	labels := make([]string, len(m.jobs))
+	for i, j := range m.jobs {
+		labels[i] = j.Label
+		if j.Pending != "" {
+			labels[i] += " (" + j.Pending + ")"
+		}
+	}
+	return labels
+}
+
+// jobItemStyle mutes the label of a job that has not started, so it recedes
+// beside the jobs that have work to show. Index 0 is the leading "all jobs"
+// summary option, which offsets the job rows. Every other row — and every row when
+// color is off, where the "(queued)" suffix carries the distinction on its own —
+// renders plain.
+func (m RunGetFlowModel) jobItemStyle(i int) lipgloss.Style {
+	if !m.opts.Color || i < 1 || i > len(m.jobs) || m.jobs[i-1].Pending == "" {
+		return lipgloss.Style{}
+	}
+	return theme.HelperStyle
 }
 
 func (m RunGetFlowModel) newExecutionSelect() components.SelectModel {
@@ -2006,8 +2046,11 @@ func statusIconStyle(symbol string) (lipgloss.Style, bool) {
 		return theme.WarningStyle, true // errored / timed out
 	case "●":
 		return theme.RunningStyle, true // running
-	case "○", "⊘":
-		return theme.HelperStyle, true // created/queued, canceled
+	case "○", "⊘", "•":
+		// Created/queued, canceled, and the neutral bullet PhaseOutcomeSymbol falls
+		// back to for a phase or outcome it does not know. The bullet is muted for the
+		// same reason: uncolored, it reads as a filled dot much like the running one.
+		return theme.HelperStyle, true
 	default:
 		return lipgloss.Style{}, false
 	}

--- a/internal/ui/run_get_flow_test.go
+++ b/internal/ui/run_get_flow_test.go
@@ -1086,6 +1086,100 @@ func TestRunGetFlow_JobReportPager(t *testing.T) {
 	}))
 }
 
+// newQueuedJobFlow builds a flow whose workflow holds a started job ("test") and
+// one that has not started yet ("deploy", queued). Only the started job has
+// executions: a queued job reports none, so picking it has no steps to show.
+func newQueuedJobFlow() ui.RunGetFlowModel {
+	started := ui.RunGetItem{ID: uuid.New(), Icon: "●", Label: "test"}
+	queued := ui.RunGetItem{ID: uuid.New(), Icon: "○", Label: "deploy", Pending: "queued"}
+	return ui.NewRunGetFlow(context.Background(), ui.RunGetFlowOptions{
+		Runs:          []ui.RunGetItem{runItem("aaaaaaa [main] - now")},
+		CurrentBranch: "main",
+		FetchWorkflows: func(context.Context, uuid.UUID) ([]ui.RunGetItem, error) {
+			return []ui.RunGetItem{{ID: uuid.New(), Icon: "●", Label: "build"}}, nil
+		},
+		FetchJobs: func(context.Context, uuid.UUID) ([]ui.RunGetItem, error) {
+			return []ui.RunGetItem{started, queued}, nil
+		},
+		FetchExecutions: func(_ context.Context, jobID uuid.UUID) ([]ui.RunGetExecution, error) {
+			if jobID != started.ID {
+				return nil, nil
+			}
+			return []ui.RunGetExecution{{Index: 0, Steps: []ui.RunGetStepItem{
+				{Label: "checkout", Icon: "✓", Execution: 0, StepNum: 100},
+			}}}, nil
+		},
+		RenderJobSummary: func(context.Context, uuid.UUID) (string, error) { return "QUEUED-JOB-REPORT-BODY", nil },
+		RenderMarkdown:   func(md string, _ int) string { return md },
+	})
+}
+
+// driveToQueuedJob selects the only run, then the single workflow, then moves the
+// cursor onto the queued job — two rows down from the leading "all jobs in
+// workflow" option, past the started job.
+func driveToQueuedJob(t *testing.T, tm *teatest.TestModel) {
+	t.Helper()
+	tm.Send(keyEnt) // select the only run
+	waitForOutput(t, tm, "See all workflows")
+	tm.Send(keyDown)
+	tm.Send(keyEnt) // select "build"
+	waitForOutput(t, tm, "All jobs in workflow")
+	tm.Send(keyDown) // → "test"
+	tm.Send(keyDown) // → "deploy (queued)"
+}
+
+// TestRunGetFlow_JobPickerLabelsQueuedJob confirms a job that has not started
+// carries its status in the label, so it does not read like the started job
+// beside it (whose label stays bare).
+func TestRunGetFlow_JobPickerLabelsQueuedJob(t *testing.T) {
+	tm := startFlow(t, newQueuedJobFlow())
+	driveToQueuedJob(t, tm)
+
+	v := flowSnapshot(t, tm)
+	assert.Check(t, cmp.Contains(v, "deploy (queued)"))
+	assert.Check(t, cmp.Contains(v, "test"))
+	assert.Check(t, !strings.Contains(v, "test ("))
+}
+
+// TestRunGetFlow_QueuedJobReportPagesInFlow confirms a job with no steps — a
+// queued one — opens its job report in the in-flow pager, so esc returns to the
+// job picker instead of the flow quitting and printing the report.
+func TestRunGetFlow_QueuedJobReportPagesInFlow(t *testing.T) {
+	tm := startFlow(t, newQueuedJobFlow())
+
+	assert.Assert(t, t.Run("the queued job opens its report in the pager", func(t *testing.T) {
+		driveToQueuedJob(t, tm)
+		tm.Send(keyEnt)
+		waitForOutput(t, tm, "QUEUED-JOB-REPORT-BODY")
+		assert.Check(t, cmp.Contains(flowSnapshot(t, tm), "esc back"))
+	}))
+
+	assert.Assert(t, t.Run("esc returns to the job picker", func(t *testing.T) {
+		tm.Send(keyEsc)
+		v := flowSnapshot(t, tm)
+		assert.Check(t, cmp.Contains(v, "Select a job"))
+		// Back on the row it was opened from.
+		assert.Check(t, cmp.Contains(v, "› ○ deploy (queued)"))
+	}))
+}
+
+// TestRunGetFlow_JobPickerOpensStartedJob is the counterpart: a job that has
+// started still leads to its step picker.
+func TestRunGetFlow_JobPickerOpensStartedJob(t *testing.T) {
+	tm := startFlow(t, newQueuedJobFlow())
+
+	tm.Send(keyEnt) // select the only run
+	waitForOutput(t, tm, "See all workflows")
+	tm.Send(keyDown)
+	tm.Send(keyEnt) // select "build"
+	waitForOutput(t, tm, "All jobs in workflow")
+	tm.Send(keyDown) // → "test"
+	tm.Send(keyEnt)
+	waitForOutput(t, tm, "checkout")
+
+	assert.Check(t, cmp.Contains(flowSnapshot(t, tm), "Select a step"))
+}
+
 // TestRunGetFlow_FullJobOutputPager confirms the "full job report" option opens
 // the full per-step output in an in-flow pager and esc returns to the step
 // picker.


### PR DESCRIPTION
This avoids dumping you out of the `run get` TUI when a job hasn't quite started yet