### PR TITLE
Make `config process` support not having auth

### DIFF
--- a/acceptance/config_test.go
+++ b/acceptance/config_test.go
@@ -695,6 +695,104 @@ func TestConfigProcess_InfersOrgFromGitRemote(t *testing.T) {
 	assert.Check(t, cmp.Equal(fake.LastCompileOwnerID(), testOrgUUID))
 }
 
+// TestConfigProcess_NoToken pins that process is usable with no API token at
+// all: the compile endpoint serves anonymous callers, so expanding a config that
+// uses only public orbs must not demand `circleci auth login` first.
+//
+// It also asserts the request carried no Authorization header. Sending a
+// valueless "Bearer" instead reads as malformed credentials rather than as an
+// anonymous request, which the real API rejects.
+func TestConfigProcess_NoToken(t *testing.T) {
+	fake := fakes.NewCircleCI(t)
+	fake.SetCompileResponse(true, testCompiledYAML)
+
+	env := testenv.New(t)
+	env.CircleCIURL = fake.URL()
+
+	dir := t.TempDir()
+	writeConfig(t, dir, testConfigYAML)
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"config", "process", ".circleci/config.yml"},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	assert.Check(t, cmp.Equal(result.ExitCode, 0), "stderr: %s", result.Stderr)
+	assert.Check(t, cmp.Contains(result.Stdout, "version"))
+
+	var compiled bool
+	for _, req := range fake.AllRequests() {
+		if req.URL.Path != "/api/v2/compile-config-with-defaults" {
+			continue
+		}
+		compiled = true
+		assert.Check(t, cmp.Equal(req.Header.Get("Authorization"), ""),
+			"anonymous process must send no Authorization header")
+	}
+	assert.Check(t, compiled, "expected a compile request")
+}
+
+// TestConfigProcess_NoTokenSkipsOrgInference pins that the anonymous path
+// makes no attempt to infer the org. Every route to an org ID needs a token, so
+// inside a git checkout with no token the project lookup would only ever 401 —
+// process compiles with an empty owner_id instead of spending the round-trip.
+func TestConfigProcess_NoTokenSkipsOrgInference(t *testing.T) {
+	fake := fakes.NewCircleCI(t)
+	fake.SetCompileResponse(true, testCompiledYAML)
+	fake.AddProjectBySlug("gh/myorg/myrepo", "00000000-0000-0000-0000-0000000000b6", "myrepo", testOrgUUID)
+
+	env := testenv.New(t)
+	env.CircleCIURL = fake.URL()
+
+	dir := t.TempDir()
+	initGitRepoWithRemote(t, dir, "https://github.com/myorg/myrepo")
+	writeConfig(t, dir, testConfigYAML)
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"config", "process", ".circleci/config.yml"},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	assert.Check(t, cmp.Equal(result.ExitCode, 0), "stderr: %s", result.Stderr)
+	assert.Check(t, cmp.Equal(fake.LastCompileOwnerID(), ""))
+	for _, req := range fake.AllRequests() {
+		assert.Check(t, cmp.Equal(req.URL.Path, "/api/v2/compile-config-with-defaults"),
+			"unexpected request on the anonymous path")
+	}
+}
+
+// TestConfigProcess_NoTokenWithOrg pins the one case where the anonymous path
+// still fails: --org cannot be honoured without a token, and quietly ignoring
+// it would expand a config while skipping the private orb resolution the user
+// explicitly asked for.
+func TestConfigProcess_NoTokenWithOrg(t *testing.T) {
+	fake := fakes.NewCircleCI(t)
+	fake.SetCompileResponse(true, testCompiledYAML)
+	fake.AddOrg(testOrgUUID, "gh/myorg", "myorg", "github")
+
+	env := testenv.New(t)
+	env.CircleCIURL = fake.URL()
+
+	dir := t.TempDir()
+	writeConfig(t, dir, testConfigYAML)
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"config", "process", ".circleci/config.yml", "--org", "gh/myorg"},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	assert.Check(t, cmp.Equal(result.ExitCode, 3))
+	assert.Check(t, cmp.Contains(result.Stderr, "Resolving --org requires a CircleCI API token."))
+	assert.Check(t, cmp.Contains(result.Stderr, "Or drop --org to process against public orbs only"))
+	assert.Check(t, cmp.Len(fake.AllRequests(), 0), "must not call the API without a token")
+}
+
 // --- config pack ---
 
 func TestConfigPack(t *testing.T) {

--- a/internal/cmd/config/config.go
+++ b/internal/cmd/config/config.go
@@ -123,17 +123,20 @@ func resolveOrgID(ctx context.Context, client *apiclient.Client, org, cmdName st
 	return id.String(), nil
 }
 
-// validateOrgID is resolveOrgID for `config validate`, which accepts an
-// unauthenticated client (see cmdutil.LoadClientOptionalAuth).
+// optionalAuthOrgID is resolveOrgID for config commands that accept an
+// unauthenticated client (validate and process; see cmdutil.LoadClientOptionalAuth).
 //
 // Every path to an org ID needs a token: inference looks the project up through
 // the API, and an org only owns orbs the caller is authorized to read. So when
 // there is no token we skip resolution entirely and compile with no owner —
 // public orbs still resolve — rather than spending a round-trip on a request
 // that can only 401. An explicit --org is a hard error instead: silently
-// ignoring it would report a config as valid while skipping the private orb
-// resolution the user asked for.
-func validateOrgID(ctx context.Context, client *apiclient.Client, org string) (string, error) {
+// ignoring it would compile without the private orb resolution the user asked
+// for.
+//
+// dropOrgHint is the last suggestion when --org is set without a token (e.g.
+// "Or drop --org to validate against public orbs only").
+func optionalAuthOrgID(ctx context.Context, client *apiclient.Client, org, cmdName, dropOrgHint string) (string, error) {
 	if !client.Authenticated() {
 		if org != "" {
 			return "", clierrors.New("auth.token_missing", "Authentication required",
@@ -141,13 +144,13 @@ func validateOrgID(ctx context.Context, client *apiclient.Client, org string) (s
 				WithSuggestions(
 					"Run: circleci auth login",
 					"Or set the CIRCLE_TOKEN environment variable",
-					"Or drop --org to validate against public orbs only",
+					dropOrgHint,
 				).
 				WithExitCode(clierrors.ExitAuthError)
 		}
 		return "", nil
 	}
-	return resolveOrgID(ctx, client, org, "circleci config validate")
+	return resolveOrgID(ctx, client, org, cmdName)
 }
 
 // printValidationErrors writes each compilation error as a bulleted line to

--- a/internal/cmd/config/process.go
+++ b/internal/cmd/config/process.go
@@ -24,6 +24,7 @@ package cmdconfig
 
 import (
 	"fmt"
+	"net/http"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
@@ -31,6 +32,7 @@ import (
 	"github.com/CircleCI-Public/circleci-cli/internal/cmdutil"
 	"github.com/CircleCI-Public/circleci-cli/internal/configcmd"
 	clierrors "github.com/CircleCI-Public/circleci-cli/internal/errors"
+	"github.com/CircleCI-Public/circleci-cli/internal/httpcl"
 	"github.com/CircleCI-Public/circleci-cli/internal/iostream"
 )
 
@@ -52,12 +54,12 @@ func newProcessCmd() *cobra.Command {
 			`, "`"),
 		},
 		Long: heredoc.Doc(`
-			Compile a CircleCI pipeline config and print the fully expanded YAML: orbs
-			inlined, matrix jobs expanded, parameter expressions resolved. The output is
-			what CircleCI would actually execute.
+			Compile a CircleCI pipeline config and print the fully expanded YAML —
+			orbs inlined, matrices expanded, parameters resolved.
 
-			Private and namespaced orbs resolve against your organization: with --org
-			omitted, from a 'circleci project link' binding, else the git remote.
+			No API token is required; without one, only public orbs resolve.
+			Private and namespaced orbs need a token and resolve against your org, taken
+			from --org, a 'circleci project link' binding, or the git remote, in that order.
 		`),
 		Example: heredoc.Doc(`
 			# Process the default config
@@ -75,10 +77,12 @@ func newProcessCmd() *cobra.Command {
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
-			client, err := cmdutil.LoadClient(ctx)
-			if err != nil {
-				return err
-			}
+
+			// Process (like validate) works without a token: the compile endpoint
+			// serves anonymous callers, and expanding a config that uses only
+			// public orbs is common in CI jobs and orb pipelines that have no
+			// token. An authenticated call is unchanged.
+			client := cmdutil.LoadClientOptionalAuth(ctx)
 
 			configYAML, err := readConfigInput(ctx, args[0])
 			if err != nil {
@@ -93,13 +97,26 @@ func newProcessCmd() *cobra.Command {
 					WithExitCode(clierrors.ExitBadArguments)
 			}
 
-			orgID, err := resolveOrgID(ctx, client, org, "circleci config process")
+			orgID, err := optionalAuthOrgID(ctx, client, org, "circleci config process",
+				"Or drop --org to process against public orbs only")
 			if err != nil {
 				return err
 			}
 
 			result, err := configcmd.Process(ctx, client, configYAML, orgID, previewNext, params)
 			if err != nil {
+				// A 401 on an anonymous call means this host will not compile
+				// without credentials, so the generic "token was rejected" wording
+				// APIErr uses for an authenticated 401 would be wrong here.
+				if !client.Authenticated() && httpcl.HasStatusCode(err, http.StatusUnauthorized) {
+					return clierrors.New("auth.token_missing", "Authentication required",
+						"This CircleCI host requires an API token to process config.").
+						WithSuggestions(
+							"Run: circleci auth login",
+							"Or set the CIRCLE_TOKEN environment variable",
+						).
+						WithExitCode(clierrors.ExitAuthError)
+				}
 				return configAPIErr(err)
 			}
 

--- a/internal/cmd/config/validate.go
+++ b/internal/cmd/config/validate.go
@@ -85,11 +85,10 @@ func newValidateCmd() *cobra.Command {
 				path = args[0]
 			}
 
-			// Validation is the one config command that works without a token:
-			// the compile endpoint serves anonymous callers, and linting a config
-			// that uses only public orbs is the first thing a new user — or a
-			// pre-commit hook, or a CI job without a token — wants to do. An
-			// authenticated call is unchanged.
+			// Validate (like process) works without a token: the compile endpoint
+			// serves anonymous callers, and linting a config that uses only public
+			// orbs is the first thing a new user — or a pre-commit hook, or a CI
+			// job without a token — wants to do. An authenticated call is unchanged.
 			client := cmdutil.LoadClientOptionalAuth(ctx)
 
 			yaml, err := readConfigInput(ctx, path)
@@ -97,7 +96,8 @@ func newValidateCmd() *cobra.Command {
 				return err
 			}
 
-			orgID, err := validateOrgID(ctx, client, org)
+			orgID, err := optionalAuthOrgID(ctx, client, org, "circleci config validate",
+				"Or drop --org to validate against public orbs only")
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/root/testdata/help/circleci/config/process.txt
+++ b/internal/cmd/root/testdata/help/circleci/config/process.txt
@@ -33,10 +33,10 @@ Global flags: `-c, --config`, `--debug`, `--no-color`, `-q, --quiet` — see `ci
 
 ## Details
 
-Compile a CircleCI pipeline config and print the fully expanded YAML: orbs
-inlined, matrix jobs expanded, parameter expressions resolved. The output is
-what CircleCI would actually execute.
+Compile a CircleCI pipeline config and print the fully expanded YAML —
+orbs inlined, matrices expanded, parameters resolved.
 
-Private and namespaced orbs resolve against your organization: with --org
-omitted, from a 'circleci project link' binding, else the git remote.
+No API token is required; without one, only public orbs resolve.
+Private and namespaced orbs need a token and resolve against your org, taken
+from --org, a 'circleci project link' binding, or the git remote, in that order.
 

--- a/internal/cmd/root/testdata/help/circleci/reference.txt
+++ b/internal/cmd/root/testdata/help/circleci/reference.txt
@@ -115,12 +115,12 @@ mapped to YAML keys in the merged document.
 
 Compile and expand a pipeline config file
 
-Compile a CircleCI pipeline config and print the fully expanded YAML: orbs
-inlined, matrix jobs expanded, parameter expressions resolved. The output is
-what CircleCI would actually execute.
+Compile a CircleCI pipeline config and print the fully expanded YAML —
+orbs inlined, matrices expanded, parameters resolved.
 
-Private and namespaced orbs resolve against your organization: with --org
-omitted, from a 'circleci project link' binding, else the git remote.
+No API token is required; without one, only public orbs resolve.
+Private and namespaced orbs need a token and resolve against your org, taken
+from --org, a 'circleci project link' binding, or the git remote, in that order.
 
 | Flag                           | Description                                                                                  |
 | ------------------------------ | -------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
## Summary
- Apply the same optional-auth treatment as `config validate` ([#1696](https://github.com/CircleCI-Public/circleci-cli/pull/1696)) to `config process`
- Anonymous compile still works for public orbs; `--org` without a token is a hard error; 401 on anonymous hosts gets an actionable auth message
- Acceptance coverage mirrors the validate no-token cases

Tracks [FACT-403](https://linear.app/circleci/issue/FACT-403/make-config-process-support-not-having-auth)

## Test plan
- [x] `go test ./acceptance/ -run 'TestConfig(Process|Validate)_NoToken' -count=1`
- [x] `go test ./acceptance/ -run TestConfig -count=1`
- [x] `go test ./internal/cmd/root/... -run TestHelp -count=1`
- [ ] Manual: unset `CIRCLE_TOKEN` / logout, run `circleci config process .circleci/config.yml` on a public-orb config