### PR TITLE
Write valid flags in deploy init marker steps

### DIFF
--- a/acceptance/testdata/TestDeployInit.config.yml
+++ b/acceptance/testdata/TestDeployInit.config.yml
@@ -14,7 +14,11 @@ jobs:
       - run: make deploy-staging
       - run:
           name: Log deploy marker
-          command: circleci run release log --component "api" --environment "staging"
+          command: |
+            circleci run release log \
+              --component-name=api \
+              --environment-name=staging \
+              --target-version=$CIRCLE_SHA1
   deploy-prod:
     docker:
       - image: cimg/base:stable
@@ -23,7 +27,11 @@ jobs:
       - run: make deploy
       - run:
           name: Log deploy marker
-          command: circleci run release log --component "api" --environment "production"
+          command: |
+            circleci run release log \
+              --component-name=api \
+              --environment-name=production \
+              --target-version=$CIRCLE_SHA1
 workflows:
   main:
     jobs:

--- a/acceptance/testdata/TestDeployInit_InferEnvironments.config.yml
+++ b/acceptance/testdata/TestDeployInit_InferEnvironments.config.yml
@@ -8,7 +8,11 @@ jobs:
       - run: make deploy-staging
       - run:
           name: Log deploy marker
-          command: circleci run release log --component "myapp" --environment "staging"
+          command: |
+            circleci run release log \
+              --component-name=myapp \
+              --environment-name=staging \
+              --target-version=$CIRCLE_SHA1
   deploy-production:
     docker:
       - image: cimg/base:stable
@@ -17,7 +21,11 @@ jobs:
       - run: make deploy-prod
       - run:
           name: Log deploy marker
-          command: circleci run release log --component "myapp" --environment "production"
+          command: |
+            circleci run release log \
+              --component-name=myapp \
+              --environment-name=production \
+              --target-version=$CIRCLE_SHA1
 workflows:
   main:
     jobs:

--- a/internal/deployinit/deployinit.go
+++ b/internal/deployinit/deployinit.go
@@ -29,6 +29,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"slices"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -295,36 +296,92 @@ func Patch(configPath string, input PatchInput, useOrb bool) (bool, error) {
 	return true, nil
 }
 
+// markerCommands are the command forms that mean a job is already instrumented.
+// `plan` counts as well as `log` even though this command only ever writes
+// `log`: a plan step is the definitive signal that deploy markers are in use,
+// so a job already tracking the full release lifecycle must be left alone
+// rather than have a redundant log step appended to it.
+var markerCommands = []string{
+	"circleci run release log",
+	"circleci run release plan",
+}
+
+// markerOrbSteps are the circleci/deploys orb steps that instrument a job.
+var markerOrbSteps = []string{"deploys/log", "deploys/plan"}
+
 // alreadyPatched returns true if stepsNode already contains a deploy marker step.
 func alreadyPatched(stepsNode *yaml.Node) bool {
 	for _, step := range stepsNode.Content {
-		step = resolve(step)
-		if step.Kind != yaml.MappingNode {
-			continue
+		if stepHasMarker(resolve(step)) {
+			return true
 		}
-		// raw run step
-		runNode := findMappingValue(step, "run")
-		if runNode != nil {
-			runNode = resolve(runNode)
-			if runNode.Kind == yaml.MappingNode {
-				cmdNode := findMappingValue(runNode, "command")
-				if cmdNode != nil && strings.Contains(cmdNode.Value, "circleci run release log") {
-					return true
-				}
+	}
+	return false
+}
+
+// stepHasMarker reports whether a single step already invokes a deploy marker.
+// A step is either a bare scalar (`- checkout`), an orb step keyed by the orb
+// command name, or a mapping whose `run` key holds either a scalar command
+// (`- run: make deploy`) or a nested mapping with `command:`.
+func stepHasMarker(step *yaml.Node) bool {
+	switch step.Kind { //nolint:exhaustive // DocumentNode/SequenceNode/AliasNode don't appear as job steps
+	case yaml.ScalarNode:
+		return containsMarkerCommand(step.Value)
+	case yaml.MappingNode:
+		for i := 0; i+1 < len(step.Content); i += 2 {
+			if slices.Contains(markerOrbSteps, step.Content[i].Value) {
+				return true
 			}
 		}
-		// orb step: deploys/log
-		for i := 0; i < len(step.Content); i++ {
-			if step.Content[i].Value == "deploys/log" {
-				return true
+		runNode := findMappingValue(step, "run")
+		if runNode == nil {
+			return false
+		}
+		runNode = resolve(runNode)
+		switch runNode.Kind { //nolint:exhaustive // a run step is either a shorthand scalar or a mapping
+		case yaml.ScalarNode:
+			return containsMarkerCommand(runNode.Value)
+		case yaml.MappingNode:
+			if cmdNode := findMappingValue(runNode, "command"); cmdNode != nil {
+				return containsMarkerCommand(cmdNode.Value)
 			}
 		}
 	}
 	return false
 }
 
+// containsMarkerCommand reports whether cmd invokes a deploy marker command.
+// Whitespace is normalised first, so the multi-line backslash-continued form
+// this command writes matches as readily as a single-line invocation.
+func containsMarkerCommand(cmd string) bool {
+	if cmd == "" {
+		return false
+	}
+	normalized := strings.Join(strings.Fields(cmd), " ")
+	for _, marker := range markerCommands {
+		if strings.Contains(normalized, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+// markerTargetVersion is the version expression written into every marker.
+// `release log` requires --target-version, so it can never be omitted.
+const markerTargetVersion = "$CIRCLE_SHA1"
+
+// makeRunStep builds the raw `run` step form of the marker. The flag names are
+// those of the `release` subcommand that build-agent injects into the job
+// (--component-name/--environment-name, not --component/--environment), and
+// --target-version is required there, so all three are always written.
+//
+// The command is a literal block so the rendered YAML stays readable at three
+// flags, matching the form documented in the deploy markers guide.
 func makeRunStep(component, env string) *yaml.Node {
-	cmd := fmt.Sprintf("circleci run release log --component %q --environment %q", component, env)
+	cmd := fmt.Sprintf(
+		"circleci run release log \\\n  --component-name=%s \\\n  --environment-name=%s \\\n  --target-version=%s\n",
+		component, env, markerTargetVersion,
+	)
 	return &yaml.Node{
 		Kind: yaml.MappingNode,
 		Content: []*yaml.Node{
@@ -333,13 +390,18 @@ func makeRunStep(component, env string) *yaml.Node {
 				Kind: yaml.MappingNode,
 				Content: []*yaml.Node{
 					scalar("name"), scalar("Log deploy marker"),
-					scalar("command"), scalar(cmd),
+					scalar("command"), literalBlock(cmd),
 				},
 			},
 		},
 	}
 }
 
+// makeOrbStep builds the circleci/deploys orb form. Its parameter names are
+// snake_case (component_name/environment_name/target_version) — the orb rejects
+// the bare component/environment spellings. target_version is passed explicitly
+// rather than left to the orb's own ${CIRCLE_SHA1:0:7} default so that both
+// forms of the marker report the same version.
 func makeOrbStep(component, env string) *yaml.Node {
 	return &yaml.Node{
 		Kind: yaml.MappingNode,
@@ -348,8 +410,9 @@ func makeOrbStep(component, env string) *yaml.Node {
 			{
 				Kind: yaml.MappingNode,
 				Content: []*yaml.Node{
-					scalar("component"), scalar(component),
-					scalar("environment"), scalar(env),
+					scalar("component_name"), scalar(component),
+					scalar("environment_name"), scalar(env),
+					scalar("target_version"), scalar(markerTargetVersion),
 				},
 			},
 		},
@@ -358,4 +421,8 @@ func makeOrbStep(component, env string) *yaml.Node {
 
 func scalar(v string) *yaml.Node {
 	return &yaml.Node{Kind: yaml.ScalarNode, Value: v, Tag: "!!str"}
+}
+
+func literalBlock(v string) *yaml.Node {
+	return &yaml.Node{Kind: yaml.ScalarNode, Value: v, Tag: "!!str", Style: yaml.LiteralStyle}
 }


### PR DESCRIPTION
## Problem

`circleci deploy init` writes a marker command that the `release` subcommand rejects, so **every job it instruments fails at flag parsing and no deploy marker is ever recorded.**

What it emitted before this change:

```yaml
- run:
    name: Log deploy marker
    command: circleci run release log --component "api" --environment "staging"
```

The `release` subcommand build-agent injects into the job takes `--component-name` and `--environment-name`, and calls `MarkFlagRequired("target-version")`. All three are wrong: two unknown flags and a missing required one.

Nothing surfaced it. The CLI prints `Done. Your next deploy will appear at: …` and exits 0 — the failure only appears once the job runs.

The orb path was wrong the same way. `circleci/deploys`'s `log` command takes `component_name` / `environment_name` / `target_version`, not the bare spellings.

This ships today: homebrew-core stable is `1.0.47993`, built from `main`.

## Fix

Raw `run` form, now matching what the subcommand actually accepts:

```yaml
- run:
    name: Log deploy marker
    command: |
      circleci run release log \
        --component-name=api \
        --environment-name=staging \
        --target-version=$CIRCLE_SHA1
```

Orb form:

```yaml
- deploys/log:
    component_name: api
    environment_name: production
    target_version: $CIRCLE_SHA1
```

`target_version` is passed explicitly to the orb rather than left to its `${CIRCLE_SHA1:0:7}` default, so both forms report the same version for the same commit.

Also: **`circleci run release plan` now counts as already-instrumented.** A plan step means the job tracks the full release lifecycle, so appending a redundant `log` step to it is wrong. Detection additionally normalises whitespace (so the new multi-line form matches itself), and handles the `- run: <cmd>` scalar shorthand and `deploys/plan`.

The `v0` branch already got all of this right in `cmd/deploy/`. This brings the v1 reimplementation in line with it — reimplemented, not imported, per the rule against depending on v0.

## Verification

Beyond the regenerated goldens, checked against the shipped binary's behaviour:

- **Raw path** produces output byte-identical to what v0 emits — a form already validated end-to-end on a real project: green pipeline, marker visible in the Deploys dashboard.
- **Orb path** emits the orb's documented param names (no golden covers this path; verified by hand).
- **Idempotency holds against the new literal-block format** — second run reports `Already configured — no changes needed.`, exactly one marker step present.
- **A job already using `release plan` is left untouched** — zero `log` steps appended.
- `golangci-lint` clean, `gofmt` clean.

## Note on CI

`TestDeprecationWarning_SunsetInOutput` fails under `-race` on **clean `main`** as well — a pre-existing data race in the test itself at `acceptance/deprecation_test.go:48-50`, unrelated to this change. Confirmed by stashing these changes and re-running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)