### PR TITLE
Add --definition-id flag to run trigger

### DIFF
--- a/acceptance/run_test.go
+++ b/acceptance/run_test.go
@@ -1568,6 +1568,45 @@ func TestRunTrigger_NoToken(t *testing.T) {
 	assert.Check(t, golden.String(result.Stderr, t.Name()+".stderr.txt"))
 }
 
+func TestRunTrigger_DefinitionID(t *testing.T) {
+	fake := fakes.NewCircleCI(t)
+	slug := watchSlug
+	defID := "d1000000-0000-4000-8000-000000000001"
+	fake.SetTriggerPipelineRunResponse(slug, map[string]any{
+		"id":         "new-run-uuid",
+		"state":      "created",
+		"number":     44,
+		"created_at": time.Now().UTC().Format(time.RFC3339),
+	})
+
+	env := testenv.New(t)
+	env.Token = testToken
+	env.CircleCIURL = fake.URL()
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"run", "trigger", "--project", slug, "--branch", "main", "--definition-id", defID},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Check(t, golden.String(result.Stdout, t.Name()+".txt"))
+
+	t.Run("check request", func(t *testing.T) {
+		parts := strings.SplitN(slug, "/", 3)
+		assert.Check(t, cmp.DeepEqual(fake.LastRequest(), &httprecorder.Request{
+			Method: http.MethodPost,
+			URL:    url.URL{Path: "/api/v2/project/" + parts[0] + "/" + parts[1] + "/" + parts[2] + "/pipeline/run"},
+			Header: http.Header{
+				"Authorization": {"Bearer test-token"},
+				"User-Agent":    {httpcl.UserAgent(runtime.GOOS, runtime.GOARCH, "dev", "")},
+			},
+			Body: new(`{"checkout":{"branch":"main"},"config":{"branch":"main"},"definition_id":"` + defID + `"}`),
+		}, ignoreCommonHeaders))
+	})
+}
+
 // --- arg whitespace trimming (tested via run get; trimming lives in PersistentPreRunE) ---
 
 func TestArgWhitespaceTrimmed(t *testing.T) {

--- a/acceptance/testdata/TestRunTrigger_DefinitionID.txt
+++ b/acceptance/testdata/TestRunTrigger_DefinitionID.txt
@@ -1,0 +1,1 @@
+Triggered run #44 (new-run-uuid) on main

--- a/internal/cmd/root/testdata/help/circleci/reference.txt
+++ b/internal/cmd/root/testdata/help/circleci/reference.txt
@@ -678,19 +678,18 @@ Use --current-branch or --branch/-b to filter runs to a specific branch.
 
 Trigger a new run
 
-Trigger a new run for a CircleCI project.
-
-The project and branch are inferred from the current git repository
-unless overridden with --project or --branch.
-
-Pass run parameters with --parameter. Values are parsed as
-booleans (true/false), integers, or strings.
+Trigger a new run for a CircleCI project. Project and branch are
+inferred from the git remote unless set via --project/--branch.
+Parameter values are coerced to booleans, integers, or strings.
 
 JSON fields: id, number, state, created_at
 
 | Flag                      | Description                                                                       |
 | ------------------------- | --------------------------------------------------------------------------------- |
 | `-b, --branch string`     | Branch to trigger (defaults to current branch)                                    |
+| `--config-branch string`  | Config branch for the pipeline definition (defaults to checkout branch)           |
+| `--config-tag string`     | Config tag for the pipeline definition                                            |
+| `--definition-id string`  | Pipeline definition ID (UUID) to trigger                                          |
 | `--jq string`             | Process values from the response using jq syntax (see `circleci help formatting`) |
 | `--json`                  | Output as JSON                                                                    |
 | `--parameter stringArray` | Run parameter as key=value (repeatable)                                           |
@@ -705,8 +704,8 @@ JSON fields: id, number, state, created_at
   `circleci run trigger --branch main`
 - Trigger with run parameters: 
   `circleci run trigger --parameter deploy_env=staging --parameter run_e2e=true`
-- Output the triggered run as JSON: 
-  `circleci run trigger --json`
+- Trigger a specific pipeline definition (config branch defaults to current branch): 
+  `circleci run trigger --definition-id <uuid> --config-branch main`
 
 #### `circleci run watch [<run-id>] [flags]`
 

--- a/internal/cmd/root/testdata/help/circleci/run/trigger.txt
+++ b/internal/cmd/root/testdata/help/circleci/run/trigger.txt
@@ -9,6 +9,9 @@ Trigger a new run
 | Flag                      | Description                                                                       |
 | ------------------------- | --------------------------------------------------------------------------------- |
 | `-b, --branch string`     | Branch to trigger (defaults to current branch)                                    |
+| `--config-branch string`  | Config branch for the pipeline definition (defaults to checkout branch)           |
+| `--config-tag string`     | Config tag for the pipeline definition                                            |
+| `--definition-id string`  | Pipeline definition ID (UUID) to trigger                                          |
 | `--jq string`             | Process values from the response using jq syntax (see `circleci help formatting`) |
 | `--json`                  | Output as JSON                                                                    |
 | `--parameter stringArray` | Run parameter as key=value (repeatable)                                           |
@@ -24,18 +27,14 @@ Global flags: `-c, --config`, `--debug`, `--no-color`, `-q, --quiet` — see `ci
   `circleci run trigger --branch main`
 - Trigger with run parameters: 
   `circleci run trigger --parameter deploy_env=staging --parameter run_e2e=true`
-- Output the triggered run as JSON: 
-  `circleci run trigger --json`
+- Trigger a specific pipeline definition (config branch defaults to current branch): 
+  `circleci run trigger --definition-id <uuid> --config-branch main`
 
 ## Details
 
-Trigger a new run for a CircleCI project.
-
-The project and branch are inferred from the current git repository
-unless overridden with --project or --branch.
-
-Pass run parameters with --parameter. Values are parsed as
-booleans (true/false), integers, or strings.
+Trigger a new run for a CircleCI project. Project and branch are
+inferred from the git remote unless set via --project/--branch.
+Parameter values are coerced to booleans, integers, or strings.
 
 JSON fields: id, number, state, created_at
 

--- a/internal/cmd/root/testdata/usage/circleci/run/trigger.txt
+++ b/internal/cmd/root/testdata/usage/circleci/run/trigger.txt
@@ -2,6 +2,9 @@ Usage:  circleci run trigger [flags]
 
 Flags:
   -b, --branch string           Branch to trigger (defaults to current branch)
+      --config-branch string    Config branch for the pipeline definition (defaults to checkout branch)
+      --config-tag string       Config tag for the pipeline definition
+      --definition-id string    Pipeline definition ID (UUID) to trigger
   -h, --help                    help for trigger
       --jq string               Process values from the response using jq syntax
       --json                    Output as JSON

--- a/internal/cmd/run/trigger.go
+++ b/internal/cmd/run/trigger.go
@@ -40,23 +40,22 @@ import (
 
 func newTriggerCmd() *cobra.Command {
 	var (
-		projectSlug string
-		branch      string
-		params      []string
-		jsonOut     bool
+		projectSlug  string
+		branch       string
+		definitionID string
+		configBranch string
+		configTag    string
+		params       []string
+		jsonOut      bool
 	)
 
 	cmd := &cobra.Command{
 		Use:   "trigger",
 		Short: "Trigger a new run",
 		Long: heredoc.Doc(`
-			Trigger a new run for a CircleCI project.
-
-			The project and branch are inferred from the current git repository
-			unless overridden with --project or --branch.
-
-			Pass run parameters with --parameter. Values are parsed as
-			booleans (true/false), integers, or strings.
+			Trigger a new run for a CircleCI project. Project and branch are
+			inferred from the git remote unless set via --project/--branch.
+			Parameter values are coerced to booleans, integers, or strings.
 
 			JSON fields: id, number, state, created_at
 		`),
@@ -70,8 +69,8 @@ func newTriggerCmd() *cobra.Command {
 			# Trigger with run parameters
 			$ circleci run trigger --parameter deploy_env=staging --parameter run_e2e=true
 
-			# Output the triggered run as JSON
-			$ circleci run trigger --json
+			# Trigger a specific pipeline definition (config branch defaults to current branch)
+			$ circleci run trigger --definition-id <uuid> --config-branch main
 		`),
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -80,12 +79,15 @@ func newTriggerCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return runTrigger(ctx, client, projectSlug, branch, params, jsonOut)
+			return runTrigger(ctx, client, projectSlug, branch, definitionID, configBranch, configTag, params, jsonOut)
 		},
 	}
 
 	cmd.Flags().StringVar(&projectSlug, "project", "", "Project slug (e.g. gh/org/repo); defaults to git remote")
 	cmd.Flags().StringVarP(&branch, "branch", "b", "", "Branch to trigger (defaults to current branch)")
+	cmd.Flags().StringVar(&definitionID, "definition-id", "", "Pipeline definition ID (UUID) to trigger")
+	cmd.Flags().StringVar(&configBranch, "config-branch", "", "Config branch for the pipeline definition (defaults to checkout branch)")
+	cmd.Flags().StringVar(&configTag, "config-tag", "", "Config tag for the pipeline definition")
 	cmd.Flags().StringArrayVar(&params, "parameter", nil, "Run parameter as key=value (repeatable)")
 	cmdutil.AddJSONFlag(cmd, &jsonOut)
 	cmdutil.AddJQFlag(cmd)
@@ -100,7 +102,7 @@ type triggerJSONOutput struct {
 	CreatedAt string `json:"created_at"`
 }
 
-func runTrigger(ctx context.Context, client *apiclient.Client, projectSlug, branch string, params []string, jsonOut bool) error {
+func runTrigger(ctx context.Context, client *apiclient.Client, projectSlug, branch, definitionID, configBranch, configTag string, params []string, jsonOut bool) error {
 	effectiveBranch := branch
 	if projectSlug == "" || effectiveBranch == "" {
 		info, err := gitremote.Detect()
@@ -121,6 +123,34 @@ func runTrigger(ctx context.Context, client *apiclient.Client, projectSlug, bran
 			err.Error()).
 			WithSuggestions("Parameters must be in key=value form, e.g. --parameter deploy_env=staging").
 			WithExitCode(clierrors.ExitBadArguments)
+	}
+
+	if definitionID != "" {
+		effectiveConfigBranch := configBranch
+		if effectiveConfigBranch == "" && configTag == "" {
+			effectiveConfigBranch = effectiveBranch
+		}
+		resp, err := client.TriggerPipelineRun(ctx, projectSlug, apiclient.TriggerPipelineRunInput{
+			DefinitionID:   definitionID,
+			ConfigBranch:   effectiveConfigBranch,
+			ConfigTag:      configTag,
+			CheckoutBranch: effectiveBranch,
+			Parameters:     parsedParams,
+		})
+		if err != nil {
+			return apiErr(err, projectSlug)
+		}
+		if jsonOut {
+			out := triggerJSONOutput{
+				ID:        resp.ID,
+				Number:    int64(resp.Number),
+				State:     resp.State,
+				CreatedAt: resp.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
+			}
+			return iostream.PrintJSON(ctx, out)
+		}
+		iostream.Printf(ctx, "Triggered run #%d (%s) on %s\n", resp.Number, resp.ID, effectiveBranch)
+		return nil
 	}
 
 	resp, err := client.TriggerPipeline(ctx, projectSlug, effectiveBranch, parsedParams)


### PR DESCRIPTION
Adds `--definition-id` to `circleci run trigger`. When set, routes to `POST .../pipeline/run` with `definition_id` in the body instead of the default `/pipeline` endpoint. Includes an acceptance test covering the new flag.