### PR TITLE
Read the GitHub App install check from the provider connections endpoint

### DIFF
--- a/acceptance/onboard_test.go
+++ b/acceptance/onboard_test.go
@@ -521,7 +521,7 @@ func TestOnboard_PostSignup_FirstPipeline_GitHubAppResolvesRepo(t *testing.T) {
 	dir, fake, env := onboardRepo(t)
 	// GitHub App is installed for the org and can access the repo, so the repo's
 	// external ID is resolved automatically — no --repo-id needed.
-	fake.SetGitHubAppInstalled(onboardOrgID, true)
+	fake.SetProviderConnected(onboardOrgID, "github_app", true)
 	fake.AddGitHubAppRepository(onboardOrgID, fakes.GitHubAppRepo{
 		ID:            987654321,
 		RepoFullName:  "myorg/my-repo",
@@ -554,7 +554,7 @@ func TestOnboard_PostSignup_FirstPipeline_GitHubAppResolvesRepo(t *testing.T) {
 // name — and no API maps a project name to its ID within an org.
 func TestOnboard_PostSignup_Rerun_Idempotent(t *testing.T) {
 	dir, fake, env := onboardRepo(t)
-	fake.SetGitHubAppInstalled(onboardOrgID, true)
+	fake.SetProviderConnected(onboardOrgID, "github_app", true)
 	fake.AddGitHubAppRepository(onboardOrgID, fakes.GitHubAppRepo{
 		ID:           987654321,
 		RepoFullName: "myorg/my-repo",
@@ -687,7 +687,7 @@ func TestOnboard_PostSignup_ProjectNameConflict(t *testing.T) {
 func TestOnboard_PostSignup_FirstPipeline_RepoNotAccessible(t *testing.T) {
 	dir, fake, env := onboardRepo(t)
 	// App is installed, but the repo the user is in was not granted to it.
-	fake.SetGitHubAppInstalled(onboardOrgID, true)
+	fake.SetProviderConnected(onboardOrgID, "github_app", true)
 	fake.AddGitHubAppRepository(onboardOrgID, fakes.GitHubAppRepo{
 		ID:           111,
 		RepoFullName: "myorg/some-other-repo",
@@ -735,7 +735,7 @@ func TestOnboard_PostSignup_FirstPipeline_MissingPrerequisiteSucceeds(t *testing
 	dir, fake, env := onboardRepo(t)
 	// The GitHub App is installed but has not been granted this repository, so the
 	// external ID cannot be resolved and no pipeline request is ever made.
-	fake.SetGitHubAppInstalled(onboardOrgID, true)
+	fake.SetProviderConnected(onboardOrgID, "github_app", true)
 	result := binary.RunCLI(t, binary.RunOpts{
 		Binary:  binaryPath,
 		Args:    []string{"onboard", "--scan"},

--- a/internal/apiclient/connection.go
+++ b/internal/apiclient/connection.go
@@ -1,0 +1,100 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package apiclient
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/CircleCI-Public/circleci-cli/internal/httpcl"
+)
+
+// ProviderConnection is an organization's connection to a VCS provider, as
+// returned by GET /api/v3/provider/connections.
+//
+// The presence of a connection is what says the provider is connected. The
+// enrichment fields come from a live call out to the provider, so they are absent
+// when ConnectionError is set — a connection that reports an error is still a
+// connection.
+type ProviderConnection struct {
+	// ID is the connection's CircleCI UUID.
+	ID string
+	// Provider is the integration, e.g. "github_app".
+	Provider string
+	// ExternalID is the provider's own id for the installation.
+	ExternalID string
+	// Login is the provider account the connection is installed on.
+	Login string
+	// RepositorySelection is "all" or "selected" when present.
+	RepositorySelection string
+	// AuthorizedUsername is the calling user's account with the provider.
+	AuthorizedUsername string
+	// ConnectionError describes why the provider could not be reached, if it
+	// could not be.
+	ConnectionError string
+}
+
+// connectionAttrs is the attributes object of a v3 provider connection entity.
+type connectionAttrs struct {
+	Provider            string `json:"provider"`
+	ExternalID          string `json:"external_id"`
+	Login               string `json:"login,omitempty"`
+	RepositorySelection string `json:"repository_selection,omitempty"`
+	AuthorizedUsername  string `json:"authorized_username,omitempty"`
+	ConnectionError     string `json:"connection_error,omitempty"`
+}
+
+// connectionEntity is the data entity of GET /api/v3/provider/connections.
+type connectionEntity struct {
+	ID         string          `json:"id"`
+	Attributes connectionAttrs `json:"attributes"`
+}
+
+// ListProviderConnections returns the organization's provider connections.
+// orgID must be the organization UUID. An organization with no connections yields
+// an empty slice, so an error means the check itself failed rather than that
+// nothing is connected.
+func (c *Client) ListProviderConnections(ctx context.Context, orgID string) ([]ProviderConnection, error) {
+	var resp v3List[connectionEntity]
+	_, err := c.main.Call(ctx, httpcl.NewRequest(http.MethodGet, "/api/v3/provider/connections",
+		filterParam("org_id", orgID),
+		httpcl.JSONDecoder(&resp),
+	))
+	if err != nil {
+		return nil, err
+	}
+
+	conns := make([]ProviderConnection, 0, len(resp.Data))
+	for _, e := range resp.Data {
+		conns = append(conns, ProviderConnection{
+			ID:                  e.ID,
+			Provider:            e.Attributes.Provider,
+			ExternalID:          e.Attributes.ExternalID,
+			Login:               e.Attributes.Login,
+			RepositorySelection: e.Attributes.RepositorySelection,
+			AuthorizedUsername:  e.Attributes.AuthorizedUsername,
+			ConnectionError:     e.Attributes.ConnectionError,
+		})
+	}
+	return conns, nil
+}

--- a/internal/apiclient/githubapp.go
+++ b/internal/apiclient/githubapp.go
@@ -24,49 +24,15 @@ package apiclient
 
 import (
 	"context"
-	"errors"
 	"net/http"
 	"strconv"
 
 	"github.com/CircleCI-Public/circleci-cli/internal/httpcl"
 )
 
-// ErrGitHubAppNotInstalled is returned by GetGitHubAppInstallation when the
-// CircleCI GitHub App is not installed for the organization (the endpoint
-// answers 404). Callers use it to branch into the install flow.
-var ErrGitHubAppNotInstalled = errors.New("CircleCI GitHub App is not installed for this organization")
-
-// GitHubAppInstallation describes a CircleCI GitHub App installation for an
-// organization, as returned by
-// GET /api/v2/github-app/organization/{orgID}/installation.
-type GitHubAppInstallation struct {
-	// ID is the GitHub App installation's external (GitHub) ID.
-	ID int64 `json:"id"`
-	// TargetType is "Organization" or "User".
-	TargetType string `json:"target_type"`
-	// Login is the GitHub account the app is installed on.
-	Login string `json:"login"`
-	// RepositorySelection is "all" or "selected" when present.
-	RepositorySelection string `json:"repository_selection,omitempty"`
-}
-
-// GetGitHubAppInstallation reports the CircleCI GitHub App installation for the
-// organization. orgID must be the organization UUID. It returns
-// ErrGitHubAppNotInstalled when the app is not installed (HTTP 404).
-func (c *Client) GetGitHubAppInstallation(ctx context.Context, orgID string) (*GitHubAppInstallation, error) {
-	var resp GitHubAppInstallation
-	_, err := c.main.Call(ctx, httpcl.NewRequest(http.MethodGet, "/api/v2/github-app/organization/%s/installation",
-		httpcl.RouteParams(orgID),
-		httpcl.JSONDecoder(&resp),
-	))
-	if err != nil {
-		if httpcl.HasStatusCode(err, http.StatusNotFound) {
-			return nil, ErrGitHubAppNotInstalled
-		}
-		return nil, err
-	}
-	return &resp, nil
-}
+// Whether the app is installed for an organization is read from the
+// provider-agnostic connections endpoint rather than a GitHub App specific one:
+// see ListProviderConnections.
 
 // InitiateGitHubAppInstall starts a GitHub App installation for the
 // organization and returns the URL the user should open to complete the

--- a/internal/githubapp/githubapp.go
+++ b/internal/githubapp/githubapp.go
@@ -45,6 +45,11 @@ const (
 	maxRepoPages = 50
 )
 
+// provider is the integration this package drives. It is the value the
+// provider-agnostic connections endpoint reports for a CircleCI GitHub App
+// installation.
+const provider = "github_app"
+
 // EnsureInstalled reports whether the CircleCI GitHub App is installed for the
 // organization, walking the user through a browser-based install when it is not.
 // returnURL is where GitHub redirects after install.
@@ -52,10 +57,12 @@ const (
 // Non-interactive sessions (or noBrowser) print the install URL and return false
 // without waiting. Callers degrade to manual guidance on false or on an error.
 func EnsureInstalled(ctx context.Context, client *apiclient.Client, orgID, returnURL string, noBrowser bool) (bool, error) {
-	if _, err := client.GetGitHubAppInstallation(ctx, orgID); err == nil {
-		return true, nil
-	} else if !errors.Is(err, apiclient.ErrGitHubAppNotInstalled) {
+	installed, err := connected(ctx, client, orgID)
+	if err != nil {
 		return false, err
+	}
+	if installed {
+		return true, nil
 	}
 
 	redirectURL, err := client.InitiateGitHubAppInstall(ctx, orgID, returnURL)
@@ -74,7 +81,7 @@ func EnsureInstalled(ctx context.Context, client *apiclient.Client, orgID, retur
 	}
 
 	sp := iostream.Spinner(ctx, true, "Waiting for GitHub App installation")
-	installed, err := pollInstalled(ctx, client, orgID)
+	installed, err = pollInstalled(ctx, client, orgID)
 	sp.Stop()
 	if err != nil {
 		return false, err
@@ -87,8 +94,28 @@ func EnsureInstalled(ctx context.Context, client *apiclient.Client, orgID, retur
 	return true, nil
 }
 
-// pollInstalled polls the installation endpoint until the app is installed, the
-// timeout elapses, or the context is cancelled.
+// connected reports whether the organization has a connection for this package's
+// provider. An organization with none is answered as an empty list rather than an
+// error, so a non-nil error means the check itself failed — a caller must not read
+// it as "not installed" and send the user into an install flow.
+func connected(ctx context.Context, client *apiclient.Client, orgID string) (bool, error) {
+	conns, err := client.ListProviderConnections(ctx, orgID)
+	if err != nil {
+		return false, err
+	}
+	for _, conn := range conns {
+		// A connection whose provider could not be reached still counts as
+		// installed: ConnectionError describes a degraded read, not a missing
+		// installation.
+		if conn.Provider == provider {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// pollInstalled polls for the connection until the app is installed, the timeout
+// elapses, or the context is cancelled.
 func pollInstalled(ctx context.Context, client *apiclient.Client, orgID string) (bool, error) {
 	ticker := time.NewTicker(pollInterval)
 	defer ticker.Stop()
@@ -102,14 +129,13 @@ func pollInstalled(ctx context.Context, client *apiclient.Client, orgID string) 
 		case <-timer.C:
 			return false, nil
 		case <-ticker.C:
-			_, err := client.GetGitHubAppInstallation(ctx, orgID)
-			if err == nil {
+			installed, err := connected(ctx, client, orgID)
+			if err != nil {
+				return false, err
+			}
+			if installed {
 				return true, nil
 			}
-			if errors.Is(err, apiclient.ErrGitHubAppNotInstalled) {
-				continue
-			}
-			return false, err
 		}
 	}
 }

--- a/internal/githubapp/githubapp_test.go
+++ b/internal/githubapp/githubapp_test.go
@@ -146,3 +146,76 @@ func TestResolveRepoID(t *testing.T) {
 		assert.Equal(t, id, "")
 	})
 }
+
+// connectionsServer serves the provider connections endpoint, returning one
+// connection per provider named, and records the paths it was asked for so a test
+// can assert the install flow was not entered.
+func connectionsServer(t *testing.T, providers ...string) (*apiclient.Client, *[]string) {
+	t.Helper()
+
+	var paths []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		data := make([]map[string]any, 0, len(providers))
+		for _, p := range providers {
+			data = append(data, map[string]any{
+				"id":         "conn-" + p,
+				"attributes": map[string]any{"provider": p, "login": "myorg"},
+			})
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": data})
+	}))
+	t.Cleanup(srv.Close)
+
+	return apiclient.New(apiclient.Config{BaseURL: srv.URL, Token: "test-token"}), &paths
+}
+
+func TestEnsureInstalled(t *testing.T) {
+	t.Run("an existing connection needs no install", func(t *testing.T) {
+		client, paths := connectionsServer(t, "github_app")
+
+		installed, err := githubapp.EnsureInstalled(testCtx(), client, "org-uuid", "https://app.circleci.com/x", true)
+
+		assert.NilError(t, err)
+		assert.Check(t, installed)
+		assert.Check(t, cmp.DeepEqual(*paths, []string{"/api/v3/provider/connections"}),
+			"an installed app must not start an install")
+	})
+
+	t.Run("another provider's connection does not count", func(t *testing.T) {
+		// Only the app's own provider means installed; a different integration on the
+		// same org must still send the user through the install.
+		client, _ := connectionsServer(t, "github_oauth")
+
+		installed, err := githubapp.EnsureInstalled(testCtx(), client, "org-uuid", "https://app.circleci.com/x", true)
+
+		assert.NilError(t, err)
+		assert.Check(t, !installed)
+	})
+
+	t.Run("no connections sends the user to install", func(t *testing.T) {
+		client, _ := connectionsServer(t)
+
+		// noBrowser prints the URL and returns rather than polling.
+		installed, err := githubapp.EnsureInstalled(testCtx(), client, "org-uuid", "https://app.circleci.com/x", true)
+
+		assert.NilError(t, err)
+		assert.Check(t, !installed)
+	})
+
+	t.Run("a failed check is an error, not a missing install", func(t *testing.T) {
+		// Reporting "not installed" here would walk the user into an install flow to
+		// fix a problem that is not a missing installation.
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		t.Cleanup(srv.Close)
+		client := apiclient.New(apiclient.Config{BaseURL: srv.URL, Token: "test-token"})
+
+		installed, err := githubapp.EnsureInstalled(testCtx(), client, "org-uuid", "https://app.circleci.com/x", true)
+
+		assert.Check(t, err != nil, "a 500 from the connections endpoint must surface")
+		assert.Check(t, !installed)
+	})
+}

--- a/internal/testing/fakes/circleci.go
+++ b/internal/testing/fakes/circleci.go
@@ -72,7 +72,7 @@ type CircleCI struct {
 	listTriggerResponses              map[string][]any        // "projectID/pipelineID" → list of v3 trigger entities
 
 	// GitHub App state.
-	githubAppInstalled      map[string]bool            // orgID → app installed (200) vs not (404)
+	providerConnections     map[string][]string        // orgID → connected providers
 	githubAppRepos          map[string][]GitHubAppRepo // orgID → repositories the app can access
 	githubAppInstallResp    any                        // response body for POST /github-app/install
 	rerunResponses          map[string]int             // workflow id → HTTP status to return
@@ -255,7 +255,7 @@ func NewCircleCI(t *testing.T, tokens ...string) *CircleCI {
 		createPipelineDefinitionResponses: map[string]any{},
 		createTriggerResponses:            map[string]any{},
 		listTriggerResponses:              map[string][]any{},
-		githubAppInstalled:                map[string]bool{},
+		providerConnections:               map[string][]string{},
 		githubAppRepos:                    map[string][]GitHubAppRepo{},
 		rerunResponses:                    map[string]int{},
 		rerunNewIDs:                       map[string]string{},
@@ -376,7 +376,7 @@ func NewCircleCI(t *testing.T, tokens ...string) *CircleCI {
 	r.Get("/api/v3/triggers", f.handleListTriggers)
 	r.Post("/api/v3/triggers", f.handleCreateTrigger)
 	// GitHub App routes.
-	r.Get("/api/v2/github-app/organization/{orgID}/installation", f.handleGetGitHubAppInstallation)
+	r.Get("/api/v3/provider/connections", f.handleListProviderConnections)
 	r.Post("/api/v2/github-app/install", f.handleInstallGitHubApp)
 	r.Get("/api/v2/github-app/organization/{orgID}/repositories", f.handleListGitHubAppRepositories)
 	// Policy routes.
@@ -3040,13 +3040,21 @@ func v3BodyRefID(r *http.Request, name string) string {
 	return body.Data.References[name].ID
 }
 
-// SetGitHubAppInstalled controls whether GET
-// /api/v2/github-app/organization/{orgID}/installation returns 200 (installed)
-// or 404 (not installed) for the org.
-func (f *CircleCI) SetGitHubAppInstalled(orgID string, installed bool) {
+// SetProviderConnected controls whether GET /api/v3/provider/connections lists a
+// connection for the org and provider. An org with no connection for a provider
+// reads as not connected, which is how the GitHub App install check spells "not
+// installed".
+func (f *CircleCI) SetProviderConnected(orgID, provider string, connected bool) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	f.githubAppInstalled[orgID] = installed
+
+	providers := slices.DeleteFunc(f.providerConnections[orgID], func(p string) bool {
+		return p == provider
+	})
+	if connected {
+		providers = append(providers, provider)
+	}
+	f.providerConnections[orgID] = providers
 }
 
 // GitHubAppRepo is a stored repository the CircleCI GitHub App can access,
@@ -3092,23 +3100,26 @@ func (f *CircleCI) SetGitHubAppInstallResponse(resp any) {
 	f.githubAppInstallResp = resp
 }
 
-func (f *CircleCI) handleGetGitHubAppInstallation(w http.ResponseWriter, r *http.Request) {
-	orgID := chi.URLParam(r, "orgID")
+func (f *CircleCI) handleListProviderConnections(w http.ResponseWriter, r *http.Request) {
+	orgID := r.URL.Query().Get("filter[org_id]")
 	f.mu.RLock()
-	installed := f.githubAppInstalled[orgID]
+	providers := slices.Clone(f.providerConnections[orgID])
 	f.mu.RUnlock()
 
-	if !installed {
-		render.Status(r, http.StatusNotFound)
-		render.JSON(w, r, map[string]any{"message": "not found"})
-		return
+	// An org with no connections is an empty collection, not a 404.
+	data := make([]any, 0, len(providers))
+	for i, p := range providers {
+		data = append(data, map[string]any{
+			"id": fmt.Sprintf("conn-uuid-%d", i+1),
+			"attributes": map[string]any{
+				"provider":             p,
+				"external_id":          "12345678",
+				"login":                "my-org",
+				"repository_selection": "all",
+			},
+		})
 	}
-	render.JSON(w, r, map[string]any{
-		"id":                   12345678,
-		"target_type":          "Organization",
-		"login":                "my-org",
-		"repository_selection": "all",
-	})
+	renderV3Collection(w, r, data)
 }
 
 func (f *CircleCI) handleInstallGitHubApp(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
<!--
  Thank you for contributing to CircleCI CLI!

  For PRs adding new features, please raise an issue first.

  Squash your commits before requesting review and before merging.
-->
## Summary
- The GitHub App install check, and the poll that follows the browser handoff during `circleci onboard`, now call `GET /api/v3/provider/connections?filter[org_id]=` instead of `GET /api/v2/github-app/organization/{orgID}/installation`.
- Connections report their own `provider`, so the check is no longer tied to one integration. `internal/githubapp` matches on the provider it drives and ignores the rest.
- No user-visible change: the same messages, spinner and fallbacks as before.

## Why the error handling changes

The v2 endpoint answered `404` for "not installed", which is indistinguishable from other reasons a lookup can 404. The v3 endpoint answers `200` with an empty collection instead, so:

- No connection for the provider means not installed, and we go to the install flow.
- An error now means the check itself failed, and we surface it rather than walking the user into an install flow that cannot fix it.

A connection carrying `connection_error` still counts as installed, since that field describes a degraded read of the provider rather than a missing installation.

## Unchanged

Install initiation (`POST /api/v2/github-app/install`) and repository resolution (`GET /api/v2/github-app/organization/{orgID}/repositories`) stay on v2 in this PR.

## Testing
- [x] New `TestEnsureInstalled` in `internal/githubapp` covers an existing connection (and asserts no install is started), another provider's connection not counting, no connections at all, and a `500` surfacing as an error rather than "not installed".
- [x] `task test` — 34 onboard acceptance tests pass. The 9 failures in `internal/gitremote` and `internal/orbinit` reproduce on a clean tree (local `commit.gpgSign` breaks go-git commit creation) and are unrelated.
- [x] `task check` clean on both modules.
- [x] Endpoint verified live in production before writing the client: the response carries `provider`, `external_id`, `login`, `repository_selection` and `authorized_username`, which is exactly what the client reads.
