### PR TITLE
Fix runner help text that documented a flag and a file it should not

### DIFF
--- a/internal/cmd/root/testdata/help/circleci/reference.txt
+++ b/internal/cmd/root/testdata/help/circleci/reference.txt
@@ -3662,10 +3662,9 @@ Resource class names use the format namespace/name (e.g. my-org/my-runner).
 
 #### `circleci runner config <resource-class> [flags]`
 
-Generate a runner agent configuration file
+Generate a machine runner configuration file
 
-Generate a runner agent configuration YAML for a resource class, suitable for
-use as the agent's circleci-runner-config.yaml.
+Generate the api.auth_token stanza for a machine runner config file.
 
 A new authentication token is created unless you pass an existing one with
 --token, which generates the YAML without an API call.
@@ -3688,8 +3687,8 @@ in the form `namespace/name` (for example, `my-org/my-runner`).
   `circleci runner config my-org/my-runner`
 - Write config directly to a file: 
   `circleci runner config my-org/my-runner --output circleci-runner-config.yaml`
-- Create a nicely-labeled token and write to a file: 
-  `circleci runner config my-org/my-runner --nickname "prod-server-1" --output /etc/circleci-runner/circleci-runner-config.yaml`
+- Create a nicely-labeled token and write to a new file: 
+  `circleci runner config my-org/my-runner --nickname "prod-server-1" --output token.yaml`
 - Generate config from an existing token value (no API token creation): 
   `circleci runner config my-org/my-runner --token "$EXISTING_TOKEN_VALUE"`
 
@@ -3760,7 +3759,7 @@ remotes.
 - Open runners for a specific organization: 
   `circleci runner open --org gh/myorg`
 - Open when your remote is on CircleCI server: 
-  `circleci runner open --host https://circleci.example.com`
+  `CIRCLE_HOST=https://circleci.example.com circleci runner open`
 
 #### `circleci runner resource-class <command>`
 

--- a/internal/cmd/root/testdata/help/circleci/runner.txt
+++ b/internal/cmd/root/testdata/help/circleci/runner.txt
@@ -12,9 +12,9 @@ Manage self-hosted runners
 
 ## Targeted Commands
 
-| Command  | Description                                |
-| -------- | ------------------------------------------ |
-| `config` | Generate a runner agent configuration file |
+| Command  | Description                                  |
+| -------- | -------------------------------------------- |
+| `config` | Generate a machine runner configuration file |
 
 ## Subcommands
 

--- a/internal/cmd/root/testdata/help/circleci/runner/config.txt
+++ b/internal/cmd/root/testdata/help/circleci/runner/config.txt
@@ -1,4 +1,4 @@
-Generate a runner agent configuration file
+Generate a machine runner configuration file
 
 ## Usage
 
@@ -25,15 +25,14 @@ Global flags: `-c, --config`, `--debug`, `--no-color`, `-q, --quiet` — see `ci
   `circleci runner config my-org/my-runner`
 - Write config directly to a file: 
   `circleci runner config my-org/my-runner --output circleci-runner-config.yaml`
-- Create a nicely-labeled token and write to a file: 
-  `circleci runner config my-org/my-runner --nickname "prod-server-1" --output /etc/circleci-runner/circleci-runner-config.yaml`
+- Create a nicely-labeled token and write to a new file: 
+  `circleci runner config my-org/my-runner --nickname "prod-server-1" --output token.yaml`
 - Generate config from an existing token value (no API token creation): 
   `circleci runner config my-org/my-runner --token "$EXISTING_TOKEN_VALUE"`
 
 ## Details
 
-Generate a runner agent configuration YAML for a resource class, suitable for
-use as the agent's circleci-runner-config.yaml.
+Generate the api.auth_token stanza for a machine runner config file.
 
 A new authentication token is created unless you pass an existing one with
 --token, which generates the YAML without an API call.

--- a/internal/cmd/root/testdata/help/circleci/runner/open.txt
+++ b/internal/cmd/root/testdata/help/circleci/runner/open.txt
@@ -19,7 +19,7 @@ Global flags: `-c, --config`, `--debug`, `--no-color`, `-q, --quiet` — see `ci
 - Open runners for a specific organization: 
   `circleci runner open --org gh/myorg`
 - Open when your remote is on CircleCI server: 
-  `circleci runner open --host https://circleci.example.com`
+  `CIRCLE_HOST=https://circleci.example.com circleci runner open`
 
 ## Details
 

--- a/internal/cmd/runner/config.go
+++ b/internal/cmd/runner/config.go
@@ -44,7 +44,7 @@ func newConfigCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "config <resource-class>",
-		Short: "Generate a runner agent configuration file",
+		Short: "Generate a machine runner configuration file",
 		Annotations: map[string]string{
 			"help:arguments": heredoc.Docf(`
 				%[1]s<resource-class>%[1]s is the runner resource class to generate config for,
@@ -52,8 +52,7 @@ func newConfigCmd() *cobra.Command {
 			`, "`"),
 		},
 		Long: heredoc.Doc(`
-			Generate a runner agent configuration YAML for a resource class, suitable for
-			use as the agent's circleci-runner-config.yaml.
+			Generate the api.auth_token stanza for a machine runner config file.
 
 			A new authentication token is created unless you pass an existing one with
 			--token, which generates the YAML without an API call.
@@ -65,8 +64,8 @@ func newConfigCmd() *cobra.Command {
 			# Write config directly to a file
 			$ circleci runner config my-org/my-runner --output circleci-runner-config.yaml
 
-			# Create a nicely-labeled token and write to a file
-			$ circleci runner config my-org/my-runner --nickname "prod-server-1" --output /etc/circleci-runner/circleci-runner-config.yaml
+			# Create a nicely-labeled token and write to a new file
+			$ circleci runner config my-org/my-runner --nickname "prod-server-1" --output token.yaml
 
 			# Generate config from an existing token value (no API token creation)
 			$ circleci runner config my-org/my-runner --token "$EXISTING_TOKEN_VALUE"

--- a/internal/cmd/runner/open.go
+++ b/internal/cmd/runner/open.go
@@ -53,7 +53,7 @@ func newOpenCmd() *cobra.Command {
 			$ circleci runner open --org gh/myorg
 
 			# Open when your remote is on CircleCI server
-			$ circleci runner open --host https://circleci.example.com
+			$ CIRCLE_HOST=https://circleci.example.com circleci runner open
 		`),
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {

--- a/internal/cmd/runner/runner.go
+++ b/internal/cmd/runner/runner.go
@@ -70,9 +70,9 @@ func runnerNotEnabledErr() *clierrors.CLIError {
 	return clierrors.New("runner.not_enabled", "Runner not available",
 		"Self-hosted runners are not available for this token or account. The API returned 404.").
 		WithSuggestions(
-			"Confirm your token has runner permissions",
-			"Check that your plan includes self-hosted runners: https://app.circleci.com/settings/plan",
+			"Confirm your token can view or administer self-hosted runners",
+			"Confirm the token belongs to the organization that owns the resource class",
 		).
-		WithRef("https://circleci.com/docs/runner-overview/").
+		WithRef("https://circleci.com/docs/guides/execution-runner/runner-overview/").
 		WithExitCode(clierrors.ExitAPIError)
 }


### PR DESCRIPTION
Three pieces of runner help text were wrong. Help text only, no behaviour
changes.

## `runner open` documented a flag that does not exist

The example advertised `--host`:

```
$ circleci runner open --host https://circleci.example.com --org gh/myorg
unknown flag: --host
```

`--host` is a hidden 0.1.x compatibility flag registered only on the `orb`
group (`internal/cmd/orb/orb.go:59`), so the example always exited 1.

Now spelled `CIRCLE_HOST=https://circleci.example.com circleci runner open`,
which is the supported form and matches the precedent in
`internal/cmd/cmdauth/login.go`. It exits 0 and resolves to
`https://app.circleci.example.com/runners/gh/myorg/inventory`.

## `runner.not_enabled` had a stale doc URL and a wrong suggestion

`circleci.com/docs/runner-overview/` 301s. `WithRef` now points at
`circleci.com/docs/guides/execution-runner/runner-overview/`, which returns 200
with no redirect.

The suggestion "Check that your plan includes self-hosted runners" was wrong:
self-hosted runners are available on all plans, and the 404 this error maps is
returned for a permission failure. Both suggestions now name permissions.

## `runner config` described its output as a complete config file

The command emits only the `api.auth_token` stanza, so the `Long` claim that it
was "suitable for use as the agent's circleci-runner-config.yaml" was wrong.

The third example made that claim concrete and was destructive:

```
$ circleci runner config my-org/my-runner --nickname "prod-server-1" --output /etc/circleci-runner/circleci-runner-config.yaml
```

`--output` truncates. Pointed at an installed config file that discards
everything else in it, after which the agent will not start. The example now
writes to a new file. What the command emits is unchanged.

## Notes

- Help goldens regenerated. `go test ./...` green, `golangci-lint` clean.
- `config` stayed inside the 40-line `--help` budget; `Long` was trimmed, never
  the examples.
- The read-only examples in the package were executed. The mutating ones
  (`resource-class create`, `--generate-token`, `token create`, `token delete`,
  `resource-class delete`) were reviewed but not run against a live
  organization.
