### PR TITLE
Add the chunk validate Stop hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -32,6 +32,17 @@
           }
         ]
       }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "chunk validate",
+            "timeout": 420
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
## What

Adds the missing `Stop` hook to `.claude/settings.json` so `chunk validate` runs at the end of an agent coding session.

## Why

This repo's `.chunk/config.json` configures a remote sidecar (`validation.sidecarImage`), but `.claude/settings.json` has no `Stop` block. Nothing runs `chunk validate` when a session ends, so the repo looks fully configured while getting no end-of-session validation.

The cause was a bug in `chunk init`'s settings merge: `Merge` handled `permissions` and `PreToolUse` but never called `mergeStopHooks` (only the Codex path did). On a repo that already had a `.claude/settings.json`, init merged the commit hooks and dropped the `Stop` hook. That is fixed in CircleCI-Public/chunk-cli#500 so it cannot recur; this PR restores the hook here.

The 420s timeout matches what `chunk init` computes for this repo's commands (30s buffer + 300 + 60 + 30).

## Separate issue, not fixed here

While verifying, I noticed the existing `PreToolUse` group uses the legacy group-level matcher `"Bash(git commit*)"`. Per the fix in CircleCI-Public/chunk-cli#484, `matcher` filters on **tool name**, so this group likely never fires either — the current form should be `"matcher": "Bash"` with a per-entry `"if": "Bash(git commit*)"`. Its commands have also drifted from `.chunk/config.json` (`task check`/`task fix` here vs `task lint`/`task fmt` in the config).

I deliberately left that out to keep this PR to the Stop hook. Happy to send a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)