### PR TITLE
Track resolved run/workflow/job IDs via a shared telemetry helper

### DIFF
--- a/internal/cmd/job/get.go
+++ b/internal/cmd/job/get.go
@@ -89,7 +89,11 @@ func newGetCmd() *cobra.Command {
 
 // Get renders a job's details exactly as "circleci job get" does. It is
 // exported so interactive callers (e.g. "circleci run get") can reuse the same
-// output without duplicating the formatting code.
+// output without duplicating the formatting code. Telemetry travels via ctx
+// (cmdutil.TrackKnownID), so it's tracked correctly no matter which top-level
+// command called this, as long as ctx flows from root's normal per-invocation
+// setup (cmdutil.WithKnownIDs) — true for every entry point this repo ships,
+// so not a caveat in practice, but not a property of ctx itself.
 func Get(ctx context.Context, client *apiclient.Client, idStr string, jsonOut bool) error {
 	return runGet(ctx, client, idStr, jsonOut)
 }
@@ -104,6 +108,8 @@ func runGet(ctx context.Context, client *apiclient.Client, idStr string, jsonOut
 	if err != nil {
 		return cmdutil.APIErr(err, id.String(), "job.not_found", "No job found for %q.")
 	}
+
+	cmdutil.TrackKnownID(ctx, cmdutil.KeyJobID, job.ID)
 
 	if jsonOut {
 		return iostream.PrintJSON(ctx, job)

--- a/internal/cmd/job/resource_usage_get.go
+++ b/internal/cmd/job/resource_usage_get.go
@@ -223,6 +223,7 @@ func fetchResourceUsage(ctx context.Context, client *apiclient.Client, jobID uui
 			"Usage is only recorded for jobs that ran an executor — an approval job, or one cancelled before it started, has none.",
 			"Check the job exists with: circleci job get "+jobID.String())
 	}
+	cmdutil.TrackKnownID(ctx, cmdutil.KeyJobID, usage.ID)
 
 	execs := usage.Executions
 	if execution != allExecutions {

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -172,6 +172,7 @@ func NewRootCmd(version string) *cobra.Command {
 		}
 
 		ctx = cmdutil.WithTelemetry(ctx, tc)
+		ctx = cmdutil.WithKnownIDs(ctx)
 
 		cmd.SetContext(ctx)
 

--- a/internal/cmd/run/get.go
+++ b/internal/cmd/run/get.go
@@ -271,6 +271,8 @@ func runGet(ctx context.Context, client *apiclient.Client, args []string, projec
 		r = &runs[0]
 	}
 
+	cmdutil.TrackKnownID(ctx, cmdutil.KeyRunID, r.ID)
+
 	if failureReport {
 		return runFailureReport(ctx, client, r)
 	}
@@ -515,6 +517,10 @@ func runGetInteractive(ctx context.Context, client *apiclient.Client, projectSlu
 
 	// The picker only collected the choice; the matching summary is printed now,
 	// after the program has exited, reusing each command's existing output code.
+	// Each of these (workflow.Get, job.Get, showJobOutput, job.ResourceUsageGet)
+	// tracks its own resolved ID via ctx once it succeeds, so nothing extra is
+	// needed here beyond the run case, which resolves the run right at this call
+	// site rather than inside a shared helper.
 	switch res.Action {
 	case ui.RunGetActionShowRun:
 		// Fetch the run by ID rather than reusing the picker list: a branch toggle
@@ -523,6 +529,7 @@ func runGetInteractive(ctx context.Context, client *apiclient.Client, projectSlu
 		if err != nil {
 			return apiErr(err, res.RunID.String())
 		}
+		cmdutil.TrackKnownID(ctx, cmdutil.KeyRunID, r.ID)
 		return displayRun(ctx, client, r, false)
 	case ui.RunGetActionShowWorkflow:
 		return workflow.Get(ctx, client, res.WorkflowID.String(), false)
@@ -854,6 +861,7 @@ func showJobOutput(ctx context.Context, client *apiclient.Client, jobID uuid.UUI
 	if err != nil {
 		return cmdutil.APIErr(err, jobID.String(), "job.not_found", "No job found for %q.")
 	}
+	cmdutil.TrackKnownID(ctx, cmdutil.KeyJobID, j.ID)
 	for _, exec := range j.Executions {
 		if err := job.OutputList(ctx, client, jobID, exec.Index, job.DefaultStepOutputTail, false); err != nil {
 			return err

--- a/internal/cmd/run/watch.go
+++ b/internal/cmd/run/watch.go
@@ -196,6 +196,8 @@ func runWatch(ctx context.Context, client *apiclient.Client, args []string, proj
 		r = &runs[0]
 	}
 
+	cmdutil.TrackKnownID(ctx, cmdutil.KeyRunID, r.ID)
+
 	displayBranch := r.Branch
 	if displayBranch == "" {
 		displayBranch = branch

--- a/internal/cmd/workflow/get.go
+++ b/internal/cmd/workflow/get.go
@@ -108,7 +108,12 @@ type jobOutput struct {
 
 // Get renders a workflow's details exactly as "circleci workflow get" does.
 // It is exported so interactive callers (e.g. "circleci run get") can reuse
-// the same output without duplicating the formatting code.
+// the same output without duplicating the formatting code. Telemetry travels
+// via ctx (cmdutil.TrackKnownID), so it's tracked correctly no matter which
+// top-level command called this, as long as ctx flows from root's normal
+// per-invocation setup (cmdutil.WithKnownIDs) — true for every entry point
+// this repo ships, so not a caveat in practice, but not a property of ctx
+// itself.
 func Get(ctx context.Context, client *apiclient.Client, idStr string, jsonOut bool) error {
 	return runGet(ctx, client, idStr, jsonOut)
 }
@@ -123,6 +128,8 @@ func runGet(ctx context.Context, client *apiclient.Client, idStr string, jsonOut
 	if err != nil {
 		return err
 	}
+
+	cmdutil.TrackKnownID(ctx, cmdutil.KeyWorkflowID, out.ID)
 
 	if jsonOut {
 		return iostream.PrintJSON(ctx, out)

--- a/internal/cmdutil/telemetry.go
+++ b/internal/cmdutil/telemetry.go
@@ -23,14 +23,86 @@
 package cmdutil
 
 import (
+	"context"
 	"slices"
 	"strings"
+	"sync"
 
+	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
 
 const telemetryPropPrefix = "telemetry_prop:"
+
+// KnownIDKey names a resource-ID telemetry property tracked via TrackKnownID.
+// Use one of the typed constants below rather than an ad hoc string literal —
+// it doesn't stop a determined caller from constructing an arbitrary
+// KnownIDKey, but it does mean the normal way to call TrackKnownID (typing
+// "cmdutil.Key" and letting completion suggest a valid one) won't produce a
+// typo'd, uncorrelated property name by accident.
+type KnownIDKey string
+
+// Valid KnownIDKey values, one per resource type TrackKnownID covers.
+const (
+	KeyRunID      KnownIDKey = "run_id"
+	KeyWorkflowID KnownIDKey = "workflow_id"
+	KeyJobID      KnownIDKey = "job_id"
+)
+
+type knownIDsContextKey struct{}
+
+// knownIDCollector is the mutable sink TrackKnownID writes into. It travels
+// via ctx rather than a *cobra.Command parameter specifically so that
+// resolution code (runGet, workflow.Get, job.Get, ...) doesn't need cmd
+// threaded through its signature just to reach telemetry — ctx is already
+// there on every one of those functions.
+type knownIDCollector struct {
+	mu  sync.Mutex
+	ids map[KnownIDKey]string
+}
+
+// WithKnownIDs seeds ctx with an empty collector for TrackKnownID. Called
+// once per command execution — see root.go, alongside the rest of the
+// per-invocation context setup — so it's present unconditionally and no
+// individual command needs to remember to wire it up itself.
+func WithKnownIDs(ctx context.Context) context.Context {
+	return context.WithValue(ctx, knownIDsContextKey{}, &knownIDCollector{ids: map[KnownIDKey]string{}})
+}
+
+// TrackKnownID attaches a resource ID to the current command's
+// command_invocation event under key.
+//
+// This is the single chokepoint every command should route a run/workflow/job
+// ID through before it reaches telemetry — never call SetTelemetryProp with a
+// raw CLI argument directly. id must already be "known": either parsed from
+// user input and then confirmed to exist by a successful API call (e.g.
+// GetRunV3), or returned directly by an API response (e.g. a search result).
+// Passing an unvalidated string defeats the point of this function, and is
+// exactly the "arbitrary user input in o11y" pattern this repo deliberately
+// avoids elsewhere (see the CLI vs. GitHub CLI discussion this followed from).
+//
+// uuid.Nil is never tracked — it is never a real resource ID, only a possible
+// zero value from a caller that skipped validation. A ctx that was never
+// passed through WithKnownIDs (e.g. a test that doesn't need telemetry) is
+// also a silent no-op, not a panic.
+//
+// EXPERIMENT: this measures adoption of ID-based lookups across run/workflow/
+// job commands, to inform whether generic per-user API-usage tracking is worth
+// building more broadly. Review by 2026-11-30; remove call sites (not this
+// function — other props may still need it) once evaluated.
+func TrackKnownID(ctx context.Context, key KnownIDKey, id uuid.UUID) {
+	if id == uuid.Nil {
+		return
+	}
+	c, ok := ctx.Value(knownIDsContextKey{}).(*knownIDCollector)
+	if !ok {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.ids[key] = id.String()
+}
 
 // SetTelemetryProp attaches an extra property to cmd that RecordTelemetryNow
 // will include in the command_invocation event.
@@ -121,6 +193,13 @@ func RecordTelemetryNow(cmd *cobra.Command) {
 		if after, ok := strings.CutPrefix(k, telemetryPropPrefix); ok {
 			props[after] = v
 		}
+	}
+	if c, ok := ctx.Value(knownIDsContextKey{}).(*knownIDCollector); ok {
+		c.mu.Lock()
+		for k, v := range c.ids {
+			props[string(k)] = v
+		}
+		c.mu.Unlock()
 	}
 
 	_ = tc.Track("command_invocation", props)

--- a/internal/cmdutil/telemetry_test.go
+++ b/internal/cmdutil/telemetry_test.go
@@ -293,6 +293,44 @@ func TestRecordTelemetry(t *testing.T) {
 	})
 }
 
+func TestTrackKnownID(t *testing.T) {
+	t.Run("does not panic on a context without WithKnownIDs", func(t *testing.T) {
+		// e.g. a unit test of some other command handler that builds its own
+		// bare context without going through root.go's bootstrapping.
+		cmdutil.TrackKnownID(context.Background(), cmdutil.KeyRunID, uuid.MustParse(instanceID))
+	})
+
+	t.Run("reaches the command_invocation event's properties under the given key, and skips uuid.Nil", func(t *testing.T) {
+		recorder, client := newTelemetry(t)
+		id := uuid.MustParse(instanceID)
+
+		cmd := &cobra.Command{
+			Use: "get",
+			RunE: func(cmd *cobra.Command, args []string) error {
+				ctx := cmd.Context()
+				cmdutil.TrackKnownID(ctx, cmdutil.KeyRunID, id)
+				cmdutil.TrackKnownID(ctx, cmdutil.KeyWorkflowID, uuid.Nil) // must not appear below
+				return nil
+			},
+		}
+		ctx := cmdutil.WithKnownIDs(cmdutil.WithTelemetry(context.Background(), client))
+		cmd.SetContext(ctx)
+		cmdutil.RecordTelemetry(cmd)
+
+		assert.NilError(t, cmd.RunE(cmd, nil))
+		assert.NilError(t, client.Close())
+
+		tracks := recorder.Tracks()
+		assert.Check(t, cmp.Len(tracks, 1))
+		if len(tracks) != 1 {
+			return
+		}
+		assert.Check(t, cmp.Equal(tracks[0].Properties["run_id"], id.String()))
+		_, hasWorkflowID := tracks[0].Properties["workflow_id"]
+		assert.Check(t, !hasWorkflowID, "uuid.Nil must not produce a workflow_id property")
+	})
+}
+
 func TestRecordTelemetryForSubcommands(t *testing.T) {
 	t.Run("instruments nested subcommands", func(t *testing.T) {
 		recorder, client := newTelemetry(t)


### PR DESCRIPTION
## What

Adds `cmdutil.TrackKnownID`, a single chokepoint for attaching a resolved
run/workflow/job ID to the `command_invocation` telemetry event, and wires it
into `run get`, `run watch`, `workflow get`, and `job get` — including all
five terminal actions of `run get`'s interactive picker.

## Why

From an internal thread about whether the CLI should track API usage at the
user level for feature-adoption analysis. The explicit requirements that came
out of it:

- Never send arbitrary/raw user input into telemetry (the concern GitHub CLI
  also avoids) — only "known," already-validated UUIDs.
- A single function all run/workflow/job ID tracking routes through, not
  scattered ad hoc calls.
- The data should travel via Go's `context.Context`, not by threading
  `*cobra.Command` through function signatures that didn't need it before.
- A robust-enough implementation, not a throwaway prototype.
- `api_path`'s existing raw-argument tracking (`circleci api <path>`) is a
  separate, still-open item — intentionally untouched here.

## How it satisfies "known UUIDs only"

Every ID that reaches `TrackKnownID` has already round-tripped through a
successful API call — either parsed from a CLI argument and then confirmed to
exist (`GetRunV3`, `GetJobV3`, ...), or returned directly by an API response
(a search result, or an earlier fetch that populated the interactive picker's
lists). `uuid.Nil` is never tracked. Keys are a small set of typed constants
(`KeyRunID`/`KeyWorkflowID`/`KeyJobID`), not free-form strings.

## How it satisfies "context, not cmd threading"

`TrackKnownID(ctx, key, id)` takes `context.Context`, not a `*cobra.Command`.
A small collector rides in `ctx`, seeded once centrally in `root.go`
(`cmdutil.WithKnownIDs`) alongside the rest of the per-invocation setup —
every command gets it automatically, none of them wire it up themselves.
`RecordTelemetryNow` reads it back out via `cmd.Context()` when the event
actually fires.

Because `ctx` was already the first parameter on every function this touches,
no function signature in this diff differs from `main`'s — confirmed by
diffing them directly. `workflow.Get`, `job.Get`, `showJobOutput`, and job's
`fetchResourceUsage` each track their own resolved ID as soon as they resolve
it, so they work correctly whether invoked from their own standalone command
or reused by `run get`'s interactive picker, with no `cmd`-availability
special-casing anywhere (an earlier revision of this PR threaded `cmd`
through five signatures and needed a `nil`-guard for exactly that reason —
this version doesn't).

## Scope notes

- This is a time-boxed experiment, not a permanent capability — see the
  `EXPERIMENT` comment on `TrackKnownID` for the review date.
- `api_path` sanitization stays untouched, as called out above.

## Testing

- `go test ./internal/...` — full suite, including `TestTrackKnownID`
  covering the no-op behavior on a context without `WithKnownIDs`, and that a
  tracked value reaches the emitted event under the right key while a
  `uuid.Nil` value under a different key never appears.
- `go test ./acceptance/... -count=1`
- `task check` (lint, license headers, mod-tidy, release-check)

## Review

Went through several rounds of review before landing here — two closed-book
AI second opinions, a separate reviewer's pass, and real feedback on the
first version of this PR that led to the context-based rewrite described
above. Also explicitly rejected moving ID resolution/tracking into
`apiclient` via context injection at the API-client layer — assessed as
disproportionate to a time-boxed experiment and a layering violation of
`apiclient`'s stated "thin HTTP client" role — and fixed an interactive-picker
placement issue so a still-revisable in-flow preview is never recorded as a
user's committed choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
