### PR TITLE
Add Origin support to onboard

### DIFF
--- a/acceptance/onboard_test.go
+++ b/acceptance/onboard_test.go
@@ -832,7 +832,7 @@ func TestOnboard_PostSignup_GitHubAppInstall_ReturnURL(t *testing.T) {
 
 	assert.Assert(t, cmp.Len(returnURLs, 1))
 	assert.Check(t, strings.HasSuffix(returnURLs[0], "/cli/github-app-installed"),
-		"return_url should land on the page that points back at the terminal, got %q", returnURLs[0])
+		"return_url should land on the page that names the integration and points back at the terminal, got %q", returnURLs[0])
 	assert.Check(t, !strings.Contains(returnURLs[0], "/pipelines/"),
 		"the project's pipelines page reads as a finish line in the browser, got %q", returnURLs[0])
 }
@@ -1055,6 +1055,66 @@ func normalizeOnboardOutput(stdout, dir string) string {
 	stdout = strings.ReplaceAll(stdout, dir, "<DIR>")
 	stdout = strings.ReplaceAll(stdout, `\`, `/`)
 	return stdout
+}
+
+// TestOnboard_PostSignup_FirstPipeline_ResolvesRepoOnSecondProvider pins that the
+// integration comes from the checkout's remote rather than being assumed.
+//
+// The remote is on a host a different integration owns, so every provider-shaped
+// value has to follow from it: the connection that is checked, the repository list
+// that is searched, and the provider written into the pipeline definition and
+// trigger.
+func TestOnboard_PostSignup_FirstPipeline_ResolvesRepoOnSecondProvider(t *testing.T) {
+	dir, fake, env := onboardRepoWithRemote(t, "https://origin.cursor.com/circleci/soc-test-repo.git")
+
+	fake.SetProviderConnected(onboardOrgID, "origin", true)
+	fake.AddProviderRepository(onboardOrgID, fakes.ProviderRepo{
+		ID:            "repo_01fake",
+		RepoFullName:  "circleci/soc-test-repo",
+		RepoName:      "soc-test-repo",
+		Owner:         "circleci",
+		DefaultBranch: "main",
+		Provider:      "origin",
+	})
+	addFirstPipelineResponses(fake)
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"onboard", "--scan"},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Check(t, cmp.Contains(result.Stdout, "Found repository circleci/soc-test-repo"))
+	assert.Check(t, cmp.Contains(result.Stdout, "Pipeline definition created"))
+	assert.Check(t, cmp.Contains(result.Stdout, "Trigger created: all-pushes"))
+
+	t.Run("writes carry the remote's provider and repository", func(t *testing.T) {
+		var defBody, trigBody string
+		for _, req := range fake.AllRequests() {
+			if req.Method != http.MethodPost || req.Body == nil {
+				continue
+			}
+			switch req.URL.Path {
+			case "/api/v3/pipelines":
+				defBody = *req.Body
+			case "/api/v3/triggers":
+				trigBody = *req.Body
+			}
+		}
+
+		assert.Assert(t, defBody != "", "no pipeline definition was created")
+		assert.Check(t, strings.Contains(defBody, `"provider":"origin"`), "definition body: %s", defBody)
+		// The full name is load-bearing for an integration that addresses a
+		// repository by owner and name, so it has to travel on the write.
+		assert.Check(t, strings.Contains(defBody, `"repo_full_name":"circleci/soc-test-repo"`), "definition body: %s", defBody)
+		assert.Check(t, strings.Contains(defBody, `"repo_id":"repo_01fake"`), "definition body: %s", defBody)
+
+		assert.Assert(t, trigBody != "", "no trigger was created")
+		assert.Check(t, strings.Contains(trigBody, `"provider":"origin"`), "trigger body: %s", trigBody)
+		assert.Check(t, strings.Contains(trigBody, `"repo_full_name":"circleci/soc-test-repo"`), "trigger body: %s", trigBody)
+	})
 }
 
 // TestOnboard_PostSignup_FirstPipeline_UnclaimedHost pins that a remote no

--- a/internal/cmdutil/appurls.go
+++ b/internal/cmdutil/appurls.go
@@ -54,11 +54,12 @@ func RunSlugURL(appURL string, slug string) (string, error) {
 	), nil
 }
 
-// GitHubAppInstalledURL returns the page to send the browser to once a CircleCI
-// GitHub App install completes. It confirms the install and points the user back
-// at their terminal, where the rest of onboarding happens.
-func GitHubAppInstalledURL(appURL string) string {
-	return fmt.Sprintf("%s/cli/github-app-installed", appURL)
+// InstalledURL returns the page to send the browser to once an install completes.
+// It confirms the install and points the user back at their terminal, where the
+// rest of onboarding happens. path comes from the integration being installed;
+// see internal/provider.
+func InstalledURL(appURL, path string) string {
+	return fmt.Sprintf("%s/%s", appURL, path)
 }
 
 // RunURL returns the CircleCI pipelines page URL for the given project slug.

--- a/internal/cmdutil/appurls_test.go
+++ b/internal/cmdutil/appurls_test.go
@@ -64,9 +64,15 @@ func TestRunURL(t *testing.T) {
 	assert.Check(t, cmp.Equal(u, "https://app.circleci.com/pipeline/8cb37115-80a4-4af6-b377-eddd0f7c7167"))
 }
 
-func TestGitHubAppInstalledURL(t *testing.T) {
-	u := GitHubAppInstalledURL(testAppURL)
-	assert.Check(t, cmp.Equal(u, "https://app.circleci.com/cli/github-app-installed"))
+func TestInstalledURL(t *testing.T) {
+	// The path comes from the integration being installed, so each one lands on the
+	// page that names it.
+	assert.Check(t, cmp.Equal(
+		InstalledURL(testAppURL, "cli/github-app-installed"),
+		"https://app.circleci.com/cli/github-app-installed"))
+	assert.Check(t, cmp.Equal(
+		InstalledURL(testAppURL, "cli/origin-installed"),
+		"https://app.circleci.com/cli/origin-installed"))
 }
 
 func TestWorkflowURL(t *testing.T) {

--- a/internal/onboarder/onboarder.go
+++ b/internal/onboarder/onboarder.go
@@ -269,11 +269,7 @@ func postSignupGuidance(ctx context.Context, dir string, opts Options) error {
 		iostream.Printf(ctx, "  Pipelines: %s\n", pipelinesURL)
 	}
 
-	// Where the provider returns the browser after an install. Landing on the
-	// project's own page reads as a finish line, in the browser, while the rest of
-	// setup is still waiting back in the terminal.
-	returnURL := cmdutil.GitHubAppInstalledURL(appURL)
-	return setupFirstPipeline(ctx, client, returnURL, proj, remote, opts)
+	return setupFirstPipeline(ctx, client, appURL, proj, remote, opts)
 }
 
 // selectOrg picks the organization to create the project in, returning nil when
@@ -503,8 +499,8 @@ func writeProjectRef(ctx context.Context, workDir string, proj *apiclient.Projec
 // attempted, so onboard prints the next step and succeeds. A request the API
 // rejected is a real error: it leaves the project half-configured, and a definition
 // with no trigger will never build.
-func setupFirstPipeline(ctx context.Context, client *apiclient.Client, returnURL string, proj *apiclient.ProjectInfo, remote gitremote.RemoteRef, opts Options) error {
-	repoID, p := resolveRepoID(ctx, client, returnURL, proj, remote, opts)
+func setupFirstPipeline(ctx context.Context, client *apiclient.Client, appURL string, proj *apiclient.ProjectInfo, remote gitremote.RemoteRef, opts Options) error {
+	repoID, p := resolveRepoID(ctx, client, appURL, proj, remote, opts)
 	if repoID == "" {
 		// No external ID, so there is nothing to attach a definition to.
 		trackOnboard(ctx, "onboard_project_setup", map[string]any{"outcome": "skipped_no_repo_id"})
@@ -633,7 +629,7 @@ func ensureTrigger(
 func resolveRepoID(
 	ctx context.Context,
 	client *apiclient.Client,
-	returnURL string,
+	appURL string,
 	proj *apiclient.ProjectInfo,
 	remote gitremote.RemoteRef,
 	opts Options,
@@ -660,6 +656,12 @@ func resolveRepoID(
 		iostream.ErrPrintf(ctx, "  Re-run with --repo-id <id> to set up the pipeline.\n")
 		return "", p
 	}
+
+	// Where the provider returns the browser after an install. Landing on the
+	// project's own page reads as a finish line, in the browser, while the rest of
+	// setup is still waiting back in the terminal, so each integration has a page
+	// that says so.
+	returnURL := cmdutil.InstalledURL(appURL, p.InstalledPath)
 
 	installed, err := providerconn.EnsureConnected(ctx, client, p, proj.OrganizationID, returnURL, opts.NoBrowser)
 	if err != nil {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -45,16 +45,28 @@ type Provider struct {
 	// integration. A host matches when it equals one of these or is a subdomain
 	// of it, so enterprise and regional hosts resolve without new entries.
 	Hosts []string
+	// InstalledPath is the app page an install returns the browser to, relative to
+	// the app URL. It confirms the install and points the user back at their
+	// terminal, so it names the integration the user just installed.
+	InstalledPath string
 }
 
 // registry is every integration the CLI can drive. Order is significant only in
 // that the first host match wins.
 var registry = []Provider{
 	{
-		Name:    "github_app",
-		Short:   "GitHub App",
-		Install: "the CircleCI GitHub App",
-		Hosts:   []string{"github.com"},
+		Name:          "github_app",
+		Short:         "GitHub App",
+		Install:       "the CircleCI GitHub App",
+		Hosts:         []string{"github.com"},
+		InstalledPath: "cli/github-app-installed",
+	},
+	{
+		Name:          "origin",
+		Short:         "Origin",
+		Install:       "the CircleCI Origin app",
+		Hosts:         []string{"origin.cursor.com"},
+		InstalledPath: "cli/origin-installed",
 	},
 }
 

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -41,6 +41,7 @@ func TestForHost(t *testing.T) {
 		// A subdomain belongs to the same integration, so regional and enterprise
 		// hosts resolve without their own registry entry.
 		{name: "subdomain", host: "eu.github.com", want: "github_app"},
+		{name: "subdomain of another integration", host: "eu.origin.cursor.com", want: "origin"},
 		{name: "unclaimed host", host: "gitlab.com", want: ""},
 		// A host that merely ends with the same letters must not match: matching on
 		// a bare suffix would hand notgithub.com to the GitHub App.
@@ -71,6 +72,9 @@ func TestRegistryIsUsable(t *testing.T) {
 			assert.Check(t, p.Short != "", "Short names the integration in progress output")
 			assert.Check(t, p.Install != "", "Install is the subject of the install prompt")
 			assert.Check(t, len(p.Hosts) > 0, "an integration with no hosts can never be resolved from a remote")
+			// A missing page sends the browser to the app root after an install, which
+			// reads as a finish line while the terminal is still waiting.
+			assert.Check(t, p.InstalledPath != "", "InstalledPath is where an install returns the browser")
 		})
 	}
 }


### PR DESCRIPTION
<!--
  Thank you for contributing to CircleCI CLI!

  For PRs adding new features, please raise an issue first.

  Squash your commits before requesting review and before merging.
-->
## Summary
`circleci onboard` resolves the integration from the checkout's git remote, so adding support for Origin is a registry entry: its API value, the copy that names it in progress output, the remote host whose repositories belong to it, and the app page its install returns to.

```go
{
    Name:          "origin",
    Short:         "Origin",
    Install:       "the CircleCI Origin app",
    Hosts:         []string{"origin.cursor.com"},
    InstalledPath: "cli/origin-installed",
}
```

Everything provider-shaped follows from that entry: the connection that is checked, the install that is started, the repository list that is searched, and the `provider` written into the pipeline definition and trigger. No other production code changed to support it.

## The one thing Origin needs that the GitHub App does not

Origin addresses a repository by owner and name rather than by id alone, so the pipeline definition and trigger writes have to carry `repo_full_name` as well as `repo_id`. `onboard` already fills it from the git remote, and the acceptance test asserts both travel on both writes.

## Also fixes the install redirect

The return URL was built before the integration was resolved, so every integration was sent to `/cli/github-app-installed`:

```go
// before, in postSignupGuidance, with no provider in scope
returnURL := cmdutil.GitHubAppInstalledURL(appURL)
```

The page now comes off the registry entry, `cmdutil.InstalledURL` takes that path rather than naming one integration, and the URL is built inside `resolveRepoID` where the provider is known. The GitHub App keeps landing on the same page as before.

## Testing
- [x] New acceptance test: the whole flow from an `origin.cursor.com` remote, asserting the definition and trigger bodies carry `"provider":"origin"`, the repository id and `repo_full_name`.
- [x] `ForHost` gains a case for a subdomain of the new host, alongside the existing one, and the lookalike-host case still rejects.
- [x] Every registry entry is now required to declare `InstalledPath`, since an empty one would send the browser to the app root after an install.
- [x] `InstalledURL` is covered for both integrations' paths.
- [x] `task test` — the 9 failures in `internal/gitremote` and `internal/orbinit` reproduce on a clean tree (local `commit.gpgSign` breaks go-git commit creation) and are unrelated.
- [x] `task check` clean on both modules.
