### PR TITLE
Add code signing commands for updating and removing profiles

### DIFF
--- a/acceptance/certificate_test.go
+++ b/acceptance/certificate_test.go
@@ -24,6 +24,7 @@ package acceptance_test
 
 import (
 	"bytes"
+	"fmt"
 	"net/http"
 	"net/url"
 	"os"
@@ -53,13 +54,21 @@ func fakeIOSCert(id, fileName string) fakes.IOSCert {
 // certFileName populates the nested certificate reference; CertID is the FK the
 // fake's cert-in-use check reads (never sent on the wire).
 func fakeIOSSigningConfig(id, name, certID, certFileName string, profileFiles ...string) fakes.IOSSigningConfig {
+	profiles := make([]fakes.IOSProfile, 0, len(profileFiles))
+	for _, fileName := range profileFiles {
+		profiles = append(profiles, fakes.IOSProfile{
+			FileName:    fileName,
+			BundleID:    "fixture-bundle:" + fileName,
+			ProfileType: "fixture-type",
+		})
+	}
 	return fakes.IOSSigningConfig{
 		ID:                   id,
 		Name:                 name,
 		CertID:               certID,
 		CertFileName:         certFileName,
 		CertType:             "distribution",
-		ProvisioningProfiles: profileFiles,
+		ProvisioningProfiles: profiles,
 	}
 }
 
@@ -79,6 +88,12 @@ func writeBinaryFile(t *testing.T, dir, name, content string) string {
 	path := filepath.Join(dir, name)
 	assert.NilError(t, os.WriteFile(path, []byte(content), 0o600))
 	return name
+}
+
+// fakeMobileProvisionContent stands in for a real .mobileprovision plist,
+// letting the fake server parse a bundle ID and profile type back out of it.
+func fakeMobileProvisionContent(bundleID, profileType string) string {
+	return fmt.Sprintf("bundle-id=%s;profile-type=%s", bundleID, profileType)
 }
 
 // --- certificate upload ---

--- a/acceptance/signing_config_test.go
+++ b/acceptance/signing_config_test.go
@@ -314,3 +314,194 @@ func TestSigningConfigDelete_RequiresForce(t *testing.T) {
 	assert.Check(t, golden.String(result.Stderr, t.Name()+".stderr.txt"))
 	assert.Check(t, !fake.DeletedIOSBundle("eccccccc-cccc-cccc-cccc-cccccccccccc"))
 }
+
+// --- signing-config profile add ---
+
+// fakeIOSSigningConfigWithProfileID is fakeIOSSigningConfig for a single
+// profile, with a known profile ID injected so profile remove tests can
+// reference it without going through a real create + list round trip.
+func fakeIOSSigningConfigWithProfileID(id, name, certID, certFileName, profileID, profileFileName string) fakes.IOSSigningConfig {
+	cfg := fakeIOSSigningConfig(id, name, certID, certFileName, profileFileName)
+	if len(cfg.ProvisioningProfiles) > 0 {
+		cfg.ProvisioningProfiles[0].ID = profileID
+	}
+	return cfg
+}
+
+func TestSigningConfigProfileAdd(t *testing.T) {
+	fake := fakes.NewCircleCI(t)
+	fake.AddIOSBundle(testIOSOrgID, fakeIOSSigningConfig("eccccccc-cccc-cccc-cccc-cccccccccccc", "production-signing", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "Distribution.p12",
+		"MyApp.mobileprovision"))
+	env := setupIOSEnv(t, fake)
+
+	dir := t.TempDir()
+	profilePath := writeBinaryFile(t, dir, "MyAppExtension.mobileprovision", "fake-profile-bytes")
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary: binaryPath,
+		Args: []string{
+			"signing-config", "profile", "add", "eccccccc-cccc-cccc-cccc-cccccccccccc",
+			"--profile", profilePath,
+		},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Check(t, golden.String(result.Stdout, t.Name()+".txt"))
+
+	t.Run("check request", func(t *testing.T) {
+		assert.Check(t, cmp.DeepEqual(fake.LastRequest(), &httprecorder.Request{
+			Method: http.MethodPost,
+			URL:    url.URL{Path: "/api/v3/signing/configs/eccccccc-cccc-cccc-cccc-cccccccccccc/update-profile"},
+			Header: http.Header{
+				"Authorization": {"Bearer test-token"},
+				"User-Agent":    {httpcl.UserAgent(runtime.GOOS, runtime.GOARCH, "dev", "")},
+			},
+			Body: new(`{"blob":"ZmFrZS1wcm9maWxlLWJ5dGVz","file_name":"MyAppExtension.mobileprovision"}`),
+		}, ignoreCommonHeaders))
+	})
+}
+
+func TestSigningConfigProfileAdd_Replace(t *testing.T) {
+	fake := fakes.NewCircleCI(t)
+	existing := fakeIOSSigningConfig("eccccccc-cccc-cccc-cccc-cccccccccccc", "production-signing", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "Distribution.p12",
+		"MyApp.mobileprovision")
+	existing.ProvisioningProfiles[0].BundleID = "com.example.myapp"
+	existing.ProvisioningProfiles[0].ProfileType = "ios-app-store"
+	fake.AddIOSBundle(testIOSOrgID, existing)
+	env := setupIOSEnv(t, fake)
+
+	// Different file name, same bundle ID and profile type: still a replace.
+	dir := t.TempDir()
+	profilePath := writeBinaryFile(t, dir, "MyApp-2026.mobileprovision", fakeMobileProvisionContent("com.example.myapp", "ios-app-store"))
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary: binaryPath,
+		Args: []string{
+			"signing-config", "profile", "add", "eccccccc-cccc-cccc-cccc-cccccccccccc",
+			"--profile", profilePath,
+		},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+
+	list := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"signing-config", "list", "--org", testIOSOrgID},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+	assert.Equal(t, list.ExitCode, 0, "stderr: %s", list.Stderr)
+	assert.Check(t, golden.String(list.Stdout, t.Name()+".txt"))
+}
+
+func TestSigningConfigProfileAdd_MissingProfile(t *testing.T) {
+	fake := fakes.NewCircleCI(t)
+	fake.AddIOSBundle(testIOSOrgID, fakeIOSSigningConfig("eccccccc-cccc-cccc-cccc-cccccccccccc", "production-signing", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "Distribution.p12"))
+	env := setupIOSEnv(t, fake)
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"signing-config", "profile", "add", "eccccccc-cccc-cccc-cccc-cccccccccccc"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 2, "stderr: %s", result.Stderr)
+	assert.Check(t, golden.String(result.Stderr, t.Name()+".stderr.txt"))
+}
+
+func TestSigningConfigProfileAdd_NotFound(t *testing.T) {
+	fake := fakes.NewCircleCI(t)
+	env := setupIOSEnv(t, fake)
+
+	dir := t.TempDir()
+	profilePath := writeBinaryFile(t, dir, "MyApp.mobileprovision", "fake-profile-bytes")
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary: binaryPath,
+		Args: []string{
+			"signing-config", "profile", "add", "eddddddd-dddd-dddd-dddd-dddddddddddd",
+			"--profile", profilePath,
+		},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	assert.Equal(t, result.ExitCode, 5, "stderr: %s", result.Stderr)
+	assert.Check(t, golden.String(result.Stderr, t.Name()+".stderr.txt"))
+}
+
+// --- signing-config profile remove ---
+
+func TestSigningConfigProfileRemove(t *testing.T) {
+	fake := fakes.NewCircleCI(t)
+	fake.AddIOSBundle(testIOSOrgID, fakeIOSSigningConfigWithProfileID("eccccccc-cccc-cccc-cccc-cccccccccccc", "production-signing", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "Distribution.p12",
+		"30000000-0000-0000-0000-000000000001", "MyApp.mobileprovision"))
+	env := setupIOSEnv(t, fake)
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary: binaryPath,
+		Args: []string{
+			"signing-config", "profile", "remove",
+			"eccccccc-cccc-cccc-cccc-cccccccccccc", "30000000-0000-0000-0000-000000000001",
+		},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Check(t, golden.String(result.Stdout, t.Name()+".txt"))
+
+	t.Run("check request", func(t *testing.T) {
+		assert.Check(t, cmp.DeepEqual(fake.LastRequest(), &httprecorder.Request{
+			Method: http.MethodPost,
+			URL:    url.URL{Path: "/api/v3/signing/configs/eccccccc-cccc-cccc-cccc-cccccccccccc/remove-profile"},
+			Header: http.Header{
+				"Authorization": {"Bearer test-token"},
+				"User-Agent":    {httpcl.UserAgent(runtime.GOOS, runtime.GOARCH, "dev", "")},
+			},
+			Body: new(`{"profile_id":"30000000-0000-0000-0000-000000000001"}`),
+		}, ignoreCommonHeaders))
+	})
+}
+
+func TestSigningConfigProfileRemove_NotFound(t *testing.T) {
+	fake := fakes.NewCircleCI(t)
+	env := setupIOSEnv(t, fake)
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary: binaryPath,
+		Args: []string{
+			"signing-config", "profile", "remove",
+			"eddddddd-dddd-dddd-dddd-dddddddddddd", "30000000-0000-0000-0000-000000000001",
+		},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 5, "stderr: %s", result.Stderr)
+	assert.Check(t, golden.String(result.Stderr, t.Name()+".stderr.txt"))
+}
+
+func TestSigningConfigProfileRemove_AlreadyAbsent(t *testing.T) {
+	fake := fakes.NewCircleCI(t)
+	fake.AddIOSBundle(testIOSOrgID, fakeIOSSigningConfigWithProfileID("eccccccc-cccc-cccc-cccc-cccccccccccc", "production-signing", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "Distribution.p12",
+		"30000000-0000-0000-0000-000000000001", "MyApp.mobileprovision"))
+	env := setupIOSEnv(t, fake)
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary: binaryPath,
+		Args: []string{
+			"signing-config", "profile", "remove",
+			"eccccccc-cccc-cccc-cccc-cccccccccccc", "39999999-9999-9999-9999-999999999999",
+		},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Check(t, golden.String(result.Stdout, t.Name()+".txt"))
+}

--- a/acceptance/testdata/TestSigningConfigProfileAdd.txt
+++ b/acceptance/testdata/TestSigningConfigProfileAdd.txt
@@ -1,0 +1,1 @@
+✓ Added profile "MyAppExtension.mobileprovision" to signing config eccccccc-cccc-cccc-cccc-cccccccccccc

--- a/acceptance/testdata/TestSigningConfigProfileAdd_MissingProfile.stderr.txt
+++ b/acceptance/testdata/TestSigningConfigProfileAdd_MissingProfile.stderr.txt
@@ -1,0 +1,1 @@
+error: Required flag --profile was not set.

--- a/acceptance/testdata/TestSigningConfigProfileAdd_NotFound.stderr.txt
+++ b/acceptance/testdata/TestSigningConfigProfileAdd_NotFound.stderr.txt
@@ -1,0 +1,7 @@
+error: No iOS signing config found for "eddddddd-dddd-dddd-dddd-dddddddddddd".
+API: {"message":"not found"}
+
+
+Suggestions:
+  • Check the signing config ID and try again
+  • Run: circleci signing-config list --org <org>

--- a/acceptance/testdata/TestSigningConfigProfileAdd_Replace.txt
+++ b/acceptance/testdata/TestSigningConfigProfileAdd_Replace.txt
@@ -1,0 +1,4 @@
+# iOS Signing Configs
+| ID                                     | Name               | Certificate Name | Profiles |
+| -------------------------------------- | ------------------ | ---------------- | -------- |
+| `eccccccc-cccc-cccc-cccc-cccccccccccc` | production-signing | Distribution.p12 | 1        |

--- a/acceptance/testdata/TestSigningConfigProfileRemove.txt
+++ b/acceptance/testdata/TestSigningConfigProfileRemove.txt
@@ -1,0 +1,1 @@
+✓ Removed profile 30000000-0000-0000-0000-000000000001 from signing config eccccccc-cccc-cccc-cccc-cccccccccccc

--- a/acceptance/testdata/TestSigningConfigProfileRemove_AlreadyAbsent.txt
+++ b/acceptance/testdata/TestSigningConfigProfileRemove_AlreadyAbsent.txt
@@ -1,0 +1,1 @@
+✓ Removed profile 39999999-9999-9999-9999-999999999999 from signing config eccccccc-cccc-cccc-cccc-cccccccccccc

--- a/acceptance/testdata/TestSigningConfigProfileRemove_NotFound.stderr.txt
+++ b/acceptance/testdata/TestSigningConfigProfileRemove_NotFound.stderr.txt
@@ -1,0 +1,7 @@
+error: No iOS signing config found for "eddddddd-dddd-dddd-dddd-dddddddddddd".
+API: {"message":"not found"}
+
+
+Suggestions:
+  • Check the signing config ID and try again
+  • Run: circleci signing-config list --org <org>

--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -218,6 +218,16 @@ func (c *Client) deleteV3(ctx context.Context, route string, opts ...func(*httpc
 	return err
 }
 
+// postV3NoContent POSTs a body to a v3 route that responds 204 No Content on
+// success. Unlike postV3, no JSONDecoder is attached — decoding an empty body
+// as JSON would fail with io.EOF.
+func (c *Client) postV3NoContent(ctx context.Context, route string, body any, opts ...func(*httpcl.Request)) error {
+	_, err := c.main.Call(ctx, httpcl.NewRequest(http.MethodPost, "/api/v3"+route, baseOpts(
+		httpcl.Body(body),
+	).With(opts)...))
+	return err
+}
+
 type baseOptions []func(*httpcl.Request)
 
 func baseOpts(opts ...func(*httpcl.Request)) baseOptions {

--- a/internal/apiclient/iossigning.go
+++ b/internal/apiclient/iossigning.go
@@ -58,8 +58,9 @@ type IOSCertificateRef struct {
 }
 
 // IOSProvisioningProfile is a base64-encoded Apple provisioning profile. Blob
-// is populated on create; list responses only echo the file name.
+// is populated on create; list responses only echo the file name and ID
 type IOSProvisioningProfile struct {
+	ID       string `json:"id,omitempty"`
 	FileName string `json:"file_name"`
 	Blob     string `json:"blob,omitempty"`
 }
@@ -183,4 +184,26 @@ func (c *Client) ListIOSSigningConfigs(ctx context.Context, orgID uuid.UUID) ([]
 // 204 No Content on success.
 func (c *Client) DeleteIOSSigningConfig(ctx context.Context, id uuid.UUID) error {
 	return c.deleteV3(ctx, "/signing/configs/%s", routeParams(id))
+}
+
+// UpdateIOSSigningConfigProfile adds or replaces a provisioning profile on an
+// existing signing config, without recreating it. The server matches profiles
+// by the bundle identifier and profile type embedded in the provisioning
+// profile file itself, a profile with the same bundle ID and type as an
+// existing one replaces it in place; any other  pairing is added as a new
+// profile. blob must be base64-encoded. The server returns 204 No Content on success.
+func (c *Client) UpdateIOSSigningConfigProfile(ctx context.Context, configID uuid.UUID, fileName, blob string) error {
+	body := map[string]any{
+		"file_name": fileName,
+		"blob":      blob,
+	}
+	return c.postV3NoContent(ctx, "/signing/configs/%s/update-profile", body, routeParams(configID))
+}
+
+// RemoveIOSSigningConfigProfile removes a provisioning profile from an
+// existing signing config by profile ID. Removing an already-absent profile
+// is a no-op.
+func (c *Client) RemoveIOSSigningConfigProfile(ctx context.Context, configID, profileID uuid.UUID) error {
+	body := map[string]any{"profile_id": profileID}
+	return c.postV3NoContent(ctx, "/signing/configs/%s/remove-profile", body, routeParams(configID))
 }

--- a/internal/cmd/root/testdata/help/circleci/reference.txt
+++ b/internal/cmd/root/testdata/help/circleci/reference.txt
@@ -4013,6 +4013,79 @@ JSON fields: id, name, certificate, provisioning_profiles
 - Get signing config names only: 
   `circleci signing-config list --json --jq '.[].name'`
 
+#### `circleci signing-config profile <command>`
+
+Add or remove provisioning profiles on a signing config
+
+Add, replace, or remove a provisioning profile on an existing signing
+config, without recreating the whole config.
+
+A profile is matched to an existing one by the bundle identifier and
+profile type embedded in the provisioning profile file itself, not by
+file name: the same bundle ID and type replaces it in place, and
+anything else is added alongside it.
+
+Recreating a signing config (delete then create) leaves a gap where
+pipelines referencing it by name fail; these commands update it in
+place instead.
+
+##### `circleci signing-config profile add <signing-config-id> [flags]`
+
+Add or replace a provisioning profile on a signing config
+
+Add a provisioning profile to a signing config, or replace one that
+already has the same bundle identifier and profile type.
+
+The file at --profile is read and base64-encoded locally, then sent
+to CircleCI. The config's other profiles and certificate are left
+untouched.
+
+| Flag               | Description                         |
+| ------------------ | ----------------------------------- |
+| `--profile string` | Path to a provisioning profile file |
+
+
+**Arguments:**
+
+`<signing-config-id>` is the ID of the signing config to update.
+Use `circleci signing-config list` to find the ID.
+
+**Examples:**
+
+- Add a new profile: 
+  `circleci signing-config profile add <signing-config-id> --profile ./MyAppExtension.mobileprovision`
+- Replace an existing profile (same bundle ID and profile type, regardless of file name): 
+  `circleci signing-config profile add <signing-config-id> --profile ./MyApp.mobileprovision`
+- Find the signing config ID first: 
+  `circleci signing-config list --json --jq '.[].id'`
+
+##### `circleci signing-config profile remove <signing-config-id> <profile-id>`
+
+Remove a provisioning profile from a signing config
+
+Remove a single provisioning profile from a signing config, without
+recreating the whole config.
+
+Removing a profile that no longer exists is not an error.
+
+**Arguments:**
+
+`<signing-config-id>` is the ID of the signing config to update.
+`<profile-id>` is the ID of the provisioning profile to remove.
+Use `circleci signing-config list --json` to find both IDs.
+
+**Aliases:**
+
+
+`circleci signing-config profile rm`
+
+**Examples:**
+
+- Remove a profile by ID: 
+  `circleci signing-config profile remove <signing-config-id> <profile-id>`
+- Find the profile ID first: 
+  `circleci signing-config list --json --jq '.[] | select(.id=="<signing-config-id>") | .provisioning_profiles'`
+
 ## User Commands
 
 ### `circleci auth <command>`

--- a/internal/cmd/root/testdata/help/circleci/signing-config.txt
+++ b/internal/cmd/root/testdata/help/circleci/signing-config.txt
@@ -17,6 +17,12 @@ Manage iOS signing configs
 | -------- | ---------------------------- |
 | `delete` | Delete an iOS signing config |
 
+## Subcommands
+
+| Command   | Description                                             |
+| --------- | ------------------------------------------------------- |
+| `profile` | Add or remove provisioning profiles on a signing config |
+
 ## Flags
 
 Global flags: `-c, --config`, `--debug`, `--no-color`, `-q, --quiet` — see `circleci --help`.

--- a/internal/cmd/root/testdata/help/circleci/signing-config/profile.txt
+++ b/internal/cmd/root/testdata/help/circleci/signing-config/profile.txt
@@ -1,0 +1,31 @@
+Add or remove provisioning profiles on a signing config
+
+## Usage
+
+`circleci signing-config profile <command> [flags]`
+
+## Available Commands
+
+| Command  | Description                                               |
+| -------- | --------------------------------------------------------- |
+| `add`    | Add or replace a provisioning profile on a signing config |
+| `remove` | Remove a provisioning profile from a signing config       |
+
+## Flags
+
+Global flags: `-c, --config`, `--debug`, `--no-color`, `-q, --quiet` — see `circleci --help`.
+
+## Details
+
+Add, replace, or remove a provisioning profile on an existing signing
+config, without recreating the whole config.
+
+A profile is matched to an existing one by the bundle identifier and
+profile type embedded in the provisioning profile file itself, not by
+file name: the same bundle ID and type replaces it in place, and
+anything else is added alongside it.
+
+Recreating a signing config (delete then create) leaves a gap where
+pipelines referencing it by name fail; these commands update it in
+place instead.
+

--- a/internal/cmd/root/testdata/help/circleci/signing-config/profile/add.txt
+++ b/internal/cmd/root/testdata/help/circleci/signing-config/profile/add.txt
@@ -1,0 +1,37 @@
+Add or replace a provisioning profile on a signing config
+
+## Usage
+
+`circleci signing-config profile add <signing-config-id> [flags]`
+
+## Arguments
+
+`<signing-config-id>` is the ID of the signing config to update.
+Use `circleci signing-config list` to find the ID.
+
+## Flags
+
+| Flag               | Description                         |
+| ------------------ | ----------------------------------- |
+| `--profile string` | Path to a provisioning profile file |
+
+Global flags: `-c, --config`, `--debug`, `--no-color`, `-q, --quiet` — see `circleci --help`.
+
+## Examples
+
+- Add a new profile: 
+  `circleci signing-config profile add <signing-config-id> --profile ./MyAppExtension.mobileprovision`
+- Replace an existing profile (same bundle ID and profile type, regardless of file name): 
+  `circleci signing-config profile add <signing-config-id> --profile ./MyApp.mobileprovision`
+- Find the signing config ID first: 
+  `circleci signing-config list --json --jq '.[].id'`
+
+## Details
+
+Add a provisioning profile to a signing config, or replace one that
+already has the same bundle identifier and profile type.
+
+The file at --profile is read and base64-encoded locally, then sent
+to CircleCI. The config's other profiles and certificate are left
+untouched.
+

--- a/internal/cmd/root/testdata/help/circleci/signing-config/profile/remove.txt
+++ b/internal/cmd/root/testdata/help/circleci/signing-config/profile/remove.txt
@@ -1,0 +1,32 @@
+Remove a provisioning profile from a signing config
+
+## Usage
+
+`circleci signing-config profile remove <signing-config-id> <profile-id> [flags]`
+
+Aliases: `circleci signing-config profile rm`
+
+## Arguments
+
+`<signing-config-id>` is the ID of the signing config to update.
+`<profile-id>` is the ID of the provisioning profile to remove.
+Use `circleci signing-config list --json` to find both IDs.
+
+## Flags
+
+Global flags: `-c, --config`, `--debug`, `--no-color`, `-q, --quiet` — see `circleci --help`.
+
+## Examples
+
+- Remove a profile by ID: 
+  `circleci signing-config profile remove <signing-config-id> <profile-id>`
+- Find the profile ID first: 
+  `circleci signing-config list --json --jq '.[] | select(.id=="<signing-config-id>") | .provisioning_profiles'`
+
+## Details
+
+Remove a single provisioning profile from a signing config, without
+recreating the whole config.
+
+Removing a profile that no longer exists is not an error.
+

--- a/internal/cmd/root/testdata/usage/circleci/signing-config.txt
+++ b/internal/cmd/root/testdata/usage/circleci/signing-config.txt
@@ -4,3 +4,4 @@ Available commands:
   create
   delete
   list
+  profile

--- a/internal/cmd/root/testdata/usage/circleci/signing-config/profile.txt
+++ b/internal/cmd/root/testdata/usage/circleci/signing-config/profile.txt
@@ -1,0 +1,5 @@
+Usage:  circleci signing-config profile <command> [flags]
+
+Available commands:
+  add
+  remove

--- a/internal/cmd/root/testdata/usage/circleci/signing-config/profile/add.txt
+++ b/internal/cmd/root/testdata/usage/circleci/signing-config/profile/add.txt
@@ -1,0 +1,6 @@
+Usage:  circleci signing-config profile add <signing-config-id> [flags]
+
+Flags:
+  -h, --help             help for add
+      --profile string   Path to a provisioning profile file
+  

--- a/internal/cmd/root/testdata/usage/circleci/signing-config/profile/remove.txt
+++ b/internal/cmd/root/testdata/usage/circleci/signing-config/profile/remove.txt
@@ -1,0 +1,5 @@
+Usage:  circleci signing-config profile remove <signing-config-id> <profile-id> [flags]
+
+Flags:
+  -h, --help   help for remove
+  

--- a/internal/cmd/signingconfig/profile.go
+++ b/internal/cmd/signingconfig/profile.go
@@ -1,0 +1,203 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package signingconfig
+
+import (
+	"fmt"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/google/uuid"
+	"github.com/spf13/cobra"
+
+	"github.com/CircleCI-Public/circleci-cli/internal/cmdutil"
+	clierrors "github.com/CircleCI-Public/circleci-cli/internal/errors"
+	"github.com/CircleCI-Public/circleci-cli/internal/iossigning"
+	"github.com/CircleCI-Public/circleci-cli/internal/iostream"
+)
+
+func newProfileCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "profile <command>",
+		Short: "Add or remove provisioning profiles on a signing config",
+		Long: heredoc.Doc(`
+			Add, replace, or remove a provisioning profile on an existing signing
+			config, without recreating the whole config.
+
+			A profile is matched to an existing one by the bundle identifier and
+			profile type embedded in the provisioning profile file itself, not by
+			file name: the same bundle ID and type replaces it in place, and
+			anything else is added alongside it.
+
+			Recreating a signing config (delete then create) leaves a gap where
+			pipelines referencing it by name fail; these commands update it in
+			place instead.
+		`),
+	}
+
+	cmd.AddCommand(newProfileAddCmd())
+	cmd.AddCommand(newProfileRemoveCmd())
+
+	return cmd
+}
+
+func parseSigningConfigID(idArg string) (uuid.UUID, error) {
+	id, err := uuid.Parse(idArg)
+	if err != nil {
+		return uuid.Nil, clierrors.New("signing_config.invalid_id", "Invalid signing config ID",
+			fmt.Sprintf("%q is not a valid signing config ID.", idArg)).
+			WithSuggestions("Run: circleci signing-config list --org <org>").
+			WithExitCode(clierrors.ExitBadArguments)
+	}
+	return id, nil
+}
+
+// --- signing-config profile add ---
+
+func newProfileAddCmd() *cobra.Command {
+	var profilePath string
+
+	cmd := &cobra.Command{
+		Use:   "add <signing-config-id>",
+		Short: "Add or replace a provisioning profile on a signing config",
+		Annotations: map[string]string{
+			"help:arguments": heredoc.Docf(`
+				%[1]s<signing-config-id>%[1]s is the ID of the signing config to update.
+				Use %[1]scircleci signing-config list%[1]s to find the ID.
+			`, "`"),
+		},
+		Long: heredoc.Doc(`
+			Add a provisioning profile to a signing config, or replace one that
+			already has the same bundle identifier and profile type.
+
+			The file at --profile is read and base64-encoded locally, then sent
+			to CircleCI. The config's other profiles and certificate are left
+			untouched.
+		`),
+		Example: heredoc.Doc(`
+			# Add a new profile
+			$ circleci signing-config profile add <signing-config-id> --profile ./MyAppExtension.mobileprovision
+
+			# Replace an existing profile (same bundle ID and profile type, regardless of file name)
+			$ circleci signing-config profile add <signing-config-id> --profile ./MyApp.mobileprovision
+
+			# Find the signing config ID first
+			$ circleci signing-config list --json --jq '.[].id'
+		`),
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := cmdutil.RequireArgs(args, "signing-config-id"); err != nil {
+				return err
+			}
+			if profilePath == "" {
+				return cmdutil.RequireFlag("profile")
+			}
+			ctx := cmd.Context()
+			idArg := args[0]
+			id, err := parseSigningConfigID(idArg)
+			if err != nil {
+				return err
+			}
+
+			fileName, blob, err := iossigning.EncodeFile(profilePath)
+			if err != nil {
+				return clierrors.New("signing_config.profile_file_unreadable", "Cannot read provisioning profile", err.Error()).
+					WithExitCode(clierrors.ExitBadArguments)
+			}
+
+			client, err := cmdutil.LoadClient(ctx)
+			if err != nil {
+				return err
+			}
+			if err := client.UpdateIOSSigningConfigProfile(ctx, id, fileName, blob); err != nil {
+				return apiErr(err, idArg)
+			}
+			iostream.Printf(ctx, "%s Added profile %q to signing config %s\n", iostream.SymbolOK(ctx), fileName, idArg)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&profilePath, "profile", "", "Path to a provisioning profile file")
+
+	return cmd
+}
+
+// --- signing-config profile remove ---
+
+func newProfileRemoveCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "remove <signing-config-id> <profile-id>",
+		Aliases: []string{"rm"},
+		Short:   "Remove a provisioning profile from a signing config",
+		Annotations: map[string]string{
+			"help:arguments": heredoc.Docf(`
+				%[1]s<signing-config-id>%[1]s is the ID of the signing config to update.
+				%[1]s<profile-id>%[1]s is the ID of the provisioning profile to remove.
+				Use %[1]scircleci signing-config list --json%[1]s to find both IDs.
+			`, "`"),
+		},
+		Long: heredoc.Doc(`
+			Remove a single provisioning profile from a signing config, without
+			recreating the whole config.
+
+			Removing a profile that no longer exists is not an error.
+		`),
+		Example: heredoc.Doc(`
+			# Remove a profile by ID
+			$ circleci signing-config profile remove <signing-config-id> <profile-id>
+
+			# Find the profile ID first
+			$ circleci signing-config list --json --jq '.[] | select(.id=="<signing-config-id>") | .provisioning_profiles'
+		`),
+		Args: cobra.MaximumNArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := cmdutil.RequireArgs(args, "signing-config-id", "profile-id"); err != nil {
+				return err
+			}
+			ctx := cmd.Context()
+			idArg, profileIDArg := args[0], args[1]
+			id, err := parseSigningConfigID(idArg)
+			if err != nil {
+				return err
+			}
+			profileID, err := uuid.Parse(profileIDArg)
+			if err != nil {
+				return clierrors.New("signing_config.invalid_profile_id", "Invalid profile ID",
+					fmt.Sprintf("%q is not a valid provisioning profile ID.", profileIDArg)).
+					WithSuggestions("Run: circleci signing-config list --json").
+					WithExitCode(clierrors.ExitBadArguments)
+			}
+
+			client, err := cmdutil.LoadClient(ctx)
+			if err != nil {
+				return err
+			}
+			if err := client.RemoveIOSSigningConfigProfile(ctx, id, profileID); err != nil {
+				return apiErr(err, idArg)
+			}
+			iostream.Printf(ctx, "%s Removed profile %s from signing config %s\n", iostream.SymbolOK(ctx), profileIDArg, idArg)
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/internal/cmd/signingconfig/signingconfig.go
+++ b/internal/cmd/signingconfig/signingconfig.go
@@ -67,6 +67,9 @@ func NewSigningConfigCmd() *cobra.Command {
 	cmdutil.AddGroup(cmd, "Targeted commands",
 		newDeleteCmd(),
 	)
+	cmdutil.AddGroup(cmd, "Subcommands",
+		newProfileCmd(),
+	)
 
 	return cmd
 }

--- a/internal/testing/fakes/circleci.go
+++ b/internal/testing/fakes/circleci.go
@@ -24,6 +24,7 @@
 package fakes
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -149,6 +150,7 @@ type CircleCI struct {
 	deletedIOSBundles map[string]bool               // bundle id → deleted
 	iosCertCounter    int                           // monotonic ID generator for uploaded certs
 	iosBundleCounter  int                           // monotonic ID generator for created bundles
+	iosProfileCounter int                           // monotonic ID generator for provisioning profiles
 
 	// Auth state.
 	tokens             map[string]bool // accepted bearer tokens; a request whose Authorization: Bearer <token> is absent from this set is rejected 401 on every non-exempt route
@@ -396,6 +398,8 @@ func NewCircleCI(t *testing.T, tokens ...string) *CircleCI {
 	r.Post("/api/v3/signing/configs", f.handleCreateIOSBundle)
 	r.Get("/api/v3/signing/configs", f.handleListIOSBundles)
 	r.Delete("/api/v3/signing/configs/{id}", f.handleDeleteIOSBundle)
+	r.Post("/api/v3/signing/configs/{id}/update-profile", f.handleUpdateIOSBundleProfile)
+	r.Post("/api/v3/signing/configs/{id}/remove-profile", f.handleRemoveIOSBundleProfile)
 	// Config compile + org routes.
 	r.Post("/api/v3/configs/compile", f.handleCompileConfig)
 	r.Get("/api/v3/tool/releases", f.handleGetReleases)
@@ -3491,6 +3495,42 @@ type IOSCert struct {
 	CertType string
 }
 
+// IOSProfile holds the ID and file name of a provisioning profile for the
+// remove-profile endpoint
+// BundleID/ProfileType mirror the real server's replace-match key (bundle
+// identifier + profile type embedded in the file, not the file name); the
+// fake reads them from a stand-in content convention instead of a real plist
+// parser (see fakeMobileProvisionContent in acceptance/certificate_test.go).
+type IOSProfile struct {
+	ID          string
+	FileName    string
+	BundleID    string
+	ProfileType string
+}
+
+// parseFakeMobileProvisionBlob extracts the bundle ID and profile type
+// fakeMobileProvisionContent encoded into a base64-encoded blob. Content that
+// doesn't follow that convention yields empty values.
+func parseFakeMobileProvisionBlob(blob string) (bundleID, profileType string) {
+	decoded, err := base64.StdEncoding.DecodeString(blob)
+	if err != nil {
+		return "", ""
+	}
+	for _, field := range strings.Split(string(decoded), ";") {
+		k, v, ok := strings.Cut(field, "=")
+		if !ok {
+			continue
+		}
+		switch k {
+		case "bundle-id":
+			bundleID = v
+		case "profile-type":
+			profileType = v
+		}
+	}
+	return bundleID, profileType
+}
+
 // IOSSigningConfig is a stored iOS signing config (bundle) served by the
 // signing config list endpoint. CertID links it to the IOSCert it uses (the
 // cert-in-use check on delete); CertFileName/CertType are the certificate
@@ -3501,7 +3541,7 @@ type IOSSigningConfig struct {
 	CertID               string
 	CertFileName         string
 	CertType             string
-	ProvisioningProfiles []string
+	ProvisioningProfiles []IOSProfile
 }
 
 // AddIOSCert registers an iOS certificate for an org, returned by
@@ -3533,7 +3573,7 @@ func iosCertEntity(c IOSCert) map[string]any {
 func iosSigningConfigEntity(b IOSSigningConfig) map[string]any {
 	profiles := make([]map[string]any, len(b.ProvisioningProfiles))
 	for i, p := range b.ProvisioningProfiles {
-		profiles[i] = map[string]any{"file_name": p}
+		profiles[i] = map[string]any{"id": p.ID, "file_name": p.FileName}
 	}
 	return map[string]any{
 		"id": b.ID,
@@ -3742,10 +3782,19 @@ func (f *CircleCI) handleCreateIOSBundle(w http.ResponseWriter, r *http.Request)
 	f.iosBundleCounter++
 	id := fmt.Sprintf("10000000-0000-0000-0000-%012d", f.iosBundleCounter)
 
-	// Provisioning-profile list response echoes only file_name, not the blob.
-	profiles := make([]string, len(body.Data.Attributes.ProvisioningProfiles))
+	// Provisioning-profile list response echoes the id and file_name, not the blob.
+	profiles := make([]IOSProfile, len(body.Data.Attributes.ProvisioningProfiles))
 	for i, p := range body.Data.Attributes.ProvisioningProfiles {
-		profiles[i], _ = p["file_name"].(string)
+		f.iosProfileCounter++
+		fileName, _ := p["file_name"].(string)
+		blob, _ := p["blob"].(string)
+		bundleID, profileType := parseFakeMobileProvisionBlob(blob)
+		profiles[i] = IOSProfile{
+			ID:          fmt.Sprintf("20000000-0000-0000-0000-%012d", f.iosProfileCounter),
+			FileName:    fileName,
+			BundleID:    bundleID,
+			ProfileType: profileType,
+		}
 	}
 
 	f.iosBundles[orgID] = append(f.iosBundles[orgID], IOSSigningConfig{
@@ -3806,6 +3855,103 @@ func (f *CircleCI) handleDeleteIOSBundle(w http.ResponseWriter, r *http.Request)
 		render.JSON(w, r, map[string]any{"message": "not found"})
 		return
 	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// findIOSBundle returns the mutable fixture map for the signing config with
+// the given id. The returned struct is the same one stored in f.iosBundles
+func (f *CircleCI) findIOSBundle(id string) *IOSSigningConfig {
+	for i := range f.iosBundles {
+		for j := range f.iosBundles[i] {
+			if f.iosBundles[i][j].ID == id {
+				return &f.iosBundles[i][j]
+			}
+		}
+	}
+	return nil
+}
+
+func (f *CircleCI) handleUpdateIOSBundleProfile(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	var body struct {
+		Blob     string `json:"blob"`
+		FileName string `json:"file_name"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		render.Status(r, http.StatusBadRequest)
+		render.JSON(w, r, map[string]any{"message": err.Error()})
+		return
+	}
+	if body.Blob == "" || body.FileName == "" {
+		render.Status(r, http.StatusBadRequest)
+		render.JSON(w, r, map[string]any{"message": "missing required fields"})
+		return
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	bundle := f.findIOSBundle(id)
+	if bundle == nil || f.deletedIOSBundles[id] {
+		render.Status(r, http.StatusNotFound)
+		render.JSON(w, r, map[string]any{"message": "not found"})
+		return
+	}
+
+	// Same bundle ID + profile type replaces in place, regardless of file name.
+	bundleID, profileType := parseFakeMobileProvisionBlob(body.Blob)
+	replaced := false
+	for i, p := range bundle.ProvisioningProfiles {
+		if p.BundleID == bundleID && p.ProfileType == profileType {
+			bundle.ProvisioningProfiles[i].FileName = body.FileName
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		f.iosProfileCounter++
+		bundle.ProvisioningProfiles = append(bundle.ProvisioningProfiles, IOSProfile{
+			ID:          fmt.Sprintf("20000000-0000-0000-0000-%012d", f.iosProfileCounter),
+			FileName:    body.FileName,
+			BundleID:    bundleID,
+			ProfileType: profileType,
+		})
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (f *CircleCI) handleRemoveIOSBundleProfile(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	var body struct {
+		ProfileID string `json:"profile_id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		render.Status(r, http.StatusBadRequest)
+		render.JSON(w, r, map[string]any{"message": err.Error()})
+		return
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	bundle := f.findIOSBundle(id)
+	if bundle == nil || f.deletedIOSBundles[id] {
+		render.Status(r, http.StatusNotFound)
+		render.JSON(w, r, map[string]any{"message": "not found"})
+		return
+	}
+
+	kept := make([]IOSProfile, 0, len(bundle.ProvisioningProfiles))
+	for _, p := range bundle.ProvisioningProfiles {
+		if p.ID == body.ProfileID {
+			continue
+		}
+		kept = append(kept, p)
+	}
+	bundle.ProvisioningProfiles = kept
+
+	// Removing an already-absent profile is idempotent: still 204.
 	w.WriteHeader(http.StatusNoContent)
 }
 


### PR DESCRIPTION
The code signing API now supports updating and removing individual provisioning profiles on existing signing configs without recreating the entire config. This pr adds commands for supporting this on the cli.

## Changes

New command group: `circleci signing-config profile`

```
circleci signing-config profile add <config-id> --profile <file> — Add or replace a provisioning profile
circleci signing-config profile remove <config-id> <profile-id> — Remove a provisioning profile
```

Summary of file changes:
- New 'circleci signing-config profile' command group with add/remove subcommands
- API client methods: UpdateIOSSigningConfigProfile, RemoveIOSSigningConfigProfile
- Fake server: handlers, IOSProfile struct, acceptance test support
- Tests covering add/replace/remove/error scenarios

## Usage examples

```sh
# Add a new profile
$ circleci signing-config profile add <config-id> --profile ./MyAppExtension.mobileprovision

# Replace an existing profile (same bundle ID, different file)
$ circleci signing-config profile add <config-id> --profile ./MyApp.mobileprovision

# Remove a profile
$ circleci signing-config profile remove <config-id> <profile-id>
```