### PR TITLE
Send CircleCI-Caller header from condensed step output CLI commands

### DIFF
--- a/internal/apiclient/job.go
+++ b/internal/apiclient/job.go
@@ -411,14 +411,20 @@ func (c *Client) GetJobStdout(ctx context.Context, jobID uuid.UUID, execution, s
 // GetJobStdoutCondensed fetches a step's stdout condensed to its most
 // error-relevant lines (noisy/repetitive output filtered out server-side).
 // The endpoint returns raw text (octet-stream).
-func (c *Client) GetJobStdoutCondensed(ctx context.Context, jobID uuid.UUID, execution, stepNum int) ([]byte, error) {
+// caller identifies the CLI flow making the request (e.g. "circleci-cli/job-output-get");
+// when non-empty it is forwarded as CircleCI-Caller so llmops-service can attribute usage.
+func (c *Client) GetJobStdoutCondensed(ctx context.Context, jobID uuid.UUID, execution, stepNum int, caller string) ([]byte, error) {
 	var output []byte
-	_, err := c.main.Call(ctx, httpcl.NewRequest(http.MethodGet, "/api/v3/jobs/%s/stdout/condensed",
+	opts := []func(*httpcl.Request){
 		httpcl.RouteParams(jobID),
 		filterParam("execution", strconv.Itoa(execution)),
 		filterParam("step_num", strconv.Itoa(stepNum)),
 		httpcl.BytesDecoder(&output),
-	))
+	}
+	if caller != "" {
+		opts = append(opts, httpcl.Header("CircleCI-Caller", caller))
+	}
+	_, err := c.main.Call(ctx, httpcl.NewRequest(http.MethodGet, "/api/v3/jobs/%s/stdout/condensed", opts...))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cmd/job/output_get.go
+++ b/internal/cmd/job/output_get.go
@@ -164,7 +164,7 @@ func writeOutput(out io.Writer, b []byte, strip bool) {
 }
 
 func runOutputGetCondensed(ctx context.Context, client *apiclient.Client, jobID uuid.UUID, execution, stepNum int) error {
-	condensed, err := client.GetJobStdoutCondensed(ctx, jobID, execution, stepNum)
+	condensed, err := client.GetJobStdoutCondensed(ctx, jobID, execution, stepNum, "circleci-cli/job-output-get")
 	if err != nil {
 		subject := fmt.Sprintf("step %d of job %s", stepNum, jobID)
 		return cmdutil.APIErr(err, subject, "job.output_not_found",

--- a/internal/cmd/run/failed_context.go
+++ b/internal/cmd/run/failed_context.go
@@ -116,7 +116,7 @@ func runFailureReport(ctx context.Context, client *apiclient.Client, r *apiclien
 						fmt.Fprintf(&out, "#### step %d: %s\n\n", step.Num, step.Name)
 					}
 
-					condensed, err := client.GetJobStdoutCondensed(ctx, j.ID, fe.exec.Index, step.Num)
+					condensed, err := client.GetJobStdoutCondensed(ctx, j.ID, fe.exec.Index, step.Num, "circleci-cli/run-get-failure-report")
 					if err != nil {
 						if httpcl.HasStatusCode(err, http.StatusNotFound) {
 							condensed = nil


### PR DESCRIPTION
## Summary

- `GetJobStdoutCondensed()` now accepts a `caller string` parameter and sets it as the `CircleCI-Caller` request header when non-empty
- `job output get --condensed` sends `circleci-cli/job-output-get`
- `run get --failure-report` sends `circleci-cli/run-get-failure-report`

llmops-service already reads this header on the `GET /api/v3/jobs/:id/stdout/condensed` endpoint and forwards it as `source` in the `api-step-output-condensed` Segment event. Until now that field was always blank for CLI calls — CLI usage was indistinguishable from web or direct API calls in analytics. public-api-service proxies this route with `httputil.ReverseProxy` which forwards all headers verbatim, so no changes are needed outside the CLI.

Closes CF2-907

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./internal/apiclient/... ./internal/cmd/job/... ./internal/cmd/run/...` passes
- [ ] Verify `CircleCI-Caller` header appears in an HTTP trace against a real or fake server for both flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)