### PR TITLE
Allow agents to initiate CLI login more easily

### DIFF
--- a/acceptance/login_agent_test.go
+++ b/acceptance/login_agent_test.go
@@ -1,0 +1,267 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package acceptance_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+
+	"github.com/CircleCI-Public/circleci-cli/internal/testing/binary"
+	testenv "github.com/CircleCI-Public/circleci-cli/internal/testing/env"
+	"github.com/CircleCI-Public/circleci-cli/internal/testing/fakes"
+)
+
+// TestAuthLogin_AgentOpensBrowser covers the one case where the
+// non-interactive login flow opens a browser itself: an AI coding agent is
+// driving the CLI, so there is no TTY to show the login TUI, but a human is at
+// this machine and the authorize URL alone would strand them in tool output
+// they may never read.
+//
+// The platform's browser opener is shadowed on PATH by a script that records
+// the URL it was handed, which is why this cannot run on Windows — there
+// cli/browser calls a syscall rather than an executable.
+func TestAuthLogin_AgentOpensBrowser(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("cli/browser opens the browser via a Windows syscall, so it cannot be shadowed on PATH")
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 25*time.Second)
+	defer cancel()
+
+	fake := fakes.NewCircleCI(t)
+	fake.SetMe(fakes.User{
+		ID:    "e4a72497-7c55-400d-a72d-dadc4b92255d",
+		Name:  "Test User",
+		Login: "testuser",
+	})
+
+	openedPath := filepath.Join(t.TempDir(), "opened.txt")
+	binDir := installFakeBrowserOpener(t, openedPath)
+
+	env := testenv.New(t)
+	env.CircleCIURL = fake.URL()
+	env.Extra["CIRCLE_LOGIN_TIMEOUT"] = "20s"
+	// Make the CLI believe an AI coding agent is driving it — this is the only
+	// thing that opts the non-interactive path into opening a browser.
+	env.Extra["AI_AGENT"] = "acceptance-test-agent"
+
+	// RunCLI blocks until the CLI exits and the CLI does not exit until the
+	// OAuth callback lands, so the callback has to come from another
+	// goroutine. Nothing in there asserts — gotest.tools' fatal assertions are
+	// only safe on the test goroutine — so the error comes back over a channel.
+	cbErr := make(chan error, 1)
+	go func() { cbErr <- completeOAuthCallbackAfterBrowserOpens(ctx, fake, openedPath) }()
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"auth", "login"},
+		Env:     withPathPrefix(env.Environ(), binDir),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.NilError(t, <-cbErr)
+
+	assert.Assert(t, t.Run("browser was opened with the authorize url", func(t *testing.T) {
+		recorded, err := os.ReadFile(openedPath)
+		assert.NilError(t, err)
+
+		opened := strings.TrimSpace(string(recorded))
+		assert.Check(t, cmp.Contains(opened, "/oauth/authorize"))
+		assert.Check(t, cmp.Contains(opened, "request_uri="))
+		// The opened URL must be the very one the CLI printed, not a second
+		// flow with different PKCE state.
+		assert.Check(t, cmp.Contains(result.Stderr, opened))
+	}))
+
+	assert.Assert(t, t.Run("tells the user to approve, and still prints the url", func(t *testing.T) {
+		assert.Check(t, cmp.Contains(result.Stderr, "Opening this URL in your browser"))
+		assert.Check(t, cmp.Contains(result.Stderr, "approve the request there to continue"))
+		assert.Check(t, terminalURLRe.MatchString(result.Stderr),
+			"the URL must still be printed as a fallback in case the browser never opens")
+	}))
+
+	assert.Assert(t, t.Run("logged in", func(t *testing.T) {
+		assert.Check(t, cmp.Equal(result.ExitCode, 0))
+		assert.Check(t, cmp.Contains(result.Stderr, "Logged in as testuser"))
+	}))
+}
+
+// TestAuthLogin_NoAgentOnlyPrintsURL is the counterpart: with no agent driving
+// it, a non-interactive login must behave exactly as it always has and only
+// print the URL. A browser opened here would surprise scripts and CI.
+func TestAuthLogin_NoAgentOnlyPrintsURL(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("cli/browser opens the browser via a Windows syscall, so it cannot be shadowed on PATH")
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 25*time.Second)
+	defer cancel()
+
+	fake := fakes.NewCircleCI(t)
+	fake.SetMe(fakes.User{
+		ID:    "e4a72497-7c55-400d-a72d-dadc4b92255d",
+		Name:  "Test User",
+		Login: "testuser",
+	})
+
+	openedPath := filepath.Join(t.TempDir(), "opened.txt")
+	binDir := installFakeBrowserOpener(t, openedPath)
+
+	env := testenv.New(t)
+	env.CircleCIURL = fake.URL()
+	env.Extra["CIRCLE_LOGIN_TIMEOUT"] = "20s"
+
+	cbErr := make(chan error, 1)
+	go func() { cbErr <- completeOAuthCallback(ctx, fake) }()
+
+	result := binary.RunCLI(t, binary.RunOpts{
+		Binary:  binaryPath,
+		Args:    []string{"auth", "login"},
+		Env:     withPathPrefix(env.Environ(), binDir),
+		WorkDir: t.TempDir(),
+	})
+
+	assert.NilError(t, <-cbErr)
+
+	assert.Check(t, cmp.Equal(result.ExitCode, 0))
+	assert.Check(t, cmp.Contains(result.Stderr, "Open this URL in your browser to continue"))
+	assert.Check(t, cmp.Contains(result.Stderr, "Logged in as testuser"))
+
+	_, err := os.Stat(openedPath)
+	assert.Check(t, os.IsNotExist(err), "no browser may be opened without an agent driving the CLI")
+}
+
+// installFakeBrowserOpener shadows the platform's browser opener on PATH with a
+// script that appends the URL it was given to recordPath, and returns the
+// directory to prepend to PATH. cli/browser runs "open" on darwin and the first
+// of xdg-open/x-www-browser/www-browser/wslview it finds on linux, so
+// shadowing xdg-open is enough there.
+func installFakeBrowserOpener(t *testing.T, recordPath string) string {
+	t.Helper()
+
+	opener := "xdg-open"
+	if runtime.GOOS == "darwin" {
+		opener = "open"
+	}
+
+	binDir := t.TempDir()
+	script := fmt.Sprintf("#!/bin/sh\nprintf '%%s\\n' \"$1\" >> %q\n", recordPath)
+	assert.NilError(t, os.WriteFile(filepath.Join(binDir, opener), []byte(script), 0o755)) //#nosec:G306 // must be executable
+
+	return binDir
+}
+
+// withPathPrefix returns environ with dir prepended to its PATH entry. Go
+// resolves duplicate environment entries by taking the first, so PATH has to
+// be rewritten in place rather than appended to the slice.
+func withPathPrefix(environ []string, dir string) []string {
+	out := make([]string, 0, len(environ)+1)
+	found := false
+	for _, e := range environ {
+		if rest, ok := strings.CutPrefix(e, "PATH="); ok {
+			out = append(out, "PATH="+dir+string(os.PathListSeparator)+rest)
+			found = true
+			continue
+		}
+		out = append(out, e)
+	}
+	if !found {
+		out = append(out, "PATH="+dir)
+	}
+	return out
+}
+
+// completeOAuthCallbackAfterBrowserOpens waits for the CLI to launch the
+// browser before delivering the callback. Without that ordering the CLI could
+// finish and exit before the fire-and-forget opener goroutine is scheduled,
+// leaving nothing recorded and the test flaky.
+func completeOAuthCallbackAfterBrowserOpens(ctx context.Context, fake *fakes.CircleCI, openedPath string) error {
+	if err := waitFor(ctx, func() bool {
+		_, err := os.Stat(openedPath)
+		return err == nil
+	}); err != nil {
+		return fmt.Errorf("browser was never opened: %w", err)
+	}
+	return completeOAuthCallback(ctx, fake)
+}
+
+// completeOAuthCallback plays the part of the browser: it recovers the loopback
+// redirect_uri and state from the pushed authorization request the CLI sent to
+// /oauth/par, then hits the redirect_uri the way a browser would once the user
+// approves the consent screen.
+func completeOAuthCallback(ctx context.Context, fake *fakes.CircleCI) error {
+	var par url.Values
+	if err := waitFor(ctx, func() bool {
+		par = fake.LastPARRequest()
+		return par != nil
+	}); err != nil {
+		return fmt.Errorf("no pushed authorization request recorded: %w", err)
+	}
+
+	redirectURI, state := par.Get("redirect_uri"), par.Get("state")
+	if redirectURI == "" || state == "" {
+		return fmt.Errorf("pushed authorization request missing redirect_uri or state: %v", par)
+	}
+
+	callbackURL := redirectURI + "?code=fake-auth-code&state=" + url.QueryEscape(state)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, callbackURL, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("loopback callback returned %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	return nil
+}
+
+// waitFor polls done until it returns true or ctx expires.
+func waitFor(ctx context.Context, done func() bool) error {
+	for {
+		if done() {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(20 * time.Millisecond):
+		}
+	}
+}

--- a/clikit/iostream/streams.go
+++ b/clikit/iostream/streams.go
@@ -167,6 +167,19 @@ func IsInteractive(ctx context.Context) bool {
 	return fromContext(ctx).IsInteractive()
 }
 
+// EnvAllowsInteractive reports whether the environment permits interactive
+// behaviour, ignoring whether the streams are TTYs: false when CI or
+// CIRCLE_NO_INTERACTIVE is set. It takes no context because the answer derives
+// entirely from the environment and not at all from the streams.
+//
+// Prefer IsInteractive for anything that reads from or draws over the terminal.
+// This covers the narrower case of behaviour that still helps a human at this
+// machine when no TTY is attached — launching a browser for an OAuth flow the
+// CLI cannot finish on its own.
+func EnvAllowsInteractive() bool {
+	return !interactiveEnvDisabled()
+}
+
 func SpinnerEnabled(ctx context.Context) bool {
 	return fromContext(ctx).SpinnerEnabled()
 }

--- a/clikit/iostream/streams_test.go
+++ b/clikit/iostream/streams_test.go
@@ -98,3 +98,39 @@ func TestBackgroundQueryableNonTerminal(t *testing.T) {
 	t.Cleanup(func() { _ = pr.Close(); _ = pw.Close() })
 	assert.Check(t, !backgroundQueryable(pr, pw))
 }
+
+// TestEnvAllowsInteractive pins the exported inverse of
+// interactiveEnvDisabled. It is the seam a caller with no TTY uses to decide
+// whether an action that still needs a human — opening a browser to finish an
+// OAuth flow — is worth attempting at all, so both the inversion and its
+// independence from TTY state matter.
+func TestEnvAllowsInteractive(t *testing.T) {
+	t.Run("allowed by default", func(t *testing.T) {
+		clearTerminalEnv(t)
+		assert.Check(t, EnvAllowsInteractive())
+	})
+
+	t.Run("CI suppresses", func(t *testing.T) {
+		clearTerminalEnv(t)
+		t.Setenv("CI", "true")
+		assert.Check(t, !EnvAllowsInteractive())
+	})
+
+	t.Run("CIRCLE_NO_INTERACTIVE suppresses", func(t *testing.T) {
+		clearTerminalEnv(t)
+		t.Setenv("CIRCLE_NO_INTERACTIVE", "1")
+		assert.Check(t, !EnvAllowsInteractive())
+	})
+
+	t.Run("true where IsInteractive is false for want of a TTY", func(t *testing.T) {
+		clearTerminalEnv(t)
+
+		pr, pw, err := os.Pipe()
+		assert.NilError(t, err)
+		t.Cleanup(func() { _ = pr.Close(); _ = pw.Close() })
+
+		s := Streams{In: pr, Out: pw, Err: pw}
+		assert.Check(t, !s.IsInteractive(), "a pipe is not a TTY")
+		assert.Check(t, EnvAllowsInteractive(), "yet the environment permits interactivity")
+	})
+}

--- a/docs/website/assets/css/main.css
+++ b/docs/website/assets/css/main.css
@@ -437,6 +437,12 @@ a:hover {
     grid-template-columns: 1fr 1.2fr;
     gap: 4rem;
     padding-block: 5rem;
+    /* Top-aligned, not centred: the left column grows by ~550px when the
+       "All platforms" details is opened, and centring would re-centre the
+       screenshot against the taller column — making it jump down the page
+       on open and back up on close. Aligned to the row start it stays put
+       and the page simply grows downward. */
+    align-items: start;
   }
 }
 

--- a/internal/cmd/cmdauth/login.go
+++ b/internal/cmd/cmdauth/login.go
@@ -34,8 +34,10 @@ import (
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 
+	"github.com/CircleCI-Public/circleci-cli/clikit/browser"
 	clierrors "github.com/CircleCI-Public/circleci-cli/clikit/errors"
 	"github.com/CircleCI-Public/circleci-cli/clikit/iostream"
+	"github.com/CircleCI-Public/circleci-cli/internal/agent"
 	"github.com/CircleCI-Public/circleci-cli/internal/apiclient"
 	"github.com/CircleCI-Public/circleci-cli/internal/cmdutil"
 	"github.com/CircleCI-Public/circleci-cli/internal/oauth"
@@ -110,10 +112,32 @@ func runLogin(ctx context.Context, noBrowser, secureStorage bool, configPath str
 	host := cfg.EffectiveHost()
 	deviceID := cfg.DeviceID()
 
-	return runLoginBrowser(ctx, host, deviceID.String(), false, secureStorage, configPath)
+	return runLoginBrowser(ctx, host, deviceID.String(), false, noBrowser, secureStorage, configPath)
 }
 
-func runLoginBrowser(ctx context.Context, host string, deviceID string, signup, secureStorage bool, configPath string) error {
+// shouldOpenBrowser reports whether the non-interactive flow should open the
+// authorize URL itself rather than only printing it. agentName is the result of
+// agent.Detect() — empty when no AI coding agent is driving the CLI. It is
+// passed in rather than detected here so the decision stays testable without
+// unsetting every agent environment variable.
+//
+// The interactive TUI deliberately waits for the user to press Enter before
+// opening a browser, and is unaffected by this: it runs in runLoginInteractive
+// and never reaches here. This only ever applies to the non-interactive path,
+// and there only when an AI coding agent is driving the CLI. An agent has no
+// TTY, so it never gets the TUI — but a human is sitting at this machine
+// watching the agent rather than the terminal, and the URL we print lands in
+// tool output they may never see. Opening the browser is what actually puts
+// them in front of the consent screen.
+//
+// --no-browser always wins, and CI / CIRCLE_NO_INTERACTIVE suppress it so an
+// agent running inside a CI job never tries to spawn a browser on a headless
+// runner.
+func shouldOpenBrowser(noBrowser bool, agentName string) bool {
+	return !noBrowser && agentName != "" && iostream.EnvAllowsInteractive()
+}
+
+func runLoginBrowser(ctx context.Context, host string, deviceID string, signup, noBrowser, secureStorage bool, configPath string) error {
 	var flow *oauth.Flow
 	var err error
 	if signup {
@@ -131,7 +155,17 @@ func runLoginBrowser(ctx context.Context, host string, deviceID string, signup, 
 	}
 	defer func() { _ = flow.Close() }()
 
-	iostream.ErrPrintf(ctx, "Open this URL in your browser to continue:\n\n  %s\n\n", flow.AuthorizeURL)
+	if shouldOpenBrowser(noBrowser, agent.Detect()) {
+		iostream.ErrPrintf(ctx, "Opening this URL in your browser — approve the request there to continue:\n\n  %s\n\n", flow.AuthorizeURL)
+		// Fire and forget, and deliberately after the URL is printed. The
+		// opener runs under cmd.Run(), which for some Linux browsers does not
+		// return until the browser itself exits, so it must not sit between
+		// here and flow.Wait below. The URL is already on stderr, so failing
+		// to launch anything costs nothing over just printing it.
+		go func() { _ = browser.OpenURL(flow.AuthorizeURL) }()
+	} else {
+		iostream.ErrPrintf(ctx, "Open this URL in your browser to continue:\n\n  %s\n\n", flow.AuthorizeURL)
+	}
 
 	waitCtx, cancel := context.WithTimeout(ctx, callbackTimeout())
 	defer cancel()

--- a/internal/cmd/cmdauth/login_test.go
+++ b/internal/cmd/cmdauth/login_test.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 Circle Internet Services, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package cmdauth
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+// TestShouldOpenBrowser covers the gate that decides whether the
+// non-interactive login/signup flow opens the authorize URL itself. The
+// interactive TUI does not consult it at all — see shouldOpenBrowser.
+func TestShouldOpenBrowser(t *testing.T) {
+	// EnvAllowsInteractive reads these, and both are "set to anything
+	// non-empty" checks, so an empty value is equivalent to unset. Clearing
+	// them keeps the table independent of the environment the test runs in —
+	// notably CI, where CI=true would otherwise fail every positive case.
+	clearInteractivityEnv := func(t *testing.T) {
+		t.Helper()
+		t.Setenv("CI", "")
+		t.Setenv("CIRCLE_NO_INTERACTIVE", "")
+	}
+
+	t.Run("opens for a detected agent", func(t *testing.T) {
+		clearInteractivityEnv(t)
+		assert.Check(t, shouldOpenBrowser(false, "claude-code"))
+	})
+
+	t.Run("does not open with no agent", func(t *testing.T) {
+		clearInteractivityEnv(t)
+		assert.Check(t, !shouldOpenBrowser(false, ""),
+			"a plain non-TTY invocation (script, pipe) must only print the URL")
+	})
+
+	t.Run("--no-browser wins over agent detection", func(t *testing.T) {
+		clearInteractivityEnv(t)
+		assert.Check(t, !shouldOpenBrowser(true, "claude-code"),
+			"--no-browser is an explicit request not to open a browser")
+	})
+
+	t.Run("CI suppresses opening", func(t *testing.T) {
+		clearInteractivityEnv(t)
+		t.Setenv("CI", "true")
+		assert.Check(t, !shouldOpenBrowser(false, "claude-code"),
+			"an agent inside a CI job must not spawn a browser on a headless runner")
+	})
+
+	t.Run("CIRCLE_NO_INTERACTIVE suppresses opening", func(t *testing.T) {
+		clearInteractivityEnv(t)
+		t.Setenv("CIRCLE_NO_INTERACTIVE", "1")
+		assert.Check(t, !shouldOpenBrowser(false, "claude-code"))
+	})
+
+	t.Run("agent name is passed through from detection", func(t *testing.T) {
+		clearInteractivityEnv(t)
+		// Any non-empty name counts; the gate does not allowlist agents.
+		for _, name := range []string{"claude-code", "codex", "mcp/gemini-cli", "amp"} {
+			assert.Check(t, shouldOpenBrowser(false, name), "agent %q", name)
+		}
+	})
+}

--- a/internal/cmd/cmdauth/signup.go
+++ b/internal/cmd/cmdauth/signup.go
@@ -159,7 +159,7 @@ func runSignup(ctx context.Context, noBrowser, secureStorage bool, configPath st
 		return runSignupInteractive(ctx, secureStorage, configPath)
 	}
 
-	return runLoginBrowser(ctx, host, deviceID.String(), true, secureStorage, configPath)
+	return runLoginBrowser(ctx, host, deviceID.String(), true, noBrowser, secureStorage, configPath)
 }
 
 func runSignupInteractive(ctx context.Context, secureStorage bool, configPath string) error {

--- a/skills/circleci/SKILL.md
+++ b/skills/circleci/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: circleci
-description: Patterns for invoking the CircleCI CLI (circleci) from agents. Covers structured output,
-  project and org targeting, which command covers each v3 endpoint, circleci api fallback.
+description: Patterns for invoking the CircleCI CLI (circleci) from agents. Covers authentication,
+  structured output, project and org targeting, which command covers each v3 endpoint, circleci api
+  fallback.
 ---
 
 # Reference
@@ -13,6 +14,29 @@ strips ANSI color, and errors out fast with a helpful message instead of
 prompting (e.g. `must provide --title and --body when not running interactively`).
 You don't need to defensively set `CIRCLECI_PAGER` or pass `--no-pager` (no such
 flag exists).
+
+## Authentication
+
+`circleci auth me` tells you whether there is a usable token; it fails with
+`No CircleCI API token found` when there is not.
+
+To authenticate, run `circleci auth login`. Don't ask the user for an API token
+— the OAuth flow needs no secret from them, and pasting tokens around is worse
+for them than a browser round-trip.
+
+With no TTY the CLI skips its login TUI, opens the authorize page in the user's
+browser, and prints the same URL to stderr. Two things follow from that:
+
+- **Tell the user to approve the request in their browser**, and pass the
+  printed URL along in case the browser never came to the front. They are
+  watching you, not your tool output.
+- **It blocks until they approve**, for up to 5 minutes. Run it in the
+  background, or with a timeout well above your default — not in a foreground
+  call that gives up after a minute.
+
+`--no-browser` prints the URL without opening anything. `CI` and
+`CIRCLE_NO_INTERACTIVE` also suppress the browser, since there is no one there
+to use it; supply `CIRCLE_TOKEN` in those environments instead.
 
 ## Parsing JSON
 


### PR DESCRIPTION
- Now we tuned https://cli.circleci.com for agents following the install instructions, tune the CLI login process so it can be initiated more easily inside an agent session by following the prompt we give from the web UI.