### PR TITLE
Auto-follow the project during onboard

### DIFF
--- a/acceptance/onboard_test.go
+++ b/acceptance/onboard_test.go
@@ -837,6 +837,65 @@ func TestOnboard_PostSignup_GitHubAppInstall_ReturnURL(t *testing.T) {
 		"the project's pipelines page reads as a finish line in the browser, got %q", returnURLs[0])
 }
 
+// TestOnboard_PostSignup_FollowsProject covers the CircleCI-native path following
+// the project it just set up. A follower is who a run's notifications go to, so
+// without this the first pipeline onboard tells the user to push can fail silently.
+//
+// The request carries the project's own slug, whose segments are opaque org and
+// project IDs rather than an org and repository name — the shape the classic path
+// sends.
+func TestOnboard_PostSignup_FollowsProject(t *testing.T) {
+	dir, fake, env := onboardRepo(t)
+	addFirstPipelineResponses(fake)
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"onboard", "--scan", "--repo-id", onboardRepoExternalID},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+
+	t.Run("reports the follow", func(t *testing.T) {
+		assert.Check(t, cmp.Contains(result.Stdout, "Following my-repo"))
+	})
+
+	t.Run("follows the project by its own slug", func(t *testing.T) {
+		var paths []string
+		for _, req := range fake.AllRequests() {
+			if req.Method == http.MethodPost && strings.HasSuffix(req.URL.Path, "/follow") {
+				paths = append(paths, req.URL.Path)
+			}
+		}
+		assert.Check(t, cmp.DeepEqual(paths, []string{
+			"/api/v1.1/project/circleci/Org1234ShortId/Proj5678ShortId/follow",
+		}))
+	})
+}
+
+// TestOnboard_PostSignup_FollowFails_ContinuesSetup pins the follow as advisory: it
+// decides who hears about a pipeline, not whether the project has one, so a
+// rejection warns and the run carries on to the definition and trigger rather than
+// leaving the project half-configured.
+func TestOnboard_PostSignup_FollowFails_ContinuesSetup(t *testing.T) {
+	dir, fake, env := onboardRepo(t)
+	addFirstPipelineResponses(fake)
+	fake.SetFollowProjectStatus(http.StatusForbidden)
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"onboard", "--scan", "--repo-id", onboardRepoExternalID},
+		Env:     env.Environ(),
+		WorkDir: dir,
+	})
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Check(t, cmp.Contains(result.Stderr, "Could not follow the project"))
+	assert.Check(t, cmp.Contains(result.Stdout, "Trigger created: all-pushes"))
+	assert.Check(t, cmp.Contains(result.Stdout, "Your project is ready!"))
+}
+
 func TestOnboard_PostSignup_ClassicOrg_FollowsProject(t *testing.T) {
 	dir := t.TempDir()
 	initGitRepoWithRemote(t, dir, "https://github.com/myorg/my-repo.git")

--- a/internal/cmd/onboard/onboard.go
+++ b/internal/cmd/onboard/onboard.go
@@ -52,7 +52,7 @@ func NewOnboardCmd() *cobra.Command {
 		},
 		Long: heredoc.Doc(`
 			Prompts for repo setup or signup unless --scan or --signup is given. Writes a
-			starter config if the repo has none, creates the project, adds a push trigger.
+			starter config if none exists, creates and follows the project, adds a trigger.
 		`),
 		Example: heredoc.Doc(`
 			# Interactive mode: choose repo setup or signup

--- a/internal/cmd/root/testdata/help/circleci/onboard.txt
+++ b/internal/cmd/root/testdata/help/circleci/onboard.txt
@@ -37,5 +37,5 @@ Global flags: `-c, --config`, `--debug`, `--no-color`, `-q, --quiet` — see `ci
 ## Details
 
 Prompts for repo setup or signup unless --scan or --signup is given. Writes a
-starter config if the repo has none, creates the project, adds a push trigger.
+starter config if none exists, creates and follows the project, adds a trigger.
 

--- a/internal/cmd/root/testdata/help/circleci/reference.txt
+++ b/internal/cmd/root/testdata/help/circleci/reference.txt
@@ -4580,7 +4580,7 @@ the run's "org/repo" repository (when known) and project_id its UUID.
 Guided onboarding: generate config, sign up, connect project
 
 Prompts for repo setup or signup unless --scan or --signup is given. Writes a
-starter config if the repo has none, creates the project, adds a push trigger.
+starter config if none exists, creates and follows the project, adds a trigger.
 
 | Flag               | Description                                                 |
 | ------------------ | ----------------------------------------------------------- |

--- a/internal/onboarder/onboarder.go
+++ b/internal/onboarder/onboarder.go
@@ -269,6 +269,8 @@ func postSignupGuidance(ctx context.Context, dir string, opts Options) error {
 		iostream.Printf(ctx, "  Pipelines: %s\n", pipelinesURL)
 	}
 
+	followProject(ctx, client, proj)
+
 	return setupFirstPipeline(ctx, client, appURL, proj, remote, opts)
 }
 
@@ -714,6 +716,36 @@ func printPipelineReadyGuidance(ctx context.Context) {
 func printManualPipelineGuidance(ctx context.Context) {
 	iostream.Printf(ctx, "\nCommit .circleci/config.yml. After your project is connected in CircleCI, pushing will start your first pipeline.\n")
 	iostream.Printf(ctx, "To set up a trigger now, run 'circleci pipeline create' then 'circleci project trigger create'.\n")
+}
+
+// followProject follows the project on the CircleCI-native path, so the first
+// pipeline the user is about to push reaches them: a follower is who the
+// notifications for a run go to, and onboard's whole promise is that the next push
+// builds. followClassicProject does the same for a classic organization, where the
+// slug's segments are the org and repository names rather than opaque IDs.
+//
+// A failure is reported and the run continues. Following decides who hears about a
+// pipeline, not whether the project has one, so it must not stand between the user
+// and a working trigger. It is idempotent, which is what makes it safe on the
+// re-run and adopt-existing paths, where the project may already be followed —
+// possibly by a teammate who created it.
+func followProject(ctx context.Context, client *apiclient.Client, proj *apiclient.ProjectInfo) {
+	vcs, orgSegment, projectSegment, err := cmdutil.ParseSlug(proj.Slug)
+	if err != nil {
+		trackOnboard(ctx, "onboard_project_follow", map[string]any{"outcome": "skipped_bad_slug"})
+		return
+	}
+
+	if err := client.FollowProject(ctx, vcs, orgSegment, projectSegment); err != nil {
+		iostream.ErrPrintf(ctx,
+			"%s Could not follow the project, so you may not be notified about its pipelines: %s\n",
+			iostream.SymbolWarn(ctx), err)
+		trackOnboard(ctx, "onboard_project_follow", map[string]any{"outcome": "failed"})
+		return
+	}
+
+	iostream.Printf(ctx, "%s Following %s\n", iostream.SymbolOK(ctx), proj.Name)
+	trackOnboard(ctx, "onboard_project_follow", map[string]any{"outcome": "followed"})
 }
 
 func followClassicProject(ctx context.Context, client *apiclient.Client, appURL, vcs, orgName, repoName string) {

--- a/internal/testing/fakes/circleci.go
+++ b/internal/testing/fakes/circleci.go
@@ -113,6 +113,7 @@ type CircleCI struct {
 	// Project / env-var state.
 	followedProjects    []FollowedProject      // projects for GET /api/v1.1/projects
 	followedSlugs       map[string]bool        // vcs+org+repo → true (for follow idempotency)
+	followProjectStatus int                    // HTTP status for POST .../follow (0 → 200 OK)
 	envVars             map[string][]EnvVar    // project slug → env vars
 	deletedEnvVars      map[string]bool        // "slug/name" → deleted
 	projectInfos        map[string]ProjectInfo // project slug → project info response
@@ -2446,6 +2447,14 @@ func (f *CircleCI) AddFollowedProject(proj FollowedProject) {
 	f.followedProjects = append(f.followedProjects, proj)
 }
 
+// SetFollowProjectStatus makes POST /api/v1.1/project/{vcs}/{org}/{repo}/follow
+// answer status instead of following the project. Pass 0 to restore the default.
+func (f *CircleCI) SetFollowProjectStatus(status int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.followProjectStatus = status
+}
+
 // followedProjectEntity renders a stored FollowedProject as its v1.1 object.
 func followedProjectEntity(p FollowedProject) map[string]any {
 	return map[string]any{
@@ -2525,6 +2534,15 @@ func (f *CircleCI) handleFollowProject(w http.ResponseWriter, r *http.Request) {
 	org := chi.URLParam(r, "org")
 	repo := chi.URLParam(r, "repo")
 	slug := vcs + "/" + org + "/" + repo
+
+	f.mu.RLock()
+	status := f.followProjectStatus
+	f.mu.RUnlock()
+	if status != 0 {
+		render.Status(r, status)
+		render.JSON(w, r, map[string]any{"message": "follow not permitted"})
+		return
+	}
 
 	f.mu.Lock()
 	if !f.followedSlugs[slug] {


### PR DESCRIPTION
## What

`circleci onboard` followed the project only on the classic path (`followClassicProject`), so the same command left a classic user following their new project and a standalone user not. A follower is who a run's notifications go to, so a standalone user could push, have their first pipeline fail, and hear nothing about it.

`followProject` closes that gap. It runs after the project is resolved, so it covers the created and adopted-existing paths alike:

```
✓ Project created: my-repo
✓ Linked this repository to the project in .circleci/info.yml
  Organization: myorg
  Pipelines: https://app.circleci.com/pipelines/circleci/<orgID>/<projectID>
✓ Following my-repo
✓ Pipeline definition created: my-repo
✓ Trigger created: all-pushes
```

## Notes

**No new API.** The legacy `POST /api/v1.1/project/{a}/{b}/{c}/follow` endpoint serves both shapes, so `followProject` sends the project's own slug rather than reassembling one: `circleci/<orgShortID>/<projectShortID>` for a standalone org, the org and repository names for a classic one. It is idempotent, which is what keeps it safe on the re-run and adopt-existing paths where the project may already be followed, possibly by the teammate who created it.

**A rejected follow is advisory.** It warns on stderr and the run continues to the pipeline definition and trigger. Following decides who hears about a pipeline, not whether the project has one, so it must not stand between the user and a working trigger.

**`circleci project follow` needed no change.** `cmdutil.ParseSlug` passes any three-segment slug straight through, and `gitremote.Detect()` prefers `.circleci/info.yml`, so in a checkout onboard has linked, a bare `circleci project follow` already resolves and follows the standalone project.

**Help text.** `Long` now says "creates and follows the project". That pushed `--help` to 41 lines against the 40-line budget, so "push trigger" became "trigger"; the output still prints `Trigger created: all-pushes`. Goldens regenerated.

## Testing

- `TestOnboard_PostSignup_FollowsProject` asserts the printed line and that exactly one follow request goes out, at the standalone slug path.
- `TestOnboard_PostSignup_FollowFails_ContinuesSetup` pins a 403 as advisory: exit 0, warning on stderr, still reaches `Trigger created: all-pushes` and `Your project is ready!`.
- New `fakes.SetFollowProjectStatus` makes that failure reachable. The follow route already existed and accepts any three segments.
- Telemetry: `onboard_project_follow` with `outcome` (`followed` / `failed` / `skipped_bad_slug`). No PII.

`task check` clean. `task test` clean apart from 9 pre-existing failures in `internal/gitremote` and `internal/orbinit` (`cannot auto-sign commit: disable commit.gpgSign`), which reproduce on a clean tree and are untouched here.