### PR TITLE
Drop GitHub from the onboard preamble

### DIFF
--- a/internal/onboarder/onboarder.go
+++ b/internal/onboarder/onboarder.go
@@ -824,7 +824,7 @@ func displayPreamble(ctx context.Context, dir string) error {
 		[]string{
 			"Generate a starter .circleci/config.yml",
 			"Sign you up for CircleCI",
-			"Create your project and connect it to GitHub",
+			"Create your project and connect your repository",
 			"Set up your first pipeline trigger",
 		},
 	)


### PR DESCRIPTION
`circleci onboard` opens with a confirmation gate listing what the run will do, and the third bullet named GitHub:

```
circleci onboard will:
  • Generate a starter .circleci/config.yml
  • Sign you up for CircleCI
  • Create your project and connect it to GitHub
  • Set up your first pipeline trigger
```

That bullet is wrong for any repository not hosted on GitHub. It also cannot be made right in place: the preamble is a gate that runs *before* the checkout's remote is read (`displayPreamble` runs from `Run`, while `detectRemote` is not reached until `postSignupGuidance`), so at that point the CLI does not yet know which integration the repository connects through.

So the bullet is now generic:

```
  • Create your project and connect your repository
```

The provider is still named later, where it is actually known ("Opening your browser to install the CircleCI GitHub App...", "GitHub App installed").

This was the only hardcoded provider name in the onboard path's user-facing output; the remaining `GitHub` references there are the internal `cmdutil.GitHubAppInstalledURL` helper and provider values that come back from the API.

## Testing

No golden file pinned the old string, so none changed. `task check` and `task test` pass; the onboard suite (`-run TestOnboard`, 36 tests) passes. The preamble only renders in an interactive session, so it is not covered by the acceptance tests.