### PR TITLE
Disambiguate pipeline definitions from pipeline runs in help

### DIFF
--- a/internal/cmd/api/api.go
+++ b/internal/cmd/api/api.go
@@ -62,8 +62,8 @@ func NewAPICmd() *cobra.Command {
 		Annotations: map[string]string{
 			"help:arguments": heredoc.Docf(`
 				%[1]s<path>%[1]s is the request path. It is relative to /api/v3 by default
-				(for example, "projects/{project-id}"). To target
-				a different version prefix, include it explicitly, for example, "api/v2/me".
+				(for example, "projects/{project-id}"). A path that starts with
+				%[1]sapi%[1]s is sent as given, so include the prefix to target another version.
 			`, "`"),
 		},
 		Long: heredoc.Doc(`
@@ -85,8 +85,8 @@ func NewAPICmd() *cobra.Command {
 			# Send a body read from a file (@- reads from stdin)
 			$ circleci api projects/{project-id}/run -d @payload.json
 
-			# Access the v1.1 API with a custom header
-			$ circleci api api/v1.1/me -H "X-Custom: value"
+			# Send a custom header
+			$ circleci api 'runs?filter[user_id]=me' -H "X-Custom: value"
 		`),
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/pipeline/pipeline.go
+++ b/internal/cmd/pipeline/pipeline.go
@@ -35,14 +35,15 @@ func NewPipelineCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "pipeline <command>",
 		GroupID: "ci",
-		Short:   "Define what will happen in a run",
+		Short:   "Manage the pipeline definitions a run executes",
 		Long: heredoc.Doc(`
 			Create and list pipeline definitions for a CircleCI project.
 
 			A pipeline definition decides what happens when a run is triggered:
 			which repository to check out and where to find the config YAML that
 			CircleCI compiles into workflows. Attach triggers to a definition with
-			'circleci project trigger create'.
+			'circleci project trigger create', and list the runs one produced with
+			'circleci run list'.
 		`),
 		RunE:               cmdutil.GroupRunE,
 		FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},

--- a/internal/cmd/root/testdata/help/circleci.txt
+++ b/internal/cmd/root/testdata/help/circleci.txt
@@ -13,8 +13,8 @@ Work with CircleCI from the command line.
 | `artifact`   | List and download a job's artifact files         |
 | `config`     | Generate, validate, process and pack config YAML |
 | `job`        | Inspect a job's details, output and artifacts    |
-| `pipeline`   | Define what will happen in a run                 |
-| `run`        | Trigger, watch and cancel CI runs                |
+| `pipeline`   | Manage the pipeline definitions a run executes   |
+| `run`        | Trigger, watch and cancel pipeline runs          |
 | `testresult` | Inspect test results for a job                   |
 | `workflow`   | Inspect, rerun and cancel workflows (job graphs) |
 

--- a/internal/cmd/root/testdata/help/circleci/api.txt
+++ b/internal/cmd/root/testdata/help/circleci/api.txt
@@ -7,8 +7,8 @@ Call the CircleCI REST API directly
 ## Arguments
 
 `<path>` is the request path. It is relative to /api/v3 by default
-(for example, "projects/{project-id}"). To target
-a different version prefix, include it explicitly, for example, "api/v2/me".
+(for example, "projects/{project-id}"). A path that starts with
+`api` is sent as given, so include the prefix to target another version.
 
 ## Flags
 
@@ -32,8 +32,8 @@ Global flags: `-c, --config`, `--debug`, `--no-color`, `-q, --quiet` — see `ci
   `circleci api projects/{project-id}/run -f definition_id=<id> -f "config[branch]=main"`
 - Send a body read from a file (@- reads from stdin): 
   `circleci api projects/{project-id}/run -d @payload.json`
-- Access the v1.1 API with a custom header: 
-  `circleci api api/v1.1/me -H "X-Custom: value"`
+- Send a custom header: 
+  `circleci api 'runs?filter[user_id]=me' -H "X-Custom: value"`
 
 ## Details
 

--- a/internal/cmd/root/testdata/help/circleci/pipeline.txt
+++ b/internal/cmd/root/testdata/help/circleci/pipeline.txt
@@ -1,4 +1,4 @@
-Define what will happen in a run
+Manage the pipeline definitions a run executes
 
 ## Usage
 
@@ -28,5 +28,6 @@ Create and list pipeline definitions for a CircleCI project.
 A pipeline definition decides what happens when a run is triggered:
 which repository to check out and where to find the config YAML that
 CircleCI compiles into workflows. Attach triggers to a definition with
-'circleci project trigger create'.
+'circleci project trigger create', and list the runs one produced with
+'circleci run list'.
 

--- a/internal/cmd/root/testdata/help/circleci/reference.txt
+++ b/internal/cmd/root/testdata/help/circleci/reference.txt
@@ -395,14 +395,15 @@ shown in the output of `circleci workflow get` and `circleci job get`.
 
 ### `circleci pipeline <command>`
 
-Define what will happen in a run
+Manage the pipeline definitions a run executes
 
 Create and list pipeline definitions for a CircleCI project.
 
 A pipeline definition decides what happens when a run is triggered:
 which repository to check out and where to find the config YAML that
 CircleCI compiles into workflows. Attach triggers to a definition with
-'circleci project trigger create'.
+'circleci project trigger create', and list the runs one produced with
+'circleci run list'.
 
 #### `circleci pipeline create [flags]`
 
@@ -510,13 +511,13 @@ JSON fields: id, state, number, created_at, triggered — or triggered, message 
 
 ### `circleci run <command>`
 
-Trigger, watch and cancel CI runs
+Trigger, watch and cancel pipeline runs
 
 Work with CircleCI runs.
 
-A run is created each time a trigger fires for a pipeline. It carries
-the VCS context for that firing and groups the workflows it produced;
-each workflow in turn contains jobs.
+A run is one execution of a pipeline, created each time a trigger
+fires. It carries the VCS context for that firing and groups the
+workflows it produced; each workflow in turn contains jobs.
 
 #### `circleci run cancel <run-number-or-id> [flags]`
 
@@ -603,10 +604,8 @@ List recent runs for a project
 
 List recent runs for a CircleCI project.
 
-The project is inferred from the current git repository's remote
-unless overridden with --project. Use --branch to filter results
-to a single branch, or --current-branch (-B) to automatically use
-the branch you have checked out.
+A run is one execution of a pipeline. The project is inferred from the
+current git repository's remote unless overridden with --project.
 
 The markdown table includes the commit subject; the JSON adds the full
 commit and repository detail.
@@ -4833,8 +4832,8 @@ Exit code reflects the HTTP response: 0 for 2xx, 4 for 4xx/5xx.
 **Arguments:**
 
 `<path>` is the request path. It is relative to /api/v3 by default
-(for example, "projects/{project-id}"). To target
-a different version prefix, include it explicitly, for example, "api/v2/me".
+(for example, "projects/{project-id}"). A path that starts with
+`api` is sent as given, so include the prefix to target another version.
 
 **Examples:**
 
@@ -4846,8 +4845,8 @@ a different version prefix, include it explicitly, for example, "api/v2/me".
   `circleci api projects/{project-id}/run -f definition_id=<id> -f "config[branch]=main"`
 - Send a body read from a file (@- reads from stdin): 
   `circleci api projects/{project-id}/run -d @payload.json`
-- Access the v1.1 API with a custom header: 
-  `circleci api api/v1.1/me -H "X-Custom: value"`
+- Send a custom header: 
+  `circleci api 'runs?filter[user_id]=me' -H "X-Custom: value"`
 
 ### `circleci env <command>`
 

--- a/internal/cmd/root/testdata/help/circleci/run.txt
+++ b/internal/cmd/root/testdata/help/circleci/run.txt
@@ -1,4 +1,4 @@
-Trigger, watch and cancel CI runs
+Trigger, watch and cancel pipeline runs
 
 ## Usage
 
@@ -28,7 +28,7 @@ Global flags: `-c, --config`, `--debug`, `--no-color`, `-q, --quiet` — see `ci
 
 Work with CircleCI runs.
 
-A run is created each time a trigger fires for a pipeline. It carries
-the VCS context for that firing and groups the workflows it produced;
-each workflow in turn contains jobs.
+A run is one execution of a pipeline, created each time a trigger
+fires. It carries the VCS context for that firing and groups the
+workflows it produced; each workflow in turn contains jobs.
 

--- a/internal/cmd/root/testdata/help/circleci/run/list.txt
+++ b/internal/cmd/root/testdata/help/circleci/run/list.txt
@@ -38,10 +38,8 @@ Global flags: `-c, --config`, `--debug`, `--no-color`, `-q, --quiet` — see `ci
 
 List recent runs for a CircleCI project.
 
-The project is inferred from the current git repository's remote
-unless overridden with --project. Use --branch to filter results
-to a single branch, or --current-branch (-B) to automatically use
-the branch you have checked out.
+A run is one execution of a pipeline. The project is inferred from the
+current git repository's remote unless overridden with --project.
 
 The markdown table includes the commit subject; the JSON adds the full
 commit and repository detail.

--- a/internal/cmd/root/usage_test.go
+++ b/internal/cmd/root/usage_test.go
@@ -94,7 +94,7 @@ var overBudget = map[string]int{
 	"circleci/project/create":         41,
 	"circleci/project/trigger/create": 41,
 	"circleci/run/get":                53,
-	"circleci/run/list":               49,
+	"circleci/run/list":               47,
 	"circleci/run/watch":              48,
 	"circleci/testresult/get":         44,
 	"circleci/testresult/list":        47,

--- a/internal/cmd/run/list.go
+++ b/internal/cmd/run/list.go
@@ -53,10 +53,8 @@ func newListCmd() *cobra.Command {
 		Long: heredoc.Doc(`
 			List recent runs for a CircleCI project.
 
-			The project is inferred from the current git repository's remote
-			unless overridden with --project. Use --branch to filter results
-			to a single branch, or --current-branch (-B) to automatically use
-			the branch you have checked out.
+			A run is one execution of a pipeline. The project is inferred from the
+			current git repository's remote unless overridden with --project.
 
 			The markdown table includes the commit subject; the JSON adds the full
 			commit and repository detail.

--- a/internal/cmd/run/run.go
+++ b/internal/cmd/run/run.go
@@ -37,13 +37,13 @@ func NewRunCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "run <command>",
 		GroupID: "ci",
-		Short:   "Trigger, watch and cancel CI runs",
+		Short:   "Trigger, watch and cancel pipeline runs",
 		Long: heredoc.Doc(`
 			Work with CircleCI runs.
 
-			A run is created each time a trigger fires for a pipeline. It carries
-			the VCS context for that firing and groups the workflows it produced;
-			each workflow in turn contains jobs.
+			A run is one execution of a pipeline, created each time a trigger
+			fires. It carries the VCS context for that firing and groups the
+			workflows it produced; each workflow in turn contains jobs.
 		`),
 	}
 

--- a/skills/circleci/SKILL.md
+++ b/skills/circleci/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: circleci
-description: Patterns for invoking the CircleCI CLI (circle) from agents. Covers structured output,
-  project and org targeting, list, circleci api fallback.
+description: Patterns for invoking the CircleCI CLI (circleci) from agents. Covers structured output,
+  project and org targeting, which command covers each v3 endpoint, circleci api fallback.
 ---
 
 # Reference
@@ -28,6 +28,39 @@ Human output from `circleci` is markdown-formatted. If you want structured data:
 
 Pass `--org <VCS>/<ORG>` to override the resolved CWD repo, where VCS is `gh` / `bb` / `circleci`.
 
+## Vocabulary: a pipeline execution is a "run"
+
+One execution of a pipeline is a **run**, matching `/api/v3/runs`, so recent
+pipelines come from `circleci run list`. `circleci pipeline` manages pipeline
+*definitions*: which repo to check out and where the config YAML lives. (The
+older v2 API called an execution a pipeline. That is the one name collision to
+watch for.)
+
+Paths below are relative to `/api/v3`, which is what `circleci api` assumes when
+you give no prefix. Every command supports `--json` and `--jq`, so there is no
+output-shape reason to reach for raw REST:
+
+| What you want | Command | v3 endpoint |
+| --- | --- | --- |
+| Recent runs for a project | `circleci run list [--branch <b>] [--project gh/org/repo]` | `GET /runs?filter[project_id]=` |
+| Your own recent runs | `circleci my runs` | `GET /runs?filter[user_id]=me` |
+| One run and its workflows | `circleci run get <run-id>` | `GET /runs/{id}` |
+| Workflows of a run | `circleci workflow list <run-id>` | `GET /workflows?filter[run_id]=` |
+| One workflow | `circleci workflow get <workflow-id>` | `GET /workflows/{id}` |
+| Jobs of a workflow | `circleci workflow get <workflow-id> --json` (`jobs[]`) | `GET /jobs?filter[workflow_id]=` |
+| One job | `circleci job get <job-id>` | `GET /jobs/{id}` |
+| Job step output | `circleci job output list <job-id>`, `circleci job output get <job-id>` | `GET /jobs/{id}/stdout` |
+| Job artifacts | `circleci artifact <job-id>` | `GET /jobs/{id}/artifacts` |
+| Test results | `circleci testresult list <job-id>` | `GET /jobs/{id}/tests` |
+| Who am I | `circleci auth me` | `GET /users` |
+| Pipeline definitions | `circleci pipeline list` | `GET /pipelines` |
+| Triggers | `circleci project trigger list` | `GET /triggers` |
+| Project env vars | `circleci envvar list` | `GET /projects/{id}/environment-variables` |
+| Contexts and their env vars | `circleci context list`, `circleci context secret list <ctx>` | `GET /contexts`, `GET /contexts/{id}/env-vars` |
+
+Run ids accept a UUID or a run number. Workflow and job ids are UUIDs, and are
+printed by `circleci run get --json` and `circleci workflow get --json`.
+
 ## Finding failed jobs
 
 `circleci run` subcommands are the starting point.
@@ -38,9 +71,12 @@ Pass `--org <VCS>/<ORG>` to override the resolved CWD repo, where VCS is `gh` / 
 - `circleci job get <job-id> --json`: will get you the job attributes, and step info without output.
 - `circleci job output get <job-id> --json`: `--step-num <step-id>` will get you the ANSI-stipped output for a specific step.
 
-## Fall back to `circleci api` for anything `--json` doesn't expose
+## Fall back to `circleci api` only when nothing above covers it
 
-Sometimes useful data isn't on the typed commands. 
+`circleci api <path>` resolves relative to `/api/v3`, so `circleci api runs`
+hits `/api/v3/runs`. Surfaces with no command yet: `usage/exports`, `analysis/*`
+and `metric/*` (charge, usage, job and test analytics), `notification/*`,
+`provider/*` and `audit/*`.
 
 - REST shortcuts: `circleci api 'projects/{project-id}'` or
   `circleci api 'runs?filter[project_id]={project-id}'` - note the


### PR DESCRIPTION
## Why

"Pipeline" is overloaded. One execution of a pipeline is a **run** here, matching `/api/v3/runs`, while the `pipeline` noun is used for pipeline *definitions* (which repo to check out, where the config YAML lives). Both are reasonable on their own, but nothing in either command's help pointed at the other:

- `circleci --help` described them in isolation: "Define what will happen in a run" and "Trigger, watch and cancel CI runs". Neither line tells you which one holds pipelines that have already run.
- `circleci pipeline --help` never mentioned `run`.
- `circleci run list --help` never used the word "pipeline".

So someone who wants recent pipelines reaches for `circleci pipeline list`, gets a table of config and checkout sources, and reasonably concludes the CLI cannot do it. The same applies to anyone arriving with the REST API's vocabulary in hand, including agents reading `--help` and the shipped skill.

## What changed

**Root listing** now contrasts the two nouns instead of describing each alone, which is where the choice actually gets made:

```
| `pipeline`   | Manage the pipeline definitions a run executes   |
| `run`        | Trigger, watch and cancel pipeline runs          |
```

**`circleci pipeline --help`** points at `circleci run list` for the runs a definition produced, folded into the sentence that already points at `circleci project trigger create`, so no new paragraph.

**`circleci run list --help`** now opens by saying a run is one execution of a pipeline. That replaced a paragraph restating `--branch` and `--current-branch` from the flag table, which is the first thing `agents/03-help-and-documentation.md` says to cut.

**`circleci api --help`** stops teaching a legacy API, which it was doing in the very command this started from. Its arguments section stated "include it explicitly, for example, `api/v2/me`"; it now states the actual rule, that a path starting with `api` is sent as given. Its last example was "Access the v1.1 API with a custom header"; the header example no longer targets a legacy version. Page length is unchanged.

**`skills/circleci/SKILL.md`** gains a table keyed on what the reader wants, giving both the command and the v3 endpoint behind it, so someone who would have called the API directly finds the command that covers it. The CLI's client is already overwhelmingly v3, and `circleci api` resolves relative to `/api/v3` when given no prefix, so the table documents v3 rather than teaching an older mental model. Every command and argument shape in it was checked against the built binary, and every endpoint against the service's generated spec, including the two required filters (`/workflows?filter[run_id]=` and `/jobs?filter[workflow_id]=`). Two other fixes there:

- The fallback section was titled "Fall back to `circleci api` for anything `--json` doesn't expose", which is broader than the truth. It now names the surfaces that genuinely have no command yet: `usage/exports`, `analysis/*` and `metric/*`, `notification/*`, `provider/*` and `audit/*`.
- The frontmatter described the binary as `circle`.

## Notes

- `run list --help` drops from 50 to 48 lines, so its `overBudget` cap ratchets from 49 to 47, probed to the floor.
- `pipeline --help` grows by one line. `run --help` and `api --help` are unchanged in length; on the `run` group only the summary line moved.
- Help and usage goldens regenerated with `task test -- ./internal/cmd/root/... -update`.

## Test plan

- `task check` clean.
- `task test` passes, other than pre-existing failures in `internal/orbinit` and `internal/gitremote` on machines with `commit.gpgSign = true` set globally, which go-git cannot honour. Both packages pass under `GIT_CONFIG_GLOBAL=/dev/null`.
- Help text reviewed by eye at `circleci --help`, `circleci pipeline --help`, `circleci pipeline list --help`, `circleci run --help`, `circleci run list --help`.

Text only. No behaviour, flags, or output shapes change.


