### PR TITLE
Resolve onboard's integration from the checkout's git remote

### DIFF
--- a/acceptance/onboard_test.go
+++ b/acceptance/onboard_test.go
@@ -840,8 +840,15 @@ func TestOnboard_PostSignup_CreateFails(t *testing.T) {
 // isolated environment pointed at it.
 func onboardRepo(t *testing.T) (string, *fakes.CircleCI, *testenv.TestEnv) {
 	t.Helper()
+	return onboardRepoWithRemote(t, "https://github.com/myorg/my-repo.git")
+}
+
+// onboardRepoWithRemote is onboardRepo for a checkout whose origin is remoteURL,
+// which is what decides the integration onboard resolves.
+func onboardRepoWithRemote(t *testing.T, remoteURL string) (string, *fakes.CircleCI, *testenv.TestEnv) {
+	t.Helper()
 	dir := t.TempDir()
-	initGitRepoWithRemote(t, dir, "https://github.com/myorg/my-repo.git")
+	initGitRepoWithRemote(t, dir, remoteURL)
 	fake, env := onboardStandaloneEnv(t, "testuser")
 	return dir, fake, env
 }
@@ -996,4 +1003,23 @@ func normalizeOnboardOutput(stdout, dir string) string {
 	stdout = strings.ReplaceAll(stdout, dir, "<DIR>")
 	stdout = strings.ReplaceAll(stdout, `\`, `/`)
 	return stdout
+}
+
+// TestOnboard_PostSignup_FirstPipeline_UnclaimedHost pins that a remote no
+// integration owns is reported rather than sent through one that cannot help.
+func TestOnboard_PostSignup_FirstPipeline_UnclaimedHost(t *testing.T) {
+	dir, _, env := onboardRepoWithRemote(t, "https://gitlab.com/myorg/my-repo.git")
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"onboard", "--scan"},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Check(t, cmp.Contains(result.Stderr, "is not on a provider CircleCI can look up"))
+	assert.Check(t, cmp.Contains(result.Stderr, "--repo-id"))
+	assert.Check(t, !strings.Contains(result.Stdout, "Pipeline definition created"),
+		"no definition should be created without a resolved repository")
 }

--- a/internal/cmd/onboard/onboard.go
+++ b/internal/cmd/onboard/onboard.go
@@ -103,6 +103,6 @@ func NewOnboardCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&noBrowser, "no-browser", false, "Print the signup URL instead of opening a browser")
 	cmd.Flags().BoolVar(&scan, "scan", false, "Skip prompt: set up this repo on CircleCI")
 	cmd.Flags().BoolVar(&signup, "signup", false, "Skip prompt: sign up for CircleCI")
-	cmd.Flags().StringVar(&repoID, "repo-id", "", "Numeric repository ID, if the GitHub App cannot resolve it")
+	cmd.Flags().StringVar(&repoID, "repo-id", "", "Repository ID, if it cannot be resolved from the git remote")
 	return cmd
 }

--- a/internal/cmd/root/testdata/help/circleci/onboard.txt
+++ b/internal/cmd/root/testdata/help/circleci/onboard.txt
@@ -10,12 +10,12 @@ Guided onboarding: generate config, sign up, connect project
 
 ## Flags
 
-| Flag               | Description                                                |
-| ------------------ | ---------------------------------------------------------- |
-| `--no-browser`     | Print the signup URL instead of opening a browser          |
-| `--repo-id string` | Numeric repository ID, if the GitHub App cannot resolve it |
-| `--scan`           | Skip prompt: set up this repo on CircleCI                  |
-| `--signup`         | Skip prompt: sign up for CircleCI                          |
+| Flag               | Description                                                 |
+| ------------------ | ----------------------------------------------------------- |
+| `--no-browser`     | Print the signup URL instead of opening a browser           |
+| `--repo-id string` | Repository ID, if it cannot be resolved from the git remote |
+| `--scan`           | Skip prompt: set up this repo on CircleCI                   |
+| `--signup`         | Skip prompt: sign up for CircleCI                           |
 
 Global flags: `-c, --config`, `--debug`, `--no-color`, `-q, --quiet` — see `circleci --help`.
 

--- a/internal/cmd/root/testdata/help/circleci/reference.txt
+++ b/internal/cmd/root/testdata/help/circleci/reference.txt
@@ -4582,12 +4582,12 @@ Guided onboarding: generate config, sign up, connect project
 Prompts for repo setup or signup unless --scan or --signup is given. Writes a
 starter config if the repo has none, creates the project, adds a push trigger.
 
-| Flag               | Description                                                |
-| ------------------ | ---------------------------------------------------------- |
-| `--no-browser`     | Print the signup URL instead of opening a browser          |
-| `--repo-id string` | Numeric repository ID, if the GitHub App cannot resolve it |
-| `--scan`           | Skip prompt: set up this repo on CircleCI                  |
-| `--signup`         | Skip prompt: sign up for CircleCI                          |
+| Flag               | Description                                                 |
+| ------------------ | ----------------------------------------------------------- |
+| `--no-browser`     | Print the signup URL instead of opening a browser           |
+| `--repo-id string` | Repository ID, if it cannot be resolved from the git remote |
+| `--scan`           | Skip prompt: set up this repo on CircleCI                   |
+| `--signup`         | Skip prompt: sign up for CircleCI                           |
 
 
 **Arguments:**

--- a/internal/cmd/root/testdata/usage/circleci/onboard.txt
+++ b/internal/cmd/root/testdata/usage/circleci/onboard.txt
@@ -3,7 +3,7 @@ Usage:  circleci onboard [path] [flags]
 Flags:
   -h, --help             help for onboard
       --no-browser       Print the signup URL instead of opening a browser
-      --repo-id string   Numeric repository ID, if the GitHub App cannot resolve it
+      --repo-id string   Repository ID, if it cannot be resolved from the git remote
       --scan             Skip prompt: set up this repo on CircleCI
       --signup           Skip prompt: sign up for CircleCI
   

--- a/internal/gitremote/detect.go
+++ b/internal/gitremote/detect.go
@@ -231,25 +231,62 @@ func SlugFromRemote(remoteURL string) (string, error) {
 	return slugFromRemote(remoteURL)
 }
 
-func slugFromRemote(remoteURL string) (string, error) {
+// RemoteRef identifies a repository as its remote URL names it, before any
+// mapping onto CircleCI's own vocabulary.
+type RemoteRef struct {
+	// Host is the remote's host, e.g. "github.com".
+	Host string
+	// Owner and Repo name the repository, e.g. "acme" and "web".
+	Owner, Repo string
+}
+
+// FullName is the "owner/repo" form the provider APIs use as a repository key.
+func (r RemoteRef) FullName() string {
+	if r.Owner == "" || r.Repo == "" {
+		return ""
+	}
+	return r.Owner + "/" + r.Repo
+}
+
+// DetectRemoteRefIn reads the origin remote of the repository containing dir and
+// returns what the URL says, without requiring the host to be one CircleCI has a
+// slug form for.
+//
+// This is the parse to use when a caller resolves the integration itself (see
+// internal/provider). DetectFromRemoteIn is the slug-producing path, and it
+// rejects any host that has no slug segment.
+func DetectRemoteRefIn(dir string) (_ RemoteRef, err error) {
+	repo, err := openRepoIn(dir)
+	if err != nil {
+		return RemoteRef{}, fmt.Errorf("could not read git remote: %w", err)
+	}
+	defer closer.ErrorHandler(repo, &err)
+
+	remoteURL, err := gitOriginURL(repo)
+	if err != nil {
+		return RemoteRef{}, fmt.Errorf("could not read git remote: %w", err)
+	}
+	return refFromRemote(remoteURL)
+}
+
+// refFromRemote parses a git remote URL into its host, owner and repository.
+func refFromRemote(remoteURL string) (RemoteRef, error) {
 	remoteURL = strings.TrimSpace(remoteURL)
 
-	if m := sshRemote.FindStringSubmatch(remoteURL); m != nil {
-		host, org, repo := m[1], m[2], m[3]
-		return buildSlug(host, org, repo)
+	for _, re := range []*regexp.Regexp{sshRemote, sshProtoRemote, httpsRemote} {
+		if m := re.FindStringSubmatch(remoteURL); m != nil {
+			return RemoteRef{Host: m[1], Owner: m[2], Repo: m[3]}, nil
+		}
 	}
+	return RemoteRef{}, fmt.Errorf("unrecognised git remote URL format: %q", remoteURL)
+}
 
-	if m := sshProtoRemote.FindStringSubmatch(remoteURL); m != nil {
-		host, org, repo := m[1], m[2], m[3]
-		return buildSlug(host, org, repo)
+func slugFromRemote(remoteURL string) (string, error) {
+	ref, err := refFromRemote(remoteURL)
+	if err != nil {
+		return "", err
 	}
-
-	if m := httpsRemote.FindStringSubmatch(remoteURL); m != nil {
-		host, org, repo := m[1], m[2], m[3]
-		return buildSlug(host, org, repo)
-	}
-
-	return "", fmt.Errorf("unrecognised git remote URL format: %q", remoteURL)
+	return buildSlug(ref.Host, ref.Owner, ref.Repo)
 }
 
 func buildSlug(host, org, repo string) (string, error) {

--- a/internal/gitremote/detect_test.go
+++ b/internal/gitremote/detect_test.go
@@ -424,3 +424,56 @@ func TestDetectFromRemote_Worktree(t *testing.T) {
 		assert.Check(t, cmp.Equal(info.DefaultBranch, "main"))
 	})
 }
+
+// TestRefFromRemote pins the parse that resolves an integration from a remote.
+// Unlike SlugFromRemote it must not reject a host CircleCI has no slug segment
+// for: that is the normal case for an integration whose repositories are
+// addressed by id.
+func TestRefFromRemote(t *testing.T) {
+	cases := []struct {
+		name  string
+		url   string
+		want  RemoteRef
+		isErr bool
+	}{
+		{
+			name: "https",
+			url:  "https://github.com/acme/web.git",
+			want: RemoteRef{Host: "github.com", Owner: "acme", Repo: "web"},
+		},
+		{
+			name: "scp-style ssh",
+			url:  "git@github.com:acme/web.git",
+			want: RemoteRef{Host: "github.com", Owner: "acme", Repo: "web"},
+		},
+		{
+			name: "ssh protocol",
+			url:  "ssh://git@github.com/acme/web.git",
+			want: RemoteRef{Host: "github.com", Owner: "acme", Repo: "web"},
+		},
+		{
+			name: "host with no slug form is still parsed",
+			url:  "https://git.example.com/acme/web.git",
+			want: RemoteRef{Host: "git.example.com", Owner: "acme", Repo: "web"},
+		},
+		{
+			name: "without the .git suffix",
+			url:  "https://git.example.com/acme/web",
+			want: RemoteRef{Host: "git.example.com", Owner: "acme", Repo: "web"},
+		},
+		{name: "not a remote URL", url: "nonsense", isErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := refFromRemote(tc.url)
+			if tc.isErr {
+				assert.Check(t, err != nil, "expected an error for %q", tc.url)
+				return
+			}
+			assert.NilError(t, err)
+			assert.Check(t, cmp.Equal(got, tc.want))
+			assert.Check(t, cmp.Equal(got.FullName(), tc.want.Owner+"/"+tc.want.Repo))
+		})
+	}
+}

--- a/internal/onboarder/onboarder.go
+++ b/internal/onboarder/onboarder.go
@@ -30,7 +30,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"strings"
 
 	tea "charm.land/bubbletea/v2"
 
@@ -41,11 +40,12 @@ import (
 	"github.com/CircleCI-Public/circleci-cli/internal/cmdutil"
 	"github.com/CircleCI-Public/circleci-cli/internal/config"
 	"github.com/CircleCI-Public/circleci-cli/internal/configgen"
-	"github.com/CircleCI-Public/circleci-cli/internal/githubapp"
 	"github.com/CircleCI-Public/circleci-cli/internal/gitremote"
 	"github.com/CircleCI-Public/circleci-cli/internal/httpcl"
 	"github.com/CircleCI-Public/circleci-cli/internal/org"
 	"github.com/CircleCI-Public/circleci-cli/internal/projectref"
+	"github.com/CircleCI-Public/circleci-cli/internal/provider"
+	"github.com/CircleCI-Public/circleci-cli/internal/providerconn"
 	"github.com/CircleCI-Public/circleci-cli/internal/ui"
 )
 
@@ -60,10 +60,6 @@ const (
 // push, which is what onboard sets up.
 const allPushesPreset = "all-pushes"
 
-// githubAppProvider is the only integration onboard sets a pipeline up for today;
-// resolving the repository goes through the GitHub App either way.
-const githubAppProvider = "github_app"
-
 // Options configures the onboarding flow.
 type Options struct {
 	ConfigPath    string
@@ -71,11 +67,11 @@ type Options struct {
 	SecureStorage bool
 	Scan          bool
 	Signup        bool
-	// RepoID is the VCS repository external ID (the numeric GitHub repo ID) used
-	// to wire up the first pipeline definition and trigger. When empty it is
-	// resolved through the CircleCI GitHub App; if that cannot resolve it, pipeline
-	// setup is skipped with manual guidance. It is never prompted for — an opaque
-	// numeric ID is not something a user can be expected to know.
+	// RepoID is the provider's repository ID used to wire up the first pipeline
+	// definition and trigger. When empty it is resolved through the integration
+	// that owns the checkout's remote; if that cannot resolve it, pipeline setup is
+	// skipped with manual guidance. It is never prompted for — an opaque ID is not
+	// something a user can be expected to know.
 	RepoID string
 }
 
@@ -213,8 +209,8 @@ func postSignupGuidance(ctx context.Context, dir string, opts Options) error {
 
 	appURL, _ := cmdutil.AppURL(ctx)
 
-	// One read of the checkout's remote serves both the suggested project name and
-	// the owner/repo the GitHub App lookup needs.
+	// One read of the checkout's remote serves the suggested project name, the
+	// integration that owns the repository, and the owner/repo its lookup needs.
 	remote := detectRemote(dir)
 
 	// Resolve a project this repository is already linked to before asking for a
@@ -268,7 +264,7 @@ func postSignupGuidance(ctx context.Context, dir string, opts Options) error {
 		iostream.Printf(ctx, "  Pipelines: %s\n", pipelinesURL)
 	}
 
-	// Where GitHub returns the browser after a GitHub App install. Landing on the
+	// Where the provider returns the browser after an install. Landing on the
 	// project's own page reads as a finish line, in the browser, while the rest of
 	// setup is still waiting back in the terminal.
 	returnURL := cmdutil.GitHubAppInstalledURL(appURL)
@@ -328,44 +324,22 @@ func promptProjectName(ctx context.Context, defaultName string) string {
 	return name
 }
 
-// gitRemote is what onboard needs to know about a checkout's origin remote.
-type gitRemote struct {
-	// VCS is the provider segment of the slug ("gh", "bb", "gl"), or "" when the
-	// remote could not be read.
-	VCS string
-	// Owner and Repo name the repository, e.g. "acme" and "web".
-	Owner, Repo string
-}
-
-// FullName is the "owner/repo" form used as the GitHub App's repository key, or
-// "" when the remote could not be read.
-func (r gitRemote) FullName() string {
-	if r.Owner == "" || r.Repo == "" {
-		return ""
-	}
-	return r.Owner + "/" + r.Repo
-}
-
-// IsGitHub reports whether this is a GitHub repository — the only provider the
-// CircleCI GitHub App can resolve.
-func (r gitRemote) IsGitHub() bool { return r.VCS == "gh" }
-
 // detectRemote reads the origin remote of the checkout at dir. A failure yields
 // the zero value rather than an error: onboard degrades to prompting for a name
 // and to manual pipeline guidance.
-func detectRemote(dir string) gitRemote {
+//
+// The host is what matters here rather than a project slug: the integration is
+// resolved from it, and slugs exist only for the hosts CircleCI has a VCS segment
+// for.
+func detectRemote(dir string) gitremote.RemoteRef {
 	if dir == "" {
-		return gitRemote{}
+		return gitremote.RemoteRef{}
 	}
-	info, err := gitremote.DetectFromRemoteIn(dir)
+	ref, err := gitremote.DetectRemoteRefIn(dir)
 	if err != nil {
-		return gitRemote{}
+		return gitremote.RemoteRef{}
 	}
-	parts := strings.Split(info.Slug, "/")
-	if len(parts) != 3 {
-		return gitRemote{}
-	}
-	return gitRemote{VCS: parts[0], Owner: parts[1], Repo: parts[2]}
+	return ref
 }
 
 // refreshConfig re-reads the config from disk when the cached copy carries no
@@ -467,17 +441,18 @@ func writeProjectRef(ctx context.Context, workDir string, proj *apiclient.Projec
 
 // setupFirstPipeline wires up a pipeline definition and an all-pushes trigger
 // for a freshly created project so the first push starts a build. It uses the
-// same v2 endpoints as `circleci pipeline create` and `circleci project trigger
-// create`, with sensible zero-prompt defaults (config at .circleci/config.yml,
-// the github_app provider, and the repo's external ID for both config and
-// checkout sources).
+// same endpoints as `circleci pipeline create` and `circleci project trigger
+// create`, with sensible zero-prompt defaults (config at .circleci/config.yml, the
+// integration that owns the checkout's remote, and the repo's ID for both config
+// and checkout sources).
 //
-// A missing prerequisite — no GitHub App, the repository not granted to it, a repo
-// that is not on GitHub — means nothing was attempted, so onboard prints the next
-// step and succeeds. A request the API rejected is a real error: it leaves the
-// project half-configured, and a definition with no trigger will never build.
-func setupFirstPipeline(ctx context.Context, client *apiclient.Client, returnURL string, proj *apiclient.ProjectInfo, remote gitRemote, opts Options) error {
-	repoID := resolveRepoID(ctx, client, returnURL, proj, remote, opts)
+// A missing prerequisite — the organization not connected to that integration, the
+// repository not granted to it, a remote no integration claims — means nothing was
+// attempted, so onboard prints the next step and succeeds. A request the API
+// rejected is a real error: it leaves the project half-configured, and a definition
+// with no trigger will never build.
+func setupFirstPipeline(ctx context.Context, client *apiclient.Client, returnURL string, proj *apiclient.ProjectInfo, remote gitremote.RemoteRef, opts Options) error {
+	repoID, p := resolveRepoID(ctx, client, returnURL, proj, remote, opts)
 	if repoID == "" {
 		// No external ID, so there is nothing to attach a definition to.
 		trackOnboard(ctx, "onboard_project_setup", map[string]any{"outcome": "skipped_no_repo_id"})
@@ -485,7 +460,7 @@ func setupFirstPipeline(ctx context.Context, client *apiclient.Client, returnURL
 		return nil
 	}
 
-	def, err := ensurePipelineDefinition(ctx, client, proj.ID, proj.Name, repoID, remote.FullName())
+	def, err := ensurePipelineDefinition(ctx, client, p, proj.ID, proj.Name, repoID, remote.FullName())
 	if err != nil {
 		trackOnboard(ctx, "onboard_project_setup", map[string]any{"outcome": "pipeline_definition_failed"})
 		return clierrors.New("onboard.pipeline_definition_failed",
@@ -498,7 +473,7 @@ func setupFirstPipeline(ctx context.Context, client *apiclient.Client, returnURL
 			WithExitCode(clierrors.ExitAPIError)
 	}
 
-	if err := ensureTrigger(ctx, client, proj.ID, def.ID, repoID, remote.FullName()); err != nil {
+	if err := ensureTrigger(ctx, client, p, proj.ID, def.ID, repoID, remote.FullName()); err != nil {
 		trackOnboard(ctx, "onboard_project_setup", map[string]any{"outcome": "trigger_failed"})
 		return clierrors.New("onboard.trigger_failed",
 			"Could not set up the trigger",
@@ -518,7 +493,12 @@ func setupFirstPipeline(ctx context.Context, client *apiclient.Client, returnURL
 // ensurePipelineDefinition returns the pipeline definition already configured
 // for the repo, or creates one. Reusing an existing definition keeps re-runs of
 // onboard from creating duplicates.
-func ensurePipelineDefinition(ctx context.Context, client *apiclient.Client, projectID, name, repoID, repoFullName string) (*apiclient.PipelineDefinition, error) {
+func ensurePipelineDefinition(
+	ctx context.Context,
+	client *apiclient.Client,
+	p provider.Provider,
+	projectID, name, repoID, repoFullName string,
+) (*apiclient.PipelineDefinition, error) {
 	defs, err := client.ListPipelineDefinitions(ctx, projectID)
 	if err != nil {
 		// Creating blindly after a failed lookup risks a duplicate definition, so
@@ -535,11 +515,11 @@ func ensurePipelineDefinition(ctx context.Context, client *apiclient.Client, pro
 
 	def, err := client.CreatePipelineDefinition(ctx, projectID, apiclient.CreatePipelineDefinitionInput{
 		Name:                 name,
-		ConfigProvider:       githubAppProvider,
+		ConfigProvider:       p.Name,
 		ConfigRepoID:         repoID,
 		ConfigRepoFullName:   repoFullName,
 		ConfigFilePath:       ".circleci/config.yml",
-		CheckoutProvider:     githubAppProvider,
+		CheckoutProvider:     p.Name,
 		CheckoutRepoID:       repoID,
 		CheckoutRepoFullName: repoFullName,
 	})
@@ -556,7 +536,12 @@ func ensurePipelineDefinition(ctx context.Context, client *apiclient.Client, pro
 // Only an all-pushes trigger counts. A definition carrying just a schedule or
 // webhook trigger would otherwise be reported as ready, and the push onboard tells
 // the user to make would build nothing.
-func ensureTrigger(ctx context.Context, client *apiclient.Client, projectID, definitionID, repoID, repoFullName string) error {
+func ensureTrigger(
+	ctx context.Context,
+	client *apiclient.Client,
+	p provider.Provider,
+	projectID, definitionID, repoID, repoFullName string,
+) error {
 	trigs, err := client.ListTriggers(ctx, projectID, definitionID)
 	if err != nil {
 		return err
@@ -571,7 +556,7 @@ func ensureTrigger(ctx context.Context, client *apiclient.Client, projectID, def
 	trig, err := client.CreateTrigger(ctx, apiclient.CreateTriggerInput{
 		ProjectID:            projectID,
 		PipelineDefinitionID: definitionID,
-		Provider:             githubAppProvider,
+		Provider:             p.Name,
 		RepoID:               repoID,
 		RepoFullName:         repoFullName,
 		EventPreset:          allPushesPreset,
@@ -588,61 +573,70 @@ func ensureTrigger(ctx context.Context, client *apiclient.Client, projectID, def
 }
 
 // resolveRepoID determines the repo external ID for the pipeline definition and
-// trigger. An explicit --repo-id wins. Otherwise it ensures the CircleCI GitHub
-// App is installed for the org and matches the git remote against the app's
-// accessible repositories. Any failure returns "" so the caller degrades to
-// manual guidance rather than prompting for an opaque numeric ID.
-func resolveRepoID(ctx context.Context, client *apiclient.Client, returnURL string, proj *apiclient.ProjectInfo, remote gitRemote, opts Options) string {
+// trigger, and returns it with the integration that owns the checkout's remote so
+// the caller can write both without resolving it again. An explicit --repo-id wins. Otherwise it ensures the org is connected
+// to the integration that owns the checkout's remote, then matches the remote
+// against the repositories that connection can reach. Any failure returns "" so
+// the caller degrades to manual guidance rather than prompting for an opaque ID.
+func resolveRepoID(
+	ctx context.Context,
+	client *apiclient.Client,
+	returnURL string,
+	proj *apiclient.ProjectInfo,
+	remote gitremote.RemoteRef,
+	opts Options,
+) (string, provider.Provider) {
+	p, hasProvider := provider.ForHost(remote.Host)
 	if opts.RepoID != "" {
-		return opts.RepoID
+		return opts.RepoID, p
 	}
 	if proj.OrganizationID == "" {
-		return ""
+		return "", p
 	}
 	fullName := remote.FullName()
 	if fullName == "" {
 		iostream.ErrPrintf(ctx, "%s Could not read this repository's git remote, so the pipeline was not set up.\n",
 			iostream.SymbolWarn(ctx))
-		return ""
+		return "", p
 	}
-	// The GitHub App resolves GitHub repositories only. Sending a GitLab or
-	// Bitbucket remote through it produces an install prompt that cannot help and
-	// a "grant access to this repository" message that can never be satisfied.
-	if !remote.IsGitHub() {
-		iostream.ErrPrintf(ctx, "%s %s is not a GitHub repository, so its ID cannot be looked up automatically.\n",
+	// A host no integration claims cannot be resolved: sending it through one
+	// produces an install prompt that cannot help and a "grant access to this
+	// repository" message that can never be satisfied.
+	if !hasProvider {
+		iostream.ErrPrintf(ctx, "%s %s is not on a provider CircleCI can look up, so its ID cannot be resolved automatically.\n",
 			iostream.SymbolWarn(ctx), fullName)
 		iostream.ErrPrintf(ctx, "  Re-run with --repo-id <id> to set up the pipeline.\n")
-		return ""
+		return "", p
 	}
 
-	installed, err := githubapp.EnsureInstalled(ctx, client, proj.OrganizationID, returnURL, opts.NoBrowser)
+	installed, err := providerconn.EnsureConnected(ctx, client, p, proj.OrganizationID, returnURL, opts.NoBrowser)
 	if err != nil {
-		iostream.ErrPrintf(ctx, "%s Could not check GitHub App installation: %s\n", iostream.SymbolWarn(ctx), err)
-		return ""
+		iostream.ErrPrintf(ctx, "%s Could not check the %s installation: %s\n", iostream.SymbolWarn(ctx), p.Short, err)
+		return "", p
 	}
 	if !installed {
-		return ""
+		return "", p
 	}
 
-	id, err := githubapp.ResolveRepoID(ctx, client, proj.OrganizationID, fullName)
-	if errors.Is(err, githubapp.ErrTooManyRepositories) {
+	id, err := providerconn.ResolveRepoID(ctx, client, p, proj.OrganizationID, fullName)
+	if errors.Is(err, providerconn.ErrTooManyRepositories) {
 		iostream.ErrPrintf(ctx, "%s This organization has too many repositories to find %s automatically.\n",
 			iostream.SymbolWarn(ctx), fullName)
 		iostream.ErrPrintf(ctx, "  Re-run with --repo-id <id> to set up the pipeline.\n")
-		return ""
+		return "", p
 	}
 	if err != nil {
-		iostream.ErrPrintf(ctx, "%s Could not list GitHub App repositories: %s\n", iostream.SymbolWarn(ctx), err)
-		return ""
+		iostream.ErrPrintf(ctx, "%s Could not list %s repositories: %s\n", iostream.SymbolWarn(ctx), p.Short, err)
+		return "", p
 	}
 	if id == "" {
-		iostream.ErrPrintf(ctx, "%s The GitHub App can't access %s yet. Grant it access to this repository, then re-run.\n",
-			iostream.SymbolWarn(ctx), fullName)
-		return ""
+		iostream.ErrPrintf(ctx, "%s %s can't access %s yet. Grant it access to this repository, then re-run.\n",
+			iostream.SymbolWarn(ctx), p.Short, fullName)
+		return "", p
 	}
 
 	iostream.Printf(ctx, "%s Found repository %s\n", iostream.SymbolOK(ctx), fullName)
-	return id
+	return id, p
 }
 
 // printPipelineReadyGuidance prints the happy-path next steps once the pipeline

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+// Package provider declares the integrations a repository can be connected to
+// CircleCI through, and how to recognise one from a git remote.
+//
+// Adding an integration means adding one entry to the registry below. Nothing
+// else in the CLI names an integration: the connection flow, repository
+// resolution, and the pipeline and trigger writes all take a Provider and read
+// what they need from it.
+package provider
+
+import "strings"
+
+// Provider describes an integration onboard can connect a repository through.
+type Provider struct {
+	// Name is the value the API uses in provider fields and filters.
+	Name string
+	// Short names the integration in progress output, e.g. "GitHub App" in
+	// "Waiting for GitHub App installation".
+	Short string
+	// Install is the subject of the install prompt, e.g. "the CircleCI GitHub
+	// App" in "Install the CircleCI GitHub App to connect your repository".
+	Install string
+	// Hosts are the git remote hosts whose repositories belong to this
+	// integration. A host matches when it equals one of these or is a subdomain
+	// of it, so enterprise and regional hosts resolve without new entries.
+	Hosts []string
+}
+
+// registry is every integration the CLI can drive. Order is significant only in
+// that the first host match wins.
+var registry = []Provider{
+	{
+		Name:    "github_app",
+		Short:   "GitHub App",
+		Install: "the CircleCI GitHub App",
+		Hosts:   []string{"github.com"},
+	},
+}
+
+// ForHost returns the integration that owns repositories on host, and whether
+// one was found. Matching is case-insensitive and ignores a port.
+func ForHost(host string) (Provider, bool) {
+	host = strings.ToLower(strings.TrimSpace(host))
+	if i := strings.IndexByte(host, ':'); i >= 0 {
+		host = host[:i]
+	}
+	if host == "" {
+		return Provider{}, false
+	}
+
+	for _, p := range registry {
+		for _, h := range p.Hosts {
+			if host == h || strings.HasSuffix(host, "."+h) {
+				return p, true
+			}
+		}
+	}
+	return Provider{}, false
+}

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package provider
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+)
+
+func TestForHost(t *testing.T) {
+	cases := []struct {
+		name string
+		host string
+		want string // provider name, or "" when no integration claims the host
+	}{
+		{name: "github", host: "github.com", want: "github_app"},
+		{name: "case is ignored", host: "GitHub.com", want: "github_app"},
+		{name: "port is ignored", host: "github.com:443", want: "github_app"},
+		// A subdomain belongs to the same integration, so regional and enterprise
+		// hosts resolve without their own registry entry.
+		{name: "subdomain", host: "eu.github.com", want: "github_app"},
+		{name: "unclaimed host", host: "gitlab.com", want: ""},
+		// A host that merely ends with the same letters must not match: matching on
+		// a bare suffix would hand notgithub.com to the GitHub App.
+		{name: "lookalike host", host: "notgithub.com", want: ""},
+		{name: "empty", host: "", want: ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p, ok := ForHost(tc.host)
+			if tc.want == "" {
+				assert.Check(t, !ok, "expected no integration for %q, got %q", tc.host, p.Name)
+				return
+			}
+			assert.Check(t, ok, "expected an integration for %q", tc.host)
+			assert.Check(t, cmp.Equal(p.Name, tc.want))
+		})
+	}
+}
+
+// TestRegistryIsUsable pins the fields the rest of the CLI reads off a registry
+// entry. An entry missing one of them fails at runtime as empty output or a
+// rejected request, so it is worth catching here.
+func TestRegistryIsUsable(t *testing.T) {
+	for _, p := range registry {
+		t.Run(p.Name, func(t *testing.T) {
+			assert.Check(t, p.Name != "", "Name is the value the API is sent")
+			assert.Check(t, p.Short != "", "Short names the integration in progress output")
+			assert.Check(t, p.Install != "", "Install is the subject of the install prompt")
+			assert.Check(t, len(p.Hosts) > 0, "an integration with no hosts can never be resolved from a remote")
+		})
+	}
+}

--- a/internal/providerconn/providerconn.go
+++ b/internal/providerconn/providerconn.go
@@ -20,10 +20,13 @@
 //
 // SPDX-License-Identifier: MIT
 
-// Package githubapp drives the CircleCI GitHub App onboarding steps: checking
-// whether the app is installed for an organization, walking the user through a
-// browser-based install, and resolving a repository's external ID.
-package githubapp
+// Package providerconn drives the onboarding steps that depend on an
+// integration: checking whether an organization is connected to one, walking the
+// user through a browser-based install, and resolving a repository's id.
+//
+// Every function takes the integration as a provider.Provider, so supporting
+// another one is a registry entry rather than a change here.
+package providerconn
 
 import (
 	"context"
@@ -35,6 +38,7 @@ import (
 	"github.com/CircleCI-Public/circleci-cli/clikit/browser"
 	"github.com/CircleCI-Public/circleci-cli/clikit/iostream"
 	"github.com/CircleCI-Public/circleci-cli/internal/apiclient"
+	"github.com/CircleCI-Public/circleci-cli/internal/provider"
 )
 
 const (
@@ -45,19 +49,20 @@ const (
 	maxRepoPages = 50
 )
 
-// provider is the integration this package drives. It is the value the
-// provider-agnostic connections endpoint reports for a CircleCI GitHub App
-// installation.
-const provider = "github_app"
-
-// EnsureInstalled reports whether the CircleCI GitHub App is installed for the
-// organization, walking the user through a browser-based install when it is not.
-// returnURL is where GitHub redirects after install.
+// EnsureConnected reports whether the organization is connected to p, walking the
+// user through a browser-based install when it is not. returnURL is where the
+// provider returns the browser once the install completes.
 //
 // Non-interactive sessions (or noBrowser) print the install URL and return false
 // without waiting. Callers degrade to manual guidance on false or on an error.
-func EnsureInstalled(ctx context.Context, client *apiclient.Client, orgID, returnURL string, noBrowser bool) (bool, error) {
-	installed, err := connected(ctx, client, orgID)
+func EnsureConnected(
+	ctx context.Context,
+	client *apiclient.Client,
+	p provider.Provider,
+	orgID, returnURL string,
+	noBrowser bool,
+) (bool, error) {
+	installed, err := connected(ctx, client, p, orgID)
 	if err != nil {
 		return false, err
 	}
@@ -65,45 +70,47 @@ func EnsureInstalled(ctx context.Context, client *apiclient.Client, orgID, retur
 		return true, nil
 	}
 
-	redirectURL, err := installURL(ctx, client, orgID, returnURL)
+	redirectURL, err := installURL(ctx, client, p, orgID, returnURL)
 	if err != nil {
 		return false, err
 	}
 
 	if noBrowser || !iostream.IsInteractive(ctx) {
-		iostream.Printf(ctx, "\nInstall the CircleCI GitHub App to connect your repository:\n%s\n", redirectURL)
+		iostream.Printf(ctx, "\nInstall %s to connect your repository:\n%s\n", p.Install, redirectURL)
 		return false, nil
 	}
 
-	iostream.Printf(ctx, "\nOpening your browser to install the CircleCI GitHub App...\n")
+	iostream.Printf(ctx, "\nOpening your browser to install %s...\n", p.Install)
 	if err := browser.OpenURLOrPrint(iostream.Err(ctx), redirectURL); err != nil {
 		iostream.Printf(ctx, "Open this URL to install the app:\n%s\n", redirectURL)
 	}
 
-	sp := iostream.Spinner(ctx, true, "Waiting for GitHub App installation")
-	installed, err = pollInstalled(ctx, client, orgID)
+	sp := iostream.Spinner(ctx, true, "Waiting for "+p.Short+" installation")
+	installed, err = pollInstalled(ctx, client, p, orgID)
 	sp.Stop()
 	if err != nil {
 		return false, err
 	}
 	if !installed {
-		iostream.ErrPrintf(ctx, "%s Timed out waiting for the GitHub App installation.\n", iostream.SymbolWarn(ctx))
+		iostream.ErrPrintf(ctx, "%s Timed out waiting for the %s installation.\n", iostream.SymbolWarn(ctx), p.Short)
 		return false, nil
 	}
-	iostream.Printf(ctx, "%s GitHub App installed\n", iostream.SymbolOK(ctx))
+	iostream.Printf(ctx, "%s %s installed\n", iostream.SymbolOK(ctx), p.Short)
 	return true, nil
 }
 
-// installURL starts a connection for this package's provider and returns the URL
-// the user has to open to finish it.
+// installURL starts a connection to p and returns the URL the user has to open to
+// finish it.
 //
 // The setup call answers with what has to happen next. A redirect is the case
 // this flow handles: CircleCI's app is registered with the provider already, so
 // the user only approves it. Anything else — today, registering an app from a
 // manifest — is a browser flow the CLI cannot complete, so it is reported rather
 // than silently opening nothing.
-func installURL(ctx context.Context, client *apiclient.Client, orgID, returnURL string) (string, error) {
-	setup, err := client.SetupProviderConnection(ctx, orgID, provider, returnURL)
+func installURL(
+	ctx context.Context, client *apiclient.Client, p provider.Provider, orgID, returnURL string,
+) (string, error) {
+	setup, err := client.SetupProviderConnection(ctx, orgID, p.Name, returnURL)
 	if err != nil {
 		return "", err
 	}
@@ -113,11 +120,11 @@ func installURL(ctx context.Context, client *apiclient.Client, orgID, returnURL 
 	return setup.URL, nil
 }
 
-// connected reports whether the organization has a connection for this package's
-// provider. An organization with none is answered as an empty list rather than an
-// error, so a non-nil error means the check itself failed — a caller must not read
-// it as "not installed" and send the user into an install flow.
-func connected(ctx context.Context, client *apiclient.Client, orgID string) (bool, error) {
+// connected reports whether the organization has a connection to p. An
+// organization with none is answered as an empty list rather than an error, so a
+// non-nil error means the check itself failed — a caller must not read it as "not
+// installed" and send the user into an install flow.
+func connected(ctx context.Context, client *apiclient.Client, p provider.Provider, orgID string) (bool, error) {
 	conns, err := client.ListProviderConnections(ctx, orgID)
 	if err != nil {
 		return false, err
@@ -126,7 +133,7 @@ func connected(ctx context.Context, client *apiclient.Client, orgID string) (boo
 		// A connection whose provider could not be reached still counts as
 		// installed: ConnectionError describes a degraded read, not a missing
 		// installation.
-		if conn.Provider == provider {
+		if conn.Provider == p.Name {
 			return true, nil
 		}
 	}
@@ -135,7 +142,7 @@ func connected(ctx context.Context, client *apiclient.Client, orgID string) (boo
 
 // pollInstalled polls for the connection until the app is installed, the timeout
 // elapses, or the context is cancelled.
-func pollInstalled(ctx context.Context, client *apiclient.Client, orgID string) (bool, error) {
+func pollInstalled(ctx context.Context, client *apiclient.Client, p provider.Provider, orgID string) (bool, error) {
 	ticker := time.NewTicker(pollInterval)
 	defer ticker.Stop()
 	timer := time.NewTimer(pollTimeout)
@@ -148,7 +155,7 @@ func pollInstalled(ctx context.Context, client *apiclient.Client, orgID string) 
 		case <-timer.C:
 			return false, nil
 		case <-ticker.C:
-			installed, err := connected(ctx, client, orgID)
+			installed, err := connected(ctx, client, p, orgID)
 			if err != nil {
 				return false, err
 			}
@@ -161,24 +168,26 @@ func pollInstalled(ctx context.Context, client *apiclient.Client, orgID string) 
 
 // ErrTooManyRepositories reports that the search hit its page cap before examining
 // every repository, so the target may well be accessible. Callers must not report it
-// as "the app cannot access that repository" — the advice that follows from that,
-// grant access and re-run, searches the same bounded prefix again.
+// as "the integration cannot access that repository" — the advice that follows from
+// that, grant access and re-run, searches the same bounded prefix again.
 var ErrTooManyRepositories = errors.New("too many repositories to search for a match")
 
-// ResolveRepoID returns the provider's ID for repoFullName ("owner/repo") among
-// the repositories the organization's connection can reach. The endpoint offers no
+// ResolveRepoID returns p's ID for repoFullName ("owner/repo") among the
+// repositories the organization's connection to p can reach. The endpoint offers no
 // name filter, so the list has to be walked.
 //
 // It returns "" with no error only when the whole list was examined and held no
 // match; hitting the page cap first returns ErrTooManyRepositories.
-func ResolveRepoID(ctx context.Context, client *apiclient.Client, orgID, repoFullName string) (string, error) {
+func ResolveRepoID(
+	ctx context.Context, client *apiclient.Client, p provider.Provider, orgID, repoFullName string,
+) (string, error) {
 	if repoFullName == "" {
 		return "", nil
 	}
 
 	cursor := ""
 	for range maxRepoPages {
-		repos, next, err := client.ListProviderRepositories(ctx, orgID, provider, cursor, repoPageLimit)
+		repos, next, err := client.ListProviderRepositories(ctx, orgID, p.Name, cursor, repoPageLimit)
 		if err != nil {
 			return "", err
 		}

--- a/internal/providerconn/providerconn_test.go
+++ b/internal/providerconn/providerconn_test.go
@@ -20,7 +20,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-package githubapp_test
+package providerconn_test
 
 import (
 	"context"
@@ -36,13 +36,24 @@ import (
 
 	"github.com/CircleCI-Public/circleci-cli/clikit/iostream"
 	"github.com/CircleCI-Public/circleci-cli/internal/apiclient"
-	"github.com/CircleCI-Public/circleci-cli/internal/githubapp"
+	"github.com/CircleCI-Public/circleci-cli/internal/provider"
+	"github.com/CircleCI-Public/circleci-cli/internal/providerconn"
 )
 
 // testCtx returns a context wired with test IO streams, which the API client's
 // debug logging requires.
 func testCtx() context.Context {
 	return iostream.Testing(context.Background())
+}
+
+// githubApp is the registry entry these cases are written against. Resolving it
+// from a remote host rather than constructing one keeps the tests honest about
+// what ships.
+func githubApp(t *testing.T) provider.Provider {
+	t.Helper()
+	p, ok := provider.ForHost("github.com")
+	assert.Assert(t, ok, "github.com must resolve to an integration")
+	return p
 }
 
 // pagedReposServer serves the provider repositories endpoint, returning at most
@@ -101,10 +112,10 @@ func TestResolveRepoID_PageCap(t *testing.T) {
 	t.Cleanup(srv.Close)
 	client := apiclient.New(apiclient.Config{BaseURL: srv.URL, Token: "test-token"})
 
-	id, err := githubapp.ResolveRepoID(testCtx(), client, "org-1", "myorg/needle")
+	id, err := providerconn.ResolveRepoID(testCtx(), client, githubApp(t), "org-1", "myorg/needle")
 
 	assert.Check(t, cmp.Equal(id, ""))
-	assert.Check(t, errors.Is(err, githubapp.ErrTooManyRepositories),
+	assert.Check(t, errors.Is(err, providerconn.ErrTooManyRepositories),
 		"hitting the page cap must be distinguishable from an absent repository, got: %v", err)
 }
 
@@ -113,28 +124,28 @@ func TestResolveRepoID(t *testing.T) {
 
 	t.Run("matches a repo on a later page", func(t *testing.T) {
 		client := pagedReposServer(t, repos)
-		id, err := githubapp.ResolveRepoID(testCtx(), client, "org-uuid", "myorg/c")
+		id, err := providerconn.ResolveRepoID(testCtx(), client, githubApp(t), "org-uuid", "myorg/c")
 		assert.NilError(t, err)
 		assert.Equal(t, id, "3")
 	})
 
 	t.Run("matches case-insensitively", func(t *testing.T) {
 		client := pagedReposServer(t, repos)
-		id, err := githubapp.ResolveRepoID(testCtx(), client, "org-uuid", "MYORG/TARGET")
+		id, err := providerconn.ResolveRepoID(testCtx(), client, githubApp(t), "org-uuid", "MYORG/TARGET")
 		assert.NilError(t, err)
 		assert.Equal(t, id, "4")
 	})
 
 	t.Run("returns empty when not found", func(t *testing.T) {
 		client := pagedReposServer(t, repos)
-		id, err := githubapp.ResolveRepoID(testCtx(), client, "org-uuid", "myorg/missing")
+		id, err := providerconn.ResolveRepoID(testCtx(), client, githubApp(t), "org-uuid", "myorg/missing")
 		assert.NilError(t, err)
 		assert.Equal(t, id, "")
 	})
 
 	t.Run("returns empty for a blank name without calling the API", func(t *testing.T) {
 		client := pagedReposServer(t, repos)
-		id, err := githubapp.ResolveRepoID(testCtx(), client, "org-uuid", "")
+		id, err := providerconn.ResolveRepoID(testCtx(), client, githubApp(t), "org-uuid", "")
 		assert.NilError(t, err)
 		assert.Equal(t, id, "")
 	})
@@ -185,11 +196,11 @@ func connectionsServerWithSetup(t *testing.T, setupAttrs any, providers ...strin
 	return apiclient.New(apiclient.Config{BaseURL: srv.URL, Token: "test-token"}), &paths
 }
 
-func TestEnsureInstalled(t *testing.T) {
+func TestEnsureConnected(t *testing.T) {
 	t.Run("an existing connection needs no install", func(t *testing.T) {
 		client, paths := connectionsServer(t, "github_app")
 
-		installed, err := githubapp.EnsureInstalled(testCtx(), client, "org-uuid", "https://app.circleci.com/x", true)
+		installed, err := providerconn.EnsureConnected(testCtx(), client, githubApp(t), "org-uuid", "https://app.circleci.com/x", true)
 
 		assert.NilError(t, err)
 		assert.Check(t, installed)
@@ -202,7 +213,7 @@ func TestEnsureInstalled(t *testing.T) {
 		// same org must still send the user through the install.
 		client, _ := connectionsServer(t, "github_oauth")
 
-		installed, err := githubapp.EnsureInstalled(testCtx(), client, "org-uuid", "https://app.circleci.com/x", true)
+		installed, err := providerconn.EnsureConnected(testCtx(), client, githubApp(t), "org-uuid", "https://app.circleci.com/x", true)
 
 		assert.NilError(t, err)
 		assert.Check(t, !installed)
@@ -212,7 +223,7 @@ func TestEnsureInstalled(t *testing.T) {
 		client, paths := connectionsServer(t)
 
 		// noBrowser prints the URL and returns rather than polling.
-		installed, err := githubapp.EnsureInstalled(testCtx(), client, "org-uuid", "https://app.circleci.com/x", true)
+		installed, err := providerconn.EnsureConnected(testCtx(), client, githubApp(t), "org-uuid", "https://app.circleci.com/x", true)
 
 		assert.NilError(t, err)
 		assert.Check(t, !installed)
@@ -230,7 +241,7 @@ func TestEnsureInstalled(t *testing.T) {
 			"state_token": "tok",
 		})
 
-		installed, err := githubapp.EnsureInstalled(testCtx(), client, "org-uuid", "https://app.circleci.com/x", true)
+		installed, err := providerconn.EnsureConnected(testCtx(), client, githubApp(t), "org-uuid", "https://app.circleci.com/x", true)
 
 		assert.Check(t, err != nil, "a register step has no CLI path and must not pass silently")
 		assert.Check(t, !installed)
@@ -245,7 +256,7 @@ func TestEnsureInstalled(t *testing.T) {
 		t.Cleanup(srv.Close)
 		client := apiclient.New(apiclient.Config{BaseURL: srv.URL, Token: "test-token"})
 
-		installed, err := githubapp.EnsureInstalled(testCtx(), client, "org-uuid", "https://app.circleci.com/x", true)
+		installed, err := providerconn.EnsureConnected(testCtx(), client, githubApp(t), "org-uuid", "https://app.circleci.com/x", true)
 
 		assert.Check(t, err != nil, "a 500 from the connections endpoint must surface")
 		assert.Check(t, !installed)


### PR DESCRIPTION
<!--
  Thank you for contributing to CircleCI CLI!

  For PRs adding new features, please raise an issue first.

  Squash your commits before requesting review and before merging.
-->
## Summary
`onboard` assumed every repository belonged to the GitHub App: it gated on a `gh` project slug, hardcoded `github_app` into the pipeline definition and trigger it creates, and called into a package named after that one integration. The endpoints it now uses (`/api/v3/provider/connections`, `/connections/setup`, `/provider/repositories`) all take the integration as a parameter, so that assumption was the last thing tying the flow to a single one.

The integration is now resolved from the checkout's git remote host, and everything provider-shaped follows from it: the connection that is checked, the install that is started, the repository list that is searched, and the `provider` written into the definition and trigger.

## What a user notices

- A remote on a host CircleCI has no integration for is reported as such, instead of "%s is not a GitHub repository". Nothing is created either way.
- Warnings name the integration they are about, rather than always naming the GitHub App.
- `--repo-id` help no longer says "Numeric repository ID, if the GitHub App cannot resolve it", since the ID is opaque and the resolver depends on the remote.

Otherwise output is unchanged: the GitHub App's messages are byte-identical, which is why no goldens moved beyond the flag help.

## `internal/provider`

One entry per integration, holding what the rest of the CLI reads off it:

```go
{
    Name:    "github_app",          // the value the API is sent
    Short:   "GitHub App",          // "Waiting for GitHub App installation"
    Install: "the CircleCI GitHub App",
    Hosts:   []string{"github.com"},
}
```

`ForHost` matches exact-or-subdomain, so a host under a known one resolves without its own entry while a lookalike (`notgithub.com`) does not.

## `internal/githubapp` becomes `internal/providerconn`

Same three steps — is the org connected, start an install, resolve a repository — with the integration as an argument instead of a package-level constant. The printed copy comes from the registry entry.

## `gitremote`: reading a remote is not the same as building a slug

`DetectFromRemoteIn` maps a remote onto CircleCI's VCS vocabulary and rejects any host it has no segment for. That is right for a slug and wrong for reading a remote, so this adds `DetectRemoteRefIn`, which returns host, owner and repo as the URL gives them. `slugFromRemote` now maps that shared parse rather than keeping a second copy of the URL grammar, so a new remote form is added in one place.

## Two things that fell out

- `detectRemote` opened the repository twice: once for the remote, once to build a slug whose only product was a struct field nothing read (its reader, `IsGitHub`, is deleted here). The second open also resolved `refs/remotes/origin/HEAD`, which in go-git falls back to a full `packed-refs` scan when that ref is absent — the shape a `git init` + `remote add` + `push` checkout has, which is exactly what `onboard` targets. Now one open.
- `resolveRepoID` returns the integration it resolved, so the caller writes with it instead of looking it up again.

## Testing
- [x] New: `ForHost` cases (exact, case, port, subdomain, unclaimed, lookalike host), registry invariants, and remote parses including a host that has no slug form — the case that used to error.
- [x] New acceptance test: a remote no integration claims is reported and no definition is created.
- [x] `providerconn` tests carried over, resolving the registry entry from a host rather than constructing one, so they exercise what ships.
- [x] `task test` — the 9 failures in `internal/gitremote` and `internal/orbinit` reproduce on a clean tree (local `commit.gpgSign` breaks go-git commit creation) and are unrelated.
- [x] `task check` clean on both modules.
