### PR TITLE
Update setup-go to v0.4.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 parameters:
   setup_go:
     type: string
-    default: github.com/circleci-functions/setup-go@v0.4.0-bfaab3a
+    default: github.com/circleci-functions/setup-go@v0.4.1-683e500
 
 commands:
   setup:


### PR DESCRIPTION
Bumps the `setup_go` function pin from `v0.4.0-bfaab3a` to `v0.4.1-683e500`.

`v0.4.1` stops build cache restores from crossing a rotation window. The build cache
had been growing without limit: its restore keys matched broadly enough to reach an
earlier rotation window, and since the teardown save writes the whole directory back,
every window inherited the previous one's contents and added to them. Moving the epoch
ahead of the checksum in the key means a restore can broaden across dependency sets
while still pinning the window, so the 72h rotation actually reclaims space again.

No flag changes — this is a version-only bump.

Existing build cache entries are orphaned by the key change, so the first job per job
name and arch on this branch compiles cold.