### PR TITLE
Record onboarding outcomes on command_invocation

### DIFF
--- a/acceptance/onboard_test.go
+++ b/acceptance/onboard_test.go
@@ -23,7 +23,9 @@
 package acceptance_test
 
 import (
+	"context"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -34,10 +36,14 @@ import (
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/golden"
+	"gotest.tools/v3/poll"
 
+	"github.com/CircleCI-Public/circleci-cli/clikit/iostream"
+	"github.com/CircleCI-Public/circleci-cli/internal/telemetry"
 	"github.com/CircleCI-Public/circleci-cli/internal/testing/binary"
 	testenv "github.com/CircleCI-Public/circleci-cli/internal/testing/env"
 	"github.com/CircleCI-Public/circleci-cli/internal/testing/fakes"
+	"github.com/CircleCI-Public/circleci-cli/internal/testing/fakesegment"
 )
 
 // Fixture IDs shared by the onboard tests. The slug segments are deliberately
@@ -1193,4 +1199,125 @@ func TestOnboard_PostSignup_FirstPipeline_UnclaimedHost(t *testing.T) {
 	assert.Check(t, cmp.Contains(result.Stderr, "--repo-id"))
 	assert.Check(t, !strings.Contains(result.Stdout, "Pipeline definition created"),
 		"no definition should be created without a resolved repository")
+}
+
+// TestOnboard_Telemetry pins the onboarding attributes on the per-invocation
+// command_invocation event, which replaced the four bespoke onboard_* events.
+// The full event shape is pinned by TestAPI_Telemetry; these subtests assert
+// only the onboarding attributes.
+func TestOnboard_Telemetry(t *testing.T) {
+	t.Run("records an outcome for every step it reaches", func(t *testing.T) {
+		dir, fake, env := onboardRepo(t)
+		addFirstPipelineResponses(fake)
+		segment := onboardTelemetryEnv(t, env)
+
+		result := binary.RunCLI(t, binary.RunOpts{
+			Binary:  binaryPath,
+			Args:    []string{"onboard", "--scan", "--repo-id", onboardRepoExternalID},
+			Env:     env.Environ(),
+			WorkDir: dir,
+		})
+		assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+
+		assert.Check(t, cmp.DeepEqual(awaitOnboardProps(t, segment), map[string]any{
+			"onboard_mode":                   "scan",
+			"onboard_org_type":               "circleci",
+			"onboard_signup_outcome":         "already_authenticated",
+			"onboard_project_setup_outcome":  "created",
+			"onboard_project_follow_outcome": "followed",
+		}))
+	})
+
+	// A classic organization follows the project through a different function than
+	// the CircleCI-native path, and stops before pipeline setup: definitions and
+	// triggers are native-only. The follow it does perform has to be reported, or
+	// the seeded not_reached would claim a step ran that plainly did.
+	t.Run("reports the follow a classic organization performs", func(t *testing.T) {
+		dir := t.TempDir()
+		initGitRepoWithRemote(t, dir, "https://github.com/myorg/my-repo.git")
+		_, env := onboardAuthenticatedEnv(t, "testuser")
+		segment := onboardTelemetryEnv(t, env)
+
+		result := binary.RunCLI(t, binary.RunOpts{
+			Binary:  binaryPath,
+			Args:    []string{"onboard", "--scan"},
+			Env:     env.Environ(),
+			WorkDir: dir,
+		})
+		assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+		assert.Check(t, cmp.Contains(result.Stdout, "Project connected: my-repo"))
+
+		assert.Check(t, cmp.DeepEqual(awaitOnboardProps(t, segment), map[string]any{
+			"onboard_mode":                   "scan",
+			"onboard_org_type":               "github",
+			"onboard_signup_outcome":         "already_authenticated",
+			"onboard_project_setup_outcome":  "not_applicable",
+			"onboard_project_follow_outcome": "followed",
+		}))
+	})
+
+	// A single event cannot express a sequence, so a step the run never got to has
+	// to say so rather than go unreported — otherwise "stopped before here" is
+	// indistinguishable from "ran and reported nothing".
+	t.Run("marks steps a failed run never reached", func(t *testing.T) {
+		env := testenv.New(t)
+		segment := onboardTelemetryEnv(t, env)
+		dir := t.TempDir()
+
+		result := binary.RunCLI(t, binary.RunOpts{
+			Binary:  binaryPath,
+			Args:    []string{"onboard", dir},
+			Env:     env.Environ(),
+			WorkDir: t.TempDir(),
+		})
+		assert.Equal(t, result.ExitCode, 2, "expected ExitBadArguments, stderr: %s", result.Stderr)
+
+		assert.Check(t, cmp.DeepEqual(awaitOnboardProps(t, segment), map[string]any{
+			"onboard_mode":                   "scan",
+			"onboard_org_type":               "not_reached",
+			"onboard_signup_outcome":         "not_reached",
+			"onboard_project_setup_outcome":  "not_reached",
+			"onboard_project_follow_outcome": "not_reached",
+		}))
+	})
+}
+
+// onboardTelemetryEnv points env's telemetry at a fake Segment service and
+// returns it, so a test can assert on the events the run actually sent.
+func onboardTelemetryEnv(t *testing.T, env *testenv.TestEnv) *fakesegment.Service {
+	t.Helper()
+
+	segment := fakesegment.New(iostream.Testing(context.Background()), telemetry.SegmentKey)
+	server := httptest.NewServer(segment)
+	t.Cleanup(server.Close)
+
+	env.Telemetry = true
+	env.Extra["CIRCLE_TELEMETRY_ENDPOINT"] = server.URL
+	return segment
+}
+
+// awaitOnboardProps waits for the command_invocation event and returns just its
+// onboard_* properties. The events are delivered by a detached subprocess, so
+// they arrive after the CLI has already exited.
+func awaitOnboardProps(t *testing.T, segment *fakesegment.Service) map[string]any {
+	t.Helper()
+
+	props := map[string]any{}
+	poll.WaitOn(t, func(t poll.LogT) poll.Result {
+		for _, batch := range segment.Batches() {
+			for _, msg := range batch.Messages {
+				if msg.Event != "command_invocation" {
+					continue
+				}
+				for key, value := range msg.Properties {
+					if strings.HasPrefix(key, "onboard_") {
+						props[key] = value
+					}
+				}
+				return poll.Success()
+			}
+		}
+		return poll.Continue("no command_invocation event yet")
+	})
+	return props
 }

--- a/internal/cmd/api/api.go
+++ b/internal/cmd/api/api.go
@@ -92,7 +92,7 @@ func NewAPICmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 
-			cmdutil.SetTelemetryProp(cmd, "api_path", args[0])
+			cmdutil.SetTelemetryProp(ctx, "api_path", args[0])
 
 			client, cliErr := cmdutil.LoadClient(ctx)
 			if cliErr != nil {

--- a/internal/cmdutil/client.go
+++ b/internal/cmdutil/client.go
@@ -123,8 +123,20 @@ func WithConfig(ctx context.Context, cfg *config.Config) context.Context {
 
 type telemetryKey struct{}
 
+// WithTelemetry returns a copy of ctx carrying the sender, plus the set of extra
+// command_invocation properties that SetTelemetryProp writes into. The two are
+// installed together because a sender with no property set silently drops every
+// property, and there is no use for one without the other.
+//
+// An existing property set is carried over rather than replaced: properties
+// belong to the invocation, not to whichever sender is current, so re-installing
+// a sender mid-run must not discard what earlier steps already recorded.
 func WithTelemetry(ctx context.Context, tc *telemetry.Sender) context.Context {
-	return context.WithValue(ctx, telemetryKey{}, tc)
+	ctx = context.WithValue(ctx, telemetryKey{}, tc)
+	if getTelemetryProps(ctx) == nil {
+		ctx = context.WithValue(ctx, telemetryPropsKey{}, &telemetryProps{})
+	}
+	return ctx
 }
 
 func GetTelemetry(ctx context.Context) *telemetry.Sender {

--- a/internal/cmdutil/telemetry.go
+++ b/internal/cmdutil/telemetry.go
@@ -23,22 +23,78 @@
 package cmdutil
 
 import (
+	"context"
 	"slices"
 	"strings"
+	"sync"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
 
-const telemetryPropPrefix = "telemetry_prop:"
+// telemetryProps is the mutable set of extra properties RecordTelemetryNow adds
+// to the command_invocation event. It is carried by the context, so a package
+// that only ever receives a ctx can record a property without reaching for the
+// running cobra command — which business logic packages must not do, since
+// commands import them and never the reverse.
+//
+// Properties describe a single invocation, so each key is written at most once
+// per run and a later write simply replaces an earlier one.
+type telemetryProps struct {
+	mu    sync.Mutex
+	props map[string]string
+}
 
-// SetTelemetryProp attaches an extra property to cmd that RecordTelemetryNow
-// will include in the command_invocation event.
-func SetTelemetryProp(cmd *cobra.Command, key, value string) {
-	if cmd.Annotations == nil {
-		cmd.Annotations = map[string]string{}
+func (p *telemetryProps) set(key, value string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.props == nil {
+		p.props = map[string]string{}
 	}
-	cmd.Annotations[telemetryPropPrefix+key] = value
+	p.props[key] = value
+}
+
+// mergeInto copies the properties into dst under the lock, so RecordTelemetryNow
+// never reads the map while another goroutine is writing it. A nil receiver — no
+// property set in the context — merges nothing.
+func (p *telemetryProps) mergeInto(dst map[string]any) {
+	if p == nil {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for key, value := range p.props {
+		dst[key] = value
+	}
+}
+
+// telemetryPropsKey carries the property set. WithTelemetry installs it, so
+// there is no separate exported installer to forget.
+type telemetryPropsKey struct{}
+
+func getTelemetryProps(ctx context.Context) *telemetryProps {
+	if ctx == nil {
+		return nil
+	}
+	p, _ := ctx.Value(telemetryPropsKey{}).(*telemetryProps)
+	return p
+}
+
+// SetTelemetryProp attaches an extra property to the current invocation that
+// RecordTelemetryNow will include in the command_invocation event. It takes a
+// ctx rather than the running command so that business logic packages can call
+// it: commands import them and never the reverse, so they never hold the cobra
+// command. A command that does hold one passes cmd.Context().
+//
+// WithTelemetry installs the property set, so a context without one has no
+// sender either. Telemetry is best-effort, so recording a property under such a
+// context — a bare context in a test, or business logic reached outside a
+// command — drops it rather than failing, the same way RecordTelemetryNow drops
+// the whole event when no sender is installed.
+func SetTelemetryProp(ctx context.Context, key, value string) {
+	if p := getTelemetryProps(ctx); p != nil {
+		p.set(key, value)
+	}
 }
 
 func DisableEverything(cmd *cobra.Command) {
@@ -126,11 +182,7 @@ func RecordTelemetryNow(cmd *cobra.Command) {
 		"command": cmd.CommandPath(),
 		"flags":   strings.Join(flags, ","),
 	}
-	for k, v := range cmd.Annotations {
-		if after, ok := strings.CutPrefix(k, telemetryPropPrefix); ok {
-			props[after] = v
-		}
-	}
+	getTelemetryProps(ctx).mergeInto(props)
 
 	_ = tc.Track("command_invocation", props)
 }

--- a/internal/cmdutil/telemetry_test.go
+++ b/internal/cmdutil/telemetry_test.go
@@ -250,12 +250,115 @@ func TestRecordTelemetry(t *testing.T) {
 		assert.Check(t, cmp.Len(recorder.Tracks(), 0))
 	})
 
+	t.Run("includes extra props set from a context-only caller", func(t *testing.T) {
+		recorder, client := newTelemetry(t)
+		cmd := &cobra.Command{
+			Use: "onboard",
+			RunE: func(cmd *cobra.Command, args []string) error {
+				// Stands in for a business logic package, which is handed a ctx and
+				// must not reach for the running command.
+				setFromBusinessLogic(cmd.Context())
+				return nil
+			},
+		}
+		ctx := cmdutil.WithTelemetry(context.Background(), client)
+		cmd.SetContext(ctx)
+		cmdutil.RecordTelemetry(cmd)
+		assert.NilError(t, cmd.RunE(cmd, nil))
+		assert.NilError(t, client.Close())
+
+		assert.Check(t, cmp.DeepEqual(properties(recorder.Tracks()), []analytics.Properties{
+			{
+				"command":        "onboard",
+				"flags":          "",
+				"onboard_mode":   "scan",
+				"onboard_signup": "completed",
+			},
+		}))
+	})
+
+	// A later write replaces an earlier one, which is what lets a step be seeded
+	// with a placeholder before the run and overwritten by its real outcome.
+	t.Run("last write of a prop wins", func(t *testing.T) {
+		recorder, client := newTelemetry(t)
+		cmd := &cobra.Command{
+			Use: "onboard",
+			RunE: func(cmd *cobra.Command, args []string) error {
+				cmdutil.SetTelemetryProp(cmd.Context(), "onboard_signup", "not_reached")
+				cmdutil.SetTelemetryProp(cmd.Context(), "onboard_signup", "completed")
+				return nil
+			},
+		}
+		ctx := cmdutil.WithTelemetry(context.Background(), client)
+		cmd.SetContext(ctx)
+		cmdutil.RecordTelemetry(cmd)
+		assert.NilError(t, cmd.RunE(cmd, nil))
+		assert.NilError(t, client.Close())
+
+		assert.Check(t, cmp.DeepEqual(properties(recorder.Tracks()), []analytics.Properties{
+			{"command": "onboard", "flags": "", "onboard_signup": "completed"},
+		}))
+	})
+
+	// Props are recorded after the handler returns, so an outcome set before a
+	// failure still reaches the event.
+	t.Run("records props set before a failing RunE returned", func(t *testing.T) {
+		recorder, client := newTelemetry(t)
+		wantErr := fmt.Errorf("trigger could not be created")
+		cmd := &cobra.Command{
+			Use: "onboard",
+			RunE: func(cmd *cobra.Command, args []string) error {
+				cmdutil.SetTelemetryProp(cmd.Context(), "onboard_project_setup", "trigger_failed")
+				return wantErr
+			},
+		}
+		ctx := cmdutil.WithTelemetry(context.Background(), client)
+		cmd.SetContext(ctx)
+		cmdutil.RecordTelemetry(cmd)
+		assert.Check(t, cmp.ErrorIs(cmd.RunE(cmd, nil), wantErr))
+		assert.NilError(t, client.Close())
+
+		assert.Check(t, cmp.DeepEqual(properties(recorder.Tracks()), []analytics.Properties{
+			{"command": "onboard", "flags": "", "onboard_project_setup": "trigger_failed"},
+		}))
+	})
+
+	// Telemetry is best-effort. WithTelemetry installs the property set, so a
+	// context without one has no sender either and nothing to attach a property
+	// to: business logic that records an outcome while running under a bare
+	// context must be dropped quietly rather than panic.
+	t.Run("recording a prop without telemetry in the context is a no-op", func(t *testing.T) {
+		cmdutil.SetTelemetryProp(context.Background(), "onboard_mode", "scan")
+	})
+
+	// A sender re-installed mid-run must not discard outcomes already recorded,
+	// since properties belong to the invocation rather than to the sender.
+	t.Run("reinstalling telemetry keeps props already recorded", func(t *testing.T) {
+		recorder, client := newTelemetry(t)
+		cmd := &cobra.Command{
+			Use: "onboard",
+			RunE: func(cmd *cobra.Command, args []string) error {
+				cmdutil.SetTelemetryProp(cmd.Context(), "onboard_mode", "scan")
+				cmd.SetContext(cmdutil.WithTelemetry(cmd.Context(), client))
+				return nil
+			},
+		}
+		cmd.SetContext(cmdutil.WithTelemetry(context.Background(), client))
+		cmdutil.RecordTelemetry(cmd)
+		assert.NilError(t, cmd.RunE(cmd, nil))
+		assert.NilError(t, client.Close())
+
+		assert.Check(t, cmp.DeepEqual(properties(recorder.Tracks()), []analytics.Properties{
+			{"command": "onboard", "flags": "", "onboard_mode": "scan"},
+		}))
+	})
+
 	t.Run("includes extra props set via SetTelemetryProp", func(t *testing.T) {
 		recorder, client := newTelemetry(t)
 		cmd := &cobra.Command{
 			Use: "api",
 			RunE: func(cmd *cobra.Command, args []string) error {
-				cmdutil.SetTelemetryProp(cmd, "api_path", "api/v2/me")
+				cmdutil.SetTelemetryProp(cmd.Context(), "api_path", "api/v2/me")
 				return nil
 			},
 		}
@@ -437,3 +540,20 @@ const (
 	userID     = "cb3ce909-79b7-4a12-baa4-ecb986047e37"
 	instanceID = "536bbd16-bf6c-4d1c-bf2c-fc2bb474fb42"
 )
+
+// setFromBusinessLogic records props the way a package outside internal/cmd does:
+// from a ctx alone, with no access to the cobra command.
+func setFromBusinessLogic(ctx context.Context) {
+	cmdutil.SetTelemetryProp(ctx, "onboard_mode", "scan")
+	cmdutil.SetTelemetryProp(ctx, "onboard_signup", "completed")
+}
+
+// properties reduces recorded tracks to their properties, for tests asserting on
+// the props alone. The full event shape is pinned by the subtests above.
+func properties(tracks []analytics.Track) []analytics.Properties {
+	props := make([]analytics.Properties, 0, len(tracks))
+	for _, track := range tracks {
+		props = append(props, track.Properties)
+	}
+	return props
+}

--- a/internal/onboarder/onboarder.go
+++ b/internal/onboarder/onboarder.go
@@ -60,6 +60,36 @@ const (
 // push, which is what onboard sets up.
 const allPushesPreset = "all-pushes"
 
+// Telemetry attributes recorded on the command_invocation event, one per step of
+// the flow. Each step happens at most once per run, which is what makes them
+// attributes of the invocation rather than events in their own right.
+//
+// One attribute per step rather than a single merged outcome: a query can
+// collapse these, but a merged value could never be taken apart again.
+const (
+	propMode          = "onboard_mode"
+	propOrgType       = "onboard_org_type"
+	propSignup        = "onboard_signup_outcome"
+	propProjectSetup  = "onboard_project_setup_outcome"
+	propProjectFollow = "onboard_project_follow_outcome"
+)
+
+const (
+	// notReached is the value every step attribute starts at. A single event per
+	// invocation cannot express a sequence, so an absent attribute would be
+	// ambiguous: it could mean the step never ran, or that it ran and said
+	// nothing. Seeding every step with notReached removes the ambiguity — "the
+	// flow stopped before here" reads differently from any outcome the step
+	// itself reports.
+	notReached = "not_reached"
+
+	// notApplicable separates a step this organization has no equivalent of from
+	// one the run stopped short of. Both would otherwise read as notReached,
+	// which would make "the user dropped out" and "there was nothing to do"
+	// indistinguishable — the ambiguity seeding exists to remove.
+	notApplicable = "not_applicable"
+)
+
 // Options configures the onboarding flow.
 type Options struct {
 	ConfigPath    string
@@ -78,24 +108,25 @@ type Options struct {
 // Run generates a starter config for a repository when it has none, and ensures
 // the CLI has an authenticated CircleCI session.
 func Run(ctx context.Context, dir string, opts Options) error {
+	// Seed before the first thing that can fail, so even a run that resolves no
+	// mode at all still reports a complete set of steps.
+	for _, prop := range []string{propMode, propOrgType, propSignup, propProjectSetup, propProjectFollow} {
+		cmdutil.SetTelemetryProp(ctx, prop, notReached)
+	}
+
 	m, err := resolveMode(ctx, opts)
 	if err != nil {
 		return err
 	}
 
-	trackOnboard(ctx, "onboard_mode_selected", map[string]any{
-		"mode": modeString(m),
-	})
+	cmdutil.SetTelemetryProp(ctx, propMode, modeString(m))
 
 	if m == modeSignup {
 		result, err := cmdauth.SignupIfNeeded(ctx, opts.NoBrowser, opts.SecureStorage, opts.ConfigPath)
 		if err != nil {
 			return err
 		}
-		trackOnboard(ctx, "onboard_signup", map[string]any{
-			"mode":    "signup",
-			"outcome": string(result.Outcome),
-		})
+		cmdutil.SetTelemetryProp(ctx, propSignup, string(result.Outcome))
 		// --signup may be run anywhere — it needs no repository — so the directory
 		// has been through none of the validation below. repoDir yields "" unless it
 		// really is a checkout, which keeps a run from a home directory out of
@@ -154,10 +185,7 @@ func Run(ctx context.Context, dir string, opts Options) error {
 	if err != nil {
 		return err
 	}
-	trackOnboard(ctx, "onboard_signup", map[string]any{
-		"mode":    "scan",
-		"outcome": string(signupResult.Outcome),
-	})
+	cmdutil.SetTelemetryProp(ctx, propSignup, string(signupResult.Outcome))
 
 	return postSignupGuidance(ctx, dir, opts)
 }
@@ -207,6 +235,11 @@ func postSignupGuidance(ctx context.Context, dir string, opts Options) error {
 		return stopWithGuidance(ctx)
 	}
 
+	// Which integration owns the organization decides which steps below exist at
+	// all, so it is recorded as its own attribute rather than left to be inferred
+	// from which step outcomes came back empty.
+	cmdutil.SetTelemetryProp(ctx, propOrgType, selectedOrg.VCSType)
+
 	appURL, _ := cmdutil.AppURL(ctx)
 
 	// One read of the checkout's remote serves the suggested project name, the
@@ -235,7 +268,11 @@ func postSignupGuidance(ctx context.Context, dir string, opts Options) error {
 			return stopWithGuidance(ctx)
 		}
 
+		// A classic organization stops here: pipeline definitions and triggers are
+		// CircleCI-native only, so the setup step does not exist on this path
+		// rather than being one the run fell short of.
 		if selectedOrg.VCSType != "circleci" {
+			cmdutil.SetTelemetryProp(ctx, propProjectSetup, notApplicable)
 			followClassicProject(ctx, client, appURL, vcs, orgName, name)
 			return nil
 		}
@@ -505,14 +542,14 @@ func setupFirstPipeline(ctx context.Context, client *apiclient.Client, appURL st
 	repoID, p := resolveRepoID(ctx, client, appURL, proj, remote, opts)
 	if repoID == "" {
 		// No external ID, so there is nothing to attach a definition to.
-		trackOnboard(ctx, "onboard_project_setup", map[string]any{"outcome": "skipped_no_repo_id"})
+		cmdutil.SetTelemetryProp(ctx, propProjectSetup, "skipped_no_repo_id")
 		printManualPipelineGuidance(ctx)
 		return nil
 	}
 
 	def, err := ensurePipelineDefinition(ctx, client, p, proj.ID, proj.Name, repoID, remote.FullName())
 	if err != nil {
-		trackOnboard(ctx, "onboard_project_setup", map[string]any{"outcome": "pipeline_definition_failed"})
+		cmdutil.SetTelemetryProp(ctx, propProjectSetup, "pipeline_definition_failed")
 		return clierrors.New("onboard.pipeline_definition_failed",
 			"Could not set up the pipeline definition",
 			fmt.Sprintf("The project was created, but its pipeline definition could not be set up: %s.", err)).
@@ -524,7 +561,7 @@ func setupFirstPipeline(ctx context.Context, client *apiclient.Client, appURL st
 	}
 
 	if err := ensureTrigger(ctx, client, p, proj.ID, def.ID, repoID, remote.FullName()); err != nil {
-		trackOnboard(ctx, "onboard_project_setup", map[string]any{"outcome": "trigger_failed"})
+		cmdutil.SetTelemetryProp(ctx, propProjectSetup, "trigger_failed")
 		return clierrors.New("onboard.trigger_failed",
 			"Could not set up the trigger",
 			fmt.Sprintf("The pipeline definition was created, but its trigger could not be: %s.", err)).
@@ -535,7 +572,7 @@ func setupFirstPipeline(ctx context.Context, client *apiclient.Client, appURL st
 			WithExitCode(clierrors.ExitAPIError)
 	}
 
-	trackOnboard(ctx, "onboard_project_setup", map[string]any{"outcome": "created"})
+	cmdutil.SetTelemetryProp(ctx, propProjectSetup, "created")
 	printPipelineReadyGuidance(ctx)
 	return nil
 }
@@ -732,7 +769,7 @@ func printManualPipelineGuidance(ctx context.Context) {
 func followProject(ctx context.Context, client *apiclient.Client, proj *apiclient.ProjectInfo) {
 	vcs, orgSegment, projectSegment, err := cmdutil.ParseSlug(proj.Slug)
 	if err != nil {
-		trackOnboard(ctx, "onboard_project_follow", map[string]any{"outcome": "skipped_bad_slug"})
+		cmdutil.SetTelemetryProp(ctx, propProjectFollow, "skipped_bad_slug")
 		return
 	}
 
@@ -740,20 +777,23 @@ func followProject(ctx context.Context, client *apiclient.Client, proj *apiclien
 		iostream.ErrPrintf(ctx,
 			"%s Could not follow the project, so you may not be notified about its pipelines: %s\n",
 			iostream.SymbolWarn(ctx), err)
-		trackOnboard(ctx, "onboard_project_follow", map[string]any{"outcome": "failed"})
+		cmdutil.SetTelemetryProp(ctx, propProjectFollow, "failed")
 		return
 	}
 
 	iostream.Printf(ctx, "%s Following %s\n", iostream.SymbolOK(ctx), proj.Name)
-	trackOnboard(ctx, "onboard_project_follow", map[string]any{"outcome": "followed"})
+	cmdutil.SetTelemetryProp(ctx, propProjectFollow, "followed")
 }
 
 func followClassicProject(ctx context.Context, client *apiclient.Client, appURL, vcs, orgName, repoName string) {
 	if err := client.FollowProject(ctx, vcs, orgName, repoName); err != nil {
 		iostream.ErrPrintf(ctx, "%s Could not connect project: %s\n", iostream.SymbolWarn(ctx), err)
+		cmdutil.SetTelemetryProp(ctx, propProjectFollow, "failed")
 		printManualGuidance(ctx)
 		return
 	}
+
+	cmdutil.SetTelemetryProp(ctx, propProjectFollow, "followed")
 
 	slug := fmt.Sprintf("%s/%s/%s", vcs, orgName, repoName)
 	iostream.Printf(ctx, "%s Project connected: %s\n", iostream.SymbolOK(ctx), repoName)
@@ -785,14 +825,6 @@ func printLinkGuidance(ctx context.Context, workDir, orgSlug string) {
 	iostream.Printf(ctx, "\nCopy that project's ID from its settings in CircleCI, then run:\n")
 	iostream.Printf(ctx, "  circleci project link %s\n", args)
 	iostream.Printf(ctx, "  circleci onboard\n")
-}
-
-func trackOnboard(ctx context.Context, event string, props map[string]any) {
-	tc := cmdutil.GetTelemetry(ctx)
-	if tc == nil {
-		return
-	}
-	_ = tc.Track(event, props)
 }
 
 func modeString(m mode) string {


### PR DESCRIPTION
## What

`circleci onboard` emitted four bespoke telemetry events. They now ride on the existing per-command `command_invocation` event as attributes, and the events are gone.

| Removed event | Now an attribute |
|---|---|
| `onboard_mode_selected` | `onboard_mode` |
| `onboard_signup` | `onboard_signup_outcome` |
| `onboard_project_setup` | `onboard_project_setup_outcome` |
| `onboard_project_follow` | `onboard_project_follow_outcome` |
| *(new)* | `onboard_org_type` |

## Why this shape fits

Each of the four fired **at most once per run**, and every emit site is a mutually exclusive early-return branch. They were one-shot status flags describing a single invocation, not a sequence of occurrences, which is what attributes are for. It also means one event to govern in the tracking plan instead of five.

## Making every step unambiguous

Every step attribute is seeded with `not_reached` before the flow starts. A single event cannot express a sequence, so an absent attribute could mean either that the step never ran or that it ran and reported nothing.

Seeding alone was not enough, because the two organization types run different steps:

- **`onboard_org_type`** records the integration that owns the organization (`circleci`, `github`, …). Which one it is decides which later steps exist at all, so it is recorded outright rather than inferred from which outcomes came back empty.
- **`not_applicable`** is reported for a step the organization has no equivalent of. A classic organization has no pipeline definition or trigger, so its setup step is not one the run fell short of. Without this, "the user dropped out" and "there was nothing to do" would both read as `not_reached`.
- The **classic follow is now reported**. It performs a real follow via `FollowProject`, which the CircleCI-native path recorded and the classic one did not, so the seeded value would have claimed the step never ran on a run where it succeeded.

Three acceptance subtests pin the resulting shapes: a CircleCI-native run through to `created`/`followed`, a classic run reporting `not_applicable`/`followed`, and a run that fails before selecting an organization reporting `not_reached` throughout.

## Context-carried properties

`internal/onboarder` is business logic, so it only ever receives a `ctx` and never holds the running cobra command (commands import business logic, never the reverse). `SetTelemetryProp` therefore takes a `ctx`; the one command already using it passes `cmd.Context()`. That replaces the previous cobra-annotation mechanism, which no context-only caller could reach.

`WithTelemetry` installs the property set alongside the sender, so there is no second installer to forget. A sender without a property set would silently drop every property, and there is no use for one without the other. An existing set is carried over rather than replaced, because properties belong to the invocation and not to whichever sender is current, so re-installing a sender mid-run cannot discard what earlier steps recorded. Both behaviours have regression tests that fail if the logic is reverted.

## Trade-off worth naming

This gives up the ability to build a native event-sequence funnel over these steps, since a single event has no sequence. Step drop-off is now derived from the attribute values instead. That is deliberate: all the steps happen inside one CLI run lasting seconds, so a multi-step funnel was not really the right frame for them.

Migration cost is low. `onboard_project_follow` was being quarantined rather than landing, so nothing could have been depending on it.