### PR TITLE
Add Nix flake for installation without nixpkgs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,6 +122,24 @@ jobs:
           name: Verify circleci binary
           command: circleci version
 
+  nix-build:
+    executor: linux
+    steps:
+      - checkout
+      - run:
+          name: Install Nix (Determinate)
+          command: |
+            curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | \
+              sh -s -- install linux --init none --no-confirm
+            echo '. /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh' >> "$BASH_ENV"
+      - run:
+          name: Start Nix daemon
+          command: sudo /nix/var/nix/profiles/default/bin/nix-daemon &
+          background: true
+      - run:
+          name: nix build
+          command: nix build --no-link --print-build-logs
+
   docs:
     executor: linux
     steps:
@@ -159,6 +177,11 @@ workflows:
       # `requires`) must opt out explicitly; downstream jobs are gated by these.
 
       - check:
+          filters:
+            branches:
+              ignore: gh-pages
+
+      - nix-build:
           filters:
             branches:
               ignore: gh-pages

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1786348146,
+        "narHash": "sha256-we5zDEFfn8TgzeWKjKDMIjeQZ59omEPl23NIF+13/ys=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d482ef84049d9b7276b83a06e4e4d76983830097",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,95 @@
+# Copyright (c) 2026 Circle Internet Services, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+{
+  description = "CircleCI CLI";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+
+        version = self.shortRev or self.dirtyShortRev or "dev";
+
+        circleci-cli = pkgs.buildGoModule {
+          pname = "circleci-cli";
+          inherit version;
+
+          src = self;
+
+          # Update this hash after any go.mod / go.sum change by running:
+          #   nix build --no-link 2>&1 | grep 'got:'
+          # and pasting the hash shown there.
+          vendorHash = "sha256-v6mXdAORGlbjtLezkoHIXK52h3nLeahihoc3OjF6JHA=";
+
+          subPackages = [ "cmd/circleci" ];
+
+          nativeBuildInputs = [ pkgs.installShellFiles ];
+
+          ldflags = [
+            "-s"
+            "-w"
+            "-X main.version=${version}"
+          ];
+
+          doCheck = false;
+
+          postInstall = ''
+            installShellCompletion --cmd circleci \
+              --bash <(HOME=$TMPDIR $out/bin/circleci completion bash) \
+              --fish <(HOME=$TMPDIR $out/bin/circleci completion fish) \
+              --zsh <(HOME=$TMPDIR $out/bin/circleci completion zsh)
+          '';
+
+          meta = with pkgs.lib; {
+            description = "Use and manage CircleCI from the command line";
+            homepage = "https://circleci.com/docs/local-cli/";
+            license = licenses.mit;
+            mainProgram = "circleci";
+          };
+        };
+      in
+      {
+        packages = {
+          inherit circleci-cli;
+          default = circleci-cli;
+        };
+
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            go
+            go-task
+          ];
+        };
+      }
+    );
+}


### PR DESCRIPTION
Closing in favour of waiting for the nixpkgs PR to be merged. The CLI's auto-update mechanism should reduce how often the nixpkgs expression needs bumping anyway.

If we revisit this, the goreleaser `nix:` publisher (same pattern as the existing `homebrew_casks:` entry) is probably the better approach — no `vendorHash` to maintain, fits the existing release tooling, and Pete's instincts were right.