### PR TITLE
Start the GitHub App install from the connections setup endpoint

### DIFF
--- a/acceptance/onboard_test.go
+++ b/acceptance/onboard_test.go
@@ -768,7 +768,7 @@ func TestOnboard_PostSignup_GitHubAppInstall_ReturnURL(t *testing.T) {
 
 	var returnURLs []string
 	for _, req := range fake.AllRequests() {
-		if req.Method != http.MethodPost || req.URL.Path != "/api/v2/github-app/install" {
+		if req.Method != http.MethodPost || req.URL.Path != "/api/v3/provider/connections/setup" {
 			continue
 		}
 		var body struct {

--- a/internal/apiclient/connection.go
+++ b/internal/apiclient/connection.go
@@ -54,6 +54,70 @@ type ProviderConnection struct {
 	ConnectionError string
 }
 
+// Next steps a connection setup can call for. Redirect is the case the CLI can
+// drive: CircleCI already has an app registered with the provider, so the user
+// only has to approve it. Register means no app exists yet and one has to be
+// registered from a manifest, which is a browser flow the CLI cannot complete.
+const (
+	ConnectionNextStepRedirect = "redirect"
+	ConnectionNextStepRegister = "register"
+)
+
+// ProviderConnectionSetup is where to send a user to finish connecting a
+// provider, as returned by POST /api/v3/provider/connections/setup. Nothing is
+// connected when it is returned: the connection only exists once the user
+// completes the flow at the provider.
+type ProviderConnectionSetup struct {
+	// NextStep is what has to happen next, one of the ConnectionNextStep values.
+	NextStep string
+	// URL is where to send the user. Present when NextStep is redirect.
+	URL string
+	// StateToken ties the provider's callback back to this setup. Present when
+	// NextStep is register.
+	StateToken string
+}
+
+// connectionSetupAttrs is the attributes object of a setup response. The manifest
+// that accompanies a register step is not modelled: the CLI cannot drive an app
+// registration, so it has nothing to do with it.
+type connectionSetupAttrs struct {
+	NextStep   string `json:"next_step"`
+	URL        string `json:"url,omitempty"`
+	StateToken string `json:"state_token,omitempty"`
+}
+
+// SetupProviderConnection starts connecting a provider to an organization.
+// orgID must be the organization UUID; returnURL is where the provider sends the
+// user once the flow completes.
+//
+// Every call mints a fresh, hour-long state token, so this is not idempotent:
+// call it when a user is about to be sent to the provider, not to probe.
+func (c *Client) SetupProviderConnection(ctx context.Context, orgID, provider, returnURL string) (*ProviderConnectionSetup, error) {
+	body := map[string]any{
+		"type":       "vcs",
+		"vcs":        map[string]any{"provider": provider},
+		"return_url": returnURL,
+	}
+
+	var resp v3Entity[struct {
+		Attributes connectionSetupAttrs `json:"attributes"`
+	}]
+	_, err := c.main.Call(ctx, httpcl.NewRequest(http.MethodPost, "/api/v3/provider/connections/setup",
+		filterParam("org_id", orgID),
+		httpcl.Body(body),
+		httpcl.JSONDecoder(&resp),
+	))
+	if err != nil {
+		return nil, err
+	}
+
+	return &ProviderConnectionSetup{
+		NextStep:   resp.Data.Attributes.NextStep,
+		URL:        resp.Data.Attributes.URL,
+		StateToken: resp.Data.Attributes.StateToken,
+	}, nil
+}
+
 // connectionAttrs is the attributes object of a v3 provider connection entity.
 type connectionAttrs struct {
 	Provider            string `json:"provider"`

--- a/internal/apiclient/githubapp.go
+++ b/internal/apiclient/githubapp.go
@@ -30,32 +30,10 @@ import (
 	"github.com/CircleCI-Public/circleci-cli/internal/httpcl"
 )
 
-// Whether the app is installed for an organization is read from the
-// provider-agnostic connections endpoint rather than a GitHub App specific one:
-// see ListProviderConnections.
-
-// InitiateGitHubAppInstall starts a GitHub App installation for the
-// organization and returns the URL the user should open to complete the
-// install on GitHub. orgID must be the organization UUID; returnURL is where
-// GitHub redirects after the install completes and must be an app.circleci.com
-// URL.
-func (c *Client) InitiateGitHubAppInstall(ctx context.Context, orgID, returnURL string) (string, error) {
-	body := map[string]any{
-		"org_id":     orgID,
-		"return_url": returnURL,
-	}
-	var resp struct {
-		RedirectURL string `json:"redirect_url"`
-	}
-	_, err := c.main.Call(ctx, httpcl.NewRequest(http.MethodPost, "/api/v2/github-app/install",
-		httpcl.Body(body),
-		httpcl.JSONDecoder(&resp),
-	))
-	if err != nil {
-		return "", err
-	}
-	return resp.RedirectURL, nil
-}
+// Both halves of the install handshake — whether the app is installed for an
+// organization, and starting an install — go through the provider-agnostic
+// connections endpoints: see ListProviderConnections and
+// SetupProviderConnection.
 
 // GitHubAppRepository is a repository the CircleCI GitHub App can access, as
 // returned by GET /api/v2/github-app/organization/{orgID}/repositories.

--- a/internal/githubapp/githubapp.go
+++ b/internal/githubapp/githubapp.go
@@ -28,6 +28,7 @@ package githubapp
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -65,7 +66,7 @@ func EnsureInstalled(ctx context.Context, client *apiclient.Client, orgID, retur
 		return true, nil
 	}
 
-	redirectURL, err := client.InitiateGitHubAppInstall(ctx, orgID, returnURL)
+	redirectURL, err := installURL(ctx, client, orgID, returnURL)
 	if err != nil {
 		return false, err
 	}
@@ -92,6 +93,25 @@ func EnsureInstalled(ctx context.Context, client *apiclient.Client, orgID, retur
 	}
 	iostream.Printf(ctx, "%s GitHub App installed\n", iostream.SymbolOK(ctx))
 	return true, nil
+}
+
+// installURL starts a connection for this package's provider and returns the URL
+// the user has to open to finish it.
+//
+// The setup call answers with what has to happen next. A redirect is the case
+// this flow handles: CircleCI's app is registered with the provider already, so
+// the user only approves it. Anything else — today, registering an app from a
+// manifest — is a browser flow the CLI cannot complete, so it is reported rather
+// than silently opening nothing.
+func installURL(ctx context.Context, client *apiclient.Client, orgID, returnURL string) (string, error) {
+	setup, err := client.SetupProviderConnection(ctx, orgID, provider, returnURL)
+	if err != nil {
+		return "", err
+	}
+	if setup.NextStep != apiclient.ConnectionNextStepRedirect || setup.URL == "" {
+		return "", fmt.Errorf("cannot start the install from here: the connection needs %q", setup.NextStep)
+	}
+	return setup.URL, nil
 }
 
 // connected reports whether the organization has a connection for this package's

--- a/internal/githubapp/githubapp_test.go
+++ b/internal/githubapp/githubapp_test.go
@@ -152,9 +152,21 @@ func TestResolveRepoID(t *testing.T) {
 // can assert the install flow was not entered.
 func connectionsServer(t *testing.T, providers ...string) (*apiclient.Client, *[]string) {
 	t.Helper()
+	return connectionsServerWithSetup(t, map[string]any{
+		"next_step": "redirect",
+		"url":       "https://github.com/apps/circleci/installations/new?state=test",
+	}, providers...)
+}
+
+// connectionsServerWithSetup serves the connections list, one connection per
+// provider named, and answers a setup call with setupAttrs. The paths it was asked
+// for are recorded so a test can assert whether an install was started.
+func connectionsServerWithSetup(t *testing.T, setupAttrs any, providers ...string) (*apiclient.Client, *[]string) {
+	t.Helper()
 
 	var paths []string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v3/provider/connections", func(w http.ResponseWriter, r *http.Request) {
 		paths = append(paths, r.URL.Path)
 		data := make([]map[string]any, 0, len(providers))
 		for _, p := range providers {
@@ -165,7 +177,16 @@ func connectionsServer(t *testing.T, providers ...string) (*apiclient.Client, *[
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{"data": data})
-	}))
+	})
+	mux.HandleFunc("/api/v3/provider/connections/setup", func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{"attributes": setupAttrs},
+		})
+	})
+
+	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
 
 	return apiclient.New(apiclient.Config{BaseURL: srv.URL, Token: "test-token"}), &paths
@@ -195,12 +216,30 @@ func TestEnsureInstalled(t *testing.T) {
 	})
 
 	t.Run("no connections sends the user to install", func(t *testing.T) {
-		client, _ := connectionsServer(t)
+		client, paths := connectionsServer(t)
 
 		// noBrowser prints the URL and returns rather than polling.
 		installed, err := githubapp.EnsureInstalled(testCtx(), client, "org-uuid", "https://app.circleci.com/x", true)
 
 		assert.NilError(t, err)
+		assert.Check(t, !installed)
+		assert.Check(t, cmp.DeepEqual(*paths, []string{
+			"/api/v3/provider/connections",
+			"/api/v3/provider/connections/setup",
+		}), "an absent connection must start one")
+	})
+
+	t.Run("a setup the CLI cannot finish is reported", func(t *testing.T) {
+		// Registering an app from a manifest is a browser flow with no terminal
+		// equivalent, so it must surface rather than open an empty URL.
+		client, _ := connectionsServerWithSetup(t, map[string]any{
+			"next_step":   "register",
+			"state_token": "tok",
+		})
+
+		installed, err := githubapp.EnsureInstalled(testCtx(), client, "org-uuid", "https://app.circleci.com/x", true)
+
+		assert.Check(t, err != nil, "a register step has no CLI path and must not pass silently")
 		assert.Check(t, !installed)
 	})
 

--- a/internal/testing/fakes/circleci.go
+++ b/internal/testing/fakes/circleci.go
@@ -74,7 +74,7 @@ type CircleCI struct {
 	// GitHub App state.
 	providerConnections     map[string][]string        // orgID → connected providers
 	githubAppRepos          map[string][]GitHubAppRepo // orgID → repositories the app can access
-	githubAppInstallResp    any                        // response body for POST /github-app/install
+	connectionSetupResp     any                        // response body for POST /provider/connections/setup
 	rerunResponses          map[string]int             // workflow id → HTTP status to return
 	rerunNewIDs             map[string]string          // workflow id → id of the workflow its rerun creates
 	rerunFromFailed         map[string]bool            // workflow id → is_from_failed as the request actually set it
@@ -377,7 +377,7 @@ func NewCircleCI(t *testing.T, tokens ...string) *CircleCI {
 	r.Post("/api/v3/triggers", f.handleCreateTrigger)
 	// GitHub App routes.
 	r.Get("/api/v3/provider/connections", f.handleListProviderConnections)
-	r.Post("/api/v2/github-app/install", f.handleInstallGitHubApp)
+	r.Post("/api/v3/provider/connections/setup", f.handleSetupProviderConnection)
 	r.Get("/api/v2/github-app/organization/{orgID}/repositories", f.handleListGitHubAppRepositories)
 	// Policy routes.
 	r.Post("/api/v2/owner/{ownerID}/context/{policyCtx}/policy-bundle", f.handleCreatePolicyBundle)
@@ -3092,12 +3092,13 @@ func gitHubAppRepoEntity(repo GitHubAppRepo) map[string]any {
 	return m
 }
 
-// SetGitHubAppInstallResponse registers the body returned by POST
-// /api/v2/github-app/install.
-func (f *CircleCI) SetGitHubAppInstallResponse(resp any) {
+// SetProviderConnectionSetupResponse registers the body returned by POST
+// /api/v3/provider/connections/setup. Pass a body whose next_step is not
+// "redirect" to exercise a flow the CLI cannot finish.
+func (f *CircleCI) SetProviderConnectionSetupResponse(resp any) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	f.githubAppInstallResp = resp
+	f.connectionSetupResp = resp
 }
 
 func (f *CircleCI) handleListProviderConnections(w http.ResponseWriter, r *http.Request) {
@@ -3122,13 +3123,18 @@ func (f *CircleCI) handleListProviderConnections(w http.ResponseWriter, r *http.
 	renderV3Collection(w, r, data)
 }
 
-func (f *CircleCI) handleInstallGitHubApp(w http.ResponseWriter, r *http.Request) {
+func (f *CircleCI) handleSetupProviderConnection(w http.ResponseWriter, r *http.Request) {
 	f.mu.RLock()
-	resp := f.githubAppInstallResp
+	resp := f.connectionSetupResp
 	f.mu.RUnlock()
 
 	if resp == nil {
-		resp = map[string]any{"redirect_url": "https://github.com/apps/circleci/installations/new?state=test"}
+		resp = map[string]any{"data": map[string]any{
+			"attributes": map[string]any{
+				"next_step": "redirect",
+				"url":       "https://github.com/apps/circleci/installations/new?state=test",
+			},
+		}}
 	}
 	render.JSON(w, r, resp)
 }


### PR DESCRIPTION
## Summary
- Initiating a GitHub App install now calls `POST /api/v3/provider/connections/setup?filter[org_id]=` instead of `POST /api/v2/github-app/install`. With #1746, both halves of the install handshake are off provider-specific endpoints.
- No user-visible change on the happy path: same browser handoff, same spinner, same fallbacks.

## The response shape is a step, not a URL

v2 answered with a bare `redirect_url`. The v3 endpoint answers with what has to happen next:

- `next_step: "redirect"` carries the `url` for an app CircleCI has already registered with the provider, which the user only has to approve. This is the case `onboard` drives.
- `next_step: "register"` carries a manifest and a state token, for registering an app before it can be approved. That is a browser flow with no terminal equivalent, so the CLI reports it instead of opening an empty URL.

Request body is a plain object rather than a data envelope, and the org travels as `filter[org_id]`:

```json
{ "type": "vcs", "vcs": { "provider": "github_app" }, "return_url": "https://app.circleci.com/cli/github-app-installed" }
```

## Not idempotent, on purpose

Each setup call mints a fresh state token valid for an hour, so the call stays exactly where it was: once, at the point the user is about to be sent to the provider. It is not safe to use as a probe, which is why the install *check* is a separate endpoint.

## Unchanged

Repository resolution (`GET /api/v2/github-app/organization/{orgID}/repositories`) is the last GitHub App specific call left in `onboard`, and it waits on the listing endpoint.

## Testing
- [x] `TestEnsureInstalled` gains a case asserting an absent connection starts a setup, and one asserting a `register` step surfaces as an error rather than passing silently. The fake server now routes the list and setup paths separately, so the setup call is actually exercised.
- [x] `TestOnboard_PostSignup_GitHubAppInstall_ReturnURL` now reads the return URL off the setup request, keeping the assertion that the browser lands on the page that points back at the terminal.
- [x] `task test` — 34 onboard acceptance tests pass. The 9 failures in `internal/gitremote` and `internal/orbinit` reproduce on a clean tree (local `commit.gpgSign` breaks go-git commit creation) and are unrelated.
- [x] `task check` clean on both modules.
- [ ] Live check against production. The request and response shapes come from reading the endpoint's handler rather than calling it, because each call mints a state token. Worth one real call before merge, which creates nothing if the flow is not completed.

