### PR TITLE
Disambiguate pipeline definitions from pipeline runs in help

### DIFF
--- a/internal/cmd/pipeline/pipeline.go
+++ b/internal/cmd/pipeline/pipeline.go
@@ -35,14 +35,15 @@ func NewPipelineCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "pipeline <command>",
 		GroupID: "ci",
-		Short:   "Define what will happen in a run",
+		Short:   "Manage the pipeline definitions a run executes",
 		Long: heredoc.Doc(`
 			Create and list pipeline definitions for a CircleCI project.
 
 			A pipeline definition decides what happens when a run is triggered:
 			which repository to check out and where to find the config YAML that
 			CircleCI compiles into workflows. Attach triggers to a definition with
-			'circleci project trigger create'.
+			'circleci project trigger create', and list the runs one produced with
+			'circleci run list'.
 		`),
 		RunE:               cmdutil.GroupRunE,
 		FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},

--- a/internal/cmd/root/testdata/help/circleci.txt
+++ b/internal/cmd/root/testdata/help/circleci.txt
@@ -13,8 +13,8 @@ Work with CircleCI from the command line.
 | `artifact`   | List and download a job's artifact files         |
 | `config`     | Generate, validate, process and pack config YAML |
 | `job`        | Inspect a job's details, output and artifacts    |
-| `pipeline`   | Define what will happen in a run                 |
-| `run`        | Trigger, watch and cancel CI runs                |
+| `pipeline`   | Manage the pipeline definitions a run executes   |
+| `run`        | Trigger, watch and cancel pipeline runs          |
 | `testresult` | Inspect test results for a job                   |
 | `workflow`   | Inspect, rerun and cancel workflows (job graphs) |
 

--- a/internal/cmd/root/testdata/help/circleci/pipeline.txt
+++ b/internal/cmd/root/testdata/help/circleci/pipeline.txt
@@ -1,4 +1,4 @@
-Define what will happen in a run
+Manage the pipeline definitions a run executes
 
 ## Usage
 
@@ -28,5 +28,6 @@ Create and list pipeline definitions for a CircleCI project.
 A pipeline definition decides what happens when a run is triggered:
 which repository to check out and where to find the config YAML that
 CircleCI compiles into workflows. Attach triggers to a definition with
-'circleci project trigger create'.
+'circleci project trigger create', and list the runs one produced with
+'circleci run list'.
 

--- a/internal/cmd/root/testdata/help/circleci/reference.txt
+++ b/internal/cmd/root/testdata/help/circleci/reference.txt
@@ -395,14 +395,15 @@ shown in the output of `circleci workflow get` and `circleci job get`.
 
 ### `circleci pipeline <command>`
 
-Define what will happen in a run
+Manage the pipeline definitions a run executes
 
 Create and list pipeline definitions for a CircleCI project.
 
 A pipeline definition decides what happens when a run is triggered:
 which repository to check out and where to find the config YAML that
 CircleCI compiles into workflows. Attach triggers to a definition with
-'circleci project trigger create'.
+'circleci project trigger create', and list the runs one produced with
+'circleci run list'.
 
 #### `circleci pipeline create [flags]`
 
@@ -510,13 +511,14 @@ JSON fields: id, state, number, created_at, triggered — or triggered, message 
 
 ### `circleci run <command>`
 
-Trigger, watch and cancel CI runs
+Trigger, watch and cancel pipeline runs
 
 Work with CircleCI runs.
 
-A run is created each time a trigger fires for a pipeline. It carries
-the VCS context for that firing and groups the workflows it produced;
-each workflow in turn contains jobs.
+A run is one execution of a pipeline, created each time a trigger
+fires. It carries the VCS context for that firing and groups the
+workflows it produced; each workflow in turn contains jobs. In the
+REST API, a run is called a pipeline.
 
 #### `circleci run cancel <run-number-or-id> [flags]`
 
@@ -603,10 +605,8 @@ List recent runs for a project
 
 List recent runs for a CircleCI project.
 
-The project is inferred from the current git repository's remote
-unless overridden with --project. Use --branch to filter results
-to a single branch, or --current-branch (-B) to automatically use
-the branch you have checked out.
+A run is one execution of a pipeline. The project is inferred from the
+current git repository's remote unless overridden with --project.
 
 The markdown table includes the commit subject; the JSON adds the full
 commit and repository detail.

--- a/internal/cmd/root/testdata/help/circleci/run.txt
+++ b/internal/cmd/root/testdata/help/circleci/run.txt
@@ -1,4 +1,4 @@
-Trigger, watch and cancel CI runs
+Trigger, watch and cancel pipeline runs
 
 ## Usage
 
@@ -28,7 +28,8 @@ Global flags: `-c, --config`, `--debug`, `--no-color`, `-q, --quiet` — see `ci
 
 Work with CircleCI runs.
 
-A run is created each time a trigger fires for a pipeline. It carries
-the VCS context for that firing and groups the workflows it produced;
-each workflow in turn contains jobs.
+A run is one execution of a pipeline, created each time a trigger
+fires. It carries the VCS context for that firing and groups the
+workflows it produced; each workflow in turn contains jobs. In the
+REST API, a run is called a pipeline.
 

--- a/internal/cmd/root/testdata/help/circleci/run/list.txt
+++ b/internal/cmd/root/testdata/help/circleci/run/list.txt
@@ -38,10 +38,8 @@ Global flags: `-c, --config`, `--debug`, `--no-color`, `-q, --quiet` — see `ci
 
 List recent runs for a CircleCI project.
 
-The project is inferred from the current git repository's remote
-unless overridden with --project. Use --branch to filter results
-to a single branch, or --current-branch (-B) to automatically use
-the branch you have checked out.
+A run is one execution of a pipeline. The project is inferred from the
+current git repository's remote unless overridden with --project.
 
 The markdown table includes the commit subject; the JSON adds the full
 commit and repository detail.

--- a/internal/cmd/root/usage_test.go
+++ b/internal/cmd/root/usage_test.go
@@ -94,7 +94,7 @@ var overBudget = map[string]int{
 	"circleci/project/create":         41,
 	"circleci/project/trigger/create": 41,
 	"circleci/run/get":                53,
-	"circleci/run/list":               49,
+	"circleci/run/list":               47,
 	"circleci/run/watch":              48,
 	"circleci/testresult/get":         44,
 	"circleci/testresult/list":        47,

--- a/internal/cmd/run/list.go
+++ b/internal/cmd/run/list.go
@@ -53,10 +53,8 @@ func newListCmd() *cobra.Command {
 		Long: heredoc.Doc(`
 			List recent runs for a CircleCI project.
 
-			The project is inferred from the current git repository's remote
-			unless overridden with --project. Use --branch to filter results
-			to a single branch, or --current-branch (-B) to automatically use
-			the branch you have checked out.
+			A run is one execution of a pipeline. The project is inferred from the
+			current git repository's remote unless overridden with --project.
 
 			The markdown table includes the commit subject; the JSON adds the full
 			commit and repository detail.

--- a/internal/cmd/run/run.go
+++ b/internal/cmd/run/run.go
@@ -37,13 +37,14 @@ func NewRunCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "run <command>",
 		GroupID: "ci",
-		Short:   "Trigger, watch and cancel CI runs",
+		Short:   "Trigger, watch and cancel pipeline runs",
 		Long: heredoc.Doc(`
 			Work with CircleCI runs.
 
-			A run is created each time a trigger fires for a pipeline. It carries
-			the VCS context for that firing and groups the workflows it produced;
-			each workflow in turn contains jobs.
+			A run is one execution of a pipeline, created each time a trigger
+			fires. It carries the VCS context for that firing and groups the
+			workflows it produced; each workflow in turn contains jobs. In the
+			REST API, a run is called a pipeline.
 		`),
 	}
 

--- a/skills/circleci/SKILL.md
+++ b/skills/circleci/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: circleci
-description: Patterns for invoking the CircleCI CLI (circle) from agents. Covers structured output,
-  project and org targeting, list, circleci api fallback.
+description: Patterns for invoking the CircleCI CLI (circleci) from agents. Covers structured output,
+  project and org targeting, which command replaces each REST endpoint, circleci api fallback.
 ---
 
 # Reference
@@ -28,6 +28,35 @@ Human output from `circleci` is markdown-formatted. If you want structured data:
 
 Pass `--org <VCS>/<ORG>` to override the resolved CWD repo, where VCS is `gh` / `bb` / `circleci`.
 
+## Vocabulary: the REST API's "pipeline" is a "run" here
+
+One execution of a pipeline is a **run** here, so recent pipelines come from
+`circleci run list`, not `circleci pipeline list`. `circleci pipeline` manages
+pipeline *definitions*: which repo to check out and where the config YAML lives.
+
+Every command below supports `--json` and `--jq`, so there is no output-shape
+reason to reach for raw REST:
+
+| Instead of | Use |
+| --- | --- |
+| `GET /api/v2/project/{slug}/pipeline` | `circleci run list [--branch <b>] [--project gh/org/repo]` |
+| `GET /api/v2/pipeline/{id}` | `circleci run get <run-id>` |
+| `GET /api/v2/pipeline/{id}/workflow` | `circleci workflow list <run-id>` |
+| `GET /api/v2/workflow/{id}` | `circleci workflow get <workflow-id>` |
+| `GET /api/v2/workflow/{id}/job` | `circleci workflow get <workflow-id> --json` (`jobs[]`) |
+| `GET /api/v2/project/{slug}/job/{n}` | `circleci job get <job-id>` |
+| job step output / logs | `circleci job output list <job-id>`, `circleci job output get <job-id>` |
+| `GET /api/v2/project/{slug}/{n}/artifacts` | `circleci artifact <job-id>` |
+| `GET /api/v2/project/{slug}/{n}/tests` | `circleci testresult list <job-id>` |
+| `GET /api/v2/me` | `circleci auth me` |
+| `GET /api/v2/project/{slug}/envvar` | `circleci envvar list` |
+| `GET /api/v2/context`, `/environment-variable` | `circleci context list`, `circleci context secret list <ctx>` |
+| `GET /api/v2/projects/{id}/pipeline-definitions` | `circleci pipeline list` |
+| `GET /api/v2/projects/{id}/triggers` | `circleci project trigger list` |
+
+Run ids accept a UUID or a run number. Workflow and job ids are UUIDs, and are
+printed by `circleci run get --json` and `circleci workflow get --json`.
+
 ## Finding failed jobs
 
 `circleci run` subcommands are the starting point.
@@ -38,9 +67,14 @@ Pass `--org <VCS>/<ORG>` to override the resolved CWD repo, where VCS is `gh` / 
 - `circleci job get <job-id> --json`: will get you the job attributes, and step info without output.
 - `circleci job output get <job-id> --json`: `--step-num <step-id>` will get you the ANSI-stipped output for a specific step.
 
-## Fall back to `circleci api` for anything `--json` doesn't expose
+## Fall back to `circleci api` only when nothing above covers it
 
-Sometimes useful data isn't on the typed commands. 
+Some data has no typed command: insights, usage exports, schedules, checkout
+keys and webhooks. Reach for the escape hatch there, on `api/v2` or `api/v3`.
+
+Don't use `api/v1.1/*`: it is the legacy API, and its common uses are already
+covered. Recent builds are `circleci run list`, one build is `circleci run get`,
+one job is `circleci job get`.
 
 - REST shortcuts: `circleci api 'projects/{project-id}'` or
   `circleci api 'runs?filter[project_id]={project-id}'` - note the


### PR DESCRIPTION
## Why

The REST API's *pipeline* means one execution of a config. In this CLI that is a **run**, and the `pipeline` noun is used for pipeline *definitions* (which repo to check out, where the config YAML lives). Both are reasonable on their own, but nothing in either command's help pointed at the other:

- `circleci --help` described them in isolation: "Define what will happen in a run" and "Trigger, watch and cancel CI runs". Neither line tells you which one holds pipelines that have already run.
- `circleci pipeline --help` never mentioned `run`.
- `circleci run list --help` never used the word "pipeline".

So someone who wants recent pipelines reaches for `circleci pipeline list`, gets a table of config and checkout sources, and reasonably concludes the CLI cannot do it. The same applies to anyone arriving with the REST API's vocabulary in hand, including agents reading `--help` and the shipped skill.

## What changed

**Root listing** now contrasts the two nouns instead of describing each alone, which is where the choice actually gets made:

```
| `pipeline`   | Manage the pipeline definitions a run executes   |
| `run`        | Trigger, watch and cancel pipeline runs          |
```

**`circleci pipeline --help`** points at `circleci run list` for the runs a definition produced, folded into the sentence that already points at `circleci project trigger create`, so no new paragraph.

**`circleci run --help`** states the mapping once, in a closing sentence: in the REST API, a run is called a pipeline. No version numbers or endpoint paths in user-facing help.

**`skills/circleci/SKILL.md`** gains an endpoint-to-command table, so a reader who knows a REST path finds the command that replaces it. Every command and argument shape in the table was checked against the built binary. Two other fixes there:

- The fallback section was titled "Fall back to `circleci api` for anything `--json` doesn't expose", which is broader than the truth. It now names the cases that genuinely have no command (insights, usage exports, schedules, checkout keys, webhooks) and steers off the legacy v1.1 API, whose common uses are already covered by `run list`, `run get` and `job get`.
- The frontmatter described the binary as `circle`.

## Notes

- `run list --help` drops from 50 to 48 lines, because the prose replaced there was restating `--branch` and `--current-branch` from the flag table, which is the first thing `agents/03-help-and-documentation.md` says to cut. Its `overBudget` cap ratchets from 49 to 47, probed to the floor.
- `pipeline --help` grows by one line, `run --help` by one; both remain inside the 40-line budget.
- Help and usage goldens regenerated with `task test -- ./internal/cmd/root/... -update`.

## Test plan

- `task check` clean.
- `task test` passes, other than pre-existing failures in `internal/orbinit` and `internal/gitremote` on machines with `commit.gpgSign = true` set globally, which go-git cannot honour. Both packages pass under `GIT_CONFIG_GLOBAL=/dev/null`.
- Help text reviewed by eye at `circleci --help`, `circleci pipeline --help`, `circleci pipeline list --help`, `circleci run --help`, `circleci run list --help`.

Text only. No behaviour, flags, or output shapes change.