### PR TITLE
Record exit code and error code on command_invocation

### DIFF
--- a/acceptance/api_test.go
+++ b/acceptance/api_test.go
@@ -38,6 +38,7 @@ import (
 	"gotest.tools/v3/golden"
 	"gotest.tools/v3/poll"
 
+	clierrors "github.com/CircleCI-Public/circleci-cli/clikit/errors"
 	"github.com/CircleCI-Public/circleci-cli/clikit/iostream"
 	"github.com/CircleCI-Public/circleci-cli/internal/config"
 	"github.com/CircleCI-Public/circleci-cli/internal/telemetry"
@@ -431,9 +432,10 @@ func TestAPI_Telemetry(t *testing.T) {
 						UserId:    telemetry.AnonymousID.String(),
 						Event:     "command_invocation",
 						Properties: analytics.Properties{
-							"command":  "circleci api",
-							"flags":    "debug,insecure-storage,theme",
-							"api_path": apiPath,
+							"command":   "circleci api",
+							"flags":     "debug,insecure-storage,theme",
+							"exit_code": float64(clierrors.ExitSuccess),
+							"api_path":  apiPath,
 						},
 						Context: &analytics.Context{
 							App: analytics.AppInfo{Name: "circleci-cli", Version: "dev"},
@@ -494,9 +496,14 @@ func TestAPI_Telemetry_CommandFailure(t *testing.T) {
 			for _, msg := range batch.Messages {
 				if msg.Event == "command_invocation" {
 					return poll.Compare(cmp.DeepEqual(msg.Properties, analytics.Properties{
-						"command":  "circleci api",
-						"flags":    "debug,insecure-storage,theme",
-						"api_path": apiPath,
+						"command": "circleci api",
+						"flags":   "debug,insecure-storage,theme",
+						// Compared against the process's own exit status rather
+						// than a literal, since the point of the property is that
+						// the two agree.
+						"exit_code":  float64(result.ExitCode),
+						"error_code": "api.request_failed",
+						"api_path":   apiPath,
 					}))
 				}
 			}

--- a/acceptance/setting_test.go
+++ b/acceptance/setting_test.go
@@ -38,6 +38,7 @@ import (
 	"gotest.tools/v3/golden"
 	"gotest.tools/v3/poll"
 
+	clierrors "github.com/CircleCI-Public/circleci-cli/clikit/errors"
 	"github.com/CircleCI-Public/circleci-cli/clikit/iostream"
 	"github.com/CircleCI-Public/circleci-cli/internal/config"
 	"github.com/CircleCI-Public/circleci-cli/internal/telemetry"
@@ -196,8 +197,9 @@ func TestSettingList_TextOutput(t *testing.T) {
 							UserId:    telemetry.AnonymousID.String(),
 							Event:     "command_invocation",
 							Properties: analytics.Properties{
-								"command": "circleci setting list",
-								"flags":   "debug,insecure-storage,theme",
+								"command":   "circleci setting list",
+								"flags":     "debug,insecure-storage,theme",
+								"exit_code": float64(clierrors.ExitSuccess),
 							},
 							Context: &analytics.Context{
 								App: analytics.AppInfo{Name: "circleci-cli", Version: "dev"},
@@ -265,8 +267,9 @@ func TestSettingList_TextOutput_Color(t *testing.T) {
 							UserId:    telemetry.AnonymousID.String(),
 							Event:     "command_invocation",
 							Properties: analytics.Properties{
-								"command": "circleci setting list",
-								"flags":   "insecure-storage,theme",
+								"command":   "circleci setting list",
+								"flags":     "insecure-storage,theme",
+								"exit_code": float64(clierrors.ExitSuccess),
 							},
 							Context: &analytics.Context{
 								App: analytics.AppInfo{Name: "circleci-cli", Version: "dev"},

--- a/internal/cmdutil/telemetry.go
+++ b/internal/cmdutil/telemetry.go
@@ -24,12 +24,15 @@ package cmdutil
 
 import (
 	"context"
+	"errors"
 	"slices"
 	"strings"
 	"sync"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+
+	clierrors "github.com/CircleCI-Public/circleci-cli/clikit/errors"
 )
 
 // telemetryProps is the mutable set of extra properties RecordTelemetryNow adds
@@ -42,14 +45,14 @@ import (
 // per run and a later write simply replaces an earlier one.
 type telemetryProps struct {
 	mu    sync.Mutex
-	props map[string]string
+	props map[string]any
 }
 
-func (p *telemetryProps) set(key, value string) {
+func (p *telemetryProps) set(key string, value any) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if p.props == nil {
-		p.props = map[string]string{}
+		p.props = map[string]any{}
 	}
 	p.props[key] = value
 }
@@ -121,6 +124,7 @@ func RecordTelemetry(cmd *cobra.Command) {
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		runErr := currentRunE(cmd, args)
 
+		recordOutcome(cmd.Context(), runErr)
 		RecordTelemetryNow(cmd)
 
 		// Events are buffered until the sender is closed, and the root command's
@@ -181,8 +185,45 @@ func RecordTelemetryNow(cmd *cobra.Command) {
 	props := map[string]any{
 		"command": cmd.CommandPath(),
 		"flags":   strings.Join(flags, ","),
+		// Overwritten by recordOutcome when the handler failed. Defaulting here
+		// rather than there keeps the property on the events that never run a
+		// handler at all — help and usage — where success is the only outcome.
+		"exit_code": clierrors.ExitSuccess,
 	}
 	getTelemetryProps(ctx).mergeInto(props)
 
 	_ = tc.Track("command_invocation", props)
+}
+
+// recordOutcome records how the invocation ended, so a command's usage can be
+// told apart from its success. Both properties describe the error the handler
+// returned; cmd/circleci/main.go reclassifies a few error kinds after Execute
+// returns, which is past the point telemetry is recorded, so an error it rewrites
+// is reported here under its original classification.
+func recordOutcome(ctx context.Context, err error) {
+	p := getTelemetryProps(ctx)
+	if p == nil {
+		return
+	}
+
+	exitCode, errorCode := classifyError(err)
+	p.set("exit_code", exitCode)
+	if errorCode != "" {
+		p.set("error_code", errorCode)
+	}
+}
+
+// classifyError reduces an error to the exit code it produces and its
+// machine-readable code. A CLIError carries both already. Anything else escaped
+// the structured error type, so it exits as a general error and is reported as
+// unclassified — which is the signal that a handler needs a real code, not just
+// a count of failures.
+func classifyError(err error) (exitCode int, errorCode string) {
+	if err == nil {
+		return clierrors.ExitSuccess, ""
+	}
+	if cliErr, ok := errors.AsType[*clierrors.CLIError](err); ok {
+		return cliErr.ExitCode, cliErr.Code
+	}
+	return clierrors.ExitGeneralError, "unclassified"
 }

--- a/internal/cmdutil/telemetry_test.go
+++ b/internal/cmdutil/telemetry_test.go
@@ -37,6 +37,7 @@ import (
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/assert/cmp"
 
+	clierrors "github.com/CircleCI-Public/circleci-cli/clikit/errors"
 	"github.com/CircleCI-Public/circleci-cli/clikit/iostream"
 	"github.com/CircleCI-Public/circleci-cli/internal/cmdutil"
 	"github.com/CircleCI-Public/circleci-cli/internal/telemetry"
@@ -74,8 +75,9 @@ func TestRecordTelemetry(t *testing.T) {
 				UserId:    userID,
 				Event:     "command_invocation",
 				Properties: analytics.Properties{
-					"command": "circleci banana list",
-					"flags":   "bool-flag,string-flag",
+					"command":   "circleci banana list",
+					"flags":     "bool-flag,string-flag",
+					"exit_code": clierrors.ExitSuccess,
 				},
 				Context: &analytics.Context{
 					App: analytics.AppInfo{
@@ -128,8 +130,10 @@ func TestRecordTelemetry(t *testing.T) {
 				UserId:    userID,
 				Event:     "command_invocation",
 				Properties: analytics.Properties{
-					"command": "fail",
-					"flags":   "",
+					"command":    "fail",
+					"flags":      "",
+					"exit_code":  clierrors.ExitGeneralError,
+					"error_code": "unclassified",
 				},
 				Context: &analytics.Context{
 					App: analytics.AppInfo{
@@ -146,6 +150,76 @@ func TestRecordTelemetry(t *testing.T) {
 				Integrations: analytics.NewIntegrations().Enable("Amplitude"),
 			},
 		}, fakesegment.CompareTrack, fakesegment.CompareTime))
+	})
+
+	// A CLIError already carries the exit code the process will use and the
+	// machine-readable code the user was shown, so telemetry reports those rather
+	// than inventing a classification of its own.
+	t.Run("records a structured error's code and exit code", func(t *testing.T) {
+		recorder, client := newTelemetry(t)
+		wantErr := clierrors.New("run.timeout", "Watch timed out", "Run did not complete in time.").
+			WithExitCode(clierrors.ExitTimeout)
+		cmd := &cobra.Command{
+			Use:  "watch",
+			RunE: func(cmd *cobra.Command, args []string) error { return wantErr },
+		}
+
+		cmd.SetContext(cmdutil.WithTelemetry(context.Background(), client))
+		cmdutil.RecordTelemetry(cmd)
+		assert.Check(t, cmp.ErrorIs(cmd.RunE(cmd, nil), wantErr))
+		assert.NilError(t, client.Close())
+
+		assert.Check(t, cmp.DeepEqual(properties(recorder.Tracks()), []analytics.Properties{
+			{
+				"command":    "watch",
+				"flags":      "",
+				"exit_code":  clierrors.ExitTimeout,
+				"error_code": "run.timeout",
+			},
+		}))
+	})
+
+	// Handlers wrap as an error travels back up, so the classification has to look
+	// through the error tree rather than at the outermost error alone.
+	t.Run("records a structured error wrapped by its caller", func(t *testing.T) {
+		recorder, client := newTelemetry(t)
+		cliErr := clierrors.New("auth.token_missing", "Authentication required", "No API token.").
+			WithExitCode(clierrors.ExitAuthError)
+		cmd := &cobra.Command{
+			Use: "me",
+			RunE: func(cmd *cobra.Command, args []string) error {
+				return fmt.Errorf("resolving the current user: %w", cliErr)
+			},
+		}
+
+		cmd.SetContext(cmdutil.WithTelemetry(context.Background(), client))
+		cmdutil.RecordTelemetry(cmd)
+		assert.Check(t, cmp.ErrorIs(cmd.RunE(cmd, nil), cliErr))
+		assert.NilError(t, client.Close())
+
+		assert.Check(t, cmp.DeepEqual(properties(recorder.Tracks()), []analytics.Properties{
+			{
+				"command":    "me",
+				"flags":      "",
+				"exit_code":  clierrors.ExitAuthError,
+				"error_code": "auth.token_missing",
+			},
+		}))
+	})
+
+	// The help and usage paths record an event without running a handler, so
+	// nothing wraps them to classify an error and default the exit code.
+	t.Run("records success for a path with no handler", func(t *testing.T) {
+		recorder, client := newTelemetry(t)
+		cmd := &cobra.Command{Use: "help"}
+		cmd.SetContext(cmdutil.WithTelemetry(context.Background(), client))
+
+		cmdutil.RecordTelemetryNow(cmd)
+		assert.NilError(t, client.Close())
+
+		assert.Check(t, cmp.DeepEqual(properties(recorder.Tracks()), []analytics.Properties{
+			{"command": "help", "flags": "", "exit_code": clierrors.ExitSuccess},
+		}))
 	})
 
 	t.Run("flags are sorted alphabetically", func(t *testing.T) {
@@ -174,8 +248,9 @@ func TestRecordTelemetry(t *testing.T) {
 				UserId:    userID,
 				Event:     "command_invocation",
 				Properties: analytics.Properties{
-					"command": "test",
-					"flags":   "alpha,middle,zebra",
+					"command":   "test",
+					"flags":     "alpha,middle,zebra",
+					"exit_code": clierrors.ExitSuccess,
 				},
 				Context: &analytics.Context{
 					App: analytics.AppInfo{
@@ -215,8 +290,9 @@ func TestRecordTelemetry(t *testing.T) {
 				UserId:    userID,
 				Event:     "command_invocation",
 				Properties: analytics.Properties{
-					"command": "test",
-					"flags":   "",
+					"command":   "test",
+					"flags":     "",
+					"exit_code": clierrors.ExitSuccess,
 				},
 				Context: &analytics.Context{
 					App: analytics.AppInfo{
@@ -271,6 +347,7 @@ func TestRecordTelemetry(t *testing.T) {
 			{
 				"command":        "onboard",
 				"flags":          "",
+				"exit_code":      clierrors.ExitSuccess,
 				"onboard_mode":   "scan",
 				"onboard_signup": "completed",
 			},
@@ -296,7 +373,12 @@ func TestRecordTelemetry(t *testing.T) {
 		assert.NilError(t, client.Close())
 
 		assert.Check(t, cmp.DeepEqual(properties(recorder.Tracks()), []analytics.Properties{
-			{"command": "onboard", "flags": "", "onboard_signup": "completed"},
+			{
+				"command":        "onboard",
+				"flags":          "",
+				"exit_code":      clierrors.ExitSuccess,
+				"onboard_signup": "completed",
+			},
 		}))
 	})
 
@@ -319,7 +401,13 @@ func TestRecordTelemetry(t *testing.T) {
 		assert.NilError(t, client.Close())
 
 		assert.Check(t, cmp.DeepEqual(properties(recorder.Tracks()), []analytics.Properties{
-			{"command": "onboard", "flags": "", "onboard_project_setup": "trigger_failed"},
+			{
+				"command":               "onboard",
+				"flags":                 "",
+				"exit_code":             clierrors.ExitGeneralError,
+				"error_code":            "unclassified",
+				"onboard_project_setup": "trigger_failed",
+			},
 		}))
 	})
 
@@ -349,7 +437,12 @@ func TestRecordTelemetry(t *testing.T) {
 		assert.NilError(t, client.Close())
 
 		assert.Check(t, cmp.DeepEqual(properties(recorder.Tracks()), []analytics.Properties{
-			{"command": "onboard", "flags": "", "onboard_mode": "scan"},
+			{
+				"command":      "onboard",
+				"flags":        "",
+				"exit_code":    clierrors.ExitSuccess,
+				"onboard_mode": "scan",
+			},
 		}))
 	})
 
@@ -374,9 +467,10 @@ func TestRecordTelemetry(t *testing.T) {
 				UserId:    userID,
 				Event:     "command_invocation",
 				Properties: analytics.Properties{
-					"command":  "api",
-					"flags":    "",
-					"api_path": "api/v2/me",
+					"command":   "api",
+					"flags":     "",
+					"exit_code": clierrors.ExitSuccess,
+					"api_path":  "api/v2/me",
 				},
 				Context: &analytics.Context{
 					App: analytics.AppInfo{
@@ -424,8 +518,9 @@ func TestRecordTelemetryForSubcommands(t *testing.T) {
 				UserId:    userID,
 				Event:     "command_invocation",
 				Properties: analytics.Properties{
-					"command": "circleci subcommand list",
-					"flags":   "",
+					"command":   "circleci subcommand list",
+					"flags":     "",
+					"exit_code": clierrors.ExitSuccess,
 				},
 				Context: &analytics.Context{
 					App: analytics.AppInfo{


### PR DESCRIPTION
## Why

`command_invocation` carried two properties: `command` and `flags`. That answers
which commands people run, but not whether any of them worked. A failed
invocation was indistinguishable from a successful one, so nothing could show an
error rate, say which commands fail most, or say why.

The information was already there and thrown away. `RecordTelemetry` wraps `RunE`
and holds the handler's error (`internal/cmdutil/telemetry.go:125`), then drops it
on the floor.

## What changed

Two properties on `command_invocation`:

| Property | Value |
|---|---|
| `exit_code` | The exit status the failure produced, or `0` |
| `error_code` | `CLIError.Code`, e.g. `setting.unknown_key`. Absent on success |

Real events, from the `--debug` telemetry log:

```
DEBU track command_invocation command="circleci setting list" flags=debug exit_code=0
DEBU track command_invocation command="circleci setting set"  flags=debug exit_code=2 error_code=setting.unknown_key
```

### What this does not collect

No new source of data is read, and nothing is collected from the environment that
was not already. Both properties are scalars derived from the error the handler
returned:

- **No command output.** Nothing a command prints to stdout or stderr is read or
  sent. `error_code` is `CLIError.Code`, a namespaced literal such as
  `setting.unknown_key`; `.Message`, which is the field that can carry an
  interpolated path or identifier, is never sent.
- **No argument or flag values.** Unchanged: `flags` has always been flag *names*
  only.
- **No new environment reads**, no file paths, no hostnames.

`CIRCLE_NO_TELEMETRY`, `NO_ANALYTICS`, `DO_NOT_TRACK` and `CI` all still disable
collection, unchanged, since this rides the existing sender.

### `error_code` is structured data we already had

Rule 2 of `agents/12-analytics.md` sanctions collecting error *types*, and the CLI
has had them all along: every failure surfaced to a user is a `clierrors.CLIError`
with a namespaced `Code`, and there are 235 distinct literals across the tree. So
this needs no new taxonomy and no mapping table, and it is low cardinality by
construction. User data lives in `.Message`, which is never sent.

An error that reaches the wrapper without being a `CLIError` reports
`unclassified`. That is a signal rather than a fallback: it counts the handlers
still returning bare errors, which critical rule 2 forbids.

### `exit_code` on paths with no handler

Defaulted to `ExitSuccess` in `RecordTelemetryNow` and overwritten by
`recordOutcome` when a handler failed. Defaulting there rather than in
`recordOutcome` keeps the property present on the help and usage events
(`internal/cmd/root/root.go:366` and `:375`), which record without ever running a
handler, and where success is the only outcome.

## Known limit

`cmd/circleci/main.go` reclassifies a few error kinds after `Execute()` returns:
`--jq` failures, HTTP 410 and a missing extension binary (`main.go:61-107`).
Telemetry is recorded inside the command lifecycle, which is earlier, so those
arrive under their original classification. Noted on `recordOutcome`. Worth
revisiting if the `unclassified` share turns out to be concentrated there.

## Tests

`TestAPI_Telemetry_CommandFailure` compares `exit_code` against the process's real
exit status rather than a literal, since the whole point of the property is that
the two agree.
