### PR TITLE
Add consent-gated page analytics to the website

### DIFF
--- a/docs/website/assets/js/analytics.js
+++ b/docs/website/assets/js/analytics.js
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2026 Circle Internet Services, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/* Segment page tracking. Injected by layouts/partials/analytics.html into a
+   type="text/plain" data-cookieconsent="statistics" script tag, so Cookiebot
+   runs this only after the visitor grants statistics consent — see that partial
+   for the full rationale. Values are supplied by the partial's template
+   execution and arrive here already quoted. */
+if (
+  /* Artifact previews and local mirrors of this build are not the tracked site. */
+  location.hostname === {{ .host }} &&
+  !navigator.webdriver &&
+  !/bot|crawl|spider|slurp|headless|preview|monitor|scan|lighthouse/i.test(navigator.userAgent)
+) {
+  /* Segment analytics.js snippet v5.2.1, verbatim from the vendor. It opens a
+     block that the load/page calls below sit inside; `}}();` closes it. */
+  !function(){var i="analytics",analytics=window[i]=window[i]||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","screen","once","off","on","addSourceMiddleware","addIntegrationMiddleware","setAnonymousId","addDestinationMiddleware","register"];analytics.factory=function(e){return function(){if(window[i].initialized)return window[i][e].apply(window[i],arguments);var n=Array.prototype.slice.call(arguments);if(["track","screen","alias","group","page","identify"].indexOf(e)>-1){var c=document.querySelector("link[rel='canonical']");n.push({__t:"bpc",c:c&&c.getAttribute("href")||void 0,p:location.pathname,u:location.href,s:location.search,t:document.title,r:document.referrer})}n.unshift(e);analytics.push(n);return analytics}};for(var n=0;n<analytics.methods.length;n++){var key=analytics.methods[n];analytics[key]=analytics.factory(key)}analytics.load=function(key,n){var t=document.createElement("script");t.type="text/javascript";t.async=!0;t.setAttribute("data-global-segment-analytics-key",i);t.src="https://cdn.segment.com/analytics.js/v1/" + key + "/analytics.min.js";var r=document.getElementsByTagName("script")[0];r.parentNode.insertBefore(t,r);analytics._loadOptions=n};analytics._writeKey={{ .writeKey }};;analytics.SNIPPET_VERSION="5.2.1";
+
+  /* Statistics consent alone must not release an advertising destination.
+     Segment's core cascades its bundled device-mode destinations when it loads,
+     and the ad destination is one of them, so withhold it unless marketing
+     consent was granted too. Segment reads this once at load and cannot be
+     reconfigured afterwards, so a later marketing grant applies on the next
+     page load. */
+  var marketingGranted = !!(window.Cookiebot && Cookiebot.consent && Cookiebot.consent.marketing);
+  analytics.load({{ .writeKey }}, marketingGranted ? {} : { integrations: { AdWords: false } });
+
+  /* Property names match the page events the web app sends, snake_cased, so
+     both can be reported on with one set of definitions. */
+  analytics.page({{ .pageName }}, {
+    action: "viewed",
+    page_type: "outer",
+    page_name: {{ .pageName }},
+    team_name: "webex",
+    path: location.pathname,
+    referrer: document.referrer,
+    search: location.search,
+    title: document.title,
+    url: location.href,
+    window_width: window.innerWidth,
+    window_height: window.innerHeight
+  });
+  }}();
+}

--- a/docs/website/hugo.toml
+++ b/docs/website/hugo.toml
@@ -55,3 +55,11 @@ disableKinds = ["taxonomy", "term", "RSS", "404"]
 # Single page for now — only emit HTML for the home page.
 [outputs]
   home = ["HTML"]
+
+# Consent banner and analytics source, shared with circleci.com and its docs so
+# events land in one place. Both are public client-side identifiers, not secrets
+# (see layouts/partials/analytics.html). Blank either one to switch that script
+# off; only production builds of the baseURL host emit them at all.
+[params.analytics]
+  cookiebotId = "a28b71f3-4d2e-4eac-93bc-34929948dd7d"
+  segmentWriteKey = "AbgkrgN4cbRhAVEwlzMkHbwvrXnxHh35"

--- a/docs/website/layouts/_default/baseof.html
+++ b/docs/website/layouts/_default/baseof.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  {{ partial "analytics.html" . }}
   <title>{{ block "title" . }}CircleCI CLI{{ end }}</title>
   <meta name="description" content="{{ block "description" . }}Command reference and documentation for the CircleCI CLI.{{ end }}">
   <link rel="alternate" type="text/markdown" href="{{ block "llms_href" . }}llms.txt{{ end }}" title="Markdown for LLMs">

--- a/docs/website/layouts/partials/analytics.html
+++ b/docs/website/layouts/partials/analytics.html
@@ -1,0 +1,82 @@
+{{- /* Cookie consent (Cookiebot) + a Segment page event. The tracking code
+       itself is assets/js/analytics.js; this partial supplies its values and
+       wraps it in a consent-gated script tag.
+
+       Cookiebot runs in MANUAL blocking mode and the tracking script is marked
+       type="text/plain" with data-cookieconsent, so Cookiebot rewrites and runs
+       it only once the visitor grants statistics consent. Manual mode is
+       deliberate — Cookiebot's automatic mode gates only what it recognises by
+       signature, which left this snippet ungated in testing, and it has blanked
+       pages elsewhere by intercepting first-party scripts. Please do not switch
+       it to "auto".
+
+       Because the gate is the tag markup and not load order, uc.js can load
+       async: a text/plain script waits to be rewritten however late Cookiebot
+       arrives, so nothing blocks first render.
+
+       Tagging the script this way also makes it fail safe: a text/plain script
+       can only run if Cookiebot rewrites it, so if Cookiebot never initialises
+       nothing is collected, rather than collecting without consent.
+
+       Neither key is a secret — a Segment write key is a public client-side
+       identifier, and both are already served in circleci.com's HTML. They live
+       in hugo.toml so a built site always carries them.
+
+       Emitted only for a production build served from the baseURL host, so
+       `hugo server`, CI artifact previews and forks stay silent instead of
+       writing noise into the production analytics source.
+
+       PREREQUISITE: the site's domain must be configured in Cookiebot. Until it
+       is, no consent banner renders and, per the fail-safe above, nothing is
+       collected. */ -}}
+
+{{- if hugo.IsProduction -}}
+  {{- $cookiebotId := "" -}}
+  {{- $writeKey := "" -}}
+  {{- with site.Params.analytics -}}
+    {{- $cookiebotId = .cookiebotId | default "" -}}
+    {{- $writeKey = .segmentWriteKey | default "" -}}
+  {{- end -}}
+
+  {{- with $cookiebotId }}
+  <script id="Cookiebot" src="https://consent.cookiebot.com/uc.js" data-cbid="{{ . }}" data-blockingmode="manual" type="text/javascript" async></script>
+  {{- end }}
+
+  {{- with $writeKey -}}
+    {{- /* Page names are kebab-case: "cli-home", "cli-reference". Values are
+           jsonify'd so they reach the JS already quoted — the script body is
+           emitted as safeHTML, because Go's template escaper rejects a
+           text/plain script body, so nothing else quotes them. */ -}}
+    {{- $pageName := cond $.IsHome "cli-home" (printf "cli-%s" (path.Base $.RelPermalink)) -}}
+    {{- /* These values are interpolated into an inline script that is emitted
+           with safeHTML, so a "<" in any of them could close the script tag
+           early and escape into HTML. Escaping it is not durable — a "\u003c"
+           is decoded straight back to "<" by the JS minifier below, which is a
+           legal JS transformation that happens to be unsafe when the JS is
+           inline. So reject the character outright: every value here comes from
+           repo config or a page path today, and a build failure is a better
+           answer than a silently unsafe page if that ever changes. */ -}}
+    {{- $host := (urls.Parse site.BaseURL).Hostname -}}
+    {{- range (slice $writeKey $pageName $host) -}}
+      {{- if strings.Contains . "<" -}}
+        {{- errorf "analytics.html: %q contains \"<\", which could close the inline script tag" . -}}
+      {{- end -}}
+    {{- end -}}
+    {{- $context := dict
+      "writeKey" ($writeKey | jsonify)
+      "pageName" ($pageName | jsonify)
+      "host" ($host | jsonify) -}}
+    {{- with resources.Get "js/analytics.js" -}}
+      {{- /* The target path is per-page on purpose: it is the cache key for the
+             executed template, so a constant name would serve the first page's
+             page_name to every other page. Nothing is published — only
+             .Content is read — so these names never reach the built site.
+
+             Minified here rather than by the site-wide --minify pass, which
+             skips scripts whose type it does not recognise as JS. */ -}}
+      {{- $target := printf "js/analytics-%s.js" $pageName -}}
+      {{- $js := . | resources.ExecuteAsTemplate $target $context | minify -}}
+      {{- printf `<script type="text/plain" data-cookieconsent="statistics">%s</script>` $js.Content | safeHTML }}
+    {{- end -}}
+  {{- end }}
+{{- end -}}


### PR DESCRIPTION
## What

The website collects no analytics today, so there is no view of traffic to it. This adds a Cookiebot consent banner and a single Segment page event, using the same analytics source as `circleci.com`.

- `docs/website/assets/js/analytics.js` — the tracking script: loads Segment and sends one `page` event
- `docs/website/layouts/partials/analytics.html` — supplies its values and wraps it in a consent-gated script tag
- `docs/website/layouts/_default/baseof.html` — loads the partial in `<head>`
- `docs/website/hugo.toml` — the Cookiebot ID and Segment write key, both public client-side identifiers

## How consent works

Cookiebot runs in **manual** blocking mode and the tracking script is tagged `type="text/plain" data-cookieconsent="statistics"`, so Cookiebot rewrites and runs it only once the visitor grants statistics consent.

Manual mode is deliberate: automatic mode gates only what Cookiebot recognises by signature — it left this snippet ungated in testing — and it can blank pages by intercepting first-party scripts. Explicit tagging is deterministic, and it fails safe, because a `text/plain` script can only run if Cookiebot rewrites it. If Cookiebot never initialises, nothing is collected rather than being collected ungated. It also means `uc.js` can load `async` without a render-blocking cost, since the gate is the markup and not load order.

The advertising destination is withheld unless marketing consent is granted too, since Segment's core would otherwise cascade it on load under statistics-only consent.

## Safety

The script body is emitted as `safeHTML`, because Go's template escaper rejects a `text/plain` script body. Any interpolated value containing `<` could therefore close the tag early, and escaping it is not durable — the JS minifier decodes `<` straight back to `<`. The build therefore **fails** if any of these values contains `<`:

```
ERROR analytics.html: "…" contains "<", which could close the inline script tag
ERROR error building site: logged 1 error(s)
```

## Scope

The scripts are emitted only for a production build served from the `baseURL` host, so `hugo server`, CI artifact previews and forks send nothing.

## Verified

- Before consent, the script stays `text/plain` and no Segment request is made; after consent it becomes `text/javascript` and Segment loads
- Page names are per page — `cli-home` and `cli-reference` — checked against the CI-built artifact, not just a local build
- A value containing `</script>` fails the build; publishing is gated on that build passing
- The site's own scripts are untouched, since manual mode only acts on tagged scripts