### PR TITLE
Put the real job ID in run watch's failed-job suggestion

### DIFF
--- a/acceptance/watch_test.go
+++ b/acceptance/watch_test.go
@@ -194,7 +194,11 @@ func TestRunWatch_Failed_SuggestsJobLogs(t *testing.T) {
 
 	assert.Equal(t, result.ExitCode, 1, "stderr: %s", result.Stderr)
 	assert.Check(t, cmp.Contains(result.Stderr, `"integration-test"`), "stderr: %s", result.Stderr)
-	assert.Check(t, cmp.Contains(result.Stderr, "circleci job get <job-id>"), "stderr: %s", result.Stderr)
+	// The suggestion carries the failed job's real UUID, not a placeholder, so
+	// it can be pasted straight into a shell.
+	assert.Check(t, cmp.Contains(result.Stderr,
+		"circleci job get d0000000-0000-4000-8000-00000000f001"), "stderr: %s", result.Stderr)
+	assert.Check(t, !strings.Contains(result.Stderr, "<job-id>"), "stderr: %s", result.Stderr)
 }
 
 // --- cancelled run → exit 6 ---
@@ -288,6 +292,8 @@ func TestRunWatch_FailFast(t *testing.T) {
 	assert.Equal(t, result.ExitCode, 1, "stderr: %s", result.Stderr)
 	assert.Check(t, cmp.Contains(result.Stderr, "failing job"), "stderr: %s", result.Stderr)
 	assert.Check(t, cmp.Contains(result.Stderr, "integration-test"), "stderr: %s", result.Stderr)
+	assert.Check(t, cmp.Contains(result.Stderr,
+		"circleci job get d0000000-0000-4000-8000-00000000f001"), "stderr: %s", result.Stderr)
 }
 
 // --- watch timeout while run still running → exit 8 ---

--- a/internal/cmd/run/watch.go
+++ b/internal/cmd/run/watch.go
@@ -521,14 +521,24 @@ func watchFinalResult(ctx context.Context, state runGetOutput, runID uuid.UUID, 
 	}
 }
 
+// failedJobLogSuggestions builds one runnable suggestion per failed job. The
+// job UUID is already in the state we just rendered, so it is interpolated
+// into the command rather than left as a placeholder the user has to resolve.
+// A job that arrived without an ID falls back to the placeholder — a nil UUID
+// would produce a command that looks copy-pasteable but cannot work.
 func failedJobLogSuggestions(state runGetOutput) []string {
 	var suggestions []string
 	for _, wf := range state.Workflows {
 		for _, j := range wf.Jobs {
-			if j.Outcome == "failed" {
-				suggestions = append(suggestions,
-					fmt.Sprintf("View logs for failed job %q: circleci job get <job-id>", j.Name))
+			if j.Outcome != "failed" {
+				continue
 			}
+			id := "<job-id>"
+			if j.ID != uuid.Nil {
+				id = j.ID.String()
+			}
+			suggestions = append(suggestions,
+				fmt.Sprintf("View logs for failed job %q: circleci job get %s", j.Name, id))
 		}
 	}
 	return suggestions

--- a/internal/cmd/run/watch_test.go
+++ b/internal/cmd/run/watch_test.go
@@ -1,0 +1,85 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package run
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+// TestFailedJobLogSuggestions verifies the suggestion attached to a failed run
+// names a job the user can actually fetch: the UUID is interpolated from the
+// state already in memory, so no lookup step is left to the reader.
+func TestFailedJobLogSuggestions(t *testing.T) {
+	jobID := uuid.MustParse("d0000000-0000-4000-8000-00000000f001")
+	otherID := uuid.MustParse("d0000000-0000-4000-8000-00000000f003")
+
+	t.Run("interpolates the failed job's id", func(t *testing.T) {
+		state := runGetOutput{Workflows: []workflowOutput{{
+			Name: "build",
+			Jobs: []jobOutput{
+				{ID: uuid.MustParse("d0000000-0000-4000-8000-00000000f002"), Name: "lint", Outcome: "succeeded"},
+				{ID: jobID, Name: "test-service", Outcome: "failed"},
+			},
+		}}}
+
+		assert.Check(t, is.DeepEqual(failedJobLogSuggestions(state), []string{
+			`View logs for failed job "test-service": circleci job get ` + jobID.String(),
+		}))
+	})
+
+	t.Run("one suggestion per failed job across workflows", func(t *testing.T) {
+		state := runGetOutput{Workflows: []workflowOutput{
+			{Name: "build", Jobs: []jobOutput{{ID: jobID, Name: "test-service", Outcome: "failed"}}},
+			{Name: "deploy", Jobs: []jobOutput{{ID: otherID, Name: "publish", Outcome: "failed"}}},
+		}}
+
+		assert.Check(t, is.DeepEqual(failedJobLogSuggestions(state), []string{
+			`View logs for failed job "test-service": circleci job get ` + jobID.String(),
+			`View logs for failed job "publish": circleci job get ` + otherID.String(),
+		}))
+	})
+
+	t.Run("falls back to the placeholder for a job with no id", func(t *testing.T) {
+		state := runGetOutput{Workflows: []workflowOutput{{
+			Name: "build",
+			Jobs: []jobOutput{{Name: "test-service", Outcome: "failed"}},
+		}}}
+
+		assert.Check(t, is.DeepEqual(failedJobLogSuggestions(state), []string{
+			`View logs for failed job "test-service": circleci job get <job-id>`,
+		}))
+	})
+
+	t.Run("no suggestions when nothing failed", func(t *testing.T) {
+		state := runGetOutput{Workflows: []workflowOutput{{
+			Name: "build",
+			Jobs: []jobOutput{{ID: jobID, Name: "test-service", Outcome: "succeeded"}},
+		}}}
+
+		assert.Check(t, is.Len(failedJobLogSuggestions(state), 0))
+	})
+}


### PR DESCRIPTION
## Problem

When `circleci run watch` finished on a failed run, the suggestion attached to the error read:

```
Suggestions:
  • View logs for failed job "test-service": circleci job get <job-id>
```

`<job-id>` was a literal placeholder. The CLI already has the real job UUID in memory at that point — it just rendered the job table from the same `runGetOutput` state — so leaving it as a stub forced the user to go look the ID up by hand, which defeats the purpose of a suggestion.

```
✗ Run d349d7f7-4211-43da-b6f5-f8e72722967e failed (0s)
error: Run d349d7f7-4211-43da-b6f5-f8e72722967e failed.

Suggestions:
  • View logs for failed job "testsuite-dynamic": circleci job get 5b5bf4f9-7b6b-4c4d-9c5f-c4cdb22c76b1
  • View logs for failed job "build": circleci job get 2a35c16a-f2d7-4811-8892-ab3e179f95b5
```
