### PR TITLE
Use setup-go v0.5.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 parameters:
   setup_go:
     type: string
-    default: github.com/circleci-functions/setup-go@v0.4.1-683e500
+    default: github.com/circleci-functions/setup-go@v0.5.1-684fd5b
 
 commands:
   setup:


### PR DESCRIPTION
setup-go now links the toolchain onto PATH instead of exporting it to $BASH_ENV. 