### PR TITLE
Report a run's own errors when watching it

### DIFF
--- a/acceptance/run_failed_context_test.go
+++ b/acceptance/run_failed_context_test.go
@@ -175,6 +175,46 @@ func TestRunGet_FailedContext_NoFailures(t *testing.T) {
 	assert.Check(t, cmp.Equal(result.Stderr, ""))
 }
 
+// TestRunGet_FailedContext_RunErrors covers the report for a run that failed
+// without any job failing: a dynamic-config run whose continued config was
+// rejected has no failed step to condense, so the error the run carries is the
+// only thing there is to report — and the report used to be empty.
+func TestRunGet_FailedContext_RunErrors(t *testing.T) {
+	fake := fakes.NewCircleCI(t)
+	run := fakeRunV3(fcRunID, runTestProjectID, "ended", "succeeded", "main", "abc1234def5678")
+	run.Errors = []fakes.RunError{{
+		Type:    "config",
+		Message: "Error calling workflow: 'deploy'\nCannot find a definition for job named release",
+	}}
+	fake.AddRunV3(fcRunID, runTestProjectID, run)
+	fake.AddRunWorkflowsV3(fcRunID, fakeWorkflowV3(fcWfID, "setup", fcRunID, runTestProjectID, "ended", "succeeded"))
+	fake.AddWorkflowJobsV3(fcWfID, fakeJobV3(fcJob3ID, "setup-job", fcWfID, runTestProjectID))
+
+	now := time.Date(2020, 1, 1, 12, 0, 0, 0, time.UTC).Format(v3TimeFormat)
+	fake.AddJobV3(fakes.JobV3{
+		ID: fcJob3ID, Name: "setup-job", Type: "build", Phase: "ended", Outcome: "succeeded",
+		StartedAt: now, EndedAt: now, WorkflowID: fcWfID, ProjectID: runTestProjectID,
+		Executions: [][]fakes.JobStep{{
+			{Name: "continue", Type: "run", Num: 100, Phase: "ended", Outcome: "succeeded", ExitCode: new(0), StartedAt: now, EndedAt: now},
+		}},
+	})
+
+	env := testenv.New(t)
+	env.Token = testToken
+	env.CircleCIURL = fake.URL()
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"run", "get", fcRunID, "--failure-report"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Check(t, cmp.Equal(result.ExitCode, 0))
+	assert.Check(t, golden.String(result.Stdout, t.Name()+".txt"))
+	assert.Check(t, cmp.Equal(result.Stderr, ""))
+}
+
 // TestRunGet_FailureReport_RejectsJSON verifies that combining --failure-report with
 // --json exits non-zero with a user-facing error.
 func TestRunGet_FailureReport_RejectsJSON(t *testing.T) {

--- a/acceptance/testdata/TestRunGet_FailedContext_RunErrors.txt
+++ b/acceptance/testdata/TestRunGet_FailedContext_RunErrors.txt
@@ -1,0 +1,5 @@
+## run errors
+
+- config: Error calling workflow: 'deploy'
+Cannot find a definition for job named release
+

--- a/acceptance/watch_test.go
+++ b/acceptance/watch_test.go
@@ -296,6 +296,82 @@ func TestRunWatch_FailFast(t *testing.T) {
 		"circleci job get d0000000-0000-4000-8000-00000000f001"), "stderr: %s", result.Stderr)
 }
 
+// --- dynamic config: the setup workflow succeeds, the continued config is rejected ---
+
+// TestRunWatch_ContinuationRejected covers the run the API reports as succeeded —
+// its only workflow, the setup one, succeeded and no job failed — while carrying
+// a config error for the continued config it would not compile. Watch used to
+// report the setup workflow's success as the run's and exit 0, never mentioning
+// the error.
+func TestRunWatch_ContinuationRejected(t *testing.T) {
+	runID := "f0000000-0000-4000-8000-00000000dc01"
+	wfID := "b0000000-0000-4000-8000-0000000dc001"
+
+	run := fakeRunV3(runID, watchProjectID, "ended", "succeeded", "main", "abc1234def5678")
+	run.Errors = []fakes.RunError{{
+		Type:    "config",
+		Message: "Error calling workflow: 'deploy'\nCannot find a definition for job named release",
+	}}
+
+	fake := fakes.NewCircleCI(t)
+	addProjectBySlug(fake, watchSlug, watchProjectID)
+	fake.AddRunV3(runID, watchProjectID, run)
+	fake.AddRunWorkflowsV3(runID, fakeWorkflowV3(wfID, "setup", runID, watchProjectID, "ended", "succeeded"))
+	fake.AddWorkflowJobsV3(wfID, fakeJobV3("d0000000-0000-4000-8000-00000000f001", "setup-job", wfID, watchProjectID))
+
+	env := testenv.New(t)
+	env.Token = testToken
+	env.CircleCIURL = fake.URL()
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"run", "watch", runID},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 7, "stderr: %s", result.Stderr) // ExitValidationFail
+	assert.Check(t, cmp.Contains(result.Stderr, "failed"), "stderr: %s", result.Stderr)
+	assert.Check(t, cmp.Contains(result.Stderr,
+		"config error: Error calling workflow: 'deploy'"), "stderr: %s", result.Stderr)
+	assert.Check(t, cmp.Contains(result.Stderr,
+		"Cannot find a definition for job named release"), "stderr: %s", result.Stderr)
+	assert.Check(t, cmp.Contains(result.Stderr,
+		"For dynamic config, validate the config the setup job generates"), "stderr: %s", result.Stderr)
+}
+
+// TestRunWatch_KeepsWatchingWhileTheRunIsGoing covers the gap a dynamic-config
+// run sits in: its setup workflow has ended and the continued workflow does not
+// exist yet. The run is not over, so the watch waits for it — here until the
+// timeout, since the fake's run never leaves that state — rather than reporting
+// the setup workflow's success as the run's.
+func TestRunWatch_KeepsWatchingWhileTheRunIsGoing(t *testing.T) {
+	runID := "f0000000-0000-4000-8000-00000000dc02"
+	wfID := "b0000000-0000-4000-8000-0000000dc002"
+
+	fake := fakes.NewCircleCI(t)
+	addProjectBySlug(fake, watchSlug, watchProjectID)
+	fake.AddRunV3(runID, watchProjectID, fakeRunV3(runID, watchProjectID, "started", "", "main", "abc1234def5678"))
+	fake.AddRunWorkflowsV3(runID, fakeWorkflowV3(wfID, "setup", runID, watchProjectID, "ended", "succeeded"))
+	fake.AddWorkflowJobsV3(wfID, fakeJobV3("d0000000-0000-4000-8000-00000000f001", "setup-job", wfID, watchProjectID))
+
+	env := testenv.New(t)
+	env.Token = testToken
+	env.CircleCIURL = fake.URL()
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"run", "watch", runID, "--timeout", "1s"},
+		Env:     env.Environ(),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.Equal(t, result.ExitCode, 8, "stderr: %s", result.Stderr) // ExitTimeout
+	assert.Check(t, cmp.Contains(result.Stderr,
+		"All workflows have ended; waiting for the run itself to finish."), "stderr: %s", result.Stderr)
+	assert.Check(t, !strings.Contains(result.Stderr, "succeeded ("), "stderr: %s", result.Stderr)
+}
+
 // --- watch timeout while run still running → exit 8 ---
 
 func TestRunWatch_Timeout(t *testing.T) {

--- a/internal/cmd/root/testdata/help/circleci/reference.txt
+++ b/internal/cmd/root/testdata/help/circleci/reference.txt
@@ -716,9 +716,9 @@ Monitor a CircleCI run and block until it reaches a terminal state. Without
 arguments, watches the latest run for the current branch. A terminal gets a
 live table of workflows and jobs; piped or in CI, each change prints a line.
 
-Exit code reflects the result: 0 all workflows succeeded, 1 one or more failed,
-6 cancelled, 8 timed out. With --sha, polls for up to 2 minutes for a run
-matching that commit to appear — useful immediately after git push.
+Exit code reflects the result: 0 succeeded, 1 failed, 6 cancelled, 7 the run's
+config was rejected (a dynamic-config continuation included), 8 timed out.
+With --sha, polls up to 2 minutes for the run to appear — useful after a push.
 
 | Flag                  | Description                                                            |
 | --------------------- | ---------------------------------------------------------------------- |

--- a/internal/cmd/root/testdata/help/circleci/run/watch.txt
+++ b/internal/cmd/root/testdata/help/circleci/run/watch.txt
@@ -42,7 +42,7 @@ Monitor a CircleCI run and block until it reaches a terminal state. Without
 arguments, watches the latest run for the current branch. A terminal gets a
 live table of workflows and jobs; piped or in CI, each change prints a line.
 
-Exit code reflects the result: 0 all workflows succeeded, 1 one or more failed,
-6 cancelled, 8 timed out. With --sha, polls for up to 2 minutes for a run
-matching that commit to appear — useful immediately after git push.
+Exit code reflects the result: 0 succeeded, 1 failed, 6 cancelled, 7 the run's
+config was rejected (a dynamic-config continuation included), 8 timed out.
+With --sha, polls up to 2 minutes for the run to appear — useful after a push.
 

--- a/internal/cmd/run/failed_context.go
+++ b/internal/cmd/run/failed_context.go
@@ -52,6 +52,17 @@ func runFailureReport(ctx context.Context, client *apiclient.Client, r *apiclien
 
 	var out strings.Builder
 
+	// The run's own errors first: a config the platform would not compile has no
+	// failed step to report, so without these the report for a dynamic-config run
+	// whose continued config was rejected would be empty.
+	if len(r.Errors) > 0 {
+		out.WriteString("## run errors\n\n")
+		for _, e := range r.Errors {
+			fmt.Fprintf(&out, "- %s: %s\n", e.Type, strings.TrimSpace(e.Message))
+		}
+		out.WriteString("\n")
+	}
+
 	for _, wf := range workflows {
 		wfWritten := false
 

--- a/internal/cmd/run/get.go
+++ b/internal/cmd/run/get.go
@@ -943,9 +943,19 @@ func buildOutput(r *apiclient.RunV3, workflows []apiclient.WorkflowV3, wfJobs []
 
 // deriveDisplayStatus computes a meaningful overall display status from
 // workflow phases and outcomes.
+//
+// A run carrying errors of its own is failed whatever its workflows say. That is
+// the dynamic-config case: the setup workflow succeeds, the continued config is
+// rejected, no continued workflow is ever created — and the API still reports the
+// run as succeeded, so the error it carries is the only thing that says
+// otherwise. A run that has produced no workflows at all is left to its own
+// phase and outcome, which already describe it.
 func deriveDisplayStatus(r runGetOutput) string {
 	if len(r.Workflows) == 0 {
 		return apiclient.PhaseOutcomeStatus(r.Phase, r.Outcome, r.CurrentOutcome)
+	}
+	if len(r.Errors) > 0 {
+		return "failed"
 	}
 	for _, wf := range r.Workflows {
 		if wf.Outcome == "failed" || wf.Outcome == "errored" || wf.CurrentOutcome == "failed" {

--- a/internal/cmd/run/get_test.go
+++ b/internal/cmd/run/get_test.go
@@ -174,6 +174,38 @@ func TestRunItemLabel(t *testing.T) {
 
 // TestErrorSummary verifies a run error is condensed to a single short line: its
 // first sentence, capped, falling back to the type when the message is empty.
+// TestDeriveDisplayStatus covers the overall status a run is reported with: its
+// workflows decide it, except when the run carries errors of its own — a config
+// the platform would not compile, or the rejected continuation of a
+// dynamic-config run, which the API reports as a succeeded run with a succeeded
+// setup workflow.
+func TestDeriveDisplayStatus(t *testing.T) {
+	t.Run("succeeded workflows are a succeeded run", func(t *testing.T) {
+		status := deriveDisplayStatus(runGetOutput{
+			Phase: "ended", CurrentOutcome: "succeeded",
+			Workflows: []workflowOutput{{Name: "build", Phase: "ended", Outcome: "succeeded"}},
+		})
+
+		assert.Check(t, is.Equal(status, "succeeded"))
+	})
+
+	t.Run("a rejected continuation fails the run its setup workflow succeeded in", func(t *testing.T) {
+		status := deriveDisplayStatus(runGetOutput{
+			Phase: "ended", CurrentOutcome: "succeeded",
+			Errors:    []errorOutput{{Type: "config", Message: "Cannot find a definition for job named release"}},
+			Workflows: []workflowOutput{{Name: "setup", Phase: "ended", Outcome: "succeeded"}},
+		})
+
+		assert.Check(t, is.Equal(status, "failed"))
+	})
+
+	t.Run("a run with no workflows is described by its own phase and outcome", func(t *testing.T) {
+		status := deriveDisplayStatus(runGetOutput{Phase: "ended", CurrentOutcome: "errored"})
+
+		assert.Check(t, is.Equal(status, "⚠️ errored"))
+	})
+}
+
 func TestErrorSummary(t *testing.T) {
 	assert.Check(t, is.Equal(errorSummary(apiclient.RunError{
 		Type: "config-fetch", Message: "No config found. See the docs.",

--- a/internal/cmd/run/watch.go
+++ b/internal/cmd/run/watch.go
@@ -82,9 +82,9 @@ func newWatchCmd() *cobra.Command {
 			arguments, watches the latest run for the current branch. A terminal gets a
 			live table of workflows and jobs; piped or in CI, each change prints a line.
 
-			Exit code reflects the result: 0 all workflows succeeded, 1 one or more failed,
-			6 cancelled, 8 timed out. With --sha, polls for up to 2 minutes for a run
-			matching that commit to appear — useful immediately after git push.
+			Exit code reflects the result: 0 succeeded, 1 failed, 6 cancelled, 7 the run's
+			config was rejected (a dynamic-config continuation included), 8 timed out.
+			With --sha, polls up to 2 minutes for the run to appear — useful after a push.
 		`),
 		Example: heredoc.Doc(`
 			# Watch the latest run on the current branch
@@ -339,6 +339,7 @@ func watchUntilDone(ctx context.Context, client *apiclient.Client, runID uuid.UU
 	start := time.Now()
 
 	var prevFingerprint string
+	notedPending := false
 	pollInterval := ui.RunWatchPollInterval
 
 	for {
@@ -357,6 +358,15 @@ func watchUntilDone(ctx context.Context, client *apiclient.Client, runID uuid.UU
 		if fingerprint := watchFingerprint(state); fingerprint != prevFingerprint {
 			printWatchLine(ctx, state, elapsed)
 			prevFingerprint = fingerprint
+		}
+
+		// A dynamic-config run goes quiet here: its setup workflow has ended and the
+		// continued workflow does not exist yet, so nothing further prints until one
+		// appears — or, if the continued config is rejected, until the run ends
+		// carrying the error. Say so once, so the wait does not read as a hung watch.
+		if !state.Done && state.AllWorkflowsEnded && !notedPending {
+			iostream.ErrPrintf(ctx, "All workflows have ended; waiting for the run itself to finish.\n")
+			notedPending = true
 		}
 
 		switch {
@@ -384,9 +394,11 @@ func watchUntilDone(ctx context.Context, client *apiclient.Client, runID uuid.UU
 // emoji shortcodes only render when passed through markdown.
 func watchState(state runGetOutput) ui.RunWatchState {
 	out := ui.RunWatchState{
-		Workflows: make([]ui.RunWatchWorkflow, 0, len(state.Workflows)),
-		Done:      allWorkflowsDone(state.Workflows),
-		Outcome:   deriveDisplayStatus(state),
+		Workflows:         make([]ui.RunWatchWorkflow, 0, len(state.Workflows)),
+		Errors:            watchErrors(state.Errors),
+		Done:              runEnded(state),
+		AllWorkflowsEnded: allWorkflowsEnded(state.Workflows),
+		Outcome:           deriveDisplayStatus(state),
 	}
 	for _, wf := range state.Workflows {
 		row := ui.RunWatchWorkflow{
@@ -456,16 +468,41 @@ func fetchWatchState(ctx context.Context, client *apiclient.Client, runID uuid.U
 	return buildOutput(r, workflows, wfJobs), nil
 }
 
-func allWorkflowsDone(workflows []workflowOutput) bool {
+// runEnded reports whether the run itself has finished, and is the only thing
+// the watch treats as the run being over. Its workflows are not: a dynamic-config
+// run whose setup workflow has ended is still going — the continued workflow does
+// not exist yet, and if its config is rejected it never will — so a watch that
+// stopped at "every workflow has ended" would report the setup workflow's success
+// as the run's, and never mention the continuation being rejected. A run that
+// failed before producing any workflow has none to read either way.
+func runEnded(r runGetOutput) bool {
+	return r.Phase == apiclient.PhaseEnded
+}
+
+// allWorkflowsEnded reports that the run has produced at least one workflow and
+// every one of them has ended. That is not the run being over (see runEnded); it
+// is what the watch says so on screen for, since the table stops changing there
+// while the run carries on.
+func allWorkflowsEnded(workflows []workflowOutput) bool {
 	if len(workflows) == 0 {
 		return false
 	}
 	for _, wf := range workflows {
-		if wf.Phase != "ended" {
+		if wf.Phase != apiclient.PhaseEnded {
 			return false
 		}
 	}
 	return true
+}
+
+// watchErrors adapts a run's own errors — a config that would not compile, a
+// continuation that was rejected — to the watch state's error type.
+func watchErrors(errs []errorOutput) []ui.RunWatchError {
+	out := make([]ui.RunWatchError, 0, len(errs))
+	for _, e := range errs {
+		out = append(out, ui.RunWatchError{Type: e.Type, Message: e.Message})
+	}
+	return out
 }
 
 // watchFingerprint summarises the statuses in a poll, so the non-interactive
@@ -528,11 +565,74 @@ func watchFinalResult(ctx context.Context, state ui.RunWatchState, runID uuid.UU
 	default:
 		iostream.ErrPrintf(ctx, "%s Run %s failed (%s)\n",
 			iostream.SymbolFail(ctx), runID, ui.FormatElapsed(elapsed))
-		return clierrors.New("run.failed", "Run failed",
-			fmt.Sprintf("Run %s failed.", runID)).
-			WithSuggestions(failedJobLogSuggestions(state)...).
-			WithExitCode(clierrors.ExitGeneralError)
+		return clierrors.New("run.failed", "Run failed", runFailureMessage(runID, state)).
+			WithSuggestions(runFailureSuggestions(state)...).
+			WithExitCode(runFailureExitCode(state))
 	}
+}
+
+// runFailureMessage explains a finished run that did not succeed. A run's own
+// errors carry the explanation when it has any: they are the failures that belong
+// to the run rather than to one of its jobs, and the case that arrives here with
+// nothing else to show is a dynamic-config run whose continued config was
+// rejected — its setup workflow succeeded, no job failed, and the API reports the
+// run itself as succeeded, so the error it carries is the only account of what
+// went wrong.
+func runFailureMessage(runID uuid.UUID, state ui.RunWatchState) string {
+	var b strings.Builder
+	_, _ = fmt.Fprintf(&b, "Run %s failed.", runID)
+	for _, e := range state.Errors {
+		_, _ = fmt.Fprintf(&b, "\n\n%s", runErrorLine(e))
+	}
+	return b.String()
+}
+
+// runErrorLine renders one run error as "<type> error: <message>", or as the
+// message alone when the API gave the error no type.
+func runErrorLine(e ui.RunWatchError) string {
+	msg := strings.TrimSpace(e.Message)
+	if e.Type == "" {
+		return "error: " + msg
+	}
+	return e.Type + " error: " + msg
+}
+
+// runFailureSuggestions is what to do next about a failed run: validate the
+// config behind a config error — which for a dynamic-config run is the config the
+// setup workflow generated, not the one in the repository — and then fetch the
+// logs of each failed job.
+func runFailureSuggestions(state ui.RunWatchState) []string {
+	var suggestions []string
+	if hasConfigError(state) {
+		suggestions = append(suggestions,
+			"Validate the config locally: circleci config validate .circleci/config.yml",
+			"For dynamic config, validate the config the setup job generates, not .circleci/config.yml",
+		)
+	}
+	return append(suggestions, failedJobLogSuggestions(state)...)
+}
+
+// runFailureExitCode separates a run the platform would not accept from one that
+// ran and failed. A config error means nothing was wrong with the run's jobs —
+// there was no valid config to build them from — so it exits like the other
+// validation failures in the CLI rather than as a general error.
+func runFailureExitCode(state ui.RunWatchState) int {
+	if hasConfigError(state) && len(state.FailedJobs()) == 0 {
+		return clierrors.ExitValidationFail
+	}
+	return clierrors.ExitGeneralError
+}
+
+// hasConfigError reports whether any of the run's own errors is a config error —
+// the type the API attaches to a config it would not compile, including the
+// continued config of a dynamic-config run.
+func hasConfigError(state ui.RunWatchState) bool {
+	for _, e := range state.Errors {
+		if e.Type == "config" {
+			return true
+		}
+	}
+	return false
 }
 
 // failedJobLogSuggestions builds one runnable suggestion per failed job. The

--- a/internal/cmd/run/watch_test.go
+++ b/internal/cmd/run/watch_test.go
@@ -29,6 +29,7 @@ import (
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 
+	clierrors "github.com/CircleCI-Public/circleci-cli/clikit/errors"
 	"github.com/CircleCI-Public/circleci-cli/internal/ui"
 )
 
@@ -94,8 +95,8 @@ func TestFailedJobLogSuggestions(t *testing.T) {
 
 // TestWatchState verifies the adapter from a polled run to the watch table's
 // rows: statuses come from the emoji-free symbol/word pair, a failed job is
-// flagged for --failfast, and the run only reads as done once every workflow has
-// ended.
+// flagged for --failfast, and the run reads as done when the run itself has
+// ended — not when its workflows have.
 func TestWatchState(t *testing.T) {
 	jobID := uuid.MustParse("d0000000-0000-4000-8000-00000000f001")
 
@@ -119,7 +120,7 @@ func TestWatchState(t *testing.T) {
 	})
 
 	t.Run("flags a failed job and the run's outcome", func(t *testing.T) {
-		state := watchState(runGetOutput{Workflows: []workflowOutput{{
+		state := watchState(runGetOutput{Phase: "ended", CurrentOutcome: "failed", Workflows: []workflowOutput{{
 			Name: "build", Phase: "ended", Outcome: "failed",
 			Jobs: []jobOutput{{ID: jobID, Name: "test", Phase: "ended", Outcome: "failed"}},
 		}}})
@@ -130,11 +131,94 @@ func TestWatchState(t *testing.T) {
 	})
 
 	t.Run("is not done while a workflow is still running", func(t *testing.T) {
-		state := watchState(runGetOutput{Workflows: []workflowOutput{
+		state := watchState(runGetOutput{Phase: "started", Workflows: []workflowOutput{
 			{Name: "build", Phase: "ended", Outcome: "succeeded"},
 			{Name: "deploy", Phase: "started"},
 		}})
 
 		assert.Check(t, !state.Done)
+		assert.Check(t, !state.AllWorkflowsEnded)
+	})
+
+	t.Run("is not done while the run is going, however its workflows ended", func(t *testing.T) {
+		// A dynamic-config run between its setup workflow ending and the continued
+		// workflow appearing. Stopping here is what reported the setup workflow's
+		// success as the whole run's.
+		state := watchState(runGetOutput{Phase: "started", Workflows: []workflowOutput{
+			{Name: "setup", Phase: "ended", Outcome: "succeeded"},
+		}})
+
+		assert.Check(t, !state.Done)
+		assert.Check(t, state.AllWorkflowsEnded)
+	})
+
+	t.Run("is done once the run has ended, with no workflows at all", func(t *testing.T) {
+		// A run whose config was rejected outright never produces a workflow, so a
+		// watch waiting on its workflows would wait until the timeout.
+		state := watchState(runGetOutput{Phase: "ended", CurrentOutcome: "errored"})
+
+		assert.Check(t, state.Done)
+		assert.Check(t, !state.AllWorkflowsEnded)
+	})
+}
+
+// TestWatchStateRunErrors covers the dynamic-config run whose continued config
+// was rejected: the setup workflow succeeded, no job failed, and the API reports
+// the run itself as succeeded — the error it carries is the only sign that the
+// run did not do what the config asked.
+func TestWatchStateRunErrors(t *testing.T) {
+	rejected := runGetOutput{
+		Phase:          "ended",
+		CurrentOutcome: "succeeded",
+		Errors: []errorOutput{{
+			Type:    "config",
+			Message: "Error calling workflow: 'deploy'\nCannot find a definition for job named release",
+		}},
+		Workflows: []workflowOutput{{Name: "setup", Phase: "ended", Outcome: "succeeded"}},
+	}
+
+	t.Run("the run's errors are carried into the watch state", func(t *testing.T) {
+		state := watchState(rejected)
+
+		assert.Assert(t, is.Len(state.Errors, 1))
+		assert.Check(t, is.Equal(state.Errors[0].Type, "config"))
+		assert.Check(t, is.Contains(state.Errors[0].Message, "Cannot find a definition for job named release"))
+	})
+
+	t.Run("a run carrying errors did not succeed", func(t *testing.T) {
+		assert.Check(t, is.Equal(watchState(rejected).Outcome, "failed"))
+	})
+
+	t.Run("the error is the message, since no job failed", func(t *testing.T) {
+		runID := uuid.MustParse("f0000000-0000-4000-8000-00000000f001")
+		msg := runFailureMessage(runID, watchState(rejected))
+
+		assert.Check(t, is.Contains(msg, "Run "+runID.String()+" failed."))
+		assert.Check(t, is.Contains(msg, "config error: Error calling workflow: 'deploy'"))
+	})
+
+	t.Run("a rejected config exits as a validation failure", func(t *testing.T) {
+		assert.Check(t, is.Equal(runFailureExitCode(watchState(rejected)), clierrors.ExitValidationFail))
+	})
+
+	t.Run("a config error alongside a failed job stays a general error", func(t *testing.T) {
+		withFailedJob := rejected
+		withFailedJob.Workflows = append(withFailedJob.Workflows, workflowOutput{
+			Name: "build", Phase: "ended", Outcome: "failed",
+			Jobs: []jobOutput{{Name: "test", Phase: "ended", Outcome: "failed"}},
+		})
+
+		assert.Check(t, is.Equal(runFailureExitCode(watchState(withFailedJob)), clierrors.ExitGeneralError))
+	})
+
+	t.Run("a run with no errors is described by its outcome alone", func(t *testing.T) {
+		runID := uuid.MustParse("f0000000-0000-4000-8000-00000000f001")
+		state := watchState(runGetOutput{
+			Phase: "ended", CurrentOutcome: "failed",
+			Workflows: []workflowOutput{{Name: "build", Phase: "ended", Outcome: "failed"}},
+		})
+
+		assert.Check(t, is.Equal(runFailureMessage(runID, state), "Run "+runID.String()+" failed."))
+		assert.Check(t, is.Equal(runFailureExitCode(state), clierrors.ExitGeneralError))
 	})
 }

--- a/internal/ui/run_watch_flow.go
+++ b/internal/ui/run_watch_flow.go
@@ -97,15 +97,35 @@ type RunWatchWorkflow struct {
 	Jobs     []RunWatchJob
 }
 
-// RunWatchState is one poll's worth of run state: the rows to draw, whether
-// every workflow has reached a terminal phase, and the run's derived display
-// status once it has. Like the run-get item types this mirrors what the API
-// client returns rather than embedding it, keeping this package independent of
+// RunWatchError is one error the run carries in its own right, rather than the
+// outcome of a job: a config that would not compile, or a dynamic-config
+// continuation whose config was rejected. The flow does not draw these — they
+// are read off the final state by the caller, which prints them with the summary
+// once the run is over.
+type RunWatchError struct {
+	Type    string
+	Message string
+}
+
+// RunWatchState is one poll's worth of run state: the rows to draw, the run's
+// own errors, whether the run has finished, and its derived display status once
+// it has. Like the run-get item types this mirrors what the API client returns
+// rather than embedding it, keeping this package independent of
 // internal/apiclient — the caller's Fetch callback does the conversion.
+//
+// Done is about the run, not its workflows: AllWorkflowsEnded says the workflows
+// are finished, which is a weaker thing (see pendingNote).
 type RunWatchState struct {
 	Workflows []RunWatchWorkflow
+	Errors    []RunWatchError
 	Done      bool
-	Outcome   string
+
+	// AllWorkflowsEnded reports that every workflow the run has produced so far
+	// has reached a terminal phase — true of a dynamic-config run waiting on its
+	// continuation, which is not done.
+	AllWorkflowsEnded bool
+
+	Outcome string
 }
 
 // FailedJobs returns every job across every workflow whose outcome is a failure,
@@ -457,6 +477,9 @@ func (m RunWatchFlowModel) buildView() tea.View {
 			b.WriteString(m.line(m.jobRow(j)))
 		}
 	}
+	if note := m.pendingNote(); note != "" {
+		b.WriteString(m.line("  " + note))
+	}
 	if footer := m.footer(); footer != "" {
 		b.WriteString("\n" + footer)
 	}
@@ -476,6 +499,19 @@ func (m RunWatchFlowModel) header() string {
 		scope = theme.SecondaryStyle.Render(scope)
 	}
 	return title + " " + scope
+}
+
+// pendingNote explains a table that looks finished but is not: every workflow the
+// run has produced so far has ended, and the run is still going. That is what a
+// dynamic-config run looks like between its setup workflow ending and the
+// continued workflow appearing — and if the continued config is rejected, the
+// rows never change again, so without this line a watch that is right to keep
+// waiting looks stuck on a finished table.
+func (m RunWatchFlowModel) pendingNote() string {
+	if m.done || !m.state.AllWorkflowsEnded {
+		return ""
+	}
+	return m.muted("All workflows have ended; waiting for the run itself to finish.")
 }
 
 // footer is the elapsed clock and the key hints, with a spinner leading them

--- a/internal/ui/run_watch_flow_test.go
+++ b/internal/ui/run_watch_flow_test.go
@@ -198,6 +198,32 @@ func TestRunWatchFlow_Table(t *testing.T) {
 	})
 }
 
+// TestRunWatchFlow_PendingNote confirms the table says why it is still being
+// watched once every workflow has ended — the state a dynamic-config run sits in
+// between its setup workflow ending and the continued workflow appearing, where
+// nothing on screen moves again until the run itself ends.
+func TestRunWatchFlow_PendingNote(t *testing.T) {
+	t.Run("shown while the run outlives its workflows", func(t *testing.T) {
+		state := doneState()
+		state.Done = false
+		state.AllWorkflowsEnded = true
+		fetch, _ := fetchStatic(state)
+		tm := startWatch(t, ui.RunWatchFlowOptions{Branch: "main", Fetch: fetch})
+
+		waitForOutput(t, tm, "All workflows have ended")
+		assert.Check(t, cmp.Contains(flowSnapshot(t, tm),
+			"All workflows have ended; waiting for the run itself to finish."))
+	})
+
+	t.Run("absent while a workflow is still going", func(t *testing.T) {
+		fetch, _ := fetchStatic(runningState())
+		tm := startWatch(t, ui.RunWatchFlowOptions{Branch: "main", Fetch: fetch})
+
+		waitForOutput(t, tm, "build-and-test")
+		assert.Check(t, !strings.Contains(flowSnapshot(t, tm), "All workflows have ended"))
+	})
+}
+
 // TestRunWatchFlow_Footer confirms the footer reports elapsed time, when the next
 // poll lands, and the two live keys. The countdown is what makes the table read
 // as live between polls.


### PR DESCRIPTION
A dynamic-config run whose continued config is rejected looked like a success: `run watch` printed the setup workflow's green tick, exited 0, and never mentioned the validation error.

Reproduced on a real project by injecting a workflow that references an undefined job into the config the setup job generates. Before:

```
[1s]  setup=running
[17s]  setup=succeeded
✓ Run fe91ea10-a813-4e27-bdb8-632d394f54ae succeeded (17s)     exit=0
```

The API's account of that run explains it — the setup workflow did succeed, no job failed, and the rejection is recorded only in the run's own `errors`, which the watch path never read:

```json
{"phase":"ended","current_outcome":"succeeded",
 "errors":[{"type":"config","message":"Error calling workflow: 'invalid-continued-workflow'\nCannot find a definition for job named no-such-job-exists"}]}
```

After, on the same run:

```
[0s]  setup=succeeded
✗ Run fe91ea10-a813-4e27-bdb8-632d394f54ae failed (0s)
error: Run fe91ea10-a813-4e27-bdb8-632d394f54ae failed.

config error: Error calling workflow: 'invalid-continued-workflow'
Cannot find a definition for job named no-such-job-exists

Suggestions:
  • Validate the config locally: circleci config validate .circleci/config.yml
  • For dynamic config, validate the config the setup job generates, not .circleci/config.yml
exit=7
```

## What changed

- **The run's phase is the one authority on when the watch is over**, not its workflows. A run still going is still watched however its workflows ended — the state a dynamic-config run sits in between the setup workflow ending and the continued workflow appearing — and a run that ended without producing a workflow at all no longer waits out the timeout.
- **The run's errors are carried into the watch state** and printed with the failure. A config error exits 7 (`ExitValidationFail`) unless a job failed too, in which case it stays 1; `--help` documents it.
- **`run get`** reports such a run as failed rather than passing on the workflow-derived "succeeded".
- **`run get --failure-report`** leads with a `## run errors` section. It printed nothing at all for these runs before — a rejected config has no failed step to condense — which is the worst version of this for an agent.
- **The live table and the CI log** say why a finished-looking table is still being watched, so the legitimate wait does not read as a hang.

## Verification

Beyond the unit, flow and acceptance tests added here, both paths were checked against the real project: the rejected-continuation run reports as above, and the healthy dynamic run still follows its continuation through (`setup=succeeded` → `no-op workflow=running` → `succeeded`, exit 0) with no added waiting.

Not covered: `run list`'s table still shows `✅ succeeded` for one of these runs, since it drops `errors` entirely (its interactive picker does show them as the row description). Same defect class, separate change.
