### PR TITLE
Add cookie policy and preferences links to the footer

### DIFF
--- a/docs/website/assets/css/main.css
+++ b/docs/website/assets/css/main.css
@@ -599,6 +599,17 @@ a:hover {
   text-decoration: none;
 }
 
+/* The cookie-preferences control is a button, since it reopens the consent
+   dialog rather than navigating; strip the button chrome so it reads as one of
+   the footer links beside it. */
+button.footer-link {
+  background: none;
+  border: 0;
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
+}
+
 @media (hover: hover) {
   .footer-link:hover { color: var(--color-site-heading); }
 }

--- a/docs/website/layouts/index.html
+++ b/docs/website/layouts/index.html
@@ -150,6 +150,8 @@
         <span>© 2026 Circle Internet Services, Inc.</span>
         <a class="footer-link" href="https://circleci.com/legal/terms-of-use/">Terms of Use</a>
         <a class="footer-link" href="https://circleci.com/legal/privacy/">Privacy Policy</a>
+        <a class="footer-link" href="https://circleci.com/legal/cookie-policy/">Cookie Policy</a>
+        {{ partial "cookie-preferences.html" . }}
       </div>
       <div class="site-footer-social">
         <a class="social-link" href="https://circleci.com/blog/feed.xml" aria-label="CircleCI blog RSS feed">

--- a/docs/website/layouts/partials/cookie-preferences.html
+++ b/docs/website/layouts/partials/cookie-preferences.html
@@ -1,0 +1,15 @@
+{{- /* Reopens the Cookiebot consent dialog so a visitor can change or withdraw
+       consent after answering the banner. Consent has to be as easy to withdraw
+       as it was to give, so this belongs anywhere the banner can appear.
+
+       A button rather than a link: it performs an action on this page instead of
+       navigating. Rendered only when Cookiebot is actually loaded (same
+       condition as analytics.html), since without it the control would do
+       nothing at all. */ -}}
+{{- if hugo.IsProduction -}}
+  {{- with site.Params.analytics -}}
+    {{- with .cookiebotId -}}
+      <button type="button" class="footer-link" onclick="Cookiebot.renew()">Cookie Preferences</button>
+    {{- end -}}
+  {{- end -}}
+{{- end -}}


### PR DESCRIPTION
## What

Adds **Cookie Policy** and **Cookie Preferences** to the site footer, beside the existing Terms of Use and Privacy Policy links.

- **Cookie Policy** links to `circleci.com/legal/cookie-policy/`
- **Cookie Preferences** reopens the consent dialog via `Cookiebot.renew()`


**Before**
<img width="817" height="159" alt="image" src="https://github.com/user-attachments/assets/77484e59-38d2-428a-a52a-d70144d739cb" />



**After**
<img width="1100" height="186" alt="image" src="https://github.com/user-attachments/assets/2392e6ac-759b-4fd0-8836-3fa701b57539" />



## Why

Consent has to be as easy to withdraw as it was to give. Until now the consent banner was the only place to set a preference, so once a visitor answered it there was no way back.

## Notes

The preferences control is a `button` rather than a link, since it acts on the current page instead of navigating; the button chrome is stripped so it reads as one of the footer links beside it.

It renders only when Cookiebot is actually loaded — the same condition the analytics partial uses — so it can never appear as a control that does nothing.

## Scope

These links are in the landing page footer. The reference page has its own separate, minimal footer and does not carry legal links today, so it is untouched here — worth a follow-up decision, since the consent banner can appear on that page too.

## Verified

- Footer renders as `© 2026 Circle Internet Services, Inc. · Terms of Use · Privacy Policy · Cookie Policy · Cookie Preferences`, with the button visually identical to the links
- `Cookiebot.renew()` confirmed present in the vendor script
- The cookie policy URL returns 200