### PR TITLE
TEST-257 Update managed extensions to prompt update when available

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -277,7 +277,7 @@ through `iostream.Streams`.
 | `CIRCLE_NO_INTERACTIVE` | Suppress all interactive prompts | `iostream` |
 | `CI` | Set by CI systems. Implies non-interactive (so: no prompts, no spinner) **and** disables telemetry | `iostream`, `config` |
 | `CIRCLE_SPINNER_DISABLED` | Replace the animated spinner with plain text | `iostream` |
-| `CIRCLE_NO_UPDATE_CHECK` | Disable checking for newer CLI releases. Same as `setting set update-check off` | `config.IsUpdateCheck()` |
+| `CIRCLE_NO_UPDATE_CHECK` | Disable checking for newer CLI and extension releases. Same as `setting set update-check off` | `config.IsUpdateCheck()` |
 | `CIRCLE_NO_PAGER` | Print long output inline instead of through a pager | `iostream` |
 | `PAGER` | Pager program for long output. Unset → built-in scrollable viewer; `cat` or empty → paging off | `iostream` |
 | `CIRCLE_NO_TELEMETRY` | Disable telemetry | `config` |

--- a/internal/cmd/extension/extension.go
+++ b/internal/cmd/extension/extension.go
@@ -34,6 +34,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
@@ -44,11 +45,16 @@ import (
 	"github.com/CircleCI-Public/circleci-cli/internal/cmdutil"
 	"github.com/CircleCI-Public/circleci-cli/internal/config"
 	"github.com/CircleCI-Public/circleci-cli/internal/extension"
+	"github.com/CircleCI-Public/circleci-cli/internal/update"
 )
 
 const (
 	// Testsuite is the official extension for running tests.
 	Testsuite = "testsuite"
+
+	// updateFetchTimeout bounds the registry call so a slow or unreachable registry
+	// delays the extension by at most this long.
+	updateFetchTimeout = 3 * time.Second
 )
 
 // RegisterExtensions registers extensions in the following order:
@@ -112,6 +118,7 @@ func newPromptCmd(name string) *cobra.Command {
 		DisableFlagParsing: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+			extArgs := ParseRootFlags(cmd)
 
 			s := iostream.Get(ctx)
 			if s.IsInteractive() {
@@ -122,7 +129,7 @@ func newPromptCmd(name string) *cobra.Command {
 						return err
 					}
 
-					return runExtension(ctx, cmd, ext)
+					return runExtension(ctx, ext, extArgs)
 				}
 			}
 
@@ -175,7 +182,11 @@ func newManagedCmd(ext extension.Manifest) *cobra.Command {
 		DisableFlagParsing: true,
 		SilenceUsage:       true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runExtension(cmd.Context(), cmd, ext)
+			ctx := cmd.Context()
+			extArgs := ParseRootFlags(cmd)
+			skipFlag, _ := cmd.Root().Flags().GetBool("skip-update-check")
+			prompted := promptForUpdate(ctx, ext, skipFlag)
+			return runExtension(ctx, prompted, extArgs)
 		},
 	}
 
@@ -190,9 +201,7 @@ func newManagedCmd(ext extension.Manifest) *cobra.Command {
 	return cmd
 }
 
-func runExtension(ctx context.Context, cmd *cobra.Command, ext extension.Manifest) error {
-	extArgs := ParseRootFlags(cmd)
-
+func runExtension(ctx context.Context, ext extension.Manifest, extArgs []string) error {
 	// Some extensions do not need a CCI account, load the client and suppress
 	// any errors; extensions are expected to handle any missing vars.
 	client, _ := cmdutil.LoadClient(ctx)
@@ -211,6 +220,100 @@ func runExtension(ctx context.Context, cmd *cobra.Command, ext extension.Manifes
 	}
 
 	return nil
+}
+
+// promptForUpdate offers to install a newer version of a managed extension
+// before it runs and returns the manifest to run.
+func promptForUpdate(ctx context.Context, ext extension.Manifest, skip bool) extension.Manifest {
+	cfg := cmdutil.GetConfig(ctx)
+
+	if !update.ShouldCheck(ctx, cfg, ext.Version) || skip {
+		return ext
+	}
+
+	statePath, err := config.StatePath()
+	if err != nil {
+		return ext
+	}
+
+	st, err := config.LoadState(ctx, statePath)
+	if err != nil {
+		return ext
+	}
+
+	if at := st.CheckedExtensionUpdateAt(ext.BinaryName); !at.IsZero() && time.Since(at) < update.CacheWindow {
+		return ext
+	}
+
+	extDir, err := config.ExtensionsDir()
+	if err != nil {
+		return ext
+	}
+
+	store := extension.NewStore(extDir)
+	m := extension.NewManager(extension.Config{
+		Version: cmdutil.GetVersion(ctx),
+		Agent:   cmdutil.GetAgentName(ctx),
+		BaseURL: cfg.EffectiveExtensionHost(),
+	})
+
+	fetchCtx, cancel := context.WithTimeout(ctx, updateFetchTimeout)
+	defer cancel()
+
+	latest, err := m.Get(fetchCtx, ext.BinaryName)
+	if err != nil {
+		iostream.DebugContext(ctx, "extension update check: fetch failed",
+			"extension", ext.BinaryName, "err", err)
+		return ext
+	}
+
+	err = config.SaveState(ctx, statePath, func(s *config.State) error {
+		s.SetCheckedExtensionUpdateAt(ext.BinaryName, time.Now())
+		return nil
+	})
+	if err != nil {
+		iostream.DebugContext(ctx, "extension update check: could not write state", "err", err)
+		return ext
+	}
+
+	newer := update.IsNewer(latest.Version, ext.Version)
+	iostream.DebugContext(ctx, "extension update check evaluated",
+		"extension", ext.BinaryName,
+		"latest", latest.Version,
+		"current", ext.Version,
+		"newer", newer)
+
+	if !newer {
+		return ext
+	}
+
+	update.PrintBinaryNotice(ctx, ext.BinaryName, ext.Version, latest.Version)
+
+	if !iostream.Get(ctx).Confirm(ctx, fmt.Sprintf("Update %s %s now?", ext.BinaryName, latest.Version)) {
+		return ext
+	}
+
+	iostream.ErrPrintf(ctx, "Updating %s to version %s...\n", ext.BinaryName, latest.Version)
+
+	binary, err := m.Download(ctx, latest)
+	if err != nil {
+		iostream.ErrPrintf(ctx, "%s Could not download %s %s: %s\n",
+			iostream.SymbolWarn(ctx), ext.BinaryName, latest.Version, err)
+		return ext
+	}
+
+	defer func() { _ = binary.Close() }()
+
+	updated, err := store.Write(latest, binary)
+	if err != nil {
+		iostream.ErrPrintf(ctx, "%s Could not install %s %s: %s\n",
+			iostream.SymbolWarn(ctx), ext.BinaryName, latest.Version, err)
+		return ext
+	}
+
+	iostream.ErrPrintf(ctx, "%s Updated %s version %s\n", iostream.SymbolOK(ctx), ext.BinaryName, latest.Version)
+
+	return updated
 }
 
 // newUnmanagedCmd returns a cobra command that dispatches to the circleci-<name>

--- a/internal/cmd/root/help_topic.go
+++ b/internal/cmd/root/help_topic.go
@@ -121,8 +121,8 @@ var helpTopics = []helpTopic{
 
 			%[1]sCIRCLE_SPINNER_DISABLED%[1]s: set to any value to replace the animated spinner with plain text.
 
-			%[1]sCIRCLE_NO_UPDATE_CHECK%[1]s: set to any value to disable checking for newer CLI releases.
-			Same effect as %[1]scircleci setting set update-check off%[1]s.
+			%[1]sCIRCLE_NO_UPDATE_CHECK%[1]s: set to any value to disable checking for newer CLI and
+			extension releases. Same effect as %[1]scircleci setting set update-check off%[1]s.
 
 			%[1]sCIRCLE_NO_PAGER%[1]s: set to any value to print long output directly instead of through a pager.
 

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -203,7 +203,7 @@ func NewRootCmd(version string) *cobra.Command {
 	cmd.PersistentFlags().BoolP("insecure-storage", "", false, "do not use the system's secure storage for storing tokens")
 	_ = cmd.PersistentFlags().MarkHidden("insecure-storage")
 
-	cmd.PersistentFlags().BoolP("skip-update-check", "", false, "skip checking for CLI updates")
+	cmd.PersistentFlags().BoolP("skip-update-check", "", false, "skip checking for CLI and extension updates")
 	_ = cmd.PersistentFlags().MarkHidden("skip-update-check")
 
 	cmd.AddGroup(&cobra.Group{
@@ -352,7 +352,7 @@ func NewRootCmd(version string) *cobra.Command {
 		// PersistentPostRunE runs only when the command's RunE succeeded, so the
 		// notice never lands on top of an error and always follows all output.
 		if rel := updateNotifier.Finish(); rel != nil {
-			update.PrintNotice(ctx, update.EffectiveVersion(version), rel)
+			update.PrintReleaseNotice(ctx, update.EffectiveVersion(version), rel)
 		}
 		tc := cmdutil.GetTelemetry(ctx)
 		_ = tc.Close()

--- a/internal/cmd/root/testdata/help/circleci/environment.txt
+++ b/internal/cmd/root/testdata/help/circleci/environment.txt
@@ -20,8 +20,8 @@ notifications are all disabled automatically.
 
 `CIRCLE_SPINNER_DISABLED`: set to any value to replace the animated spinner with plain text.
 
-`CIRCLE_NO_UPDATE_CHECK`: set to any value to disable checking for newer CLI releases.
-Same effect as `circleci setting set update-check off`.
+`CIRCLE_NO_UPDATE_CHECK`: set to any value to disable checking for newer CLI and
+extension releases. Same effect as `circleci setting set update-check off`.
 
 `CIRCLE_NO_PAGER`: set to any value to print long output directly instead of through a pager.
 

--- a/internal/config/state.go
+++ b/internal/config/state.go
@@ -96,6 +96,10 @@ type State struct {
 type stateData struct {
 	CheckedForUpdateAt time.Time `yaml:"checked_for_update_at,omitempty"`
 	LatestRelease      Release   `yaml:"latest_release,omitempty"`
+	// CheckedExtensionUpdatesAt is keyed by extension binary name
+	// ("circleci-testsuite"), because each managed extension is versioned and
+	// checked independently of the CLI and of every other extension.
+	CheckedExtensionUpdatesAt map[string]time.Time `yaml:"checked_extension_updates_at,omitempty"`
 }
 
 // Release is the newest release recorded by the last successful update check.
@@ -117,6 +121,21 @@ func (s *State) LatestRelease() Release { return s.data.LatestRelease }
 // SetLatestRelease records the newest release seen (pass the zero Release to
 // clear it).
 func (s *State) SetLatestRelease(r Release) { s.data.LatestRelease = r }
+
+// CheckedExtensionUpdateAt reports when the registry was last queried for a
+// newer version of the named extension.
+func (s *State) CheckedExtensionUpdateAt(binaryName string) time.Time {
+	return s.data.CheckedExtensionUpdatesAt[binaryName]
+}
+
+// SetCheckedExtensionUpdateAt records when the named extension was last checked
+// against the registry.
+func (s *State) SetCheckedExtensionUpdateAt(binaryName string, t time.Time) {
+	if s.data.CheckedExtensionUpdatesAt == nil {
+		s.data.CheckedExtensionUpdatesAt = make(map[string]time.Time, 1)
+	}
+	s.data.CheckedExtensionUpdatesAt[binaryName] = t
+}
 
 // LoadState reads the state file at path under a shared advisory lock, mirroring
 // the lock Config's read path takes. A missing file yields a zero State. path is

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -72,12 +72,12 @@ const (
 	// users can fetch the latest immediately regardless).
 	notifyDelay = 6 * time.Hour
 
-	// cacheWindow is how often we are willing to hit the network. Matched to our
+	// CacheWindow is how often we are willing to hit the network. Matched to our
 	// ~daily release cadence so the version we advertise never lags reality by
 	// more than about a day: a longer window would keep pointing at a stale
 	// "latest" (still a correct nag, just an out-of-date target) while a shorter
 	// one would probe more often than a new release can appear.
-	cacheWindow = 24 * time.Hour
+	CacheWindow = 24 * time.Hour
 )
 
 // ReleaseInfo is the newest stable release the source reported.
@@ -135,7 +135,7 @@ func ShouldCheck(ctx context.Context, cfg *config.Config, version string) bool {
 }
 
 // Check returns a release worth telling the user about, or nil. It refreshes
-// from src at most once per cacheWindow, but evaluates notifyDelay against cached
+// from src at most once per CacheWindow, but evaluates notifyDelay against cached
 // state on every call — so a notice suppressed by the delay appears the moment
 // the delay elapses, without waiting for the next network fetch.
 //
@@ -159,7 +159,7 @@ func Check(ctx context.Context, src Source, statePath, currentVersion string) (*
 	release := ReleaseInfo{Version: stored.Version, PublishedAt: stored.PublishedAt}
 	checkedAt := st.CheckedForUpdateAt()
 
-	if checkedAt.IsZero() || time.Since(checkedAt) >= cacheWindow {
+	if checkedAt.IsZero() || time.Since(checkedAt) >= CacheWindow {
 		info, ferr := src.Latest(ctx)
 		if ferr != nil {
 			// Transient/unexpected failure: don't write state, so the cache
@@ -185,7 +185,7 @@ func Check(ctx context.Context, src Source, statePath, currentVersion string) (*
 		}
 		if info == nil {
 			// Recognised-but-unactionable (e.g. 400/401/403): state is written so
-			// we back off for cacheWindow, but there is nothing to show.
+			// we back off for CacheWindow, but there is nothing to show.
 			return nil, nil
 		}
 		release = *info
@@ -196,7 +196,7 @@ func Check(ctx context.Context, src Source, statePath, currentVersion string) (*
 		"latest", release.Version,
 		"current", currentVersion,
 		"published_at", release.PublishedAt,
-		"newer", isNewer(release.Version, currentVersion),
+		"newer", IsNewer(release.Version, currentVersion),
 		"within_delay", !release.PublishedAt.IsZero() && time.Since(release.PublishedAt) < notifyDelay,
 		"notify", result != nil,
 	)
@@ -208,7 +208,7 @@ func evaluate(release ReleaseInfo, currentVersion string) *ReleaseInfo {
 	if release.Version == "" {
 		return nil
 	}
-	if !isNewer(release.Version, currentVersion) {
+	if !IsNewer(release.Version, currentVersion) {
 		return nil
 	}
 	// Blanket delay: stay quiet until the package managers have had time to catch
@@ -241,9 +241,9 @@ func normalizeBuildVersion(v string) string {
 	return fmt.Sprintf("%s.%s.%d-pre.0", m[1], m[2], patch+1)
 }
 
-// isNewer reports whether latest is a strictly greater semver than current,
+// IsNewer reports whether latest is a strictly greater semver than current,
 // after normalising a git-describe current version.
-func isNewer(latest, current string) bool {
+func IsNewer(latest, current string) bool {
 	current = normalizeBuildVersion(current)
 	lv, lerr := goversion.NewVersion(latest)
 	cv, cerr := goversion.NewVersion(current)
@@ -296,7 +296,7 @@ func (n *Notifier) Finish() *ReleaseInfo {
 	return rel
 }
 
-// PrintNotice writes the two-line update notice to stderr, blank-line padded and
+// PrintReleaseNotice writes the two-line update notice to stderr, blank-line padded and
 // after all command output. The second line links the new release's GitHub
 // release page. It is a no-op when rel is nil.
 //
@@ -304,16 +304,28 @@ func (n *Notifier) Finish() *ReleaseInfo {
 // color is always safe here — there is no pipe to corrupt. The color helpers
 // still fall back to plain text under NO_COLOR / TERM=dumb, so the message text
 // is unchanged when color is disabled.
-func PrintNotice(ctx context.Context, currentVersion string, rel *ReleaseInfo) {
+func PrintReleaseNotice(ctx context.Context, currentVersion string, rel *ReleaseInfo) {
 	if rel == nil {
 		return
 	}
+	printNotice(ctx, "circleci", currentVersion, rel.Version)
+	iostream.ErrPrintf(ctx, "%s\n\n", iostream.Muted(ctx, releaseURL(rel.Version)))
+}
+
+// PrintBinaryNotice writes the update notice to stderr for the given binary and version.
+func PrintBinaryNotice(ctx context.Context, binaryName, installedVersion, latestVersion string) {
+	printNotice(ctx, binaryName, installedVersion, latestVersion)
+}
+
+// printNotice writes the shared "a new version is available" line: a leading
+// blank line to separate it from command output, then the name of the thing that
+// is behind and the version transition.
+func printNotice(ctx context.Context, name, currentVersion, latestVersion string) {
 	iostream.ErrPrintf(ctx,
-		"\n%s %s → %s\n%s\n\n",
-		iostream.Warning(ctx, "A new version of circleci is available:"),
+		"\n%s %s → %s\n",
+		iostream.Warning(ctx, fmt.Sprintf("A new version of %s is available:", name)),
 		iostream.Muted(ctx, currentVersion),
-		iostream.Success(ctx, rel.Version),
-		iostream.Muted(ctx, releaseURL(rel.Version)))
+		iostream.Success(ctx, latestVersion))
 }
 
 // releaseURL returns the GitHub release page for version, tolerating a leading

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -71,7 +71,7 @@ func TestIsNewer(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Check(t, cmp.Equal(isNewer(tt.latest, tt.current), tt.want))
+			assert.Check(t, cmp.Equal(IsNewer(tt.latest, tt.current), tt.want))
 		})
 	}
 }
@@ -80,9 +80,9 @@ func TestIsNewer(t *testing.T) {
 // every channel, including @next prerelease users.
 func TestSingleSourceAcrossChannels(t *testing.T) {
 	// A @next user on an rc is told about the stable release above it...
-	assert.Check(t, cmp.Equal(isNewer("1.3.0", "1.3.0-rc.1"), true))
+	assert.Check(t, cmp.Equal(IsNewer("1.3.0", "1.3.0-rc.1"), true))
 	// ...and told nothing when stable is below their rc.
-	assert.Check(t, cmp.Equal(isNewer("1.2.0", "1.3.0-rc.1"), false))
+	assert.Check(t, cmp.Equal(IsNewer("1.2.0", "1.3.0-rc.1"), false))
 }
 
 func TestNormalizeBuildVersion(t *testing.T) {


### PR DESCRIPTION
To keep managed extensions up to date with the latest changes, this change adds a prompt to update when a new version is found.

For extension like the `testsuite`, where it is available locally and in CI, this will result in a consistent behaviour across both environments as CI will always run the latest.

This change shares as much of the existing update checker for the CLI to keep it consistent; version notice, 24-hour cache, etc.