### PR TITLE
Make agents follow the rules more consistently

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,8 +10,9 @@ A new CircleCI CLI built from scratch in Go + Cobra, targeting exemplary CLI des
 
 ## Critical rules — read before writing any command
 
-These are the seven design decisions that must not be violated. They exist because the
-current circleci CLI got them wrong, and this project exists to fix them.
+These are the eight design decisions that must not be violated. The first seven exist
+because the current circleci CLI got them wrong, and this project exists to fix them; the
+eighth exists because the rest of the guidance is worthless if nobody opens it.
 
 **1. Every data-returning command gets `--json` with field enumeration in `--help`.**
 No exceptions. Consistent JSON coverage is the #1 differentiator between a scripting
@@ -46,13 +47,25 @@ budget; `Long` is what yields. Enforced per command by `TestHelp` in
 `internal/cmd/root/usage_test.go` — see [agents/03-help-and-documentation.md](agents/03-help-and-documentation.md)
 for how to trim.
 
+**8. Open the guideline file before writing the code it governs.**
+The table below maps a kind of work to the file that governs it. It is not a reading list to
+consult when something looks unclear — a row is a precondition: if you are about to do the
+thing on the left, you read the file on the right *first*. Read the file, not its headings; the
+rules are in the prose. Inferring a convention from neighbouring code instead is how the wrong
+pattern spreads — several files in this tree predate a rule and are marked as such. Two rules
+are enforced by tests rather than by review: `TestHelp` in `internal/cmd/root/usage_test.go`
+(rule 7) and `internal/conventions` (the testing rules). A green build is not evidence you
+followed the others.
+
 ---
 
 ## Design guidelines
 
 The normative design guidelines live in [`agents/`](agents/README.md). **Read the linked file
 before you write the code it governs** — not after, and not only at review time. Each line below
-is a trigger: if you are about to do the thing on the left, open the file on the right first.
+is a trigger: if you are about to do the thing on the left, open the file on the right first
+(rule 8 above). Every `agents/` file opens with its rules in short form, so its first screen is
+enough to know what binds you; the rest of the file is the reasoning and the examples.
 
 | If you are about to… | Read first |
 |---|---|
@@ -65,7 +78,8 @@ is a trigger: if you are about to do the thing on the left, open the file on the
 | Add a flag or positional argument | [agents/06-arguments-and-flags.md](agents/06-arguments-and-flags.md) |
 | Add a prompt, spinner, or TUI flow | [agents/07-interactivity.md](agents/07-interactivity.md) |
 | Add or restructure a subcommand | [agents/08-subcommands.md](agents/08-subcommands.md) |
-| Write or change tests | [agents/14-testing.md](agents/14-testing.md) |
+| Write or change **any** test — including one test in a file of many | [agents/14-testing.md](agents/14-testing.md) |
+| Write an implementation plan into `agents/` | [agents/plan-template.md](agents/plan-template.md) |
 
 Consult when the topic comes up: [agents/09-robustness.md](agents/09-robustness.md) ·
 [agents/10-configuration-and-env.md](agents/10-configuration-and-env.md) ·
@@ -232,7 +246,10 @@ internal/
 ├── telemetry/            Segment event sender + background delegate + receiver/.
 ├── agent/                Detect() — identifies the calling AI agent / MCP host so telemetry
 │                         attributes tool-call subprocesses correctly.
-└── bulkhead/             Runs a slice of work with bounded parallelism.
+├── bulkhead/             Runs a slice of work with bounded parallelism.
+└── conventions/          Tests enforcing this repo's own house rules (currently the testing
+                          rules from agents/14-testing.md), with allowlists naming the files
+                          that predate them. No production code.
 ```
 
 `iostream`, `errors`, `mdtable`, `jq`, `jsoncolor`, `browser`, `closer`, `ui/components` and

--- a/agents/01-philosophy.md
+++ b/agents/01-philosophy.md
@@ -1,6 +1,32 @@
 # Philosophy
 
-CLI design is guided by eight core principles. These aren't rules to follow mechanically — they're lenses for making judgment calls when the right answer isn't obvious.
+**The nine principles** — in short form, so the whole set is visible at once. Each
+has a section below with the reasoning; read those when a trade-off is close.
+
+1. **Human-first design.** Optimise for the human at the terminal; composability is
+   opt-in (`--json`, pipes), not paid for by usability.
+2. **Simple parts that work together.** Standard streams, exit codes, signals,
+   plain text — good alone, good in a pipeline.
+3. **Consistency.** Follow the conventions of tools users already know. Break one
+   only deliberately, with a reason, and consistently within this tool.
+4. **Say just enough.** Confirm what happened, surface what needs acting on, stay
+   out of the way when scripted. Non-JSON output is markdown, via the helper in
+   `iostream`.
+5. **Ease of discovery.** Help text, examples and error suggestions should let a
+   user orient without leaving the terminal.
+6. **Conversation as the norm.** Suggest corrections, clarify state, confirm
+   dangerous actions, show what happened.
+7. **Robustness.** Handle errors gracefully, be idempotent, don't surprise. Keep
+   implementations simple — complexity breeds fragility.
+8. **Empathy.** Anticipate mistakes, explain in human terms, suggest the next step,
+   never silently do the wrong thing.
+9. **Transparency.** Every action the command takes must be visible. Implicit steps
+   — file writes, network calls, credential lookups the user didn't ask for — are
+   dangerous and erode trust.
+
+---
+
+CLI design is guided by these nine core principles. These aren't rules to follow mechanically — they're lenses for making judgment calls when the right answer isn't obvious.
 
 ---
 

--- a/agents/02-basics.md
+++ b/agents/02-basics.md
@@ -1,5 +1,19 @@
 # The Basics
 
+**Rules**
+
+1. **Use an argument parsing library** (cobra here) — never hand-rolled parsing.
+2. **Exit `0` on success, non-zero on every failure**; `2` for bad arguments. Map
+   your important failure modes to documented codes — in this repo they live in
+   `clikit/errors/exitcodes.go`.
+3. **Primary output goes to stdout**, machine-readable output included. It is what
+   a pipe captures.
+4. **Messages, status, warnings and errors go to stderr**, so they stay visible to
+   a human without corrupting a pipe.
+5. **Never hang on an empty stdin TTY** — show help and exit instead.
+
+---
+
 These are the non-negotiable foundations. Every CLI should get these right before worrying about anything else.
 
 ---

--- a/agents/03-help-and-documentation.md
+++ b/agents/03-help-and-documentation.md
@@ -1,5 +1,27 @@
 # Help and Documentation
 
+**Rules**
+
+1. **`--help` must fit 40 lines; design for 35.** Usage, Arguments, the *complete*
+   flag table and 3+ examples all fit inside the budget. Enforced per command by
+   `TestHelp` in `internal/cmd/root/usage_test.go`.
+2. **Prose is what yields**, in this order: delete what the flag table already
+   says, then what `## Arguments` already says, cap `Long` at ~6 lines, cap
+   examples at 5 (3 is the floor).
+3. **Prose worth keeping moves to a help topic** (`internal/cmd/root/help_topic.go`),
+   which is exempt from the budget. There is no separate web copy: `Long` also
+   feeds the docs site, `llms.txt`, the man page and the MCP tool description.
+4. **Two documentation levels for every command and flag**: a one-line summary that
+   never wraps, and a full description shown only in that command's `--help`.
+5. **Lead with examples**, simple → complex, and **show every flag's default**.
+6. **Show concise help, never an error or a hang,** when a command that needs
+   arguments is run without them.
+7. **Suggest corrections, never auto-correct** a typo'd command or flag.
+8. **`-h` always means help** — never overload it.
+9. **Group flags into named sections** once a command has more than ~8.
+
+---
+
 Good help text is often the difference between a tool that gets adopted and one that gets abandoned. Users should be able to orient themselves entirely from within the terminal.
 
 ---

--- a/agents/04-output.md
+++ b/agents/04-output.md
@@ -1,5 +1,26 @@
 # Output
 
+**Rules**
+
+1. **Detect the TTY, and check stdout and stderr independently.** Human formatting
+   when a terminal is attached; plain, unanimated output when it is not. In this
+   repo that decision belongs to `iostream.Streams`, never a raw `os.Stdout` check.
+2. **Every data-returning command gets `--json`**, pretty-printed, on stdout.
+3. **`--json` suppresses all human output**, errors included — the only thing on
+   stdout is the JSON.
+4. **Report state changes.** An action command that changes something must say what
+   changed; silence is only golden for scripts.
+5. **Colour carries meaning, never decoration**, and is disabled when there is no
+   TTY, when `NO_COLOR` is set, when `TERM=dumb`, or when `--no-color` is passed.
+6. **Progress indicators go to stderr and only inside a TTY** — a re-rendering bar
+   turns a CI log into a Christmas tree.
+7. **Don't go silent for 10+ seconds.** Periodic status beats an unexplained pause.
+8. **Make cross-boundary actions explicit** — file writes and network calls the
+   user didn't ask for.
+9. **Keep output grep-parseable** for commands whose job is to display data.
+
+---
+
 Output design is where the human-first principle becomes most visible. The goal is output that's clear to humans by default, but degrades gracefully for machines.
 
 ---

--- a/agents/05-errors.md
+++ b/agents/05-errors.md
@@ -1,5 +1,30 @@
 # Errors
 
+**Rules**
+
+1. **Every error is the structured type in `clikit/errors`** — never `fmt.Errorf`
+   in a handler. It carries `code`, `title`, `message`, `suggestions[]` and `ref`.
+2. **Return `error`, never `*clierrors.CLIError`,** from any function that can
+   return nil: a typed nil in an `error` interface is not nil, which silently
+   breaks `if err != nil` and `assert.NilError`. Use the concrete type only for
+   locals and builder chains.
+3. **Answer three questions**: what happened, why, and what to do next. One
+   concrete action per suggestion.
+4. **All errors go to stderr**, and **every failure exits non-zero** with a code
+   from `clikit/errors/exitcodes.go` — document a new code there before using it.
+5. **Validate input before doing any work**, and say what was wrong with what was
+   given: `--timeout must be a positive integer (got: "fast")`.
+6. **Hide stack traces by default**; expose them behind `--debug` / an env var.
+7. **Structured errors when `--json` is active**, on stderr.
+8. **Suggest corrections for typos, never auto-correct.**
+9. **Never fail silently, never print an exception verbatim, never exit `0` after
+   an error.**
+
+Test assertions match a `CLIError`'s `message`, never its `title` — see
+[14-testing.md](./14-testing.md).
+
+---
+
 Error messages are one of the highest-value parts of a CLI. A good error message turns a frustrating dead-end into a clear path forward.
 
 ---

--- a/agents/06-arguments-and-flags.md
+++ b/agents/06-arguments-and-flags.md
@@ -1,5 +1,34 @@
 # Arguments and Flags
 
+**Rules**
+
+1. **Prefer flags to positional arguments.** One positional is fine, two is
+   questionable, three is never. Flags are self-documenting and can be added
+   without breaking existing invocations.
+2. **Follow the standard flag names** (`-h/--help`, `-v/--verbose`, `-q/--quiet`,
+   `-f/--force`, `-n/--dry-run`, `-o/--output`, `-c/--config`, …) and never
+   overload `-h`.
+3. **Provide both short and long forms** for common flags; support `-abc` grouping
+   and both `--flag=value` and `--flag value`.
+4. **A flag that takes a value always requires one** — no context-dependent
+   optional values.
+5. **Declare flags as typed** (int, URL, file, enum) so the parser validates before
+   the command runs, and **document every default** in help text.
+6. **Declare flag relationships** (depends-on, mutually exclusive, exactly-one) at
+   the flag level rather than checking them in the handler.
+7. **Flag descriptions are lowercase, concise, no trailing period.**
+8. **Basic functionality works with no flags.** Flags modify behaviour; they are
+   not the gate to it.
+9. **Booleans default to false** and are enabled by presence; use `--no-x` to
+   disable something on by default.
+10. **Support `--` passthrough** for commands that wrap a child process, and let a
+    sensitive flag read its value from stdin (`--token -`) to keep it out of shell
+    history.
+11. **Give major flags an environment-variable equivalent**, declared with the flag
+    so help documents it — see [10-configuration-and-env.md](./10-configuration-and-env.md).
+
+---
+
 Arguments and flags are the primary interface between your user and your command. Getting the conventions right makes your tool feel familiar; getting them wrong creates constant friction.
 
 ---

--- a/agents/07-interactivity.md
+++ b/agents/07-interactivity.md
@@ -1,5 +1,31 @@
 # Interactivity
 
+**Rules**
+
+1. **Spec the flag interface first, then add prompts on top.** A prompt is a
+   first-time-user affordance, never the primary interface, and must never be
+   *required* — every prompt has a flag that answers it.
+2. **Confirm before anything destructive or irreversible**, naming what will
+   change, with the safe answer as the default: `[y/N]`.
+3. **Support `--force` to skip confirmation and `--dry-run` to preview.**
+4. **Missing required input prompts in a TTY and errors outside one**, listing the
+   flags that would have supplied it. Optional input gets a default, not a prompt.
+5. **Never prompt for something the user already expressed via flags**, and never
+   prompt for every optional setting.
+6. **Build interactive flows with bubbletea**: the program lives in `internal/ui`,
+   reusable components in `clikit/ui/components`, and standard
+   `charm.land/bubbles/v2` components are preferred over new ones.
+7. **Show defaults in brackets, mask secrets, and validate on entry** (re-prompt
+   rather than accepting and failing later).
+8. **Interactivity must be switch-off-able** — flags, `CI=true`, or the
+   no-interactive environment variable; in this repo that decision comes from
+   `iostream.Streams`, never a direct env read.
+
+Testing: component-level tests go through teatest — see
+[14-testing.md](./14-testing.md), the single source of truth for testing rules.
+
+---
+
 Interactive prompts help humans but break automation. The key is knowing when to be interactive and when to get out of the way.
 
 ---
@@ -91,8 +117,9 @@ Re-usable components should be in the `clikit/ui/components` package.
 
 Standard components from `charm.land/bubbles/v2` should be preferred over custom ones from scratch.
 
-Detailed component-level tests should be written using the `github.com/charmbracelet/x/exp/teatest/v2` package, while
-higher level end-to-end tests go in the regular `acceptance` package, using the test runner from `internal/testing/binary`.
+For how to test any of this — component-level tests through teatest, end-to-end
+tests in `acceptance/` — see [14-testing.md](./14-testing.md). It is the single
+source of truth for testing rules; don't rely on finding them here.
 
 ### Be clear and direct
 State exactly what you're asking for. Don't use vague prompts like "Value:".

--- a/agents/08-subcommands.md
+++ b/agents/08-subcommands.md
@@ -1,5 +1,27 @@
 # Subcommands
 
+**Rules**
+
+1. **Maximum two levels of nesting.** Three levels means restructuring or adding a
+   top-level alias — the alias is the primary user-facing command and the deep path
+   is a thin wrapper over the same business logic. Four levels must never occur.
+2. **Pick noun-first or verb-first and never mix them.** This repo is noun-first
+   (`context secret set`), so related operations cluster under their resource.
+3. **Every group command sets `RunE: cmdutil.GroupRunE` and
+   `FParseErrWhitelist{UnknownFlags: true}`.** Without both, an unknown subcommand
+   exits 0 (indistinguishable from success) and an unknown flag after it produces a
+   misleading "unknown flag" diagnosis.
+4. **Use one naming vocabulary throughout** — not `list` here and `ls` there — and
+   follow the conventional verbs (`create`, `delete`, `list`, `get`, `update`,
+   `init`, `run`).
+5. **Every subcommand carries its own `--help`**, and the root lists the
+   subcommands with the most-used first.
+6. **Don't add a subcommand just to namespace a flag.**
+7. **Be clear about global versus subcommand flags** — global before the
+   subcommand, specific after.
+
+---
+
 Subcommands let you group related functionality under a single tool. Used well, they create an intuitive namespace. Used poorly, they create a confusing maze.
 
 ---

--- a/agents/09-robustness.md
+++ b/agents/09-robustness.md
@@ -1,5 +1,33 @@
 # Robustness
 
+**Rules**
+
+1. **Validate everything before doing any work** — arguments, flag values, file
+   permissions, credentials. A failure after partial work is worse than a failure
+   before it.
+2. **Fail fast, and say how far you got.** Don't carry on past an error and leave
+   inconsistent state.
+3. **Be idempotent where you can.** Setup, init and install commands especially;
+   where you can't, document it and require confirmation.
+4. **Handle SIGINT, SIGTERM and SIGPIPE.** Ctrl+C cleans up and exits non-zero;
+   SIGTERM shuts down gracefully; a broken pipe (`… | head -5`) exits cleanly with
+   no error.
+5. **Every required setting that can have a sensible default has one**, documented
+   in help.
+6. **Handle the awkward inputs**: empty files, unicode and leading-dash names,
+   missing optional files, inputs too large to hold in memory, read-only
+   filesystems.
+7. **Resolve configuration flags > env vars > project config > user config >
+   defaults** — see [10-configuration-and-env.md](./10-configuration-and-env.md).
+8. **Mark state formally** (`beta`, `deprecated`) rather than writing it into a
+   description, and a deprecation names its replacement, its removal version and a
+   migration example.
+9. **Don't break backward compatibility casually.** Output formats and flag
+   semantics are an interface scripts depend on: deprecate, warn, then remove.
+10. **Test the error paths**, not just the happy one.
+
+---
+
 Robustness is both objective (the tool actually handles edge cases correctly) and subjective (the tool *feels* solid). Users should never be surprised by unexpected behavior.
 
 ---

--- a/agents/10-configuration-and-env.md
+++ b/agents/10-configuration-and-env.md
@@ -1,5 +1,29 @@
 # Configuration and Environment Variables
 
+**Rules**
+
+1. **Resolve configuration in one order, always**: CLI flags > environment
+   variables > project config > user config > built-in defaults.
+2. **Follow XDG for file locations** and document every path that is searched. In
+   this repo that is `~/.config/circleci/config.yml` via `internal/config`.
+3. **Environment variables are `UPPERCASE_WITH_UNDERSCORES`, prefixed with the
+   program name**, and mirror their flag: `--api-key` → `CIRCLE_TOKEN`-style
+   naming, consistent with what already exists.
+4. **Honour the cross-tool standards** — `NO_COLOR`, `TERM=dumb`, `CI`, `EDITOR`,
+   `PAGER`, `LANG`/`LC_ALL` — rather than inventing an equivalent.
+5. **Document every variable the tool reads.** In this repo the authoritative list
+   is the `circleci help environment` topic, so adding a user-facing variable means
+   updating that topic, not just a table.
+6. **Never read the environment directly from a command.** Auth, host and telemetry
+   go through `internal/config`; anything about the terminal goes through
+   `iostream.Streams`.
+7. **Never put secrets in a config file that could be committed.** Take them from
+   the environment, a flag, a permissions-protected credentials file or the system
+   keychain, and when one is missing say exactly how to supply it.
+8. **Provide `--config`** so an alternative file can be used side-by-side or in CI.
+
+---
+
 Configuration lets users set persistent defaults so they don't have to repeat themselves. Environment variables bridge configuration and scripting. Together they make your tool adaptable without being complicated.
 
 ---

--- a/agents/11-naming-and-distribution.md
+++ b/agents/11-naming-and-distribution.md
@@ -1,5 +1,26 @@
 # Naming and Distribution
 
+**Rules**
+
+1. **Command names are lowercase, short, hyphen-separated**, descriptive of purpose,
+   and never shadow a standard UNIX tool.
+2. **Semantic versioning, with `--version` / `-V`** exposing the version plus build
+   context (Go version, OS/arch, commit, build time), and git tags matching.
+3. **Ship through the package managers users actually have**, plus direct binary
+   downloads for anyone who can't use one, and keep installation to a single
+   command.
+4. **Provide shell completion** for bash, zsh and fish.
+5. **Update notices never block, never touch stdout, and go quiet when they can't
+   help** — no TTY on either stream, CI, agents/MCP, no token, dev builds, or
+   opted out. They run in the background during `PersistentPreRunE` and are drained
+   in `PersistentPostRunE`, which only runs on success, so a notice never lands on
+   top of an error. Implementation in `internal/update`.
+6. **Stay channel-agnostic in user-facing upgrade text.** This CLI ships through
+   seven channels, so link the release page rather than naming one package
+   manager's upgrade command.
+
+---
+
 How you name your command and how you distribute it affects whether users can find, install, and remember your tool.
 
 ---

--- a/agents/12-analytics.md
+++ b/agents/12-analytics.md
@@ -1,5 +1,20 @@
 # Analytics and Telemetry
 
+**Rules**
+
+1. **Document exactly what is collected**, in the README, in help text and on a
+   linked page — a user must never have to read source to find out.
+2. **Collect the minimum**: which commands ran, error *types*, version, OS/arch.
+3. **Never collect** file paths or names, argument or flag values, environment
+   variable names or values, hostnames, IPs, or anything else identifying.
+4. **Always allow opt-out**, and honour the cross-tool signals as well as your own:
+   `CIRCLE_NO_TELEMETRY`, `NO_ANALYTICS`, `DO_NOT_TRACK`, and `CI`.
+5. **Telemetry is asynchronous, fire-and-forget, and swallows its own errors.** It
+   must never block a command or surface a failure to the user.
+6. **Collect nothing before consent** where telemetry is opt-in.
+
+---
+
 Telemetry can provide valuable insight into how your tool is used. It can also erode user trust if done poorly. The rules here are straightforward: be transparent, collect minimally, and always allow opt-out.
 
 ---

--- a/agents/13-extensibility.md
+++ b/agents/13-extensibility.md
@@ -1,5 +1,24 @@
 # Extensibility and Lifecycle Hooks
 
+**Rules**
+
+1. **Cross-cutting behaviour belongs in a lifecycle hook, not copied into every
+   command** — auth checks, update notifications, analytics, config loading.
+2. **Know what each hook point is for**: `init` (setup, config, telemetry start),
+   `preparse`, `prerun` (validation that applies everywhere), `postrun`
+   (analytics and cleanup — **only fires on success**), `command_not_found` (typo
+   suggestions and renamed commands).
+3. **Keep hooks lightweight.** They run on every invocation, including `--help` and
+   `--version`; anything slow is async and cached.
+4. **An optional hook swallows its own errors.** A failed update check must never
+   stop the user's command.
+5. **Assume no ordering between hooks** from different plugins — they can run
+   concurrently, so keep them independent.
+6. **Cleanup that must always run goes in `init` plus a signal handler**, never in
+   `postrun`.
+
+---
+
 For CLIs that support plugins or need shared cross-cutting behaviour across many commands, a lifecycle hook system is the standard pattern. Hooks let plugins extend the CLI at specific points without modifying core code.
 
 ---

--- a/agents/14-testing.md
+++ b/agents/14-testing.md
@@ -1,4 +1,61 @@
-# Test Assertions
+# Testing
+
+**Rules** — the whole of this file in short form. Read the rest for the reasoning
+and the examples.
+
+1. **Component-level tests drive the model through
+   `github.com/charmbracelet/x/exp/teatest/v2`** — never by calling `Update`
+   directly. Enforced by `TestUIComponentTestsUseTeatest` in
+   `internal/conventions`.
+2. **Break a test into `t.Run` groupings** rather than comment-delimited blocks of
+   setup and assertions. Enforced for long tests by
+   `TestUITestsGroupWithSubtests` in `internal/conventions`.
+3. **Prefer `assert.Check`**; use `assert.Assert` / `assert.NilError` only as
+   gates, where continuing would be pointless or unsafe.
+4. **Use `cmp` comparisons** from `gotest.tools/v3/assert/cmp` over raw booleans —
+   they print the values on failure.
+5. **Named assertion functions are fatal** (`assert.Equal`, `assert.DeepEqual`,
+   `assert.ErrorContains`, …). Use `assert.Check(t, cmp.X(...))` for the
+   non-fatal equivalent.
+6. **End-to-end tests go in `acceptance/`**, running the compiled binary via
+   `internal/testing/binary` against a fake from `internal/testing/fakes`.
+7. **Assert command output with `golden.String`**, and never hand-write a golden
+   file — regenerate with `task test -- ./acceptance/... -update`.
+8. **Assert on a `CLIError`'s `Message`, never its `Title`** — only the message
+   reaches stderr.
+
+---
+
+## Which kind of test
+
+| Testing | Where | How |
+|---|---|---|
+| A reusable component (`clikit/ui/components`) | `<component>_test.go` beside it | teatest: run the model as a program, send keys, assert on frames and state |
+| A flow (`internal/ui`) | `<flow>_test.go` beside it | teatest, usually with a small harness that answers a snapshot/probe message from inside the program loop |
+| A command end to end | `acceptance/` | `binary.RunCLI` (or `binary.RunCLIInteractive`) against `fakes.NewCircleCI` |
+| Pure business logic, renderers, helpers | beside the code | plain table-driven tests; there is no program loop to drive |
+
+**Why teatest and not a direct `Update` call.** A model called directly never sees
+the program loop: message ordering, the commands its `Update` returns, resize
+handling and the renderer are all bypassed — which is where the interesting bugs
+are. Driving it as a program also exercises the same path a user hits.
+
+A component's `Update` never returns `tea.Quit` (the host flow decides when it is
+done), so wrap it in a harness that quits on request. Two patterns are already in
+the tree: `selectHarness` in `clikit/ui/components/select_test.go` (quits when the
+model reports `Done`), and `treeHarness` in `filetree_test.go` plus `flowHarness`
+in `internal/ui/run_get_flow_test.go` (answer a probe/snapshot message from inside
+the loop, so the program keeps running and every key sent beforehand is known to
+have been applied).
+
+Note that a bubbletea renderer emits only what changed between frames, so a line
+that is still on screen may never appear in the output stream again. Wait on the
+model's own frames (`waitForFrame` in `internal/ui/run_get_flow_test.go`) rather
+than the accumulated output when asserting on something that may not have moved.
+
+---
+
+## Test Assertions
 
 Use `gotest.tools/v3/assert` for test assertions:
 
@@ -15,10 +72,15 @@ expression, a `cmp.Comparison`, or an `error`.
 
 ## Document in code rather than comments
 
-Prefer to break up the tests into meaningful groupings using `t.Run`. This offers some advantages:
+Break up the tests into meaningful groupings using `t.Run` rather than leaving
+comments over blocks of setup and assertions. This offers some advantages:
 - It groups the output of the specific assertions, setup, etc together.
 - The timings for those groups are automatically recorded.
 - The purpose of the groups is logged clearly in the test output, without needing to read the code.
+
+Where later groups depend on earlier ones — a sequence of keys driving a flow —
+gate them: `assert.Assert(t, t.Run("...", func(t *testing.T) { ... }))` stops the
+test rather than running the remaining phases against the wrong screen.
 
 ## Assert vs Check
 

--- a/agents/plan-template.md
+++ b/agents/plan-template.md
@@ -1,0 +1,79 @@
+# Plan template
+
+**Rules**
+
+1. **A plan written into `agents/` opens with "Guidelines consulted"** — the
+   `agents/` files you actually read before writing it, each with the rule you
+   took from it. An empty or hand-waved list is the signal that the plan is
+   guesswork.
+2. **Read the files the [CLAUDE.md](../CLAUDE.md) trigger table names for the work
+   you are planning** — including [14-testing.md](./14-testing.md), because a plan
+   that specifies the wrong test approach gets implemented that way.
+3. **Say what you researched and rejected**, with the reason. "We can't reuse X
+   because Y" is the most reusable part of a plan.
+4. **Record deviations as you implement.** A plan that silently stops matching the
+   code is worse than no plan; add a "What changed during implementation" section
+   rather than editing history.
+5. **Name the file `plan-<topic>.md`** and keep it beside the guidelines it cites.
+
+---
+
+## Why "Guidelines consulted" is first
+
+A plan is reviewed before any code exists, which makes it the cheapest place to
+catch a wrong convention — and the most expensive place to hide one, because a
+plan gets implemented faithfully. Listing the files read turns "did you check the
+rules?" into something a reviewer can see rather than infer.
+
+This is not paperwork: it is the record that rule 8 in
+[CLAUDE.md](../CLAUDE.md) was followed. If a row of the trigger table applies to
+the work and its file is not in the list, the plan is not ready for review.
+
+---
+
+## Skeleton
+
+```markdown
+# Plan — <what this adds or changes>
+
+<One paragraph: what is being built, where it lives, and for whom.>
+
+Status: **<not started | implemented>.** <Where deviations are recorded.>
+
+## Guidelines consulted
+
+| File | What it required of this work |
+|---|---|
+| [14-testing.md](./14-testing.md) | Component tests via teatest; `t.Run` groupings |
+| [07-interactivity.md](./07-interactivity.md) | Program in `internal/ui`, reusable parts in `clikit/ui/components` |
+| … | … |
+
+## Research: what already exists
+
+<What you looked at, what you are reusing, and what you rejected with the reason.
+Include the upstream libraries you checked, not just this repo.>
+
+## Design
+
+<The user-facing behaviour first — keys, output, errors — then the internals.>
+
+## Files to change
+
+<Per file or package: what changes, and any refactor that has to land first.>
+
+## Tests
+
+<Which kind of test covers what, per 14-testing.md's "Which kind of test" table.>
+
+## Order of work
+
+<Numbered steps, each independently verifiable. Put refactors first, on their own.>
+
+## Deferred, and why
+
+<What you are explicitly not doing, so a reader stops wondering.>
+
+## What changed during implementation
+
+<Filled in as you go: every departure from the design above, with the reason.>
+```

--- a/internal/conventions/doc.go
+++ b/internal/conventions/doc.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+// Package conventions holds tests that enforce the repository's own conventions
+// — the ones that are house rules rather than compiler or linter rules, and that
+// would otherwise be enforced only by whoever happens to review a diff.
+//
+// It follows the precedent of TestHelp in internal/cmd/root, which turns the
+// 40-line --help budget from a guideline into a failing build. A convention that
+// only exists in agents/ drifts: the test files that predate the rules here are
+// the evidence, and they are listed in the allowlists as the to-do list they are.
+//
+// The package deliberately contains no production code — nothing imports it.
+package conventions

--- a/internal/conventions/uitests_test.go
+++ b/internal/conventions/uitests_test.go
@@ -1,0 +1,236 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package conventions_test
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+// repoRoot is where this test's own package sits relative to the repository, so
+// both Go modules (the CLI and clikit) can be read from one place.
+const repoRoot = "../.."
+
+// uiPackages are the packages these rules cover: the reusable interactive
+// components and the flows that compose them. Everything here is a bubbletea
+// program or a piece of one, which is what makes the teatest rule meaningful.
+var uiPackages = []string{
+	"internal/ui",
+	"clikit/ui",
+	"clikit/ui/components",
+}
+
+// teatestImport is the package agents/14-testing.md requires component-level
+// tests to drive their model through.
+const teatestImport = "github.com/charmbracelet/x/exp/teatest/v2"
+
+// maxUngroupedStmts is how many top-level statements a test may have before
+// agents/14-testing.md's "break tests into meaningful groupings with t.Run"
+// stops being a preference and starts being the difference between a readable
+// failure and a wall of assertions. It is a proxy for "this test has phases",
+// deliberately loose: a short, single-purpose test needs no subtests.
+const maxUngroupedStmts = 11
+
+// teatestExempt lists test files that drive a bubbletea model without teatest.
+// They predate the rule; each entry is a file to convert, not a style to copy —
+// see the note at the top of the file itself.
+var teatestExempt = map[string]string{
+	"internal/ui/run_filter_dialog_test.go": "drives runFilterDialog by calling Update directly",
+}
+
+// groupingExempt lists long test functions that predate the t.Run rule, keyed by
+// "<package>/<file>:<test>". As with teatestExempt, this is a to-do list: group
+// one and delete its line. Nothing new belongs here.
+var groupingExempt = map[string]string{
+	"clikit/ui/components/pager_test.go:TestPagerModel_SearchHistoryRecall":                      "predates the rule",
+	"internal/ui/orb_init_flow_test.go:TestOrbInitFlow_AdoptedRepoSkipsBranchAndRemote":          "predates the rule",
+	"internal/ui/orb_init_flow_test.go:TestOrbInitFlow_AdoptedRepoWithoutCommitsStillAsksBranch": "predates the rule",
+	"internal/ui/orb_init_flow_test.go:TestOrbInitFlow_Categories":                               "predates the rule",
+	"internal/ui/orb_init_flow_test.go:TestOrbInitFlow_CategoryLimit":                            "predates the rule",
+	"internal/ui/orb_init_flow_test.go:TestOrbInitFlow_GathersOrgNamespaceOrbName":               "predates the rule",
+	"internal/ui/orb_init_flow_test.go:TestOrbInitFlow_GitEndToEnd":                              "predates the rule",
+	"internal/ui/orb_init_flow_test.go:TestOrbInitFlow_GitGathersBranchAndRemote":                "predates the rule",
+	"internal/ui/orb_init_flow_test.go:TestOrbInitFlow_NoGit":                                    "predates the rule",
+	"internal/ui/orb_init_flow_test.go:TestOrbInitFlow_OrbExistsContinue":                        "predates the rule",
+	"internal/ui/orb_init_flow_test.go:TestOrbInitFlow_OrbExistsDeclineCancels":                  "predates the rule",
+	"internal/ui/orb_init_flow_test.go:TestOrbInitFlow_SkipGitPresetEndsAfterContext":            "predates the rule",
+	"internal/ui/orb_init_flow_test.go:TestOrbInitFlow_TemplateOnly":                             "predates the rule",
+	"internal/ui/run_filter_dialog_test.go:TestRunFilterDialog_TabSwitching":                     "predates the rule",
+	"internal/ui/run_get_flow_test.go:TestRunGetFlow_FilterApplyCreated":                         "predates the rule",
+	"internal/ui/run_get_flow_test.go:TestRunGetFlow_StepPagerCollapsesCarriageReturns":          "predates the rule",
+}
+
+// TestUIComponentTestsUseTeatest checks that every bubbletea model in the UI
+// packages with a test file of its own is driven through teatest, as
+// agents/14-testing.md requires. A model tested by calling Update directly
+// bypasses the program loop — message ordering, commands, the renderer — which is
+// exactly where the interesting bugs live.
+func TestUIComponentTestsUseTeatest(t *testing.T) {
+	for _, pkg := range uiPackages {
+		t.Run(pkg, func(t *testing.T) {
+			dir := filepath.Join(repoRoot, pkg)
+			files, err := os.ReadDir(dir)
+			assert.NilError(t, err)
+
+			for _, entry := range files {
+				name := entry.Name()
+				if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+					continue
+				}
+				if !declaresBubbleteaUpdate(t, filepath.Join(dir, name)) {
+					continue
+				}
+				testFile := strings.TrimSuffix(name, ".go") + "_test.go"
+				testPath := filepath.Join(dir, testFile)
+				if _, err := os.Stat(testPath); err != nil {
+					// No test file of its own: covered elsewhere, or not covered at
+					// all — either way, a different problem than this rule's.
+					continue
+				}
+				key := pkg + "/" + testFile
+				if reason, ok := teatestExempt[key]; ok {
+					t.Logf("%s: exempt (%s) — convert it and drop the exemption", key, reason)
+					continue
+				}
+				imports := fileImports(t, testPath)
+				assert.Check(t, imports[teatestImport],
+					"%s drives a bubbletea model, so it must import %s (agents/14-testing.md)", key, teatestImport)
+			}
+		})
+	}
+}
+
+// TestUITestsGroupWithSubtests checks that long test functions in the UI packages
+// break themselves up with t.Run, as agents/14-testing.md requires: the grouping
+// is what names the failing phase in the test output instead of leaving a reader
+// to map an assertion back onto a comment.
+func TestUITestsGroupWithSubtests(t *testing.T) {
+	for _, pkg := range uiPackages {
+		t.Run(pkg, func(t *testing.T) {
+			dir := filepath.Join(repoRoot, pkg)
+			files, err := os.ReadDir(dir)
+			assert.NilError(t, err)
+
+			for _, entry := range files {
+				name := entry.Name()
+				if !strings.HasSuffix(name, "_test.go") {
+					continue
+				}
+				for _, fn := range longUngroupedTests(t, filepath.Join(dir, name)) {
+					key := pkg + "/" + name + ":" + fn
+					if reason, ok := groupingExempt[key]; ok {
+						t.Logf("%s: exempt (%s) — group it and drop the exemption", key, reason)
+						continue
+					}
+					t.Errorf("%s has more than %d statements and no t.Run: group it into subtests (agents/14-testing.md)",
+						key, maxUngroupedStmts)
+				}
+			}
+		})
+	}
+}
+
+// declaresBubbleteaUpdate reports whether path declares an Update method taking a
+// bubbletea message — the marker of a model that has to be driven by a program
+// rather than called.
+func declaresBubbleteaUpdate(t *testing.T, path string) bool {
+	t.Helper()
+	file := parse(t, path)
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Recv == nil || fn.Name.Name != "Update" || len(fn.Type.Params.List) == 0 {
+			continue
+		}
+		// tea.Msg, however the bubbletea import is named.
+		if sel, ok := fn.Type.Params.List[0].Type.(*ast.SelectorExpr); ok && sel.Sel.Name == "Msg" {
+			return true
+		}
+	}
+	return false
+}
+
+// fileImports is the set of import paths in path.
+func fileImports(t *testing.T, path string) map[string]bool {
+	t.Helper()
+	out := map[string]bool{}
+	for _, spec := range parse(t, path).Imports {
+		out[strings.Trim(spec.Path.Value, `"`)] = true
+	}
+	return out
+}
+
+// longUngroupedTests names the Test functions in path with more than
+// maxUngroupedStmts statements and no t.Run call.
+func longUngroupedTests(t *testing.T, path string) []string {
+	t.Helper()
+	decls := parse(t, path).Decls
+	out := make([]string, 0, len(decls))
+	for _, decl := range decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		switch {
+		case !ok, fn == nil:
+			continue
+		case fn.Recv != nil, fn.Body == nil:
+			continue
+		case !strings.HasPrefix(fn.Name.Name, "Test"):
+			continue
+		case len(fn.Body.List) <= maxUngroupedStmts:
+			continue
+		case callsSubtest(fn.Body):
+			continue
+		}
+		out = append(out, fn.Name.Name)
+	}
+	return out
+}
+
+// callsSubtest reports whether body contains a t.Run call. It matches on the
+// receiver being named t so a program's own Run method cannot pass for a subtest.
+func callsSubtest(body *ast.BlockStmt) bool {
+	found := false
+	ast.Inspect(body, func(n ast.Node) bool {
+		sel, ok := n.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != "Run" {
+			return true
+		}
+		if recv, ok := sel.X.(*ast.Ident); ok && recv.Name == "t" {
+			found = true
+		}
+		return true
+	})
+	return found
+}
+
+func parse(t *testing.T, path string) *ast.File {
+	t.Helper()
+	file, err := parser.ParseFile(token.NewFileSet(), path, nil, parser.SkipObjectResolution)
+	assert.NilError(t, err)
+	return file
+}

--- a/internal/ui/run_filter_dialog_test.go
+++ b/internal/ui/run_filter_dialog_test.go
@@ -20,6 +20,13 @@
 //
 // SPDX-License-Identifier: MIT
 
+// STYLE NOTE: this file drives runFilterDialog by calling Update directly, which
+// predates the rule in agents/14-testing.md that component-level tests go through
+// github.com/charmbracelet/x/exp/teatest/v2. It is exempted by name in
+// internal/conventions — a file to convert, not a style to copy. For the current
+// pattern see run_get_flow_test.go (flowHarness) or
+// clikit/ui/components/filetree_test.go (treeHarness).
+
 package ui
 
 import (


### PR DESCRIPTION
- Put rules at the start of the docs (agents often only read the start)
- Add meta-test to make sure UI tests are written with teatest.

<!--
  Thank you for contributing to CircleCI CLI!

  For PRs adding new features, please raise an issue first.

  Squash your commits before requesting review and before merging.
-->
