### PR TITLE
Move pipeline definitions and triggers onto the v3 API

### DIFF
--- a/acceptance/onboard_test.go
+++ b/acceptance/onboard_test.go
@@ -391,23 +391,11 @@ func TestOnboard_PostSignup_KeepsExistingProjectRef(t *testing.T) {
 // all-pushes trigger satisfies onboard, not a schedule-only definition.
 func TestOnboard_PostSignup_AddsPushTriggerAlongsideOthers(t *testing.T) {
 	dir, fake, env := onboardRepo(t)
-	fake.AddPipelineDefinition(onboardProjectID, map[string]any{
-		"id":   onboardPipelineDefID,
-		"name": "my-repo",
-		"config_source": map[string]any{
-			"provider": "github_app",
-			"repo":     map[string]any{"external_id": onboardRepoExternalID},
-		},
-	})
+	fake.AddPipelineDefinition(onboardProjectID, onboardPipelineEntity(onboardRepoExternalID))
 	// Only a schedule trigger exists — no push would build anything.
-	fake.AddTrigger(onboardProjectID, onboardPipelineDefID, map[string]any{
-		"id":           "trig-schedule",
-		"event_preset": "schedule",
-	})
-	fake.SetCreateTriggerResponse(onboardProjectID, onboardPipelineDefID, map[string]any{
-		"id":           "trig-uuid-1",
-		"event_preset": "all-pushes",
-	})
+	fake.AddTrigger(onboardProjectID, onboardPipelineDefID, onboardTriggerEntity("trig-schedule", "schedule"))
+	fake.SetCreateTriggerResponse(onboardProjectID, onboardPipelineDefID,
+		onboardTriggerEntity("trig-uuid-1", "all-pushes"))
 
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
@@ -505,15 +493,15 @@ func TestOnboard_PathArgument_UsesGivenDirectory(t *testing.T) {
 func TestOnboard_PostSignup_FirstPipelineCreated(t *testing.T) {
 	dir, fake, env := onboardRepo(t)
 	fake.SetCreatePipelineDefinitionResponse(onboardProjectID, map[string]any{
-		"id":         onboardPipelineDefID,
-		"name":       "my-repo",
-		"created_at": "2026-07-23T00:00:00Z",
+		"id": onboardPipelineDefID,
+		"attributes": map[string]any{
+			"name":       "my-repo",
+			"created_at": "2026-07-23T00:00:00Z",
+		},
 	})
-	fake.SetCreateTriggerResponse(onboardProjectID, onboardPipelineDefID, map[string]any{
-		"id":           "trig-uuid-1",
-		"created_at":   "2026-07-23T00:00:00Z",
-		"event_preset": "all-pushes",
-	})
+	fake.SetCreateTriggerResponse(onboardProjectID, onboardPipelineDefID,
+		onboardTriggerEntity("trig-uuid-1", "all-pushes"))
+
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
 		Args:    []string{"onboard", "--scan", "--repo-id", onboardRepoExternalID},
@@ -604,18 +592,8 @@ func TestOnboard_PostSignup_Rerun_Idempotent(t *testing.T) {
 		"staging only config.yml would leave the project ID uncommitted")
 
 	// The project now has its pipeline definition and trigger.
-	fake.AddPipelineDefinition(onboardProjectID, map[string]any{
-		"id":   onboardPipelineDefID,
-		"name": "my-repo",
-		"config_source": map[string]any{
-			"provider": "github_app",
-			"repo":     map[string]any{"external_id": "987654321"},
-		},
-	})
-	fake.AddTrigger(onboardProjectID, onboardPipelineDefID, map[string]any{
-		"id":           "trig-uuid-1",
-		"event_preset": "all-pushes",
-	})
+	fake.AddPipelineDefinition(onboardProjectID, onboardPipelineEntity("987654321"))
+	fake.AddTrigger(onboardProjectID, onboardPipelineDefID, onboardTriggerEntity("trig-uuid-1", "all-pushes"))
 
 	second := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
@@ -733,10 +711,7 @@ func TestOnboard_PostSignup_FirstPipeline_RepoNotAccessible(t *testing.T) {
 // exits non-zero: a definition with no trigger will never build.
 func TestOnboard_PostSignup_FirstPipeline_TriggerFails(t *testing.T) {
 	dir, fake, env := onboardRepo(t)
-	fake.SetCreatePipelineDefinitionResponse(onboardProjectID, map[string]any{
-		"id":   onboardPipelineDefID,
-		"name": "my-repo",
-	})
+	fake.SetCreatePipelineDefinitionResponse(onboardProjectID, onboardCreatedPipelineEntity())
 	// No trigger response registered → the trigger create fails.
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
@@ -874,14 +849,47 @@ func onboardRepo(t *testing.T) (string, *fakes.CircleCI, *testenv.TestEnv) {
 // addFirstPipelineResponses registers the create responses for the pipeline
 // definition and all-pushes trigger that onboard wires up on the happy path.
 func addFirstPipelineResponses(fake *fakes.CircleCI) {
-	fake.SetCreatePipelineDefinitionResponse(onboardProjectID, map[string]any{
-		"id":   onboardPipelineDefID,
-		"name": "my-repo",
-	})
-	fake.SetCreateTriggerResponse(onboardProjectID, onboardPipelineDefID, map[string]any{
-		"id":           "trig-uuid-1",
-		"event_preset": "all-pushes",
-	})
+	fake.SetCreatePipelineDefinitionResponse(onboardProjectID, onboardCreatedPipelineEntity())
+	fake.SetCreateTriggerResponse(onboardProjectID, onboardPipelineDefID,
+		onboardTriggerEntity("trig-uuid-1", "all-pushes"))
+}
+
+// onboardCreatedPipelineEntity is the v3 pipeline entity returned when onboard
+// creates a definition.
+func onboardCreatedPipelineEntity() map[string]any {
+	return map[string]any{
+		"id":         onboardPipelineDefID,
+		"attributes": map[string]any{"name": "my-repo"},
+	}
+}
+
+// onboardPipelineEntity is a v3 pipeline entity already attached to repoID, which
+// is what makes a re-run of onboard reuse it instead of creating a second one.
+func onboardPipelineEntity(repoID string) map[string]any {
+	return map[string]any{
+		"id": onboardPipelineDefID,
+		"attributes": map[string]any{
+			"name": "my-repo",
+			"config": map[string]any{
+				"type": "vcs",
+				"vcs":  map[string]any{"provider": "github_app", "repo_id": repoID},
+			},
+		},
+	}
+}
+
+// onboardTriggerEntity is a v3 trigger entity carrying preset as its event filter.
+func onboardTriggerEntity(id, preset string) map[string]any {
+	return map[string]any{
+		"id": id,
+		"attributes": map[string]any{
+			"event": map[string]any{
+				"type":   "vcs",
+				"vcs":    map[string]any{"provider": "github_app"},
+				"filter": map[string]any{"preset": preset},
+			},
+		},
+	}
 }
 
 func onboardStandaloneEnv(t *testing.T, login string) (*fakes.CircleCI, *testenv.TestEnv) {

--- a/acceptance/pipeline_test.go
+++ b/acceptance/pipeline_test.go
@@ -49,26 +49,35 @@ const (
 	pipelineRepoID    = "987654321"
 )
 
+// fakePipelineDefPayload builds a v3 pipeline data entity with both sources
+// VCS-backed, which is what every pipeline fixture here needs.
 func fakePipelineDefPayload(id, name, configProvider, configRepoID, configFile, checkoutProvider, checkoutRepoID string) map[string]any {
 	now := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
 	return map[string]any{
-		"id":         id,
-		"name":       name,
-		"created_at": now.Format(time.RFC3339),
-		"config_source": map[string]any{
-			"provider":  configProvider,
-			"file_path": configFile,
-			"repo": map[string]any{
-				"external_id": configRepoID,
-				"full_name":   "myorg/myrepo",
+		"id": id,
+		"attributes": map[string]any{
+			"name":       name,
+			"created_at": now.Format(time.RFC3339),
+			"config": map[string]any{
+				"type":      "vcs",
+				"file_path": configFile,
+				"vcs": map[string]any{
+					"provider":       configProvider,
+					"repo_id":        configRepoID,
+					"repo_full_name": "myorg/myrepo",
+				},
+			},
+			"checkout": map[string]any{
+				"type": "vcs",
+				"vcs": map[string]any{
+					"provider":       checkoutProvider,
+					"repo_id":        checkoutRepoID,
+					"repo_full_name": "myorg/myrepo",
+				},
 			},
 		},
-		"checkout_source": map[string]any{
-			"provider": checkoutProvider,
-			"repo": map[string]any{
-				"external_id": checkoutRepoID,
-				"full_name":   "myorg/myrepo",
-			},
+		"references": map[string]any{
+			"project": map[string]any{"id": pipelineProjectID},
 		},
 	}
 }
@@ -91,33 +100,39 @@ func setupPipelineFake(t *testing.T) (*fakes.CircleCI, *testenv.TestEnv) {
 
 var pipelineListFixtures = []map[string]any{
 	{
-		"id":         "pdef-uuid-0001",
-		"name":       "main-pipeline",
-		"created_at": "2024-01-01T00:00:00Z",
-		"config_source": map[string]any{
-			"provider":  "github_app",
-			"file_path": ".circleci/config.yml",
-			"repo":      map[string]any{"external_id": "111111111", "full_name": "myorg/myrepo"},
+		"id": "pdef-uuid-0001",
+		"attributes": map[string]any{
+			"name":       "main-pipeline",
+			"created_at": "2024-01-01T00:00:00Z",
+			"config": map[string]any{
+				"type":      "vcs",
+				"file_path": ".circleci/config.yml",
+				"vcs":       map[string]any{"provider": "github_app", "repo_id": "111111111", "repo_full_name": "myorg/myrepo"},
+			},
+			"checkout": map[string]any{
+				"type": "vcs",
+				"vcs":  map[string]any{"provider": "github_app", "repo_id": "111111111", "repo_full_name": "myorg/myrepo"},
+			},
 		},
-		"checkout_source": map[string]any{
-			"provider": "github_app",
-			"repo":     map[string]any{"external_id": "111111111", "full_name": "myorg/myrepo"},
-		},
+		"references": map[string]any{"project": map[string]any{"id": pipelineProjectID}},
 	},
 	{
-		"id":          "pdef-uuid-0002",
-		"name":        "nightly",
-		"description": "Runs every night",
-		"created_at":  "2024-02-01T00:00:00Z",
-		"config_source": map[string]any{
-			"provider":  "github_app",
-			"file_path": ".circleci/nightly.yml",
-			"repo":      map[string]any{"external_id": "111111111", "full_name": "myorg/myrepo"},
+		"id": "pdef-uuid-0002",
+		"attributes": map[string]any{
+			"name":        "nightly",
+			"description": "Runs every night",
+			"created_at":  "2024-02-01T00:00:00Z",
+			"config": map[string]any{
+				"type":      "vcs",
+				"file_path": ".circleci/nightly.yml",
+				"vcs":       map[string]any{"provider": "github_app", "repo_id": "111111111", "repo_full_name": "myorg/myrepo"},
+			},
+			"checkout": map[string]any{
+				"type": "vcs",
+				"vcs":  map[string]any{"provider": "github_app", "repo_id": "111111111", "repo_full_name": "myorg/myrepo"},
+			},
 		},
-		"checkout_source": map[string]any{
-			"provider": "github_app",
-			"repo":     map[string]any{"external_id": "111111111", "full_name": "myorg/myrepo"},
-		},
+		"references": map[string]any{"project": map[string]any{"id": pipelineProjectID}},
 	},
 }
 
@@ -148,12 +163,12 @@ func TestPipelineCreate(t *testing.T) {
 	t.Run("check request", func(t *testing.T) {
 		assert.Check(t, cmp.DeepEqual(fake.LastRequest(), &httprecorder.Request{
 			Method: http.MethodPost,
-			URL:    url.URL{Path: "/api/v2/projects/" + pipelineProjectID + "/pipeline-definitions"},
+			URL:    url.URL{Path: "/api/v3/pipelines"},
 			Header: http.Header{
 				"Authorization": {"Bearer test-token"},
 				"User-Agent":    {httpcl.UserAgent(runtime.GOOS, runtime.GOARCH, "dev", "")},
 			},
-			Body: new(`{"checkout_source":{"provider":"github_app","repo":{"external_id":"987654321"}},"config_source":{"file_path":".circleci/config.yml","provider":"github_app","repo":{"external_id":"987654321"}},"name":"my-pipeline"}`),
+			Body: new(`{"data":{"attributes":{"name":"my-pipeline","config":{"type":"vcs","file_path":".circleci/config.yml","vcs":{"provider":"github_app","repo_id":"987654321"}},"checkout":{"vcs":{"provider":"github_app","repo_id":"987654321"}}},"references":{"project":{"id":"` + pipelineProjectID + `"}}}}`),
 		}, ignoreCommonHeaders))
 	})
 }

--- a/acceptance/project_test.go
+++ b/acceptance/project_test.go
@@ -605,16 +605,24 @@ const (
 )
 
 var triggerFixture = map[string]any{
-	"id":         triggerID,
-	"created_at": "2026-01-01T00:00:00Z",
-	"event_source": map[string]any{
-		"provider": "github_app",
-		"repo": map[string]any{
-			"external_id": triggerRepoID,
-			"full_name":   "myorg/myrepo",
+	"id": triggerID,
+	"attributes": map[string]any{
+		"created_at":  "2026-01-01T00:00:00Z",
+		"is_disabled": false,
+		"event": map[string]any{
+			"type": "vcs",
+			"vcs": map[string]any{
+				"provider":       "github_app",
+				"repo_id":        triggerRepoID,
+				"repo_full_name": "myorg/myrepo",
+			},
+			"filter": map[string]any{"preset": "all-pushes"},
 		},
 	},
-	"event_preset": "all-pushes",
+	"references": map[string]any{
+		"project":  map[string]any{"id": triggerProjectID},
+		"pipeline": map[string]any{"id": triggerPipelineDefID},
+	},
 }
 
 func setupTriggerFake(t *testing.T) (*fakes.CircleCI, *testenv.TestEnv) {
@@ -731,12 +739,12 @@ func TestProjectTriggerCreate(t *testing.T) {
 	t.Run("check request", func(t *testing.T) {
 		assert.Check(t, cmp.DeepEqual(fake.LastRequest(), &httprecorder.Request{
 			Method: http.MethodPost,
-			URL:    url.URL{Path: "/api/v2/projects/" + triggerProjectID + "/pipeline-definitions/" + triggerPipelineDefID + "/triggers"},
+			URL:    url.URL{Path: "/api/v3/triggers", RawQuery: "filter%5Bproject_id%5D=" + triggerProjectID},
 			Header: http.Header{
 				"Authorization": {"Bearer test-token"},
 				"User-Agent":    {httpcl.UserAgent(runtime.GOOS, runtime.GOARCH, "dev", "")},
 			},
-			Body: new(`{"event_source":{"provider":"github_app","repo":{"external_id":"987654321"}}}`),
+			Body: new(`{"data":{"attributes":{"is_disabled":false,"event":{"type":"vcs","vcs":{"provider":"github_app","repo_id":"987654321"}}},"references":{"pipeline":{"id":"` + triggerPipelineDefID + `"}}}}`),
 		}, ignoreCommonHeaders))
 	})
 }

--- a/internal/apiclient/pipeline_definition.go
+++ b/internal/apiclient/pipeline_definition.go
@@ -55,30 +55,121 @@ type PipelineDefinition struct {
 	CheckoutSource *PipelineDefinitionSource `json:"checkout_source,omitempty"`
 }
 
-// ListPipelineDefinitions returns all pipeline definitions for a project.
+// hostedConfigProvider is the one provider whose config lives outside a repo, so
+// it is the only one that maps to a "hosted" rather than a "vcs" config source.
+const hostedConfigProvider = "circleci"
+
+// config.type / checkout.type values on the v3 pipelines endpoints.
+const (
+	sourceTypeVCS    = "vcs"
+	sourceTypeHosted = "hosted"
+)
+
+// vcsAttrs identifies a VCS integration and repository. repo_id is the external
+// repository id as an opaque string — numeric for the GitHub providers, text for
+// providers on the generic schema. repo_full_name is decorative for the GitHub
+// providers but load-bearing for those that address a repo by owner and name.
+type vcsAttrs struct {
+	Provider     string `json:"provider"`
+	RepoID       string `json:"repo_id,omitempty"`
+	RepoFullName string `json:"repo_full_name,omitempty"`
+}
+
+// hostedAttrs identifies a config hosted outside a VCS repo.
+type hostedAttrs struct {
+	Provider string `json:"provider"`
+}
+
+// pipelineConfigAttrs is the config half of a pipeline: a tagged union on Type,
+// where exactly one of VCS/Hosted is populated. FilePath is common to both.
+type pipelineConfigAttrs struct {
+	Type     string       `json:"type"`
+	FilePath string       `json:"file_path"`
+	VCS      *vcsAttrs    `json:"vcs,omitempty"`
+	Hosted   *hostedAttrs `json:"hosted,omitempty"`
+}
+
+// pipelineCheckoutAttrs is the checkout half: a union that today only ever
+// carries the vcs variant.
+type pipelineCheckoutAttrs struct {
+	Type string    `json:"type,omitempty"`
+	VCS  *vcsAttrs `json:"vcs,omitempty"`
+}
+
+// pipelineAttrs is the attributes object of a v3 pipeline entity, used for both
+// the create body and the response.
+type pipelineAttrs struct {
+	Name        string                `json:"name"`
+	Description string                `json:"description,omitempty"`
+	CreatedAt   *time.Time            `json:"created_at,omitempty"`
+	Config      pipelineConfigAttrs   `json:"config"`
+	Checkout    pipelineCheckoutAttrs `json:"checkout"`
+}
+
+// pipelineRefs carries the owning project. On create it is where the project
+// travels; the endpoint takes no project in the path.
+type pipelineRefs struct {
+	Project entityRef `json:"project"`
+}
+
+// entityRef is a reference to another entity by id.
+type entityRef struct {
+	ID string `json:"id"`
+}
+
+// pipelineEntity is the data entity of GET/POST /api/v3/pipelines.
+type pipelineEntity struct {
+	ID         string        `json:"id"`
+	Attributes pipelineAttrs `json:"attributes"`
+	References pipelineRefs  `json:"references"`
+}
+
+// The create body is a narrower document than the entity: the endpoint rejects
+// unknown members, so it must carry no id and no created_at.
+type pipelineCreateAttrs struct {
+	Name        string                `json:"name"`
+	Description string                `json:"description,omitempty"`
+	Config      pipelineConfigAttrs   `json:"config"`
+	Checkout    pipelineCheckoutAttrs `json:"checkout"`
+}
+
+type pipelineCreateData struct {
+	Attributes pipelineCreateAttrs `json:"attributes"`
+	References pipelineRefs        `json:"references"`
+}
+
+// ListPipelineDefinitions returns all pipeline definitions for a project via
+// GET /api/v3/pipelines.
 func (c *Client) ListPipelineDefinitions(ctx context.Context, projectID string) ([]PipelineDefinition, error) {
-	var resp struct {
-		Items []PipelineDefinition `json:"items"`
-	}
-	_, err := c.main.Call(ctx, httpcl.NewRequest(http.MethodGet, "/api/v2/projects/%s/pipeline-definitions",
-		httpcl.RouteParams(projectID),
+	var resp v3List[pipelineEntity]
+	_, err := c.main.Call(ctx, httpcl.NewRequest(http.MethodGet, "/api/v3/pipelines",
+		filterParam("project_id", projectID),
 		httpcl.JSONDecoder(&resp),
 	))
 	if err != nil {
 		return nil, err
 	}
-	return resp.Items, nil
+
+	defs := make([]PipelineDefinition, 0, len(resp.Data))
+	for _, e := range resp.Data {
+		defs = append(defs, e.toPipelineDefinition())
+	}
+	return defs, nil
 }
 
 // CreatePipelineDefinitionInput contains all fields for creating a pipeline definition.
+// The RepoFullName fields are required by providers that address a repository by
+// owner and name rather than by id, and ignored by the rest.
 type CreatePipelineDefinitionInput struct {
-	Name             string
-	Description      string
-	ConfigProvider   string
-	ConfigRepoID     string
-	ConfigFilePath   string
-	CheckoutProvider string
-	CheckoutRepoID   string
+	Name                 string
+	Description          string
+	ConfigProvider       string
+	ConfigRepoID         string
+	ConfigRepoFullName   string
+	ConfigFilePath       string
+	CheckoutProvider     string
+	CheckoutRepoID       string
+	CheckoutRepoFullName string
 }
 
 // TriggerPipelineRunInput contains the options for triggering a pipeline run.
@@ -170,44 +261,90 @@ func (c *Client) TriggerPipelineRun(ctx context.Context, projectSlug string, inp
 	}, nil
 }
 
-// CreatePipelineDefinition creates a new pipeline definition for a project.
+// CreatePipelineDefinition creates a new pipeline definition for a project via
+// POST /api/v3/pipelines. The owning project travels in the body's references
+// rather than the path.
 func (c *Client) CreatePipelineDefinition(ctx context.Context, projectID string, input CreatePipelineDefinitionInput) (*PipelineDefinition, error) {
-	configSource := map[string]any{
-		"provider":  input.ConfigProvider,
-		"file_path": input.ConfigFilePath,
+	attrs := pipelineCreateAttrs{
+		Name:        input.Name,
+		Description: input.Description,
+		Config: pipelineConfigAttrs{
+			Type:     sourceTypeVCS,
+			FilePath: input.ConfigFilePath,
+			VCS: &vcsAttrs{
+				Provider:     input.ConfigProvider,
+				RepoID:       input.ConfigRepoID,
+				RepoFullName: input.ConfigRepoFullName,
+			},
+		},
+		Checkout: pipelineCheckoutAttrs{
+			VCS: &vcsAttrs{
+				Provider:     input.CheckoutProvider,
+				RepoID:       input.CheckoutRepoID,
+				RepoFullName: input.CheckoutRepoFullName,
+			},
+		},
 	}
-	if input.ConfigRepoID != "" {
-		configSource["repo"] = map[string]any{
-			"external_id": input.ConfigRepoID,
+	// A config not backed by a repository is the "hosted" variant, which carries a
+	// provider and no repo. The checkout stays a VCS repo either way.
+	if input.ConfigProvider == hostedConfigProvider {
+		attrs.Config = pipelineConfigAttrs{
+			Type:     sourceTypeHosted,
+			FilePath: input.ConfigFilePath,
+			Hosted:   &hostedAttrs{Provider: input.ConfigProvider},
 		}
 	}
 
-	checkoutSource := map[string]any{
-		"provider": input.CheckoutProvider,
-	}
-	if input.CheckoutRepoID != "" {
-		checkoutSource["repo"] = map[string]any{
-			"external_id": input.CheckoutRepoID,
-		}
-	}
+	body := v3Entity[pipelineCreateData]{Data: pipelineCreateData{
+		Attributes: attrs,
+		References: pipelineRefs{Project: entityRef{ID: projectID}},
+	}}
 
-	body := map[string]any{
-		"name":            input.Name,
-		"config_source":   configSource,
-		"checkout_source": checkoutSource,
-	}
-	if input.Description != "" {
-		body["description"] = input.Description
-	}
-
-	var resp PipelineDefinition
-	_, err := c.main.Call(ctx, httpcl.NewRequest(http.MethodPost, "/api/v2/projects/%s/pipeline-definitions",
-		httpcl.RouteParams(projectID),
+	var resp v3Entity[pipelineEntity]
+	_, err := c.main.Call(ctx, httpcl.NewRequest(http.MethodPost, "/api/v3/pipelines",
 		httpcl.Body(body),
 		httpcl.JSONDecoder(&resp),
 	))
 	if err != nil {
 		return nil, err
 	}
-	return &resp, nil
+	def := resp.Data.toPipelineDefinition()
+	return &def, nil
+}
+
+// toPipelineDefinition flattens a v3 pipeline entity into the definition shape the
+// commands render: the config and checkout unions become one source struct each,
+// so a hosted config reports its provider with no repo.
+func (e pipelineEntity) toPipelineDefinition() PipelineDefinition {
+	def := PipelineDefinition{
+		ID:          e.ID,
+		Name:        e.Attributes.Name,
+		Description: e.Attributes.Description,
+	}
+	if e.Attributes.CreatedAt != nil {
+		def.CreatedAt = *e.Attributes.CreatedAt
+	}
+
+	cfg := e.Attributes.Config
+	switch {
+	case cfg.Hosted != nil:
+		def.ConfigSource = &PipelineDefinitionSource{Provider: cfg.Hosted.Provider, FilePath: cfg.FilePath}
+	case cfg.VCS != nil:
+		def.ConfigSource = sourceFromVCS(cfg.VCS)
+		def.ConfigSource.FilePath = cfg.FilePath
+	}
+
+	if vcs := e.Attributes.Checkout.VCS; vcs != nil {
+		def.CheckoutSource = sourceFromVCS(vcs)
+	}
+	return def
+}
+
+// sourceFromVCS maps a v3 vcs object onto the provider/repo source shape.
+func sourceFromVCS(vcs *vcsAttrs) *PipelineDefinitionSource {
+	src := &PipelineDefinitionSource{Provider: vcs.Provider}
+	if vcs.RepoID != "" || vcs.RepoFullName != "" {
+		src.Repo = &PipelineDefinitionRepo{ExternalID: vcs.RepoID, FullName: vcs.RepoFullName}
+	}
+	return src
 }

--- a/internal/apiclient/trigger.go
+++ b/internal/apiclient/trigger.go
@@ -24,6 +24,7 @@ package apiclient
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"time"
 
@@ -37,13 +38,15 @@ type TriggerEventSourceRepo struct {
 }
 
 // TriggerEventSourceWebhook holds webhook information for a trigger event source.
+// Source is the source system (e.g. "vercel"); Name is the event it sends.
 type TriggerEventSourceWebhook struct {
-	URL    string `json:"url,omitempty"`
-	Sender string `json:"sender,omitempty"`
+	Name   string `json:"name,omitempty"`
+	Source string `json:"source,omitempty"`
 }
 
 // TriggerEventSourceSchedule holds schedule information for a trigger event source.
 type TriggerEventSourceSchedule struct {
+	Name           string `json:"name,omitempty"`
 	CronExpression string `json:"cron_expression,omitempty"`
 }
 
@@ -67,54 +70,250 @@ type Trigger struct {
 	Disabled    bool               `json:"disabled"`
 }
 
-// ListTriggers returns all triggers for a project's pipeline definition.
+// event.type values on the v3 triggers endpoints. Every provider that is not a
+// custom webhook or a schedule is VCS-backed.
+const (
+	eventTypeVCS      = "vcs"
+	eventTypeWebhook  = "webhook"
+	eventTypeSchedule = "schedule"
+)
+
+// triggerRefAttrs wraps a git ref override for the config or checkout.
+type triggerRefAttrs struct {
+	Ref string `json:"ref,omitempty"`
+}
+
+// triggerFilterAttrs is the event filter: which events the trigger fires on.
+// Preset is the trigger-level event key shared by all of its rules; it is absent
+// for a trigger whose rules match no preset.
+type triggerFilterAttrs struct {
+	Preset string `json:"preset,omitempty"`
+}
+
+// triggerEventAttrs is a tagged union on Type: exactly one of VCS/Webhook/Schedule
+// is populated. Schedule stays raw — the CLI only reads the cron expression out of
+// it, and re-encoding the rest would lose fields.
+type triggerEventAttrs struct {
+	Type     string              `json:"type"`
+	VCS      *vcsAttrs           `json:"vcs,omitempty"`
+	Webhook  *webhookAttrs       `json:"webhook,omitempty"`
+	Schedule json.RawMessage     `json:"schedule,omitempty"`
+	Filter   *triggerFilterAttrs `json:"filter,omitempty"`
+}
+
+// webhookAttrs describes a custom webhook trigger.
+type webhookAttrs struct {
+	Name   string `json:"name,omitempty"`
+	Source string `json:"source,omitempty"`
+}
+
+// triggerAttrs is the attributes object of a v3 trigger entity, used for both the
+// create body and the response.
+type triggerAttrs struct {
+	IsDisabled bool               `json:"is_disabled"`
+	CreatedAt  *time.Time         `json:"created_at,omitempty"`
+	Event      *triggerEventAttrs `json:"event,omitempty"`
+	Config     *triggerRefAttrs   `json:"config,omitempty"`
+	Checkout   *triggerRefAttrs   `json:"checkout,omitempty"`
+}
+
+// triggerRefs is the references object of a trigger entity: the owning project and
+// the pipeline the trigger hangs off.
+type triggerRefs struct {
+	Project  entityRef `json:"project"`
+	Pipeline entityRef `json:"pipeline"`
+}
+
+// triggerEntity is the data entity of GET/POST /api/v3/triggers.
+type triggerEntity struct {
+	ID         string       `json:"id"`
+	Attributes triggerAttrs `json:"attributes"`
+	References triggerRefs  `json:"references"`
+}
+
+// The create body is a narrower document than the entity: the endpoint rejects
+// unknown members, so it must carry no id, no created_at, and no project
+// reference (the project is derived from the pipeline, or from
+// filter[project_id]).
+type triggerCreateAttrs struct {
+	IsDisabled bool               `json:"is_disabled"`
+	Event      *triggerEventAttrs `json:"event,omitempty"`
+	Config     *triggerRefAttrs   `json:"config,omitempty"`
+	Checkout   *triggerRefAttrs   `json:"checkout,omitempty"`
+}
+
+type triggerCreateRefs struct {
+	Pipeline entityRef `json:"pipeline"`
+}
+
+type triggerCreateData struct {
+	Attributes triggerCreateAttrs `json:"attributes"`
+	References triggerCreateRefs  `json:"references"`
+}
+
+// ListTriggers returns all triggers for a project's pipeline definition via
+// GET /api/v3/triggers. Both filters are sent so a trigger has to belong to the
+// project as well as the pipeline, matching the old project-scoped route.
 func (c *Client) ListTriggers(ctx context.Context, projectID, pipelineDefinitionID string) ([]Trigger, error) {
-	var resp struct {
-		Items []Trigger `json:"items"`
-	}
-	_, err := c.main.Call(ctx, httpcl.NewRequest(http.MethodGet, "/api/v2/projects/%s/pipeline-definitions/%s/triggers",
-		httpcl.RouteParams(projectID, pipelineDefinitionID),
+	var resp v3List[triggerEntity]
+	_, err := c.main.Call(ctx, httpcl.NewRequest(http.MethodGet, "/api/v3/triggers",
+		filterParam("project_id", projectID),
+		filterParam("pipeline_id", pipelineDefinitionID),
 		httpcl.JSONDecoder(&resp),
 	))
 	if err != nil {
 		return nil, err
 	}
-	return resp.Items, nil
+
+	triggers := make([]Trigger, 0, len(resp.Data))
+	for _, e := range resp.Data {
+		triggers = append(triggers, e.toTrigger())
+	}
+	return triggers, nil
 }
 
-// CreateTrigger creates a new trigger for a project's pipeline definition.
-// provider must be one of: github_app, github_server, github_oauth, webhook, schedule.
-// repoID is the repository external ID; required for github_app, github_server, and github_oauth.
-func (c *Client) CreateTrigger(ctx context.Context, projectID, pipelineDefinitionID, provider, repoID, eventPreset, configRef, checkoutRef string) (*Trigger, error) {
-	eventSource := map[string]any{
-		"provider": provider,
-	}
-	if repoID != "" {
-		eventSource["repo"] = map[string]any{
-			"external_id": repoID,
+// CreateTriggerInput contains the fields for creating a trigger.
+// Provider must be one of: github_app, github_server, github_oauth, origin,
+// webhook, schedule. RepoID is the repository external ID, required by every
+// VCS-backed provider; RepoFullName is additionally required by providers that
+// address a repository by owner and name rather than by id.
+type CreateTriggerInput struct {
+	ProjectID            string
+	PipelineDefinitionID string
+	Provider             string
+	RepoID               string
+	RepoFullName         string
+	EventPreset          string
+	ConfigRef            string
+	CheckoutRef          string
+}
+
+// CreateTrigger creates a new trigger for a project's pipeline definition via
+// POST /api/v3/triggers. filter[project_id] is sent so triggers on a project's
+// synthetic OAuth pipeline — whose id resolves to no stored row — can be created
+// too.
+func (c *Client) CreateTrigger(ctx context.Context, input CreateTriggerInput) (*Trigger, error) {
+	event := &triggerEventAttrs{Type: eventTypeForProvider(input.Provider)}
+	switch event.Type {
+	case eventTypeWebhook:
+		event.Webhook = &webhookAttrs{}
+	case eventTypeSchedule:
+		// A schedule's cron expression has no flag yet, so the server rejects the
+		// create rather than inventing one.
+	default:
+		event.VCS = &vcsAttrs{
+			Provider:     input.Provider,
+			RepoID:       input.RepoID,
+			RepoFullName: input.RepoFullName,
+		}
+		if input.EventPreset != "" {
+			event.Filter = &triggerFilterAttrs{Preset: input.EventPreset}
 		}
 	}
-	body := map[string]any{
-		"event_source": eventSource,
+
+	attrs := triggerCreateAttrs{Event: event}
+	if input.ConfigRef != "" {
+		attrs.Config = &triggerRefAttrs{Ref: input.ConfigRef}
 	}
-	if eventPreset != "" {
-		body["event_preset"] = eventPreset
-	}
-	if configRef != "" {
-		body["config_ref"] = configRef
-	}
-	if checkoutRef != "" {
-		body["checkout_ref"] = checkoutRef
+	if input.CheckoutRef != "" {
+		attrs.Checkout = &triggerRefAttrs{Ref: input.CheckoutRef}
 	}
 
-	var resp Trigger
-	_, err := c.main.Call(ctx, httpcl.NewRequest(http.MethodPost, "/api/v2/projects/%s/pipeline-definitions/%s/triggers",
-		httpcl.RouteParams(projectID, pipelineDefinitionID),
+	body := v3Entity[triggerCreateData]{Data: triggerCreateData{
+		Attributes: attrs,
+		References: triggerCreateRefs{Pipeline: entityRef{ID: input.PipelineDefinitionID}},
+	}}
+
+	var resp v3Entity[triggerEntity]
+	_, err := c.main.Call(ctx, httpcl.NewRequest(http.MethodPost, "/api/v3/triggers",
+		filterParam("project_id", input.ProjectID),
 		httpcl.Body(body),
 		httpcl.JSONDecoder(&resp),
 	))
 	if err != nil {
 		return nil, err
 	}
-	return &resp, nil
+	trig := resp.Data.toTrigger()
+	return &trig, nil
+}
+
+// eventTypeForProvider maps a provider onto the event union's discriminator.
+func eventTypeForProvider(provider string) string {
+	switch provider {
+	case eventTypeWebhook:
+		return eventTypeWebhook
+	case eventTypeSchedule:
+		return eventTypeSchedule
+	default:
+		return eventTypeVCS
+	}
+}
+
+// toTrigger flattens a v3 trigger entity into the shape the commands render. A
+// non-VCS trigger reports its event type as the provider, which is the vocabulary
+// --provider already uses.
+func (e triggerEntity) toTrigger() Trigger {
+	t := Trigger{
+		ID:       e.ID,
+		Disabled: e.Attributes.IsDisabled,
+	}
+	if e.Attributes.CreatedAt != nil {
+		t.CreatedAt = *e.Attributes.CreatedAt
+	}
+	if e.Attributes.Config != nil {
+		t.ConfigRef = e.Attributes.Config.Ref
+	}
+	if e.Attributes.Checkout != nil {
+		t.CheckoutRef = e.Attributes.Checkout.Ref
+	}
+
+	event := e.Attributes.Event
+	if event == nil {
+		return t
+	}
+	if event.Filter != nil {
+		t.EventPreset = event.Filter.Preset
+	}
+
+	switch {
+	case event.Webhook != nil:
+		t.EventSource = TriggerEventSource{
+			Provider: eventTypeWebhook,
+			Webhook:  &TriggerEventSourceWebhook{Name: event.Webhook.Name, Source: event.Webhook.Source},
+		}
+		// The source system is the trigger's stored name, so it is what identifies
+		// the event to a reader.
+		t.EventName = event.Webhook.Source
+	case event.Type == eventTypeSchedule:
+		t.EventSource = TriggerEventSource{
+			Provider: eventTypeSchedule,
+			Schedule: scheduleFromRaw(event.Schedule),
+		}
+		if t.EventSource.Schedule != nil {
+			t.EventName = t.EventSource.Schedule.Name
+		}
+	case event.VCS != nil:
+		t.EventSource = TriggerEventSource{Provider: event.VCS.Provider}
+		if event.VCS.RepoID != "" || event.VCS.RepoFullName != "" {
+			t.EventSource.Repo = &TriggerEventSourceRepo{
+				ExternalID: event.VCS.RepoID,
+				FullName:   event.VCS.RepoFullName,
+			}
+		}
+	}
+	return t
+}
+
+// scheduleFromRaw pulls the fields the CLI shows out of the schedule object,
+// ignoring the rest. Unparseable input yields no schedule rather than an error:
+// the trigger itself is still worth reporting.
+func scheduleFromRaw(raw json.RawMessage) *TriggerEventSourceSchedule {
+	if len(raw) == 0 {
+		return nil
+	}
+	var s TriggerEventSourceSchedule
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return nil
+	}
+	return &s
 }

--- a/internal/cmd/project/trigger.go
+++ b/internal/cmd/project/trigger.go
@@ -445,7 +445,15 @@ func runTriggerCreate(
 		}
 	}
 
-	resp, err := client.CreateTrigger(ctx, resolvedProjectID, pipelineDefinitionID, provider, repoID, eventPreset, configRef, checkoutRef)
+	resp, err := client.CreateTrigger(ctx, apiclient.CreateTriggerInput{
+		ProjectID:            resolvedProjectID,
+		PipelineDefinitionID: pipelineDefinitionID,
+		Provider:             provider,
+		RepoID:               repoID,
+		EventPreset:          eventPreset,
+		ConfigRef:            configRef,
+		CheckoutRef:          checkoutRef,
+	})
 	if err != nil {
 		return cmdutil.APIErr(err, resolvedProjectID, "trigger.create_failed", "Failed to create trigger for project %q.",
 			"Ensure the GitHub App is installed in your repository",

--- a/internal/onboarder/onboarder.go
+++ b/internal/onboarder/onboarder.go
@@ -60,6 +60,10 @@ const (
 // push, which is what onboard sets up.
 const allPushesPreset = "all-pushes"
 
+// githubAppProvider is the only integration onboard sets a pipeline up for today;
+// resolving the repository goes through the GitHub App either way.
+const githubAppProvider = "github_app"
+
 // Options configures the onboarding flow.
 type Options struct {
 	ConfigPath    string
@@ -481,7 +485,7 @@ func setupFirstPipeline(ctx context.Context, client *apiclient.Client, returnURL
 		return nil
 	}
 
-	def, err := ensurePipelineDefinition(ctx, client, proj.ID, proj.Name, repoID)
+	def, err := ensurePipelineDefinition(ctx, client, proj.ID, proj.Name, repoID, remote.FullName())
 	if err != nil {
 		trackOnboard(ctx, "onboard_project_setup", map[string]any{"outcome": "pipeline_definition_failed"})
 		return clierrors.New("onboard.pipeline_definition_failed",
@@ -494,7 +498,7 @@ func setupFirstPipeline(ctx context.Context, client *apiclient.Client, returnURL
 			WithExitCode(clierrors.ExitAPIError)
 	}
 
-	if err := ensureTrigger(ctx, client, proj.ID, def.ID, repoID); err != nil {
+	if err := ensureTrigger(ctx, client, proj.ID, def.ID, repoID, remote.FullName()); err != nil {
 		trackOnboard(ctx, "onboard_project_setup", map[string]any{"outcome": "trigger_failed"})
 		return clierrors.New("onboard.trigger_failed",
 			"Could not set up the trigger",
@@ -514,7 +518,7 @@ func setupFirstPipeline(ctx context.Context, client *apiclient.Client, returnURL
 // ensurePipelineDefinition returns the pipeline definition already configured
 // for the repo, or creates one. Reusing an existing definition keeps re-runs of
 // onboard from creating duplicates.
-func ensurePipelineDefinition(ctx context.Context, client *apiclient.Client, projectID, name, repoID string) (*apiclient.PipelineDefinition, error) {
+func ensurePipelineDefinition(ctx context.Context, client *apiclient.Client, projectID, name, repoID, repoFullName string) (*apiclient.PipelineDefinition, error) {
 	defs, err := client.ListPipelineDefinitions(ctx, projectID)
 	if err != nil {
 		// Creating blindly after a failed lookup risks a duplicate definition, so
@@ -530,12 +534,14 @@ func ensurePipelineDefinition(ctx context.Context, client *apiclient.Client, pro
 	}
 
 	def, err := client.CreatePipelineDefinition(ctx, projectID, apiclient.CreatePipelineDefinitionInput{
-		Name:             name,
-		ConfigProvider:   "github_app",
-		ConfigRepoID:     repoID,
-		ConfigFilePath:   ".circleci/config.yml",
-		CheckoutProvider: "github_app",
-		CheckoutRepoID:   repoID,
+		Name:                 name,
+		ConfigProvider:       githubAppProvider,
+		ConfigRepoID:         repoID,
+		ConfigRepoFullName:   repoFullName,
+		ConfigFilePath:       ".circleci/config.yml",
+		CheckoutProvider:     githubAppProvider,
+		CheckoutRepoID:       repoID,
+		CheckoutRepoFullName: repoFullName,
 	})
 	if err != nil {
 		return nil, err
@@ -550,7 +556,7 @@ func ensurePipelineDefinition(ctx context.Context, client *apiclient.Client, pro
 // Only an all-pushes trigger counts. A definition carrying just a schedule or
 // webhook trigger would otherwise be reported as ready, and the push onboard tells
 // the user to make would build nothing.
-func ensureTrigger(ctx context.Context, client *apiclient.Client, projectID, definitionID, repoID string) error {
+func ensureTrigger(ctx context.Context, client *apiclient.Client, projectID, definitionID, repoID, repoFullName string) error {
 	trigs, err := client.ListTriggers(ctx, projectID, definitionID)
 	if err != nil {
 		return err
@@ -562,7 +568,14 @@ func ensureTrigger(ctx context.Context, client *apiclient.Client, projectID, def
 		}
 	}
 
-	trig, err := client.CreateTrigger(ctx, projectID, definitionID, "github_app", repoID, allPushesPreset, "", "")
+	trig, err := client.CreateTrigger(ctx, apiclient.CreateTriggerInput{
+		ProjectID:            projectID,
+		PipelineDefinitionID: definitionID,
+		Provider:             githubAppProvider,
+		RepoID:               repoID,
+		RepoFullName:         repoFullName,
+		EventPreset:          allPushesPreset,
+	})
 	if err != nil {
 		return err
 	}

--- a/internal/testing/fakes/circleci.go
+++ b/internal/testing/fakes/circleci.go
@@ -24,9 +24,11 @@
 package fakes
 
 import (
+	"bytes"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -64,10 +66,10 @@ type CircleCI struct {
 	triggerResponses                  map[string]any          // project slug → trigger response body
 	triggerPipelineRunResponses       map[string]any          // project slug → trigger run response body
 	triggerPipelineRunStatuses        map[string]int          // project slug → HTTP status (default 201)
-	pipelineDefinitions               map[string][]any        // projectID → list of pipeline definition objects
-	createPipelineDefinitionResponses map[string]any          // projectID → response body
-	createTriggerResponses            map[string]any          // "projectID/pipelineDefinitionID" → response body
-	listTriggerResponses              map[string][]any        // "projectID/pipelineDefinitionID" → list of triggers
+	pipelineDefinitions               map[string][]any        // projectID → list of v3 pipeline entities
+	createPipelineDefinitionResponses map[string]any          // projectID → v3 pipeline entity
+	createTriggerResponses            map[string]any          // "projectID/pipelineID" → v3 trigger entity
+	listTriggerResponses              map[string][]any        // "projectID/pipelineID" → list of v3 trigger entities
 
 	// GitHub App state.
 	githubAppInstalled      map[string]bool            // orgID → app installed (200) vs not (404)
@@ -368,10 +370,10 @@ func NewCircleCI(t *testing.T, tokens ...string) *CircleCI {
 	r.Post("/api/v2/project/{vcs}/{org}/{repo}/envvar", f.handleSetEnvVar)
 	r.Delete("/api/v2/project/{vcs}/{org}/{repo}/envvar/{name}", f.handleDeleteEnvVar)
 	r.Get("/api/v2/project/{vcs}/{org}/{repo}", f.handleGetProjectInfo)
-	r.Get("/api/v2/projects/{projectID}/pipeline-definitions", f.handleListPipelineDefinitions)
-	r.Post("/api/v2/projects/{projectID}/pipeline-definitions", f.handleCreatePipelineDefinition)
-	r.Get("/api/v2/projects/{projectID}/pipeline-definitions/{pipelineDefinitionID}/triggers", f.handleListTriggers)
-	r.Post("/api/v2/projects/{projectID}/pipeline-definitions/{pipelineDefinitionID}/triggers", f.handleCreateTrigger)
+	r.Get("/api/v3/pipelines", f.handleListPipelineDefinitions)
+	r.Post("/api/v3/pipelines", f.handleCreatePipelineDefinition)
+	r.Get("/api/v3/triggers", f.handleListTriggers)
+	r.Post("/api/v3/triggers", f.handleCreateTrigger)
 	// GitHub App routes.
 	r.Get("/api/v2/github-app/organization/{orgID}/installation", f.handleGetGitHubAppInstallation)
 	r.Post("/api/v2/github-app/install", f.handleInstallGitHubApp)
@@ -2373,16 +2375,17 @@ func (f *CircleCI) handleResolveProjectBySlug(w http.ResponseWriter, r *http.Req
 	render.JSON(w, r, map[string]any{"data": data, "page": map[string]any{"next": nil, "prev": nil}})
 }
 
-// AddPipelineDefinition registers a pipeline definition for a project, returned by
-// GET /api/v2/projects/{projectID}/pipeline-definitions.
+// AddPipelineDefinition registers a pipeline entity for a project, returned by
+// GET /api/v3/pipelines?filter[project_id]=. def is a v3 data entity
+// ({id, attributes, references}); the fake supplies the collection envelope.
 func (f *CircleCI) AddPipelineDefinition(projectID string, def any) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.pipelineDefinitions[projectID] = append(f.pipelineDefinitions[projectID], def)
 }
 
-// SetCreatePipelineDefinitionResponse registers the response body returned when
-// POST /api/v2/projects/{projectID}/pipeline-definitions is called.
+// SetCreatePipelineDefinitionResponse registers the entity returned when
+// POST /api/v3/pipelines is called with this project in its references.
 // Pass nil to simulate a 404.
 func (f *CircleCI) SetCreatePipelineDefinitionResponse(projectID string, resp any) {
 	f.mu.Lock()
@@ -2390,8 +2393,8 @@ func (f *CircleCI) SetCreatePipelineDefinitionResponse(projectID string, resp an
 	f.createPipelineDefinitionResponses[projectID] = resp
 }
 
-// AddTrigger registers a trigger returned by GET
-// /api/v2/projects/{projectID}/pipeline-definitions/{pipelineDefinitionID}/triggers.
+// AddTrigger registers a trigger entity returned by GET /api/v3/triggers when
+// filtered by this project and pipeline.
 func (f *CircleCI) AddTrigger(projectID, pipelineDefinitionID string, trigger any) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -2399,9 +2402,9 @@ func (f *CircleCI) AddTrigger(projectID, pipelineDefinitionID string, trigger an
 	f.listTriggerResponses[key] = append(f.listTriggerResponses[key], trigger)
 }
 
-// SetCreateTriggerResponse registers the response body returned when POST
-// /api/v2/projects/{projectID}/pipeline-definitions/{pipelineDefinitionID}/triggers
-// is called. Pass nil to simulate a 404.
+// SetCreateTriggerResponse registers the entity returned when POST
+// /api/v3/triggers is called for this project and pipeline. Pass nil to simulate
+// a 404.
 func (f *CircleCI) SetCreateTriggerResponse(projectID, pipelineDefinitionID string, resp any) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -2945,19 +2948,18 @@ func (f *CircleCI) handleDeleteContextRestriction(w http.ResponseWriter, r *http
 }
 
 func (f *CircleCI) handleListPipelineDefinitions(w http.ResponseWriter, r *http.Request) {
-	projectID := chi.URLParam(r, "projectID")
+	projectID := r.URL.Query().Get("filter[project_id]")
 	f.mu.RLock()
 	items := f.pipelineDefinitions[projectID]
 	f.mu.RUnlock()
 
-	if items == nil {
-		items = []any{}
-	}
-	render.JSON(w, r, map[string]any{"items": items})
+	renderV3Collection(w, r, items)
 }
 
 func (f *CircleCI) handleCreatePipelineDefinition(w http.ResponseWriter, r *http.Request) {
-	projectID := chi.URLParam(r, "projectID")
+	// The v3 create takes the owning project in the body's references rather than
+	// the path, so the registered response is keyed off what the client sent.
+	projectID := v3BodyRefID(r, "project")
 	f.mu.RLock()
 	resp, ok := f.createPipelineDefinitionResponses[projectID]
 	f.mu.RUnlock()
@@ -2968,27 +2970,23 @@ func (f *CircleCI) handleCreatePipelineDefinition(w http.ResponseWriter, r *http
 		return
 	}
 	render.Status(r, http.StatusCreated)
-	render.JSON(w, r, resp)
+	render.JSON(w, r, map[string]any{"data": resp})
 }
 
 func (f *CircleCI) handleListTriggers(w http.ResponseWriter, r *http.Request) {
-	projectID := chi.URLParam(r, "projectID")
-	pipelineDefinitionID := chi.URLParam(r, "pipelineDefinitionID")
-	key := projectID + "/" + pipelineDefinitionID
+	q := r.URL.Query()
+	key := q.Get("filter[project_id]") + "/" + q.Get("filter[pipeline_id]")
 	f.mu.RLock()
 	items := f.listTriggerResponses[key]
 	f.mu.RUnlock()
 
-	if items == nil {
-		items = []any{}
-	}
-	render.JSON(w, r, map[string]any{"items": items})
+	renderV3Collection(w, r, items)
 }
 
 func (f *CircleCI) handleCreateTrigger(w http.ResponseWriter, r *http.Request) {
-	projectID := chi.URLParam(r, "projectID")
-	pipelineDefinitionID := chi.URLParam(r, "pipelineDefinitionID")
-	key := projectID + "/" + pipelineDefinitionID
+	// The project stays a query filter on the v3 create, but the parent pipeline
+	// moves into the body's references.
+	key := r.URL.Query().Get("filter[project_id]") + "/" + v3BodyRefID(r, "pipeline")
 	f.mu.RLock()
 	resp, ok := f.createTriggerResponses[key]
 	f.mu.RUnlock()
@@ -2999,7 +2997,45 @@ func (f *CircleCI) handleCreateTrigger(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	render.Status(r, http.StatusCreated)
-	render.JSON(w, r, resp)
+	render.JSON(w, r, map[string]any{"data": resp})
+}
+
+// renderV3Collection writes items as a v3 collection, so an empty set is an empty
+// data array rather than a null.
+func renderV3Collection(w http.ResponseWriter, r *http.Request, items []any) {
+	if items == nil {
+		items = []any{}
+	}
+	render.JSON(w, r, map[string]any{
+		"data": items,
+		"meta": map[string]any{"total_count": len(items)},
+	})
+}
+
+// v3BodyRefID reads data.references.<name>.id out of a v3 create body, restoring
+// the request body for any later reader. It returns "" when the body is absent or
+// not shaped that way, which lands the caller on the fake's 404.
+func v3BodyRefID(r *http.Request, name string) string {
+	if r.Body == nil {
+		return ""
+	}
+	raw, err := io.ReadAll(r.Body)
+	if err != nil {
+		return ""
+	}
+	r.Body = io.NopCloser(bytes.NewReader(raw))
+
+	var body struct {
+		Data struct {
+			References map[string]struct {
+				ID string `json:"id"`
+			} `json:"references"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(raw, &body); err != nil {
+		return ""
+	}
+	return body.Data.References[name].ID
 }
 
 // SetGitHubAppInstalled controls whether GET


### PR DESCRIPTION
<!--
  Thank you for contributing to CircleCI CLI!

  For PRs adding new features, please raise an issue first.

  Squash your commits before requesting review and before merging.
-->
## Summary
- `circleci pipeline list/create`, `circleci project trigger list/create` and the pipeline definition + trigger that `circleci onboard` sets up now call the v3 pipelines and triggers endpoints instead of the v2 `pipeline-definitions` routes. v3 is the current surface for managing pipelines and triggers, and it is where new work lands.
- Command output keeps its existing JSON field names, so there are no help text or golden changes and nothing breaks for scripts or agents.

## Endpoint mapping

| Before | After |
|---|---|
| `GET /api/v2/projects/{id}/pipeline-definitions` | `GET /api/v3/pipelines?filter[project_id]=` |
| `POST /api/v2/projects/{id}/pipeline-definitions` | `POST /api/v3/pipelines` |
| `GET /api/v2/projects/{id}/pipeline-definitions/{def}/triggers` | `GET /api/v3/triggers?filter[project_id]=&filter[pipeline_id]=` |
| `POST /api/v2/projects/{id}/pipeline-definitions/{def}/triggers` | `POST /api/v3/triggers?filter[project_id]=` |

## Request bodies

Three details of the v3 endpoints drove the implementation:

**1. Both creates reject unknown members,** so the request bodies are narrow types carrying no `id`, `created_at`, `checkout.type` or `project` reference. Sending the response entity back as a request body returns 400.

**2. `config` is a tagged union.** `--config-provider circleci` sends the `hosted` variant; every other provider sends `vcs`:

```json
{
  "data": {
    "attributes": {
      "name": "my-pipeline",
      "config": {
        "type": "vcs",
        "file_path": ".circleci/config.yml",
        "vcs": { "provider": "github_app", "repo_id": "987654321", "repo_full_name": "myorg/myrepo" }
      },
      "checkout": {
        "vcs": { "provider": "github_app", "repo_id": "987654321", "repo_full_name": "myorg/myrepo" }
      }
    },
    "references": { "project": { "id": "<project-uuid>" } }
  }
}
```

**3. Trigger create sends `filter[project_id]`,** which is what lets a trigger be created on a project's synthetic OAuth pipeline, whose id resolves to no stored row. `event_preset` moves inside the event union as `event.filter.preset`, and the parent pipeline moves from the path into the body:

```json
{
  "data": {
    "attributes": {
      "is_disabled": false,
      "event": {
        "type": "vcs",
        "vcs": { "provider": "github_app", "repo_id": "987654321" },
        "filter": { "preset": "all-pushes" }
      }
    },
    "references": { "pipeline": { "id": "<pipeline-uuid>" } }
  }
}
```

## API changes in `internal/apiclient`

- `CreateTrigger` takes a `CreateTriggerInput` struct instead of seven positional strings.
- `CreatePipelineDefinitionInput` and `CreateTriggerInput` carry the repository's full name, which providers that address a repository by owner and name rather than by id require.
- `TriggerEventSourceWebhook` is `{name, source}` and `TriggerEventSourceSchedule` gains `name`, matching what v3 returns.

## Test plan
- [x] `task test` — 46 pipeline/trigger and 35 onboard acceptance tests pass. The 9 failures in `internal/gitremote` and `internal/orbinit` reproduce identically on a clean tree (local `commit.gpgSign` breaks go-git commit creation) and are unrelated to this change.
- [x] `task check` clean on both modules.
- [x] Read-only calls against production with the built binary: `pipeline list` decodes every real pipeline on this repo's project, covering both the hosted-config and synthetic-OAuth cases, and `project trigger list` maps a real trigger's preset, provider and repository.
- [ ] After merge: `circleci onboard` end to end on a fresh project.
