### PR TITLE
Fix --next: send should_preview_next, not enable_next_preview

### DIFF
--- a/acceptance/config_test.go
+++ b/acceptance/config_test.go
@@ -583,7 +583,7 @@ func TestConfigValidate_UsesV3Compile(t *testing.T) {
 	attrs, _ := data["attributes"].(map[string]any)
 	assert.Assert(t, attrs != nil)
 	assert.Check(t, cmp.Equal(attrs["config"], testConfigYAML))
-	assert.Check(t, cmp.Equal(attrs["enable_next_preview"], true))
+	assert.Check(t, cmp.Equal(attrs["should_preview_next"], true))
 	_, hasValues := attrs["pipeline_values"]
 	assert.Check(t, hasValues, "expected locally fabricated pipeline_values")
 	assert.Check(t, cmp.DeepEqual(data["references"], map[string]any{

--- a/internal/apiclient/config.go
+++ b/internal/apiclient/config.go
@@ -74,7 +74,7 @@ type compileV3Data struct {
 
 type compileV3Attributes struct {
 	Config             string         `json:"config"`
-	EnableNextPreview  bool           `json:"enable_next_preview,omitempty"`
+	ShouldPreviewNext  bool           `json:"should_preview_next,omitempty"`
 	PipelineParameters map[string]any `json:"pipeline_parameters,omitempty"`
 	PipelineValues     map[string]any `json:"pipeline_values,omitempty"`
 }
@@ -120,7 +120,7 @@ func (c *Client) Compile(ctx context.Context, in CompileInput) (*CompileResult, 
 		Data: compileV3Data{
 			Attributes: compileV3Attributes{
 				Config:             in.ConfigYAML,
-				EnableNextPreview:  in.PreviewNext,
+				ShouldPreviewNext:  in.PreviewNext,
 				PipelineParameters: in.PipelineParameters,
 				PipelineValues:     in.PipelineValues,
 			},

--- a/internal/apiclient/config_test.go
+++ b/internal/apiclient/config_test.go
@@ -93,7 +93,7 @@ func TestClient_Compile(t *testing.T) {
 			"data": map[string]any{
 				"attributes": map[string]any{
 					"config":              "version: 2.1",
-					"enable_next_preview": true,
+					"should_preview_next": true,
 				},
 				"references": map[string]any{
 					"org": map[string]any{"id": testCompileOrgID},


### PR DESCRIPTION
<!--
  Thank you for contributing to CircleCI CLI!

  For PRs adding new features, please raise an issue first.

  Squash your commits before requesting review and before merging.
-->

## What

`config validate --next` and `config process --next` silently stopped enabling preview-next behavior after #1713 moved these commands onto the v3 compile endpoint. The request sends the flag as `enable_next_preview`, but the server expects `should_preview_next`. Because the unrecognized field is silently dropped rather than rejected, the request still succeeds — it just never enables preview-next.

This renames the CLI's request field to `should_preview_next` to match what the server actually expects, and updates the two tests that pinned the wrong field name.

## Test plan

- [x] `go test ./internal/apiclient/...` passes
- [x] `go test ./acceptance/... -run 'TestConfigValidate_UsesV3Compile|TestConfigValidate_InvalidOnV3'` passes, and the recorded request body now carries `should_preview_next`
- [x] Manually verified against the live compile endpoint on circleci.com with curl, using a config whose `matches` pattern has a regex backreference (`(.+)\1`) — valid under the default regex engine, rejected only under preview-next:
  - No preview flag → succeeded
  - `should_preview_next: true` → failed, invalid regular expression
  - `enable_next_preview: true` (old field name) → succeeded, confirming it was being silently ignored and reproducing the bug this PR fixes