### PR TITLE
Show pending approval jobs as on hold, not running

### DIFF
--- a/acceptance/run_test.go
+++ b/acceptance/run_test.go
@@ -214,6 +214,45 @@ func TestRunGet_ByID(t *testing.T) {
 	assert.Check(t, golden.String(normalizeAppHost(result.Stdout, fake.URL()), t.Name()+".txt"))
 }
 
+// TestRunGet_ByID_ApprovalOnHold pins the display status of an approval gate
+// waiting on a decision. The V3 API reports such a job in the "started" phase,
+// which the plain phase vocabulary renders as "running" — but nothing is
+// executing, and nothing will until somebody approves or cancels it.
+func TestRunGet_ByID_ApprovalOnHold(t *testing.T) {
+	fake := fakes.NewCircleCI(t)
+	runID := getRunID
+	wfID := testWfID
+	now := time.Now().UTC().Format(time.RFC3339)
+	approval := fakeJobV3("d0000000-0000-4000-8000-000000000002", "hold", wfID, runTestProjectID)
+	approval["attributes"] = map[string]any{
+		"name":       "hold",
+		"phase":      "started",
+		"type":       "approval",
+		"started_at": now,
+	}
+	fake.AddRunV3(runID, runTestProjectID, fakeRunV3(runID, runTestProjectID, "started", "", "main", "abc1234def5678"))
+	fake.AddRunWorkflowsV3(runID, fakeWorkflowV3(wfID, "build", runID, runTestProjectID, "started", ""))
+	fake.AddWorkflowJobsV3(wfID,
+		fakeJobV3("d0000000-0000-4000-8000-000000000001", "run-tests", wfID, runTestProjectID),
+		approval,
+	)
+
+	env := testenv.New(t)
+	env.Token = testToken
+	env.CircleCIURL = fake.URL()
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"run", "get", runID},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 0)
+	assert.Check(t, cmp.Contains(result.Stdout, "on hold"))
+	assert.Check(t, golden.String(normalizeAppHost(result.Stdout, fake.URL()), t.Name()+".txt"))
+}
+
 func TestRunGet_ByID_WorkflowsNotFound(t *testing.T) {
 	fake := fakes.NewCircleCI(t)
 	runID := getRunID

--- a/acceptance/testdata/TestRunGet_ByID_ApprovalOnHold.txt
+++ b/acceptance/testdata/TestRunGet_ByID_ApprovalOnHold.txt
@@ -1,0 +1,20 @@
+# Run
+- ID: `5034460f-c7c4-4c43-9457-de07e2029e7b`
+- Branch: main
+- Commit: abc1234
+- Subject: Fix the widget
+- Author: Ada Lovelace
+- URL: http://app.circleci.test/pipeline/5034460f-c7c4-4c43-9457-de07e2029e7b
+- Status: running
+- Created: 2020-01-01 12:00:00 UTC
+
+## Workflows
+### build
+- ID: `b0000000-0000-4000-8000-000000000001`
+- Status: 🔵 running
+#### Jobs
+| Name      | Status       | Type     | ID                                     |
+| --------- | ------------ | -------- | -------------------------------------- |
+| run-tests | ✅ succeeded | build    | `d0000000-0000-4000-8000-000000000001` |
+| hold      | ⏸️ on hold   | approval | `d0000000-0000-4000-8000-000000000002` |
+

--- a/internal/apiclient/job.go
+++ b/internal/apiclient/job.go
@@ -134,9 +134,9 @@ type JobV3 struct {
 	WorkflowID uuid.UUID        `json:"workflow_id"`
 }
 
-// Status derives a display status from phase and outcome.
+// Status derives a display status from type, phase and outcome.
 func (j JobV3) Status() string {
-	return PhaseOutcomeStatus(j.Phase, j.Outcome, "")
+	return JobPhaseOutcomeStatus(j.Type, j.Phase, j.Outcome, "")
 }
 
 // JobV3Execution groups the steps that ran on a single executor.
@@ -285,6 +285,50 @@ func phaseOutcomeParts(phase, outcome, currentOutcome string) (emoji, text strin
 	default:
 		return "", phase
 	}
+}
+
+// JobTypeApproval is the V3 job type of a manual approval gate — a job that
+// runs nothing and waits for a person to approve or cancel it.
+const JobTypeApproval = "approval"
+
+// jobOnHold reports whether a job is an approval gate still waiting on a
+// decision. The V3 API reports a pending approval job in the "started" phase
+// (and, before the workflow reaches it, one of the pre-start phases), so the
+// plain phase vocabulary renders it as "running" — which is wrong twice over:
+// nothing is executing, and it will stay that way until someone acts. Any
+// phase short of "ended" therefore reads as on hold; once ended, the job's
+// outcome (succeeded when approved, canceled when not) tells the real story.
+func jobOnHold(jobType, phase string) bool {
+	return jobType == JobTypeApproval && phase != PhaseEnded
+}
+
+// JobPhaseOutcomeStatus is PhaseOutcomeStatus for a job, whose type decides
+// whether the phase means what it says: a pending approval job is on hold, not
+// running. Use it wherever the job type is known; workflows and runs, which
+// have no type, keep using PhaseOutcomeStatus.
+func JobPhaseOutcomeStatus(jobType, phase, outcome, currentOutcome string) string {
+	if jobOnHold(jobType, phase) {
+		return "⏸️ on hold"
+	}
+	return PhaseOutcomeStatus(phase, outcome, currentOutcome)
+}
+
+// JobPhaseOutcomeText is JobPhaseOutcomeStatus without the leading emoji — the
+// plain status word, for raw fixed-width layouts.
+func JobPhaseOutcomeText(jobType, phase, outcome, currentOutcome string) string {
+	if jobOnHold(jobType, phase) {
+		return "on hold"
+	}
+	return PhaseOutcomeText(phase, outcome, currentOutcome)
+}
+
+// JobPhaseOutcomeSymbol is JobPhaseOutcomeStatus as a single plain,
+// single-width glyph, the job-aware counterpart of PhaseOutcomeSymbol.
+func JobPhaseOutcomeSymbol(jobType, phase, outcome, currentOutcome string) string {
+	if jobOnHold(jobType, phase) {
+		return "‖"
+	}
+	return PhaseOutcomeSymbol(phase, outcome, currentOutcome)
 }
 
 // PhaseOutcomeSymbol is like PhaseOutcomeStatus but returns a single plain,

--- a/internal/apiclient/phase_outcome_test.go
+++ b/internal/apiclient/phase_outcome_test.go
@@ -106,3 +106,30 @@ func TestStatusPhaseOutcome(t *testing.T) {
 		assert.Check(t, is.Equal(outcome, c.outcome), "status %q current_outcome", c.status)
 	}
 }
+
+// TestJobPhaseOutcome_Approval pins the approval-gate correction. The V3 API
+// reports a pending approval job in the "started" phase, which the plain phase
+// vocabulary renders as "running" — wrong twice over: nothing is executing, and
+// nothing will until a person approves or cancels it. Any phase short of
+// "ended" therefore reads as on hold; once ended, the outcome stands.
+func TestJobPhaseOutcome_Approval(t *testing.T) {
+	const approval = apiclient.JobTypeApproval
+
+	// Waiting on a decision, whatever pre-ended phase the API reports.
+	for _, phase := range []string{"created", "queued", "started"} {
+		assert.Check(t, is.Equal(apiclient.JobPhaseOutcomeStatus(approval, phase, "", ""), "⏸️ on hold"), "phase %q", phase)
+		assert.Check(t, is.Equal(apiclient.JobPhaseOutcomeText(approval, phase, "", ""), "on hold"), "phase %q", phase)
+		assert.Check(t, is.Equal(apiclient.JobPhaseOutcomeSymbol(approval, phase, "", ""), "‖"), "phase %q", phase)
+	}
+
+	// Once decided, the outcome tells the story: approved is a success, an
+	// unapproved gate is canceled with the rest of the workflow.
+	assert.Check(t, is.Equal(apiclient.JobPhaseOutcomeStatus(approval, "ended", "succeeded", ""), "✅ succeeded"))
+	assert.Check(t, is.Equal(apiclient.JobPhaseOutcomeText(approval, "ended", "canceled", ""), "canceled"))
+	assert.Check(t, is.Equal(apiclient.JobPhaseOutcomeSymbol(approval, "ended", "canceled", ""), "⊘"))
+
+	// A build job is untouched — the correction keys on the job type.
+	assert.Check(t, is.Equal(apiclient.JobPhaseOutcomeStatus("build", "started", "", ""), "🔵 running"))
+	assert.Check(t, is.Equal(apiclient.JobPhaseOutcomeText("", "started", "", ""), "running"))
+	assert.Check(t, is.Equal(apiclient.JobPhaseOutcomeSymbol("build", "started", "", ""), "●"))
+}

--- a/internal/apiclient/workflow.go
+++ b/internal/apiclient/workflow.go
@@ -192,9 +192,9 @@ type WorkflowJobV3 struct {
 	EndedAt        *time.Time `json:"ended_at,omitempty"`
 }
 
-// Status derives a display status from phase and outcome.
+// Status derives a display status from type, phase and outcome.
 func (w WorkflowJobV3) Status() string {
-	return PhaseOutcomeStatus(w.Phase, w.Outcome, w.CurrentOutcome)
+	return JobPhaseOutcomeStatus(w.Type, w.Phase, w.Outcome, w.CurrentOutcome)
 }
 
 func (w workflowJobWire) toDomain() WorkflowJobV3 {

--- a/internal/cmd/run/get.go
+++ b/internal/cmd/run/get.go
@@ -559,7 +559,7 @@ func jobItems(client *apiclient.Client) func(context.Context, uuid.UUID) ([]ui.R
 		for i, j := range jobs {
 			items[i] = ui.RunGetItem{
 				ID:      j.ID,
-				Icon:    apiclient.PhaseOutcomeSymbol(j.Phase, j.Outcome, j.CurrentOutcome),
+				Icon:    apiclient.JobPhaseOutcomeSymbol(j.Type, j.Phase, j.Outcome, j.CurrentOutcome),
 				Label:   j.Name,
 				Pending: pendingJobStatus(j),
 			}
@@ -569,18 +569,20 @@ func jobItems(client *apiclient.Client) func(context.Context, uuid.UUID) ([]ui.R
 }
 
 // pendingJobStatus names the status of a job that has not started — "queued",
-// "created", or the phase verbatim for a pre-start state this client does not know
-// — and is empty once the job is running or finished. Such a job has no steps yet,
+// "created", "on hold" for an approval gate awaiting a decision, or the phase
+// verbatim for a pre-start state this client does not know — and is empty once
+// the job is running or finished. Such a job has no steps yet,
 // so the picker labels the row with the status rather than letting a hollow or
 // neutral dot pass for a running job (see ui.RunGetItem.Pending). The phase it
 // reads has already been corrected for the jobs list's optimistic "started" (see
 // apiclient.effectiveJobPhase), which is what made a queued job indistinguishable
 // from a running one here.
 func pendingJobStatus(j apiclient.WorkflowJobV3) string {
-	if !apiclient.PhaseNotStarted(j.Phase) {
+	onHold := j.Type == apiclient.JobTypeApproval && j.Phase != apiclient.PhaseEnded
+	if !apiclient.PhaseNotStarted(j.Phase) && !onHold {
 		return ""
 	}
-	return apiclient.PhaseOutcomeText(j.Phase, j.Outcome, j.CurrentOutcome)
+	return apiclient.JobPhaseOutcomeText(j.Type, j.Phase, j.Outcome, j.CurrentOutcome)
 }
 
 // executionItems returns a fetch closure for the run-get picker: it lists a
@@ -927,7 +929,7 @@ func runMarkdown(r runGetOutput, u string) string {
 			md.WriteString("#### Jobs\n")
 			mdTable := mdtable.New("Name", "Status", "Type", "ID")
 			for _, j := range w.Jobs {
-				mdTable.Row(j.Name, apiclient.PhaseOutcomeStatus(j.Phase, j.Outcome, j.CurrentOutcome), j.Type, "`"+j.ID.String()+"`")
+				mdTable.Row(j.Name, apiclient.JobPhaseOutcomeStatus(j.Type, j.Phase, j.Outcome, j.CurrentOutcome), j.Type, "`"+j.ID.String()+"`")
 			}
 			md.WriteString(mdTable.Render())
 		}

--- a/internal/cmd/run/watch.go
+++ b/internal/cmd/run/watch.go
@@ -431,7 +431,7 @@ func printWatchTable(ctx context.Context, state runGetOutput, elapsed time.Durat
 		}
 		lines++
 		for _, j := range wf.Jobs {
-			jSym, jWord := watchStatusParts(j.Phase, j.Outcome, j.CurrentOutcome)
+			jSym, jWord := watchJobStatusParts(j.Type, j.Phase, j.Outcome, j.CurrentOutcome)
 			iostream.ErrPrintf(ctx, "    %-30s  %s %-10s  %s\n", j.Name, jSym, jWord, j.Type)
 			lines++
 		}
@@ -454,6 +454,14 @@ func watchStatusParts(phase, outcome, currentOutcome string) (symbol, word strin
 		apiclient.PhaseOutcomeText(phase, outcome, currentOutcome)
 }
 
+// watchJobStatusParts is watchStatusParts for a job, whose type decides whether
+// the phase means what it says: an approval gate awaiting a decision is on
+// hold, not running.
+func watchJobStatusParts(jobType, phase, outcome, currentOutcome string) (symbol, word string) {
+	return apiclient.JobPhaseOutcomeSymbol(jobType, phase, outcome, currentOutcome),
+		apiclient.JobPhaseOutcomeText(jobType, phase, outcome, currentOutcome)
+}
+
 func printWatchTableFinal(ctx context.Context, state runGetOutput) {
 	for _, wf := range state.Workflows {
 		wfSym, wfWord := watchStatusParts(wf.Phase, wf.Outcome, wf.CurrentOutcome)
@@ -463,7 +471,7 @@ func printWatchTableFinal(ctx context.Context, state runGetOutput) {
 			iostream.ErrPrintf(ctx, "  %-28s  %s %s\n", wf.Name, wfSym, wfWord)
 		}
 		for _, j := range wf.Jobs {
-			jSym, jWord := watchStatusParts(j.Phase, j.Outcome, j.CurrentOutcome)
+			jSym, jWord := watchJobStatusParts(j.Type, j.Phase, j.Outcome, j.CurrentOutcome)
 			iostream.ErrPrintf(ctx, "    %-30s  %s %-10s  %s\n", j.Name, jSym, jWord, j.Type)
 		}
 	}

--- a/internal/cmd/workflow/get.go
+++ b/internal/cmd/workflow/get.go
@@ -219,7 +219,7 @@ func workflowMarkdown(w workflowGetOutput, u string) string {
 		_, _ = fmt.Fprintf(&md, "\n## Jobs\n")
 		table := mdtable.New("Name", "Status", "Type", "ID")
 		for _, j := range w.Jobs {
-			table.Row(j.Name, apiclient.PhaseOutcomeStatus(j.Phase, j.Outcome, j.CurrentOutcome), j.Type, "`"+j.ID.String()+"`")
+			table.Row(j.Name, apiclient.JobPhaseOutcomeStatus(j.Type, j.Phase, j.Outcome, j.CurrentOutcome), j.Type, "`"+j.ID.String()+"`")
 		}
 		md.WriteString(table.Render())
 	}

--- a/internal/ui/run_get_flow.go
+++ b/internal/ui/run_get_flow.go
@@ -2046,6 +2046,8 @@ func statusIconStyle(symbol string) (lipgloss.Style, bool) {
 		return theme.WarningStyle, true // errored / timed out
 	case "●":
 		return theme.RunningStyle, true // running
+	case "‖":
+		return theme.WarningStyle, true // approval gate on hold, waiting on a person
 	case "○", "⊘", "•":
 		// Created/queued, canceled, and the neutral bullet PhaseOutcomeSymbol falls
 		// back to for a phase or outcome it does not know. The bullet is muted for the


### PR DESCRIPTION
The V3 API reports an approval gate awaiting a decision in the `started` phase, so every job display rendered it as `🔵 running`

## Change

- `internal/apiclient/job.go`: new `JobTypeApproval` const and job-type-aware `JobPhaseOutcomeStatus` / `JobPhaseOutcomeText` / `JobPhaseOutcomeSymbol`. An approval job in any phase short of `ended` renders `⏸️ on hold` / `on hold` / `‖`; once ended, its outcome stands (succeeded when approved, canceled when not). Non-approval jobs are untouched.
- `WorkflowJobV3.Status()` and `JobV3.Status()` now go through the type-aware helpers.
- Call sites that know the job type use them: `run get` (markdown table, picker icon, `pendingJobStatus`), `workflow get`, `job get`, `run watch`. Runs and workflows have no type, so they keep the plain helpers.
- The picker styles the `‖` glyph with `WarningStyle` — the job is waiting on a person.

The predicate is "phase is not `ended`" rather than "phase is `started`": a pending approval never waits on an executor, and `effectiveJobPhase` rewrites a started-with-no-`started_at` job to `queued`, so both states are on hold.

## Testing

- `TestJobPhaseOutcome_Approval` unit test covers each pre-ended phase, both terminal outcomes, and a build job as a control.
- `TestRunGet_ByID_ApprovalOnHold` acceptance test with golden output.
- `task check` and `task test` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)