### PR TITLE
Rename onboard_ telemetry events to onboarding_ prefix

### DIFF
--- a/internal/onboarder/onboarder.go
+++ b/internal/onboarder/onboarder.go
@@ -83,7 +83,7 @@ func Run(ctx context.Context, dir string, opts Options) error {
 		return err
 	}
 
-	trackOnboard(ctx, "onboard_mode_selected", map[string]any{
+	trackOnboard(ctx, "onboarding_mode_selected", map[string]any{
 		"mode": modeString(m),
 	})
 
@@ -92,7 +92,7 @@ func Run(ctx context.Context, dir string, opts Options) error {
 		if err != nil {
 			return err
 		}
-		trackOnboard(ctx, "onboard_signup", map[string]any{
+		trackOnboard(ctx, "onboarding_signup", map[string]any{
 			"mode":    "signup",
 			"outcome": string(result.Outcome),
 		})
@@ -154,7 +154,7 @@ func Run(ctx context.Context, dir string, opts Options) error {
 	if err != nil {
 		return err
 	}
-	trackOnboard(ctx, "onboard_signup", map[string]any{
+	trackOnboard(ctx, "onboarding_signup", map[string]any{
 		"mode":    "scan",
 		"outcome": string(signupResult.Outcome),
 	})
@@ -505,14 +505,14 @@ func setupFirstPipeline(ctx context.Context, client *apiclient.Client, appURL st
 	repoID, p := resolveRepoID(ctx, client, appURL, proj, remote, opts)
 	if repoID == "" {
 		// No external ID, so there is nothing to attach a definition to.
-		trackOnboard(ctx, "onboard_project_setup", map[string]any{"outcome": "skipped_no_repo_id"})
+		trackOnboard(ctx, "onboarding_project_setup", map[string]any{"outcome": "skipped_no_repo_id"})
 		printManualPipelineGuidance(ctx)
 		return nil
 	}
 
 	def, err := ensurePipelineDefinition(ctx, client, p, proj.ID, proj.Name, repoID, remote.FullName())
 	if err != nil {
-		trackOnboard(ctx, "onboard_project_setup", map[string]any{"outcome": "pipeline_definition_failed"})
+		trackOnboard(ctx, "onboarding_project_setup", map[string]any{"outcome": "pipeline_definition_failed"})
 		return clierrors.New("onboard.pipeline_definition_failed",
 			"Could not set up the pipeline definition",
 			fmt.Sprintf("The project was created, but its pipeline definition could not be set up: %s.", err)).
@@ -524,7 +524,7 @@ func setupFirstPipeline(ctx context.Context, client *apiclient.Client, appURL st
 	}
 
 	if err := ensureTrigger(ctx, client, p, proj.ID, def.ID, repoID, remote.FullName()); err != nil {
-		trackOnboard(ctx, "onboard_project_setup", map[string]any{"outcome": "trigger_failed"})
+		trackOnboard(ctx, "onboarding_project_setup", map[string]any{"outcome": "trigger_failed"})
 		return clierrors.New("onboard.trigger_failed",
 			"Could not set up the trigger",
 			fmt.Sprintf("The pipeline definition was created, but its trigger could not be: %s.", err)).
@@ -535,7 +535,7 @@ func setupFirstPipeline(ctx context.Context, client *apiclient.Client, appURL st
 			WithExitCode(clierrors.ExitAPIError)
 	}
 
-	trackOnboard(ctx, "onboard_project_setup", map[string]any{"outcome": "created"})
+	trackOnboard(ctx, "onboarding_project_setup", map[string]any{"outcome": "created"})
 	printPipelineReadyGuidance(ctx)
 	return nil
 }
@@ -732,7 +732,7 @@ func printManualPipelineGuidance(ctx context.Context) {
 func followProject(ctx context.Context, client *apiclient.Client, proj *apiclient.ProjectInfo) {
 	vcs, orgSegment, projectSegment, err := cmdutil.ParseSlug(proj.Slug)
 	if err != nil {
-		trackOnboard(ctx, "onboard_project_follow", map[string]any{"outcome": "skipped_bad_slug"})
+		trackOnboard(ctx, "onboarding_project_follow", map[string]any{"outcome": "skipped_bad_slug"})
 		return
 	}
 
@@ -740,12 +740,12 @@ func followProject(ctx context.Context, client *apiclient.Client, proj *apiclien
 		iostream.ErrPrintf(ctx,
 			"%s Could not follow the project, so you may not be notified about its pipelines: %s\n",
 			iostream.SymbolWarn(ctx), err)
-		trackOnboard(ctx, "onboard_project_follow", map[string]any{"outcome": "failed"})
+		trackOnboard(ctx, "onboarding_project_follow", map[string]any{"outcome": "failed"})
 		return
 	}
 
 	iostream.Printf(ctx, "%s Following %s\n", iostream.SymbolOK(ctx), proj.Name)
-	trackOnboard(ctx, "onboard_project_follow", map[string]any{"outcome": "followed"})
+	trackOnboard(ctx, "onboarding_project_follow", map[string]any{"outcome": "followed"})
 }
 
 func followClassicProject(ctx context.Context, client *apiclient.Client, appURL, vcs, orgName, repoName string) {


### PR DESCRIPTION
## What

Renames every telemetry event emitted by `circleci onboard` so the context prefix is `onboarding` rather than `onboard`:

| Before | After |
|---|---|
| `onboard_mode_selected` | `onboarding_mode_selected` |
| `onboard_signup` | `onboarding_signup` |
| `onboard_project_setup` | `onboarding_project_setup` |
| `onboard_project_follow` | `onboarding_project_follow` |

All emit sites in `internal/onboarder/onboarder.go` are updated. Event properties are untouched: `mode_selected` keeps its existing payload, and the `outcome` values on the other three (`skipped_no_repo_id`, `pipeline_definition_failed`, `trigger_failed`, `created`, `skipped_bad_slug`, `failed`, `followed`) are unchanged.

## Why

`onboard_project_follow` was landing in the blocked-events quarantine because its context prefix did not match the naming convention the tracking plan expects, which is `onboarding` as the first segment. The other three events in this flow had the same prefix, so all four are renamed together rather than leaving the group split across two conventions.

## Compatibility

These are new-ish events from the v1 CLI onboarding flow. Any dashboard or query built on the old names needs to point at the new ones, since a rename is not a redirect: the old names simply stop being emitted from the next release onward.