### PR TITLE
Compile config through the v3 configs/compile endpoint

### DIFF
--- a/acceptance/config_test.go
+++ b/acceptance/config_test.go
@@ -503,7 +503,7 @@ func TestConfigValidate_NoToken(t *testing.T) {
 
 	var compiled bool
 	for _, req := range fake.AllRequests() {
-		if req.URL.Path != "/api/v2/compile-config-with-defaults" {
+		if req.URL.Path != "/api/v3/configs/compile" {
 			continue
 		}
 		compiled = true
@@ -539,9 +539,83 @@ func TestConfigValidate_NoTokenSkipsOrgInference(t *testing.T) {
 	assert.Check(t, cmp.Equal(result.ExitCode, 0), "stderr: %s", result.Stderr)
 	assert.Check(t, cmp.Equal(fake.LastCompileOwnerID(), ""))
 	for _, req := range fake.AllRequests() {
-		assert.Check(t, cmp.Equal(req.URL.Path, "/api/v2/compile-config-with-defaults"),
+		assert.Check(t, cmp.Equal(req.URL.Path, "/api/v3/configs/compile"),
 			"unexpected request on the anonymous path")
 	}
+}
+
+// TestConfigValidate_UsesV3Compile pins the request the CLI sends to the v3
+// compile endpoint. The endpoint rejects unknown members, so the body shape —
+// config under data.attributes, the org as a data.references entry — is part of
+// the contract, not an implementation detail.
+func TestConfigValidate_UsesV3Compile(t *testing.T) {
+	fake := fakes.NewCircleCI(t)
+	fake.SetCompileResponse(true, testCompiledYAML)
+	fake.AddOrg(testOrgUUID, "gh/myorg", "myorg", "github")
+
+	env := testenv.New(t)
+	env.Token = testToken
+	env.CircleCIURL = fake.URL()
+
+	dir := t.TempDir()
+	writeConfig(t, dir, testConfigYAML)
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"config", "validate", "--config", ".circleci/config.yml", "--org", "gh/myorg", "--next"},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	assert.Check(t, cmp.Equal(result.ExitCode, 0), "stderr: %s", result.Stderr)
+	assert.Check(t, cmp.Equal(fake.LastCompileAPIVersion(), "v3"))
+	assert.Check(t, cmp.Equal(fake.LastCompileOwnerID(), testOrgUUID))
+
+	var body map[string]any
+	for _, req := range fake.AllRequests() {
+		if req.URL.Path == "/api/v3/configs/compile" {
+			assert.NilError(t, req.Decode(&body))
+		}
+	}
+	assert.Assert(t, body != nil, "expected a v3 compile request")
+
+	data, _ := body["data"].(map[string]any)
+	assert.Assert(t, data != nil)
+	attrs, _ := data["attributes"].(map[string]any)
+	assert.Assert(t, attrs != nil)
+	assert.Check(t, cmp.Equal(attrs["config"], testConfigYAML))
+	assert.Check(t, cmp.Equal(attrs["enable_next_preview"], true))
+	_, hasValues := attrs["pipeline_values"]
+	assert.Check(t, hasValues, "expected locally fabricated pipeline_values")
+	assert.Check(t, cmp.DeepEqual(data["references"], map[string]any{
+		"org": map[string]any{"id": testOrgUUID},
+	}))
+}
+
+// TestConfigValidate_InvalidOnV3 pins that a config the v3 endpoint reports as
+// outcome "failed" — HTTP 200, reasons in meta.messages — still exits 7 with the
+// messages bulleted on stderr, exactly as the v2 errors array did.
+func TestConfigValidate_InvalidOnV3(t *testing.T) {
+	fake := fakes.NewCircleCI(t)
+	fake.SetCompileResponse(false, "", "unknown key 'foo'")
+
+	env := testenv.New(t)
+	env.Token = testToken
+	env.CircleCIURL = fake.URL()
+
+	dir := t.TempDir()
+	writeConfig(t, dir, testConfigYAML)
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"config", "validate", "--config", ".circleci/config.yml"},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	assert.Check(t, cmp.Equal(result.ExitCode, 7))
+	assert.Check(t, cmp.Equal(fake.LastCompileAPIVersion(), "v3"))
+	assert.Check(t, cmp.Contains(result.Stderr, "• unknown key 'foo'"))
 }
 
 // TestConfigValidate_NoTokenWithOrg pins the one case where the anonymous path
@@ -724,7 +798,7 @@ func TestConfigProcess_NoToken(t *testing.T) {
 
 	var compiled bool
 	for _, req := range fake.AllRequests() {
-		if req.URL.Path != "/api/v2/compile-config-with-defaults" {
+		if req.URL.Path != "/api/v3/configs/compile" {
 			continue
 		}
 		compiled = true
@@ -760,7 +834,7 @@ func TestConfigProcess_NoTokenSkipsOrgInference(t *testing.T) {
 	assert.Check(t, cmp.Equal(result.ExitCode, 0), "stderr: %s", result.Stderr)
 	assert.Check(t, cmp.Equal(fake.LastCompileOwnerID(), ""))
 	for _, req := range fake.AllRequests() {
-		assert.Check(t, cmp.Equal(req.URL.Path, "/api/v2/compile-config-with-defaults"),
+		assert.Check(t, cmp.Equal(req.URL.Path, "/api/v3/configs/compile"),
 			"unexpected request on the anonymous path")
 	}
 }

--- a/internal/apiclient/config.go
+++ b/internal/apiclient/config.go
@@ -24,6 +24,122 @@ package apiclient
 
 import "context"
 
+// CompileInput holds everything a config compilation needs. It is the input to
+// Compile, in the CLI's own terms rather than the wire shape.
+type CompileInput struct {
+	// ConfigYAML is the raw pipeline config to compile. Required.
+	ConfigYAML string
+	// OrgID is the owning organization UUID. Optional; supplying one enables
+	// private and namespaced orb resolution.
+	OrgID string
+	// PreviewNext enables "config next", previewing upcoming and potentially
+	// breaking config changes.
+	PreviewNext bool
+	// PipelineValues is the << pipeline.* >> template context. The CLI
+	// fabricates it locally from git state (see configcmd.LocalPipelineValues).
+	PipelineValues map[string]any
+	// PipelineParameters are the user parameters injected at
+	// << pipeline.parameters.* >>.
+	PipelineParameters map[string]any
+}
+
+// CompileResult is the outcome of a config compilation. An invalid config is not
+// an error: Valid is false and Errors holds the compilation messages.
+type CompileResult struct {
+	Valid        bool
+	CompiledYAML string
+	Errors       []string
+}
+
+// compileOutcomeSucceeded is the outcome the v3 compile endpoint reports for a
+// config that compiled. Anything else — "failed", or an outcome this client does
+// not know — is treated as invalid.
+const compileOutcomeSucceeded = "succeeded"
+
+// compileV3Request is the data-envelope body of POST /api/v3/configs/compile.
+// The endpoint rejects unknown members, so nothing outside this shape may be sent.
+type compileV3Request struct {
+	Data compileV3Data `json:"data"`
+}
+
+type compileV3Data struct {
+	Attributes compileV3Attributes  `json:"attributes"`
+	References *compileV3References `json:"references,omitempty"`
+}
+
+type compileV3Attributes struct {
+	Config             string         `json:"config"`
+	EnableNextPreview  bool           `json:"enable_next_preview,omitempty"`
+	PipelineParameters map[string]any `json:"pipeline_parameters,omitempty"`
+	PipelineValues     map[string]any `json:"pipeline_values,omitempty"`
+}
+
+type compileV3References struct {
+	Org compileV3OrgRef `json:"org"`
+}
+
+type compileV3OrgRef struct {
+	ID string `json:"id"`
+}
+
+// compileV3Response is the entity returned by POST /api/v3/configs/compile.
+// A config that fails to compile is still HTTP 200: outcome is "failed" and the
+// reasons arrive in meta.messages.
+//
+// The entity also carries a phase, but it is always "ended" for a synchronous
+// compile, so there is nothing to read it for; if a deferred compile path ever
+// appears, that is the field to start honouring.
+type compileV3Response struct {
+	Data struct {
+		Attributes struct {
+			Outcome        string `json:"outcome"`
+			CompiledConfig string `json:"compiled_config"`
+		} `json:"attributes"`
+	} `json:"data"`
+	Meta struct {
+		Messages []struct {
+			Title string `json:"title"`
+		} `json:"messages"`
+	} `json:"meta"`
+}
+
+// Compile compiles a pipeline config via POST /api/v3/configs/compile and
+// reports whether it is valid, along with the fully expanded YAML. `config
+// validate` and `config process` are the same operation — compilation — and
+// differ only in which fields of the result they read.
+//
+// Transport and request-level failures are returned as errors; a config that
+// merely fails to compile comes back as a CompileResult with Valid false.
+func (c *Client) Compile(ctx context.Context, in CompileInput) (*CompileResult, error) {
+	req := compileV3Request{
+		Data: compileV3Data{
+			Attributes: compileV3Attributes{
+				Config:             in.ConfigYAML,
+				EnableNextPreview:  in.PreviewNext,
+				PipelineParameters: in.PipelineParameters,
+				PipelineValues:     in.PipelineValues,
+			},
+		},
+	}
+	if in.OrgID != "" {
+		req.Data.References = &compileV3References{Org: compileV3OrgRef{ID: in.OrgID}}
+	}
+
+	var resp compileV3Response
+	if err := c.postV3(ctx, "/configs/compile", req, &resp); err != nil {
+		return nil, err
+	}
+
+	result := &CompileResult{Valid: resp.Data.Attributes.Outcome == compileOutcomeSucceeded}
+	if result.Valid {
+		result.CompiledYAML = resp.Data.Attributes.CompiledConfig
+	}
+	for _, msg := range resp.Meta.Messages {
+		result.Errors = append(result.Errors, msg.Title)
+	}
+	return result, nil
+}
+
 // CompileConfigRequest is sent to POST /api/v2/compile-config-with-defaults.
 type CompileConfigRequest struct {
 	ConfigYAML string               `json:"config_yaml"`

--- a/internal/apiclient/config_test.go
+++ b/internal/apiclient/config_test.go
@@ -1,0 +1,173 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package apiclient_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/render"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+
+	"github.com/CircleCI-Public/circleci-cli/internal/apiclient"
+	"github.com/CircleCI-Public/circleci-cli/internal/iostream"
+	"github.com/CircleCI-Public/circleci-cli/internal/testing/httprecorder"
+	"github.com/CircleCI-Public/circleci-cli/internal/testing/httprecorder/chirecorder"
+)
+
+const testCompileOrgID = "f22b6566-597d-46d5-ba74-99ef5bb3d85c"
+
+// compileServer serves POST /api/v3/configs/compile, responding with status and
+// body (a non-200 status responds with a plain message instead of body).
+func compileServer(t *testing.T, rec *httprecorder.RequestRecorder, status int, body map[string]any) *httptest.Server {
+	t.Helper()
+
+	r := chi.NewMux()
+	r.Use(chirecorder.Middleware(rec))
+	r.Post("/api/v3/configs/compile", func(w http.ResponseWriter, r *http.Request) {
+		if status != http.StatusOK {
+			render.Status(r, status)
+			render.JSON(w, r, map[string]any{"message": http.StatusText(status)})
+			return
+		}
+		render.JSON(w, r, body)
+	})
+	srv := httptest.NewServer(r)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestClient_Compile(t *testing.T) {
+	ctx := iostream.Testing(context.Background())
+
+	t.Run("a compiled config is valid and carries the expanded YAML", func(t *testing.T) {
+		rec := httprecorder.New()
+		srv := compileServer(t, rec, http.StatusOK, map[string]any{
+			"data": map[string]any{
+				"attributes": map[string]any{
+					"phase":           "ended",
+					"outcome":         "succeeded",
+					"compiled_config": "version: 2.1\njobs: {}",
+				},
+			},
+		})
+
+		c := apiclient.New(apiclient.Config{BaseURL: srv.URL, Token: "the-token"})
+		res, err := c.Compile(ctx, apiclient.CompileInput{
+			ConfigYAML:  "version: 2.1",
+			OrgID:       testCompileOrgID,
+			PreviewNext: true,
+		})
+		assert.NilError(t, err)
+		assert.Check(t, cmp.Equal(res.Valid, true))
+		assert.Check(t, cmp.Equal(res.CompiledYAML, "version: 2.1\njobs: {}"))
+		assert.Check(t, cmp.Len(res.Errors, 0))
+
+		var body map[string]any
+		assert.NilError(t, rec.LastRequest().Decode(&body))
+		assert.Check(t, cmp.DeepEqual(body, map[string]any{
+			"data": map[string]any{
+				"attributes": map[string]any{
+					"config":              "version: 2.1",
+					"enable_next_preview": true,
+				},
+				"references": map[string]any{
+					"org": map[string]any{"id": testCompileOrgID},
+				},
+			},
+		}))
+	})
+
+	t.Run("outcome failed is an invalid config, not an error", func(t *testing.T) {
+		rec := httprecorder.New()
+		srv := compileServer(t, rec, http.StatusOK, map[string]any{
+			"data": map[string]any{
+				"attributes": map[string]any{
+					"phase":   "ended",
+					"outcome": "failed",
+				},
+			},
+			"meta": map[string]any{
+				"messages": []map[string]any{
+					{"title": "jobs.build.docker: required key [image] not found"},
+				},
+			},
+		})
+
+		c := apiclient.New(apiclient.Config{BaseURL: srv.URL, Token: "the-token"})
+		res, err := c.Compile(ctx, apiclient.CompileInput{ConfigYAML: "version: 2.1"})
+		assert.NilError(t, err)
+		assert.Check(t, cmp.Equal(res.Valid, false))
+		assert.Check(t, cmp.Equal(res.CompiledYAML, ""))
+		assert.Check(t, cmp.DeepEqual(res.Errors, []string{
+			"jobs.build.docker: required key [image] not found",
+		}))
+	})
+
+	t.Run("no org means no references member", func(t *testing.T) {
+		rec := httprecorder.New()
+		srv := compileServer(t, rec, http.StatusOK, map[string]any{
+			"data": map[string]any{"attributes": map[string]any{"outcome": "succeeded"}},
+		})
+
+		c := apiclient.New(apiclient.Config{BaseURL: srv.URL, Token: "the-token"})
+		_, err := c.Compile(ctx, apiclient.CompileInput{ConfigYAML: "version: 2.1"})
+		assert.NilError(t, err)
+
+		var body map[string]any
+		assert.NilError(t, rec.LastRequest().Decode(&body))
+		data, _ := body["data"].(map[string]any)
+		assert.Assert(t, data != nil)
+		_, hasRefs := data["references"]
+		assert.Check(t, !hasRefs, "an absent org must not send an empty references object")
+	})
+}
+
+// TestClient_Compile_RequestFailures pins that a request the endpoint refuses is
+// an error, not a compile result: there is no second endpoint to try, so every
+// such status has to reach the caller. A 404 in particular must not be mistaken
+// for "invalid config" — it means the host does not serve the route.
+func TestClient_Compile_RequestFailures(t *testing.T) {
+	ctx := iostream.Testing(context.Background())
+
+	for _, status := range []int{
+		http.StatusBadRequest,
+		http.StatusUnauthorized,
+		http.StatusForbidden,
+		http.StatusNotFound,
+	} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			rec := httprecorder.New()
+			srv := compileServer(t, rec, status, nil)
+
+			c := apiclient.New(apiclient.Config{BaseURL: srv.URL, Token: "the-token"})
+			_, err := c.Compile(ctx, apiclient.CompileInput{ConfigYAML: "version: 2.1"})
+			assert.Check(t, err != nil)
+			assert.Check(t, cmp.Len(rec.AllRequests(), 1))
+		})
+	}
+}

--- a/internal/configcmd/compile.go
+++ b/internal/configcmd/compile.go
@@ -38,33 +38,42 @@ type ValidateResult struct {
 // Validate compiles the config YAML against the CircleCI API and returns whether it
 // is valid. orgID may be empty; pass one to enable private orb resolution.
 func Validate(ctx context.Context, client *apiclient.Client, configYAML, orgID string, previewNext bool) (*ValidateResult, error) {
-	resp, err := client.CompileConfig(ctx, configYAML, orgID, previewNext, LocalPipelineValues(nil), nil)
-	if err != nil {
-		return nil, err
-	}
-	result := &ValidateResult{Valid: resp.Valid, CompiledYAML: resp.OutputYAML}
-	for _, e := range resp.Errors {
-		result.Errors = append(result.Errors, e.Message)
-	}
-	// The API can return valid:false without explicit errors — treat that as invalid.
-	if !resp.Valid && len(result.Errors) == 0 {
-		result.Errors = []string{"config compilation failed"}
-	}
-	return result, nil
+	return compile(ctx, client, apiclient.CompileInput{
+		ConfigYAML:     configYAML,
+		OrgID:          orgID,
+		PreviewNext:    previewNext,
+		PipelineValues: LocalPipelineValues(nil),
+	})
 }
 
 // Process compiles the config YAML and returns the fully expanded output YAML.
 // params are pipeline parameters injected at << pipeline.parameters.* >>.
 func Process(ctx context.Context, client *apiclient.Client, configYAML, orgID string, previewNext bool, params map[string]any) (*ValidateResult, error) {
-	resp, err := client.CompileConfig(ctx, configYAML, orgID, previewNext, LocalPipelineValues(params), params)
+	return compile(ctx, client, apiclient.CompileInput{
+		ConfigYAML:         configYAML,
+		OrgID:              orgID,
+		PreviewNext:        previewNext,
+		PipelineValues:     LocalPipelineValues(params),
+		PipelineParameters: params,
+	})
+}
+
+// compile runs a compilation and shapes it into a ValidateResult. Validation and
+// processing are the same server-side operation; they differ only in the inputs
+// they supply and the fields the caller reads.
+func compile(ctx context.Context, client *apiclient.Client, in apiclient.CompileInput) (*ValidateResult, error) {
+	res, err := client.Compile(ctx, in)
 	if err != nil {
 		return nil, err
 	}
-	result := &ValidateResult{Valid: resp.Valid, CompiledYAML: resp.OutputYAML}
-	for _, e := range resp.Errors {
-		result.Errors = append(result.Errors, e.Message)
+	result := &ValidateResult{
+		Valid:        res.Valid,
+		CompiledYAML: res.CompiledYAML,
+		Errors:       res.Errors,
 	}
-	if !resp.Valid && len(result.Errors) == 0 {
+	// The API can report an invalid config without explicit messages — say
+	// something rather than fail silently.
+	if !res.Valid && len(result.Errors) == 0 {
 		result.Errors = []string{"config compilation failed"}
 	}
 	return result, nil

--- a/internal/testing/fakes/circleci.go
+++ b/internal/testing/fakes/circleci.go
@@ -193,6 +193,7 @@ type CircleCI struct {
 	compileOutputYAML  string
 	compileErrors      []string
 	lastCompileOwnerID string
+	lastCompileAPIVer  string // "v3" or "v2" — which compile route served the last call
 
 	// Org state.
 	orgs        map[string]map[string]any
@@ -395,6 +396,7 @@ func NewCircleCI(t *testing.T) *CircleCI {
 	r.Get("/api/v3/signing/configs", f.handleListIOSBundles)
 	r.Delete("/api/v3/signing/configs/{id}", f.handleDeleteIOSBundle)
 	// Config compile + org routes.
+	r.Post("/api/v3/configs/compile", f.handleCompileConfigV3)
 	r.Post("/api/v2/compile-config-with-defaults", f.handleCompileConfig)
 	r.Get("/api/v3/tool/releases", f.handleGetReleases)
 	r.Get("/api/v3/orgs", f.handleResolveOrg)
@@ -4246,8 +4248,8 @@ func (f *CircleCI) handleSetPolicySettings(w http.ResponseWriter, r *http.Reques
 
 // --- Config compile + org helpers ---
 
-// SetCompileResponse configures what the fake returns for POST /compile-config-with-defaults.
-// Pass valid=false and one or more error messages to simulate a compilation failure.
+// SetCompileResponse configures what both compile routes return. Pass
+// valid=false and one or more error messages to simulate a compilation failure.
 func (f *CircleCI) SetCompileResponse(valid bool, outputYAML string, errors ...string) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -4256,13 +4258,21 @@ func (f *CircleCI) SetCompileResponse(valid bool, outputYAML string, errors ...s
 	f.compileErrors = errors
 }
 
-// LastCompileOwnerID returns the owner_id sent on the most recent
-// POST /compile-config-with-defaults request (empty if none yet). Tests use it
-// to assert that --org resolved to the expected organization UUID.
+// LastCompileOwnerID returns the owning org UUID sent on the most recent compile
+// request, from either route (empty if none yet). Tests use it to assert that
+// --org resolved to the expected organization UUID.
 func (f *CircleCI) LastCompileOwnerID() string {
 	f.mu.RLock()
 	defer f.mu.RUnlock()
 	return f.lastCompileOwnerID
+}
+
+// LastCompileAPIVersion returns "v3" or "v2" for whichever compile route served
+// the most recent request (empty if none yet).
+func (f *CircleCI) LastCompileAPIVersion() string {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return f.lastCompileAPIVer
 }
 
 // AddOrg registers an org resolvable by slug via GET /api/v3/orgs.
@@ -4278,6 +4288,53 @@ func (f *CircleCI) AddOrg(id, slug, name, vcsType string) {
 	f.orgsByUUID[id] = true
 }
 
+// handleCompileConfigV3 serves POST /api/v3/configs/compile. A config that fails
+// to compile is still a 200: outcome is "failed" and the reasons ride in
+// meta.messages, mirroring the real endpoint.
+func (f *CircleCI) handleCompileConfigV3(w http.ResponseWriter, r *http.Request) {
+	// Capture the referenced org so tests can assert that --org (slug or UUID)
+	// resolved to the expected organization UUID before the compile call.
+	var body struct {
+		Data struct {
+			References struct {
+				Org struct {
+					ID string `json:"id"`
+				} `json:"org"`
+			} `json:"references"`
+		} `json:"data"`
+	}
+	_ = json.NewDecoder(r.Body).Decode(&body)
+
+	f.mu.Lock()
+	f.lastCompileOwnerID = body.Data.References.Org.ID
+	f.lastCompileAPIVer = "v3"
+	valid := f.compileValid
+	outputYAML := f.compileOutputYAML
+	errs := f.compileErrors
+	f.mu.Unlock()
+
+	attrs := map[string]any{"phase": "ended", "outcome": "succeeded"}
+	if !valid {
+		attrs["outcome"] = "failed"
+	} else {
+		attrs["compiled_config"] = outputYAML
+	}
+
+	resp := map[string]any{"data": map[string]any{
+		"id":         "00000000-0000-0000-0000-00000000c0de",
+		"attributes": attrs,
+	}}
+	if !valid {
+		messages := make([]map[string]any, len(errs))
+		for i, e := range errs {
+			messages[i] = map[string]any{"title": e}
+		}
+		resp["meta"] = map[string]any{"messages": messages}
+	}
+
+	render.JSON(w, r, resp)
+}
+
 func (f *CircleCI) handleCompileConfig(w http.ResponseWriter, r *http.Request) {
 	// Capture the resolved owner_id so tests can assert that --org (slug or UUID)
 	// resolved to the expected organization UUID before the compile call.
@@ -4290,6 +4347,7 @@ func (f *CircleCI) handleCompileConfig(w http.ResponseWriter, r *http.Request) {
 
 	f.mu.Lock()
 	f.lastCompileOwnerID = body.Options.OwnerID
+	f.lastCompileAPIVer = "v2"
 	valid := f.compileValid
 	outputYAML := f.compileOutputYAML
 	errs := f.compileErrors


### PR DESCRIPTION
Moves `config validate` and `config process` onto the new `POST /api/v3/configs/compile` API endpoint.

Validation and processing are the same server-side operation (compilation); they differ only in the inputs they send and the fields they read. Both now go through one client method.

## `Client.Compile`

`internal/apiclient/config.go` gains `Compile(ctx, CompileInput) (*CompileResult, error)`:

- **Request** — the V3 data envelope: `data.attributes.{config,enable_next_preview,pipeline_parameters,pipeline_values}`, with the org as `data.references.org.id`. `references` is omitted entirely when there is no org, since the endpoint rejects unknown members.
- **Response** — `attributes.outcome == "succeeded"` is a valid config, `attributes.compiled_config` is the expanded YAML, and `meta.messages[].title` are the compilation problems. A config that fails to compile is still HTTP 200, so it stays a result rather than becoming a Go error — the same split the v2 `valid` flag gave us.

Note the request field is `enable_next_preview`, not the `should_preview_next` an earlier draft of the API design used — the deployed endpoint binds the former, and an unknown member is a 400.

## No v2 fallback

An earlier revision of this branch fell back to `POST /api/v2/compile-config-with-defaults` when the v3 route 404'd. That is gone: the v3 endpoint is already live on circleci.com, including for anonymous callers, so there is no second endpoint to try. A status the endpoint refuses is an error — a 404 in particular must not be read as "invalid config" — and only `outcome: "failed"` means the config itself is bad.

Verified by hand against production with the built binary:

| Case | Result |
|---|---|
| valid config | `POST /api/v3/configs/compile` → 200, "is valid", exit 0 |
| this repo's unpacked `.circleci/config.yml` | 200 with `meta.messages`, bulleted on stderr, exit 7 |
| `--json` / `config process` | `compiled_yaml` / expanded YAML off `attributes.compiled_config` |
| clean `HOME`, no token | v3 → 200; anonymous validate still works |

The v2 `Client.CompileConfig` method stays, because `policy test` and `policy eval` still compile through it directly (`internal/cmd/policy/test.go:129`, `internal/cmd/policy/compile.go:58`). Moving those over is a small follow-up.

## Tests

- `internal/apiclient/config_test.go` (new) — the exact v3 request body, invalid config via `meta.messages`, no-org omitting `references`, and that 400/401/403/404 each surface as an error after a single request.
- `acceptance/config_test.go` — new coverage for the v3 request shape end-to-end (including `--org` → UUID and `--next`) and an invalid config exiting 7 with bulleted stderr. Two existing tests that asserted the v2 path were repointed at the v3 route.
- `internal/testing/fakes` — serves `POST /api/v3/configs/compile`, plus `LastCompileAPIVersion()` to assert which route served a call.

`go test ./acceptance/ ./internal/...` is clean locally. `task check` could not run in my checkout — `go tool -modfile tools/go.mod golangci-lint` fails to resolve `honnef.co/go/tools/go/ir` before it analyses anything, which is unrelated to this change; `gofmt -l` on the touched files is clean, so CI lint is the real check.