### PR TITLE
Make onboard re-runnable when its project already exists

### DIFF
--- a/acceptance/onboard_test.go
+++ b/acceptance/onboard_test.go
@@ -44,8 +44,11 @@ import (
 // opaque short IDs rather than names, mirroring a real CircleCI-native project,
 // whose slug the API will not accept in name form.
 const (
-	onboardOrgID          = "org-uuid-1234"
-	onboardProjectID      = "proj-uuid-5678"
+	// The org and project IDs are real UUIDs: the v3 entities the CLI decodes type
+	// them as such, so a placeholder string would fail to parse rather than fail an
+	// assertion.
+	onboardOrgID          = "a0000000-0000-4000-8000-00000000d001"
+	onboardProjectID      = "a0000000-0000-4000-8000-00000000d002"
 	onboardPipelineDefID  = "pdef-uuid-1"
 	onboardRepoExternalID = "123456789"
 )
@@ -565,7 +568,7 @@ func TestOnboard_PostSignup_Rerun_Idempotent(t *testing.T) {
 	// The second run looks the project up by the slug projectref derives from the
 	// recorded UUIDs. The real API accepts that form and canonicalises it to the
 	// short-ID slug.
-	fake.AddProjectInfo("circleci/org-uuid-1234/proj-uuid-5678", fakes.ProjectInfo{
+	fake.AddProjectInfo("circleci/"+onboardOrgID+"/"+onboardProjectID, fakes.ProjectInfo{
 		ID:               onboardProjectID,
 		Slug:             "circleci/Org1234ShortId/Proj5678ShortId",
 		Name:             "my-repo",
@@ -659,11 +662,11 @@ func TestOnboard_PostSignup_LinkedProjectInAnotherOrg(t *testing.T) {
 	assert.Check(t, !strings.Contains(result.Stderr, "409"), "stderr should not leak an HTTP status")
 }
 
-// TestOnboard_PostSignup_ProjectNameConflict covers a name collision that onboard
-// cannot resolve: the org already has a project with this name, but the checkout
-// has no .circleci/info.yml recording its ID. Since a project cannot be looked up
-// by name, onboard points at `circleci project link` rather than reporting a raw
-// HTTP conflict.
+// TestOnboard_PostSignup_ProjectNameConflict covers a name collision onboard
+// cannot resolve: the create is rejected, and the name resolves to no project this
+// organization holds — someone else's project, or one the caller cannot read. There
+// is nothing to adopt, so onboard points at `circleci project link` rather than
+// reporting a raw HTTP conflict.
 func TestOnboard_PostSignup_ProjectNameConflict(t *testing.T) {
 	dir, fake, env := onboardRepo(t)
 	fake.SetCreateProjectConflict()
@@ -682,6 +685,55 @@ func TestOnboard_PostSignup_ProjectNameConflict(t *testing.T) {
 	// No raw HTTP internals for a conflict the user can resolve with one command.
 	assert.Check(t, !strings.Contains(result.Stderr, "409"), "stderr should not leak an HTTP status")
 	assert.Check(t, !strings.Contains(result.Stderr, "/api/v2/"), "stderr should not leak an API path")
+}
+
+// TestOnboard_PostSignup_ProjectNameConflict_Resumes pins that a re-run picks up
+// where an interrupted one left off. The org already holds the project onboard
+// would create, so it adopts it and carries on into pipeline setup instead of
+// sending the user to copy an ID out of the UI.
+func TestOnboard_PostSignup_ProjectNameConflict_Resumes(t *testing.T) {
+	dir, fake, env := onboardRepo(t)
+	fake.SetCreateProjectConflict()
+	fake.AddProjectBySlug("circleci/myorg/my-repo", onboardProjectID, "my-repo", onboardOrgID)
+	// Adopting it hydrates the record from the slug its UUIDs build, which is the
+	// only handle available once the name is taken.
+	fake.AddProjectInfo("circleci/"+onboardOrgID+"/"+onboardProjectID, fakes.ProjectInfo{
+		ID:               onboardProjectID,
+		Slug:             "circleci/myorg/my-repo",
+		Name:             "my-repo",
+		OrganizationName: "myorg",
+		OrganizationSlug: "circleci/myorg",
+		OrganizationID:   onboardOrgID,
+	})
+	fake.SetProviderConnected(onboardOrgID, "github_app", true)
+	fake.AddProviderRepository(onboardOrgID, fakes.ProviderRepo{
+		ID:           "987654321",
+		RepoFullName: "myorg/my-repo",
+		RepoName:     "my-repo",
+		Owner:        "myorg",
+	})
+	addFirstPipelineResponses(fake)
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"onboard", "--scan"},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Check(t, cmp.Contains(result.Stdout, "Using existing project: my-repo"))
+	assert.Check(t, cmp.Contains(result.Stdout, "Pipeline definition created"))
+	assert.Check(t, cmp.Contains(result.Stdout, "Trigger created: all-pushes"))
+	// The hand-off this replaces: no ID to copy, no second command to run.
+	assert.Check(t, !strings.Contains(result.Stdout, "circleci project link"),
+		"an adopted project needs no manual link step")
+	assert.Check(t, !strings.Contains(result.Stderr, "409"), "stderr should not leak an HTTP status")
+
+	// Recorded, so the next run resolves the project before attempting a create.
+	body, err := os.ReadFile(filepath.Join(dir, ".circleci", "info.yml"))
+	assert.NilError(t, err)
+	assert.Check(t, strings.Contains(string(body), onboardProjectID), "info.yml: %s", body)
 }
 
 func TestOnboard_PostSignup_FirstPipeline_RepoNotAccessible(t *testing.T) {

--- a/internal/apiclient/project.go
+++ b/internal/apiclient/project.go
@@ -183,6 +183,33 @@ func (c *Client) GetProjectBySlug(ctx context.Context, slug string) (*ProjectRef
 	}, nil
 }
 
+// GetProjectByName resolves a project by its name within an organization via
+// GET /api/v3/projects. orgID must be the organization UUID.
+//
+// Use this where a name is all that is known — a project whose slug carries
+// opaque IDs cannot be addressed by slug, so its name is the only handle a user
+// (or a previous run of the same command) supplies.
+func (c *Client) GetProjectByName(ctx context.Context, orgID, name string) (*ProjectRef, error) {
+	var env v3List[projectEntity]
+	_, err := c.main.Call(ctx, httpcl.NewRequest(http.MethodGet, "/api/v3/projects",
+		filterParam("org_id", orgID),
+		filterParam("name", name),
+		httpcl.JSONDecoder(&env),
+	))
+	if err != nil {
+		return nil, err
+	}
+	if len(env.Data) == 0 {
+		return nil, fmt.Errorf("%w: %q", ErrProjectNotFound, name)
+	}
+	p := env.Data[0]
+	return &ProjectRef{
+		ID:    p.ID,
+		Name:  p.Attributes.Name,
+		OrgID: p.References.Org.ID,
+	}, nil
+}
+
 // GetProjectByID resolves a project UUID to its name (and owning org UUID) via
 // GET /api/v3/projects/:id. Use this to label runs when only the project UUID is
 // known — e.g. the cross-project "my runs" listing, where runs span projects

--- a/internal/onboarder/onboarder.go
+++ b/internal/onboarder/onboarder.go
@@ -241,19 +241,24 @@ func postSignupGuidance(ctx context.Context, dir string, opts Options) error {
 		}
 
 		created, err := client.CreateProject(ctx, vcs, orgName, name)
-		if err != nil {
-			if httpcl.HasStatusCode(err, http.StatusConflict) {
-				iostream.ErrPrintf(ctx, "%s A project named %q already exists in %s.\n",
-					iostream.SymbolWarn(ctx), name, selectedOrg.Slug)
-				printLinkGuidance(ctx, dir, selectedOrg.Slug)
+		switch {
+		case httpcl.HasStatusCode(err, http.StatusConflict):
+			// The name is taken, which on a re-run is this checkout's own project from
+			// an earlier attempt. Adopting it is what makes onboard resumable: the rest
+			// of the flow skips whatever already exists, so continuing gets the user to
+			// a working pipeline where stopping to fetch an ID by hand does not.
+			proj = adoptExistingProject(ctx, client, dir, selectedOrg, name)
+			if proj == nil {
 				return nil
 			}
+		case err != nil:
 			iostream.ErrPrintf(ctx, "%s Could not create project: %s\n", iostream.SymbolWarn(ctx), err)
 			return stopWithGuidance(ctx)
+		default:
+			proj = created
+			iostream.Printf(ctx, "%s Project created: %s\n", iostream.SymbolOK(ctx), proj.Name)
+			writeProjectRef(ctx, dir, proj)
 		}
-		proj = created
-		iostream.Printf(ctx, "%s Project created: %s\n", iostream.SymbolOK(ctx), proj.Name)
-		writeProjectRef(ctx, dir, proj)
 	} else {
 		iostream.Printf(ctx, "%s Using existing project: %s\n", iostream.SymbolOK(ctx), proj.Name)
 	}
@@ -362,6 +367,53 @@ func refreshConfig(ctx context.Context, opts Options) context.Context {
 		return ctx
 	}
 	return cmdutil.WithConfig(ctx, cfg)
+}
+
+// adoptExistingProject resolves the project that already holds name in the
+// organization, records it for this checkout, and returns it so the flow can carry
+// on into pipeline setup. A nil result means the caller should stop, with the
+// reason already reported.
+//
+// The name is the only handle available: a CircleCI-native project's slug carries
+// opaque IDs, so it cannot be built from what the user typed. Its UUIDs can be
+// turned back into a slug though, which is what hydrates the rest of the record.
+func adoptExistingProject(
+	ctx context.Context,
+	client *apiclient.Client,
+	workDir string,
+	selectedOrg *apiclient.Collaboration,
+	name string,
+) *apiclient.ProjectInfo {
+	// Only a project this organization holds can be adopted. When it cannot be
+	// resolved — the name belongs to an organization the caller cannot read, say —
+	// the manual route is still the way through, so it is reported as before rather
+	// than guessed at.
+	existing, err := client.GetProjectByName(ctx, selectedOrg.ID, name)
+	if err != nil {
+		reportUnresolvedConflict(ctx, workDir, selectedOrg, name)
+		return nil
+	}
+
+	proj, err := client.GetProjectInfo(ctx, projectref.SlugFor(existing.OrgID.String(), existing.ID.String()))
+	if err != nil {
+		reportUnresolvedConflict(ctx, workDir, selectedOrg, name)
+		return nil
+	}
+
+	iostream.Printf(ctx, "%s Using existing project: %s\n", iostream.SymbolOK(ctx), proj.Name)
+	writeProjectRef(ctx, workDir, proj)
+	return proj
+}
+
+// reportUnresolvedConflict explains a name collision onboard could not resolve and
+// points at the command that fixes it. The project exists but this checkout cannot
+// be pointed at it without its ID.
+func reportUnresolvedConflict(
+	ctx context.Context, workDir string, selectedOrg *apiclient.Collaboration, name string,
+) {
+	iostream.ErrPrintf(ctx, "%s A project named %q already exists in %s.\n",
+		iostream.SymbolWarn(ctx), name, selectedOrg.Slug)
+	printLinkGuidance(ctx, workDir, selectedOrg.Slug)
 }
 
 // resolveLinkedProject returns the project recorded in .circleci/info.yml, or nil

--- a/internal/projectref/projectref.go
+++ b/internal/projectref/projectref.go
@@ -91,9 +91,16 @@ func (i *Info) EffectiveSlug() string {
 		return ""
 	}
 	if strings.HasPrefix(i.Project.Slug, "circleci/") && i.Project.ID != "" && i.Organization.ID != "" {
-		return "circleci/" + i.Organization.ID + "/" + i.Project.ID
+		return SlugFor(i.Organization.ID, i.Project.ID)
 	}
 	return i.Project.Slug
+}
+
+// SlugFor builds the slug of a CircleCI-native project from its organization and
+// project IDs. The API accepts UUIDs in place of the compact IDs a slug usually
+// carries, which is what lets a caller holding only IDs address the project.
+func SlugFor(orgID, projectID string) string {
+	return "circleci/" + orgID + "/" + projectID
 }
 
 // ErrNotFound is returned by Read when no info file exists.

--- a/internal/testing/fakes/circleci.go
+++ b/internal/testing/fakes/circleci.go
@@ -2359,10 +2359,27 @@ func projectV3Entity(p ProjectV3) map[string]any {
 }
 
 func (f *CircleCI) handleResolveProjectBySlug(w http.ResponseWriter, r *http.Request) {
-	slug := r.URL.Query().Get("filter[slug]")
+	q := r.URL.Query()
+	slug := q.Get("filter[slug]")
 	if slug == "" {
-		render.Status(r, http.StatusBadRequest)
-		render.JSON(w, r, map[string]any{"error": map[string]any{"title": "Bad Request", "detail": "filter[slug] is required"}})
+		// The real endpoint takes either a slug or an org, and pairs the org with an
+		// optional name. Registered projects are keyed by slug, so an org-scoped
+		// lookup matches on the name and the org the project records.
+		orgID, name := q.Get("filter[org_id]"), q.Get("filter[name]")
+		if orgID == "" {
+			render.Status(r, http.StatusBadRequest)
+			render.JSON(w, r, map[string]any{"error": map[string]any{"title": "Bad Request", "detail": "filter[slug] or filter[org_id] is required"}})
+			return
+		}
+		f.mu.RLock()
+		matches := []any{}
+		for _, p := range f.projectsBySlug {
+			if p.OrgID == orgID && (name == "" || p.Name == name) {
+				matches = append(matches, projectV3Entity(p))
+			}
+		}
+		f.mu.RUnlock()
+		render.JSON(w, r, map[string]any{"data": matches, "page": map[string]any{"next": nil, "prev": nil}})
 		return
 	}
 	f.mu.RLock()


### PR DESCRIPTION
<!--
  Thank you for contributing to CircleCI CLI!

  For PRs adding new features, please raise an issue first.

  Squash your commits before requesting review and before merging.
-->
## Summary
`onboard` is meant to be safe to run repeatedly, and almost every step already is: it reports `Using existing config`, `Already signed in as`, `Pipeline definition already exists`, `Trigger already exists`, and reuses a project this checkout is linked to. Creating the project was the one step that stopped the run outright — a conflict ended it with instructions to copy an ID out of the CircleCI UI, run `circleci project link`, and start over.

This closes that gap. When the name is taken, `onboard` resolves the project by name within the chosen organization and carries on into pipeline setup, so a second run finishes the job rather than handing back homework.

## When this happens

Any time the project exists but this checkout has no record of it:

- A teammate clones the repository and runs `onboard`. The project is there; their `.circleci/info.yml` may not be, or may not be committed.
- The project was created in the CircleCI UI rather than by the CLI.
- An earlier attempt was interrupted, or was run from a different directory.

## Before and after

**Before:**

```
✓ Using organization circleci/myorg
⚠ A project named "my-repo" already exists in circleci/myorg.

Copy that project's ID from its settings in CircleCI, then run:
  circleci project link --project circleci/myorg/<projectID>
  circleci onboard
```

**After:**

```
✓ Using organization circleci/myorg
✓ Using existing project: my-repo
✓ Linked this repository to the project in .circleci/info.yml
✓ Found repository myorg/my-repo
✓ Pipeline definition created: my-repo
✓ Trigger created: all-pushes
```

The second run also writes `.circleci/info.yml`, so every later run resolves the project before it ever attempts a create.

## How it resolves

A CircleCI-native project's slug carries opaque IDs, so the name the user typed cannot be turned into an address — which is why the old path asked for an ID. `GET /api/v3/projects` accepts `filter[org_id]` with `filter[name]`, and the UUIDs it returns do build a slug the API accepts, which hydrates the rest of the record. `projectref.SlugFor` is now the single place that knows that slug form; `EffectiveSlug` uses it too.

## When it still cannot resolve

A name that resolves to no project this organization holds — someone else's project, or one the caller cannot read — reports the conflict and points at `circleci project link` exactly as before. Without an ID there is nothing to attach a pipeline to, and guessing would wire this repository to a project that is not its own.

## Test fixtures now use real UUIDs

`onboardOrgID` and `onboardProjectID` were placeholder strings. The v3 entities the CLI decodes type project and org ids as `uuid.UUID`, so those values could never round-trip through a v3 response — the lookup failed to parse rather than failing an assertion. One test also had the old strings hardcoded into a slug instead of deriving it from the constants.

## Testing
- [x] New acceptance test: a conflict whose name resolves is adopted, pipeline setup continues, `.circleci/info.yml` records the project so the next run resolves it before attempting a create, and no `project link` guidance is printed.
- [x] The existing re-run test still passes, along with the two conflict tests covering an unresolvable name and a project in another organization.
- [x] `task test` — the 9 failures in `internal/gitremote` and `internal/orbinit` reproduce on a clean tree (local `commit.gpgSign` breaks go-git commit creation) and are unrelated.
- [x] `task check` clean on both modules.
- [x] Verified against production that `filter[org_id]` + `filter[name]` resolves an existing project to its UUID.

## One judgement call worth a reviewer's eye

An adopted project is used without confirmation. If someone types a name that belongs to an unrelated project in the same organization, `onboard` will attach this repository's definition and trigger to it. The run prints `Using existing project` before doing anything and the writes are per-repository, so nothing is overwritten, but a prompt before adopting is a reasonable alternative if that trade reads wrong.
