### PR TITLE
Add filter input to the reference page sidebar

### DIFF
--- a/docs/website/assets/css/main.css
+++ b/docs/website/assets/css/main.css
@@ -1235,3 +1235,61 @@ a:hover {
     top: calc(var(--nav-height) + 0.6rem);
   }
 }
+
+/* ── TOC filter ─────────────────────────────────────────────────────────── */
+.toc-filter {
+  padding-top: 0.75rem;
+  padding-bottom: 0.5rem;
+}
+
+.toc-filter-wrap {
+  position: relative;
+}
+
+.toc-filter-input {
+  display: block;
+  width: 100%;
+  appearance: none;
+  border-radius: 0.375rem;
+  border: 1px solid var(--color-site-border-strong);
+  background-color: var(--color-site-code-bg);
+  padding-inline: 0.625rem;
+  padding-block: 0.5rem;
+  padding-right: 3rem;
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+  color: var(--color-site-fg);
+  outline: none;
+}
+
+.toc-filter-input::placeholder {
+  color: var(--color-site-muted);
+}
+
+.toc-filter-input:focus {
+  border-color: var(--color-site-accent);
+}
+
+.toc-filter-wrap:focus-within .toc-filter-input {
+  padding-right: 0.625rem;
+}
+
+.toc-filter-hint {
+  pointer-events: none;
+  position: absolute;
+  right: 0.5rem;
+  top: 50%;
+  transform: translateY(-50%);
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  color: var(--color-site-muted);
+  border: 1px solid var(--color-site-border-strong);
+  border-radius: 0.25rem;
+  padding-inline: 0.25rem;
+  padding-block: 0.125rem;
+  transition: opacity 0.1s;
+}
+
+.toc-filter-wrap:focus-within .toc-filter-hint {
+  opacity: 0;
+}

--- a/docs/website/layouts/reference/list.html
+++ b/docs/website/layouts/reference/list.html
@@ -16,6 +16,14 @@
 
   <div class="layout">
     <aside class="sidebar">
+      <div class="toc-filter">
+        <div class="toc-filter-wrap">
+          <input type="search" id="toc-filter" class="toc-filter-input"
+                 placeholder="Filter" aria-label="Filter"
+                 autocomplete="off" spellcheck="false">
+          <span class="toc-filter-hint" aria-hidden="true">⌘/</span>
+        </div>
+      </div>
       {{/* Build the command nav from the page's heading tree. The page has two
            top-level sections ("Getting started" and "Reference"); under
            Reference the commands are grouped (CI / Management / User / ...), so
@@ -37,9 +45,6 @@
     </div>
   </div>
 
-  {{/* Progressive enhancement: open/close already works without JS via the
-       checkbox. This just closes the mobile nav after a link is chosen or on
-       Escape, so it doesn't stay covering the content. */}}
   <script>
     (function () {
       var toggle = document.getElementById('nav-toggle');
@@ -50,6 +55,67 @@
       });
       document.addEventListener('keydown', function (e) {
         if (e.key === 'Escape') toggle.checked = false;
+      });
+
+      var input = document.getElementById('toc-filter');
+      if (!input) return;
+
+      // Show the platform-appropriate shortcut hint.
+      var hint = document.querySelector('.toc-filter-hint');
+      if (hint) {
+        var isMac = /mac/i.test((navigator.userAgentData && navigator.userAgentData.platform) || navigator.platform || '');
+        hint.textContent = isMac ? '⌘/' : 'Ctrl+/';
+      }
+
+      input.addEventListener('input', function () {
+        var q = input.value.trim().toLowerCase();
+        var items = toc.querySelectorAll('li');
+
+        if (!q) {
+          items.forEach(function (li) { li.hidden = false; });
+          return;
+        }
+
+        // Hide everything, then reveal matching items and their ancestors.
+        items.forEach(function (li) { li.hidden = true; });
+
+        toc.querySelectorAll('a[data-depth]').forEach(function (a) {
+          if (a.textContent.trim().toLowerCase().indexOf(q) === -1) return;
+
+          var depth = parseInt(a.dataset.depth);
+          var li = a.closest('li');
+
+          // Show the matched item and walk up to reveal its ancestor <li>s.
+          while (li && li !== toc) {
+            li.hidden = false;
+            li = li.parentElement && li.parentElement.closest('li');
+          }
+
+          // For non-section-header matches, also expand the full subtree so
+          // sibling subcommands stay visible alongside the matched one.
+          if (depth >= 2) {
+            a.closest('li').querySelectorAll('li').forEach(function (child) {
+              child.hidden = false;
+            });
+          }
+        });
+      });
+
+      // Clear on Escape when the filter has focus.
+      input.addEventListener('keydown', function (e) {
+        if (e.key === 'Escape') {
+          input.value = '';
+          input.dispatchEvent(new Event('input'));
+        }
+      });
+
+      // Cmd+/ (Mac) or Ctrl+/ (Windows/Linux) focuses the filter.
+      document.addEventListener('keydown', function (e) {
+        if (e.key === '/' && (e.metaKey || e.ctrlKey)) {
+          e.preventDefault();
+          input.focus();
+          input.select();
+        }
       });
     })();
   </script>


### PR DESCRIPTION
## Summary

- Adds a text input above the TOC on the reference page that filters sidebar entries in real time
- Matching items are shown with their ancestor sections visible for context; depth-2+ matches also expand their subtree so sibling subcommands stay visible
- Section headers (depth 1) can be matched directly (e.g. typing "gett" shows "Getting started")
- Escape clears the filter; Cmd+/ (⌘/ on Mac, Ctrl+/ elsewhere) focuses the input from anywhere on the page
- A platform-appropriate shortcut hint badge is displayed inside the input when unfocused, and fades out on focus

https://github.com/user-attachments/assets/1951a8f3-5cb1-4a55-8710-d72afad3e4b4


## Test plan

- [ ] `task docs:server` and open the reference page
- [ ] Type into the filter and verify matching items appear with their parent sections
- [ ] Verify Escape clears the filter
- [ ] Verify Cmd+/ (or Ctrl+/) focuses the input
- [ ] Verify the shortcut hint fades on focus and the clear button sits flush with the right edge

🤖 Generated with [Claude Code](https://claude.com/claude-code)